### PR TITLE
chore: update Cargo.lock for v0.2.9

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2837,7 +2837,7 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tmai"
-version = "0.2.8"
+version = "0.2.9"
 dependencies = [
  "ansi-to-tui",
  "anyhow",


### PR DESCRIPTION
## Summary
- Update Cargo.lock version to match v0.2.9 (fixes `cargo publish` CI failure)

## Test plan
- [x] CI passes (no code changes, only lock file version bump)

🤖 Generated with [Claude Code](https://claude.com/claude-code)