### PR TITLE
v0.2.4: Internal quality improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.4]
+
+### Security
+- Web API now supports `Authorization: Bearer <token>` header authentication
+  - Header takes priority over query parameter when present
+  - Query parameter fallback preserved for SSE EventSource connections
+- Frontend `fetch()` calls migrated to use Authorization header instead of URL query parameter
+
+### Improved
+- Team member search optimized with HashMap-based cmdline cache (eliminates duplicate PID lookups)
+- Task summary counts pre-computed in TeamSnapshot (avoids per-frame iteration)
+- API operation logging added for state-changing endpoints (approve, select, submit, input)
+
+### Fixed
+- State directory creation race condition (TOCTOU) in PTY wrapper
+  - Now uses idempotent `create_dir_all` + metadata verification + permission auto-repair
+- Defensive digit parsing in key handler (`unwrap()` → `unwrap_or(0)`)
+
+### Added
+- Web API test suite with 12 test cases covering all endpoints
+  - Empty state, 404, 400, path traversal validation, agent state checks
+
 ## [0.2.3]
 
 ### Improved

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2809,7 +2809,7 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tmai"
-version = "0.2.3"
+version = "0.2.4"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -2818,6 +2818,8 @@ dependencies = [
  "clap",
  "crossterm",
  "dirs",
+ "http",
+ "http-body-util",
  "image",
  "local-ip-address",
  "mime_guess",
@@ -2835,6 +2837,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "toml",
+ "tower",
  "tower-http",
  "tracing",
  "tracing-subscriber",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmai"
-version = "0.2.3"
+version = "0.2.4"
 edition = "2021"
 authors = ["TrustDelta"]
 description = "Tmux Multi Agent Interface - Monitor and control AI agents in tmux"
@@ -50,6 +50,9 @@ nix = { version = "0.31", features = ["signal", "process", "term"] }
 
 [dev-dependencies]
 pretty_assertions = "1"
+tower = { version = "0.5", features = ["util"] }
+http = "1"
+http-body-util = "0.1"
 
 [[bin]]
 name = "tmai"

--- a/src/state/store.rs
+++ b/src/state/store.rs
@@ -224,6 +224,14 @@ pub struct TeamSnapshot {
     pub member_panes: HashMap<String, String>,
     /// When this snapshot was last updated
     pub last_scan: chrono::DateTime<chrono::Utc>,
+    /// Pre-computed completed task count
+    pub task_done: usize,
+    /// Pre-computed total task count
+    pub task_total: usize,
+    /// Pre-computed in-progress task count
+    pub task_in_progress: usize,
+    /// Pre-computed pending task count
+    pub task_pending: usize,
 }
 
 /// Application state

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -369,7 +369,7 @@ impl App {
             // Support both half-width (1-9) and full-width (１-９) digits
             KeyCode::Char(c) if matches!(c, '1'..='9' | '１'..='９') => {
                 let num = if c.is_ascii_digit() {
-                    c.to_digit(10).unwrap() as usize
+                    c.to_digit(10).unwrap_or(0) as usize
                 } else {
                     // Full-width digit: convert '１'-'９' to 1-9
                     (c as u32 - '０' as u32) as usize

--- a/src/ui/components/session_list.rs
+++ b/src/ui/components/session_list.rs
@@ -9,7 +9,6 @@ use unicode_width::UnicodeWidthStr;
 
 use crate::agents::{AgentStatus, MonitoredAgent};
 use crate::state::{AppState, SortBy};
-use crate::teams::TaskStatus;
 use crate::ui::SplitDirection;
 
 /// Optional task summary for team group headers
@@ -275,14 +274,9 @@ impl SessionList {
                             // Extract team name from "Team: {name}" format
                             let team_name = group_key.strip_prefix("Team: ");
                             team_name.and_then(|name| {
-                                state.teams.get(name).map(|snapshot| {
-                                    let total = snapshot.tasks.len();
-                                    let done = snapshot
-                                        .tasks
-                                        .iter()
-                                        .filter(|t| t.status == TaskStatus::Completed)
-                                        .count();
-                                    GroupTaskSummary { done, total }
+                                state.teams.get(name).map(|snapshot| GroupTaskSummary {
+                                    done: snapshot.task_done,
+                                    total: snapshot.task_total,
                                 })
                             })
                         } else {

--- a/src/web/assets/app.js
+++ b/src/web/assets/app.js
@@ -50,6 +50,20 @@ class TmaiRemote {
     }
 
     /**
+     * Fetch wrapper that automatically adds Authorization header
+     * @param {string} url
+     * @param {Object} options - fetch options
+     * @returns {Promise<Response>}
+     */
+    apiFetch(url, options = {}) {
+        const headers = options.headers instanceof Headers
+            ? options.headers
+            : new Headers(options.headers || {});
+        headers.set('Authorization', `Bearer ${this.token}`);
+        return fetch(url, { ...options, headers });
+    }
+
+    /**
      * Load theme from localStorage or system preference
      */
     loadTheme() {
@@ -158,7 +172,7 @@ class TmaiRemote {
      */
     async loadAgents() {
         try {
-            const response = await fetch(`/api/agents?token=${this.token}`);
+            const response = await this.apiFetch('/api/agents');
             if (!response.ok) {
                 throw new Error('Failed to load agents');
             }
@@ -758,7 +772,7 @@ class TmaiRemote {
      * API: Approve agent
      */
     async approve(id) {
-        const response = await fetch(`/api/agents/${encodeURIComponent(id)}/approve?token=${this.token}`, {
+        const response = await this.apiFetch(`/api/agents/${encodeURIComponent(id)}/approve`, {
             method: 'POST'
         });
         if (!response.ok) throw new Error('Approve failed');
@@ -770,7 +784,7 @@ class TmaiRemote {
      * API: Select choice
      */
     async select(id, choice) {
-        const response = await fetch(`/api/agents/${encodeURIComponent(id)}/select?token=${this.token}`, {
+        const response = await this.apiFetch(`/api/agents/${encodeURIComponent(id)}/select`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ choice })
@@ -790,7 +804,7 @@ class TmaiRemote {
         }
 
         // Then submit
-        const response = await fetch(`/api/agents/${encodeURIComponent(id)}/submit?token=${this.token}`, {
+        const response = await this.apiFetch(`/api/agents/${encodeURIComponent(id)}/submit`, {
             method: 'POST'
         });
         if (!response.ok) throw new Error('Submit failed');
@@ -802,7 +816,7 @@ class TmaiRemote {
      * @param {string} text
      */
     async sendText(id, text) {
-        const response = await fetch(`/api/agents/${encodeURIComponent(id)}/input?token=${this.token}`, {
+        const response = await this.apiFetch(`/api/agents/${encodeURIComponent(id)}/input`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ text })
@@ -816,7 +830,7 @@ class TmaiRemote {
      * @returns {Promise<string>}
      */
     async getPreview(id) {
-        const response = await fetch(`/api/agents/${encodeURIComponent(id)}/preview?token=${this.token}`);
+        const response = await this.apiFetch(`/api/agents/${encodeURIComponent(id)}/preview`);
         if (!response.ok) throw new Error('Get preview failed');
         const data = await response.json();
         return data.content;


### PR DESCRIPTION
## Summary
- **Security**: Authorization Bearer header auth for Web API, frontend migrated to header-based auth
- **Performance**: HashMap-based cmdline cache for team search, pre-computed task summary counts
- **Robustness**: TOCTOU fix in state directory creation, defensive digit parsing
- **Tests**: 12 new Web API test cases (total 145 tests passing)

## Changes
- `src/web/auth.rs`: Bearer header auth with query param fallback for SSE
- `src/web/assets/app.js`: `apiFetch()` helper with Authorization header
- `src/web/api.rs`: tracing logs for state-changing endpoints + 12 test cases
- `src/monitor/poller.rs`: HashMap cmdline cache, matched member skip
- `src/state/store.rs`: `task_done/total/in_progress/pending` fields on TeamSnapshot
- `src/ui/components/session_list.rs`: use pre-computed task summary
- `src/ui/app.rs`: `unwrap()` → `unwrap_or(0)`
- `src/wrap/state_file.rs`: idempotent dir creation + metadata check + permission repair

## Test plan
- [x] `cargo check` — no errors
- [x] `cargo clippy` — no warnings
- [x] `cargo test` — 145 tests passing
- [x] `cargo fmt --check` — clean
- [x] `cargo build --release` — success
- [ ] CI pipeline passes
- [ ] Manual test: `cargo run -- --debug` + Web Remote approve/select

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート v0.2.4

* **新機能**
  * Bearer トークン認証ヘッダーのサポートを追加
  * APIテストスイートを追加

* **セキュリティ**
  * 認証メカニズムを強化

* **バグ修正**
  * PTYラッパーのレース条件を修正
  * 数値パース処理の安全性を向上

* **改善**
  * API操作のロギング機能を追加
  * キャッシングと事前計算メトリクスによるパフォーマンス最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->