### PR TITLE
chore: simplify branch strategy (main only)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,7 +2,7 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
-    target-branch: "develop"
+    target-branch: "main"
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,10 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [master]
-  push:
-    branches: [develop]
-
+    branches: [main]
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## Summary
- Remove `develop` branch from workflow (single-branch strategy)
- Update CI to only trigger on PRs to `main` (remove `push: branches: [develop]`)
- Update dependabot target branch from `develop` to `main`

## Rationale
- `develop` branch adds overhead without benefit for a solo-developer OSS project
- All quality gates (CI, CodeRabbit) are enforced via PR, making `develop` redundant
- `master` has been renamed to `main` via GitHub API

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores

* Dependabot設定を更新し、Cargoアップデートのターゲットブランチをmainに変更しました。
* CIワークフローのトリガーを更新し、mainブランチに統一しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->