### PR TITLE
chore: bump version to v0.8.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.3] - 2026-02-27
+
+### Fixed
+- Add `--no-session-persistence` to auto-approve Claude CLI calls to prevent session file accumulation in `~/.claude/projects/`
+
 ## [0.8.2] - 2026-02-27
 
 ### Improved

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,7 +2941,7 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tmai"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "tmai-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "tmai"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 rust-version = "1.91"
 authors = ["TrustDelta"]
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [dependencies]
-tmai-core = { version = "0.8.2", path = "crates/tmai-core" }
+tmai-core = { version = "0.8.3", path = "crates/tmai-core" }
 ratatui = "0.30"
 crossterm = "0.29"
 tokio = { version = "1", features = ["full"] }

--- a/crates/tmai-core/Cargo.toml
+++ b/crates/tmai-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmai-core"
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 rust-version = "1.91"
 authors = ["TrustDelta"]

--- a/crates/tmai-core/src/auto_approve/judge.rs
+++ b/crates/tmai-core/src/auto_approve/judge.rs
@@ -90,6 +90,7 @@ impl JudgmentProvider for ClaudeHaikuJudge {
         let mut child = tokio::process::Command::new(command)
             .args([
                 "-p",
+                "--no-session-persistence",
                 "--model",
                 &self.model,
                 "--output-format",


### PR DESCRIPTION
## Summary
- Bump version from 0.8.2 to 0.8.3
- Update CHANGELOG.md

## Changes
### Fixed
- Add `--no-session-persistence` to auto-approve Claude CLI calls to prevent session file accumulation in `~/.claude/projects/`

## Checklist
- [x] Version bumped in Cargo.toml and crates/tmai-core/Cargo.toml
- [x] CHANGELOG.md updated
- [x] Cargo.lock updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * CLIフラグ `--no-session-persistence` を追加しました。このフラグを使用することで、セッションファイルの自動蓄積を防ぎ、プロジェクトディレクトリを整理した状態に保つことができます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->