### PR TITLE
feat: add Hook-as-Teacher detection validation logging

### DIFF
--- a/crates/tmai-core/src/audit/analyze.rs
+++ b/crates/tmai-core/src/audit/analyze.rs
@@ -220,6 +220,87 @@ pub fn compute_disagreements(events: &[AuditEvent], limit: usize) -> Disagreemen
     summary
 }
 
+/// Accuracy stats per hook status (e.g., "processing", "idle")
+#[derive(Debug, Default)]
+pub struct StatusAccuracy {
+    /// Total validation events for this hook status
+    pub total: usize,
+    /// Number of IPC agreements
+    pub ipc_agree: usize,
+    /// Total IPC comparisons (excluding None)
+    pub ipc_total: usize,
+    /// Number of capture-pane agreements
+    pub capture_agree: usize,
+}
+
+/// Summary of DetectionValidation events (hook vs IPC/capture-pane accuracy)
+#[derive(Debug, Default)]
+pub struct ValidationSummary {
+    /// Total validation events (disagreements only)
+    pub total: usize,
+    /// Number of IPC agreements
+    pub ipc_agreement_count: usize,
+    /// Total IPC comparisons (excluding None)
+    pub ipc_total: usize,
+    /// Number of capture-pane agreements
+    pub capture_agreement_count: usize,
+    /// Capture-pane disagreement frequency by rule name
+    pub capture_disagreements_by_rule: Vec<(String, usize)>,
+    /// Accuracy breakdown by hook status
+    pub by_hook_status: HashMap<String, StatusAccuracy>,
+}
+
+/// Compute validation statistics from DetectionValidation events
+pub fn compute_validation_stats(events: &[AuditEvent]) -> ValidationSummary {
+    let mut summary = ValidationSummary::default();
+    let mut rule_map: HashMap<String, usize> = HashMap::new();
+
+    for event in events {
+        if let AuditEvent::DetectionValidation {
+            hook_status,
+            capture_reason,
+            ipc_agrees,
+            capture_agrees,
+            ..
+        } = event
+        {
+            summary.total += 1;
+
+            let entry = summary
+                .by_hook_status
+                .entry(hook_status.clone())
+                .or_default();
+            entry.total += 1;
+
+            // IPC stats
+            if let Some(agrees) = ipc_agrees {
+                summary.ipc_total += 1;
+                entry.ipc_total += 1;
+                if *agrees {
+                    summary.ipc_agreement_count += 1;
+                    entry.ipc_agree += 1;
+                }
+            }
+
+            // capture-pane stats
+            if *capture_agrees {
+                summary.capture_agreement_count += 1;
+                entry.capture_agree += 1;
+            } else {
+                // Track which capture rules disagree
+                *rule_map.entry(capture_reason.rule.clone()).or_default() += 1;
+            }
+        }
+    }
+
+    // Sort rules by frequency descending
+    let mut by_rule: Vec<(String, usize)> = rule_map.into_iter().collect();
+    by_rule.sort_by(|a, b| b.1.cmp(&a.1));
+    summary.capture_disagreements_by_rule = by_rule;
+
+    summary
+}
+
 /// Extract timestamp from any event variant
 fn event_ts(event: &AuditEvent) -> u64 {
     match event {
@@ -228,6 +309,7 @@ fn event_ts(event: &AuditEvent) -> u64 {
         | AuditEvent::AgentAppeared { ts, .. }
         | AuditEvent::AgentDisappeared { ts, .. }
         | AuditEvent::AutoApproveJudgment { ts, .. }
+        | AuditEvent::DetectionValidation { ts, .. }
         | AuditEvent::UserInputDuringProcessing { ts, .. } => *ts,
     }
 }
@@ -240,6 +322,7 @@ fn event_type_name(event: &AuditEvent) -> &'static str {
         AuditEvent::AgentAppeared { .. } => "AgentAppeared",
         AuditEvent::AgentDisappeared { .. } => "AgentDisappeared",
         AuditEvent::AutoApproveJudgment { .. } => "AutoApproveJudgment",
+        AuditEvent::DetectionValidation { .. } => "DetectionValidation",
         AuditEvent::UserInputDuringProcessing { .. } => "UserInputDuringProcessing",
     }
 }
@@ -252,6 +335,7 @@ fn event_agent_type(event: &AuditEvent) -> &str {
         | AuditEvent::AgentAppeared { agent_type, .. }
         | AuditEvent::AgentDisappeared { agent_type, .. }
         | AuditEvent::AutoApproveJudgment { agent_type, .. }
+        | AuditEvent::DetectionValidation { agent_type, .. }
         | AuditEvent::UserInputDuringProcessing { agent_type, .. } => agent_type,
     }
 }
@@ -261,6 +345,7 @@ fn event_reason(event: &AuditEvent) -> Option<&crate::detectors::DetectionReason
     match event {
         AuditEvent::StateChanged { reason, .. } => Some(reason),
         AuditEvent::SourceDisagreement { capture_reason, .. } => Some(capture_reason),
+        AuditEvent::DetectionValidation { capture_reason, .. } => Some(capture_reason),
         AuditEvent::UserInputDuringProcessing {
             detection_reason, ..
         } => detection_reason.as_ref(),
@@ -414,5 +499,124 @@ mod tests {
         assert_eq!(summary.by_capture_rule[0], ("no_spinner".to_string(), 1));
         assert_eq!(summary.by_pane[0], ("1".to_string(), 1));
         assert_eq!(summary.records.len(), 1);
+    }
+
+    /// Helper to build a DetectionValidation event
+    fn validation_event(
+        hook_status: &str,
+        ipc_status: Option<&str>,
+        capture_status: &str,
+        capture_rule: &str,
+    ) -> AuditEvent {
+        let ipc_agrees = ipc_status.map(|s| s == hook_status);
+        let capture_agrees = capture_status == hook_status;
+        AuditEvent::DetectionValidation {
+            ts: 1000,
+            pane_id: "1".to_string(),
+            agent_type: "ClaudeCode".to_string(),
+            hook_status: hook_status.to_string(),
+            hook_event: "PreToolUse".to_string(),
+            ipc_status: ipc_status.map(|s| s.to_string()),
+            capture_status: capture_status.to_string(),
+            capture_reason: DetectionReason {
+                rule: capture_rule.to_string(),
+                confidence: DetectionConfidence::Medium,
+                matched_text: None,
+            },
+            ipc_agrees,
+            capture_agrees,
+            hook_tool_input: None,
+            hook_permission_mode: None,
+            screen_context: None,
+        }
+    }
+
+    #[test]
+    fn test_compute_validation_stats_empty() {
+        let summary = compute_validation_stats(&[]);
+        assert_eq!(summary.total, 0);
+        assert_eq!(summary.ipc_total, 0);
+        assert_eq!(summary.capture_agreement_count, 0);
+    }
+
+    #[test]
+    fn test_compute_validation_stats_capture_disagree() {
+        let events = vec![
+            // capture disagrees: hook=processing, capture=idle
+            validation_event("processing", None, "idle", "no_spinner"),
+            // capture disagrees again: hook=idle, capture=processing
+            validation_event("idle", None, "processing", "spinner_verb"),
+        ];
+
+        let summary = compute_validation_stats(&events);
+        assert_eq!(summary.total, 2);
+        assert_eq!(summary.capture_agreement_count, 0);
+        assert_eq!(summary.ipc_total, 0);
+        assert_eq!(summary.ipc_agreement_count, 0);
+
+        // Both rules should appear in disagreements
+        assert_eq!(summary.capture_disagreements_by_rule.len(), 2);
+
+        // By hook status
+        assert_eq!(summary.by_hook_status["processing"].total, 1);
+        assert_eq!(summary.by_hook_status["processing"].capture_agree, 0);
+        assert_eq!(summary.by_hook_status["idle"].total, 1);
+        assert_eq!(summary.by_hook_status["idle"].capture_agree, 0);
+    }
+
+    #[test]
+    fn test_compute_validation_stats_with_ipc() {
+        let events = vec![
+            // IPC agrees, capture disagrees
+            validation_event("processing", Some("processing"), "idle", "no_spinner"),
+            // IPC disagrees, capture disagrees
+            validation_event("processing", Some("idle"), "idle", "fallback_no_indicator"),
+        ];
+
+        let summary = compute_validation_stats(&events);
+        assert_eq!(summary.total, 2);
+        assert_eq!(summary.ipc_total, 2);
+        assert_eq!(summary.ipc_agreement_count, 1);
+        assert_eq!(summary.capture_agreement_count, 0);
+
+        let status_acc = &summary.by_hook_status["processing"];
+        assert_eq!(status_acc.total, 2);
+        assert_eq!(status_acc.ipc_total, 2);
+        assert_eq!(status_acc.ipc_agree, 1);
+        assert_eq!(status_acc.capture_agree, 0);
+    }
+
+    #[test]
+    fn test_compute_validation_stats_mixed_events() {
+        // Mix validation events with other event types
+        let events = vec![
+            state_changed(1000, "rule_a", DetectionConfidence::High),
+            validation_event("processing", Some("processing"), "idle", "no_spinner"),
+            AuditEvent::AgentAppeared {
+                ts: 500,
+                pane_id: "1".to_string(),
+                agent_type: "ClaudeCode".to_string(),
+                source: "capture_pane".to_string(),
+                initial_status: "idle".to_string(),
+            },
+        ];
+
+        let summary = compute_validation_stats(&events);
+        // Only 1 validation event
+        assert_eq!(summary.total, 1);
+        assert_eq!(summary.ipc_total, 1);
+        assert_eq!(summary.ipc_agreement_count, 1);
+    }
+
+    #[test]
+    fn test_compute_stats_includes_validation() {
+        let events = vec![validation_event("processing", None, "idle", "no_spinner")];
+
+        let stats = compute_stats(&events);
+        assert_eq!(stats.total_events, 1);
+        assert_eq!(stats.by_event_type["DetectionValidation"], 1);
+        // capture_reason should be counted
+        assert_eq!(stats.by_confidence[&DetectionConfidence::Medium], 1);
+        assert_eq!(stats.rule_hits[0], ("no_spinner".to_string(), 1));
     }
 }

--- a/crates/tmai-core/src/audit/events.rs
+++ b/crates/tmai-core/src/audit/events.rs
@@ -76,6 +76,38 @@ pub enum AuditEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         screen_context: Option<String>,
     },
+    /// Hook vs IPC/capture-pane detection accuracy validation
+    /// Logged only on disagreement (when IPC or capture-pane differ from hook ground truth)
+    DetectionValidation {
+        ts: u64,
+        pane_id: String,
+        agent_type: String,
+        /// Hook ground truth status
+        hook_status: String,
+        /// Hook event name that produced the status
+        hook_event: String,
+        /// IPC detection result (None if no IPC connection)
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ipc_status: Option<String>,
+        /// capture-pane detection result
+        capture_status: String,
+        /// capture-pane detection reason
+        capture_reason: DetectionReason,
+        /// Whether IPC result agrees with hook (None if no IPC)
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        ipc_agrees: Option<bool>,
+        /// Whether capture-pane result agrees with hook
+        capture_agrees: bool,
+        /// Tool input from hook (included on disagreement, max 500 chars)
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hook_tool_input: Option<serde_json::Value>,
+        /// Permission mode from hook
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        hook_permission_mode: Option<String>,
+        /// Last N lines of screen content (included on disagreement, max 1000 chars)
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        screen_context: Option<String>,
+    },
     /// User sent input while agent was detected as Processing
     /// (possible false negative — detection may have missed an approval prompt)
     UserInputDuringProcessing {
@@ -97,4 +129,111 @@ pub enum AuditEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         screen_context: Option<String>,
     },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::detectors::DetectionConfidence;
+
+    #[test]
+    fn test_detection_validation_serde_roundtrip() {
+        let event = AuditEvent::DetectionValidation {
+            ts: 1234567890,
+            pane_id: "5".to_string(),
+            agent_type: "ClaudeCode".to_string(),
+            hook_status: "processing".to_string(),
+            hook_event: "PreToolUse".to_string(),
+            ipc_status: Some("idle".to_string()),
+            capture_status: "idle".to_string(),
+            capture_reason: DetectionReason {
+                rule: "no_spinner".to_string(),
+                confidence: DetectionConfidence::Medium,
+                matched_text: None,
+            },
+            ipc_agrees: Some(false),
+            capture_agrees: false,
+            hook_tool_input: Some(serde_json::json!({"command": "cargo test"})),
+            hook_permission_mode: Some("default".to_string()),
+            screen_context: Some("last few lines".to_string()),
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        let deserialized: AuditEvent = serde_json::from_str(&json).unwrap();
+
+        if let AuditEvent::DetectionValidation {
+            ts,
+            pane_id,
+            hook_status,
+            hook_event,
+            ipc_status,
+            capture_status,
+            ipc_agrees,
+            capture_agrees,
+            hook_tool_input,
+            hook_permission_mode,
+            screen_context,
+            ..
+        } = deserialized
+        {
+            assert_eq!(ts, 1234567890);
+            assert_eq!(pane_id, "5");
+            assert_eq!(hook_status, "processing");
+            assert_eq!(hook_event, "PreToolUse");
+            assert_eq!(ipc_status.as_deref(), Some("idle"));
+            assert_eq!(capture_status, "idle");
+            assert_eq!(ipc_agrees, Some(false));
+            assert!(!capture_agrees);
+            assert!(hook_tool_input.is_some());
+            assert_eq!(hook_permission_mode.as_deref(), Some("default"));
+            assert_eq!(screen_context.as_deref(), Some("last few lines"));
+        } else {
+            panic!("Expected DetectionValidation");
+        }
+    }
+
+    #[test]
+    fn test_detection_validation_serde_minimal() {
+        // No optional fields
+        let event = AuditEvent::DetectionValidation {
+            ts: 100,
+            pane_id: "1".to_string(),
+            agent_type: "ClaudeCode".to_string(),
+            hook_status: "idle".to_string(),
+            hook_event: "Stop".to_string(),
+            ipc_status: None,
+            capture_status: "processing".to_string(),
+            capture_reason: DetectionReason {
+                rule: "spinner_verb".to_string(),
+                confidence: DetectionConfidence::High,
+                matched_text: Some("Analyzing".to_string()),
+            },
+            ipc_agrees: None,
+            capture_agrees: false,
+            hook_tool_input: None,
+            hook_permission_mode: None,
+            screen_context: None,
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        // Optional None fields should be omitted
+        assert!(!json.contains("ipc_status"));
+        assert!(!json.contains("ipc_agrees"));
+        assert!(!json.contains("hook_tool_input"));
+        assert!(!json.contains("hook_permission_mode"));
+        assert!(!json.contains("screen_context"));
+
+        let deserialized: AuditEvent = serde_json::from_str(&json).unwrap();
+        if let AuditEvent::DetectionValidation {
+            capture_agrees,
+            capture_status,
+            ..
+        } = deserialized
+        {
+            assert!(!capture_agrees);
+            assert_eq!(capture_status, "processing");
+        } else {
+            panic!("Expected DetectionValidation");
+        }
+    }
 }

--- a/crates/tmai-core/src/hooks/handler.rs
+++ b/crates/tmai-core/src/hooks/handler.rs
@@ -7,7 +7,7 @@ use crate::api::CoreEvent;
 use crate::state::SharedState;
 
 use super::registry::{HookRegistry, SessionPaneMap};
-use super::types::{event_names, HookEventPayload, HookState, HookStatus};
+use super::types::{event_names, HookContext, HookEventPayload, HookState, HookStatus};
 
 /// Process an incoming hook event and update the registry
 ///
@@ -35,7 +35,8 @@ pub fn handle_hook_event(
 
     match event {
         event_names::SESSION_START => {
-            let state = HookState::new(payload.session_id.clone(), payload.cwd.clone());
+            let mut state = HookState::new(payload.session_id.clone(), payload.cwd.clone());
+            state.last_context = build_context(payload);
             let mut reg = hook_registry.write();
             reg.insert(pane_id.to_string(), state);
             None
@@ -43,6 +44,7 @@ pub fn handle_hook_event(
 
         event_names::USER_PROMPT_SUBMIT => {
             // Clear last_tool on new prompt (fresh processing cycle)
+            let ctx = build_context(payload);
             let mut reg = hook_registry.write();
             if let Some(state) = reg.get_mut(pane_id) {
                 state.status = HookStatus::Processing;
@@ -50,10 +52,12 @@ pub fn handle_hook_event(
                 if payload.cwd.is_some() {
                     state.cwd = payload.cwd.clone();
                 }
+                state.last_context = ctx;
                 state.touch();
             } else {
                 let mut state = HookState::new(payload.session_id.clone(), payload.cwd.clone());
                 state.status = HookStatus::Processing;
+                state.last_context = ctx;
                 reg.insert(pane_id.to_string(), state);
             }
             None
@@ -77,9 +81,11 @@ pub fn handle_hook_event(
             // Keep last_tool so the display shows which tool was last used.
             // It will be overwritten by the next PreToolUse or cleared by
             // UserPromptSubmit / Stop.
+            let ctx = build_context(payload);
             let mut reg = hook_registry.write();
             if let Some(state) = reg.get_mut(pane_id) {
                 state.status = HookStatus::Processing;
+                state.last_context = ctx;
                 state.touch();
             }
             None
@@ -118,10 +124,12 @@ pub fn handle_hook_event(
 
         event_names::STOP => {
             // Clear last_tool on stop (session returns to idle)
+            let ctx = build_context(payload);
             let mut reg = hook_registry.write();
             if let Some(state) = reg.get_mut(pane_id) {
                 state.status = HookStatus::Idle;
                 state.last_tool = None;
+                state.last_context = ctx;
                 state.touch();
             }
             None
@@ -237,6 +245,15 @@ pub fn resolve_pane_id(
     None
 }
 
+/// Build a HookContext from a hook event payload
+fn build_context(payload: &HookEventPayload) -> HookContext {
+    HookContext {
+        event_name: payload.hook_event_name.clone(),
+        tool_input: payload.tool_input.clone(),
+        permission_mode: payload.permission_mode.clone(),
+    }
+}
+
 /// Update hook state for a pane, creating entry if needed
 fn update_status(
     registry: &HookRegistry,
@@ -254,12 +271,14 @@ fn update_status(
         if payload.cwd.is_some() {
             state.cwd = payload.cwd.clone();
         }
+        state.last_context = build_context(payload);
         state.touch();
     } else {
         // Auto-create entry if not registered via SessionStart
         let mut state = HookState::new(payload.session_id.clone(), payload.cwd.clone());
         state.status = status;
         state.last_tool = tool_name;
+        state.last_context = build_context(payload);
         reg.insert(pane_id.to_string(), state);
     }
 }
@@ -622,5 +641,88 @@ mod tests {
         let state = reg.get("5").unwrap();
         assert_eq!(state.status, HookStatus::Idle);
         assert!(state.last_tool.is_none());
+    }
+
+    #[test]
+    fn test_last_context_set_on_pre_tool_use() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        handle_hook_event(&make_payload("SessionStart"), "5", &registry, &map);
+
+        let payload: HookEventPayload = serde_json::from_value(serde_json::json!({
+            "hook_event_name": "PreToolUse",
+            "session_id": "test-session",
+            "tool_name": "Bash",
+            "tool_input": {"command": "cargo test"},
+            "permission_mode": "default"
+        }))
+        .unwrap();
+        handle_hook_event(&payload, "5", &registry, &map);
+
+        let reg = registry.read();
+        let state = reg.get("5").unwrap();
+        assert_eq!(state.last_context.event_name, "PreToolUse");
+        assert!(state.last_context.tool_input.is_some());
+        assert_eq!(
+            state.last_context.permission_mode.as_deref(),
+            Some("default")
+        );
+    }
+
+    #[test]
+    fn test_last_context_updated_across_events() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        handle_hook_event(&make_payload("SessionStart"), "5", &registry, &map);
+        {
+            let reg = registry.read();
+            assert_eq!(
+                reg.get("5").unwrap().last_context.event_name,
+                "SessionStart"
+            );
+        }
+
+        handle_hook_event(&make_payload("UserPromptSubmit"), "5", &registry, &map);
+        {
+            let reg = registry.read();
+            assert_eq!(
+                reg.get("5").unwrap().last_context.event_name,
+                "UserPromptSubmit"
+            );
+        }
+
+        handle_hook_event(&make_payload("Stop"), "5", &registry, &map);
+        {
+            let reg = registry.read();
+            assert_eq!(reg.get("5").unwrap().last_context.event_name, "Stop");
+        }
+    }
+
+    #[test]
+    fn test_last_context_set_on_post_tool_use() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        handle_hook_event(&make_payload("SessionStart"), "5", &registry, &map);
+
+        let payload: HookEventPayload = serde_json::from_value(serde_json::json!({
+            "hook_event_name": "PostToolUse",
+            "session_id": "test-session",
+            "tool_name": "Bash",
+            "tool_input": {"command": "npm test"},
+            "permission_mode": "dontAsk"
+        }))
+        .unwrap();
+        handle_hook_event(&payload, "5", &registry, &map);
+
+        let reg = registry.read();
+        let state = reg.get("5").unwrap();
+        assert_eq!(state.last_context.event_name, "PostToolUse");
+        assert_eq!(
+            state.last_context.permission_mode.as_deref(),
+            Some("dontAsk")
+        );
     }
 }

--- a/crates/tmai-core/src/hooks/types.rs
+++ b/crates/tmai-core/src/hooks/types.rs
@@ -121,6 +121,17 @@ pub enum HookStatus {
     AwaitingApproval,
 }
 
+/// Rich context from a hook event (for audit validation)
+#[derive(Debug, Clone, Default)]
+pub struct HookContext {
+    /// Hook event name that produced this context
+    pub event_name: String,
+    /// Tool input parameters (from PreToolUse/PostToolUse/PermissionRequest)
+    pub tool_input: Option<serde_json::Value>,
+    /// Current permission mode (e.g., "default", "plan", "dontAsk")
+    pub permission_mode: Option<String>,
+}
+
 /// Internal state tracked per agent based on hook events
 #[derive(Debug, Clone)]
 pub struct HookState {
@@ -134,6 +145,8 @@ pub struct HookState {
     pub cwd: Option<String>,
     /// Timestamp of last hook event (Unix millis)
     pub last_event_at: u64,
+    /// Rich context from the last hook event (for audit validation)
+    pub last_context: HookContext,
 }
 
 impl HookState {
@@ -145,6 +158,7 @@ impl HookState {
             session_id,
             cwd,
             last_event_at: current_time_millis(),
+            last_context: HookContext::default(),
         }
     }
 

--- a/crates/tmai-core/src/monitor/poller.rs
+++ b/crates/tmai-core/src/monitor/poller.rs
@@ -326,13 +326,22 @@ impl Poller {
 
                 // Optimize capture-pane based on selection and detection source:
                 // - Selected: ANSI capture for preview (always needed)
-                // - Non-selected + hook/IPC: skip capture-pane entirely
+                // - Non-selected + audit + hook: plain capture for validation
+                // - Non-selected + hook/IPC (no audit): skip capture-pane entirely
                 // - Non-selected + capture-pane mode: plain capture for detection only
+                let audit_enabled = self.settings.audit.enabled;
                 let (content_ansi, mut content) = if is_selected {
                     // Selected agent: full ANSI capture for preview
                     let ansi = self.client.capture_pane(&pane.target).unwrap_or_default();
                     let plain = strip_ansi(&ansi);
                     (ansi, plain)
+                } else if audit_enabled && has_fresh_hook {
+                    // Non-selected + audit + hook: plain capture for validation
+                    let plain = self
+                        .client
+                        .capture_pane_plain(&pane.target)
+                        .unwrap_or_default();
+                    (String::new(), plain)
                 } else if has_fresh_hook || wrap_state.is_some() {
                     // Non-selected + hook/IPC mode: skip capture-pane entirely
                     (String::new(), String::new())
@@ -365,6 +374,94 @@ impl Poller {
                         confidence: DetectionConfidence::High,
                         matched_text,
                     };
+
+                    // Validation: compare IPC/capture-pane against hook ground truth
+                    if audit_enabled {
+                        let hook_status_str = status_name(&status).to_string();
+                        let hook_event = hs.last_context.event_name.clone();
+
+                        // IPC validation
+                        let ipc_status_str = wrap_state
+                            .as_ref()
+                            .map(|ws| status_name(&wrap_state_to_agent_status(ws)).to_string());
+                        let ipc_agrees = ipc_status_str.as_ref().map(|s| *s == hook_status_str);
+
+                        // capture-pane validation
+                        let (capture_status_str, capture_reason) = if !content.is_empty() {
+                            let detection_context = DetectionContext {
+                                cwd: Some(pane.cwd.as_str()),
+                                settings_cache: Some(&self.claude_settings_cache),
+                            };
+                            let detector = get_detector(&agent_type);
+                            let result = detector.detect_status_with_reason(
+                                &title,
+                                &content,
+                                &detection_context,
+                            );
+                            (status_name(&result.status).to_string(), result.reason)
+                        } else {
+                            (
+                                "unknown".to_string(),
+                                DetectionReason {
+                                    rule: "no_capture".to_string(),
+                                    confidence: DetectionConfidence::Low,
+                                    matched_text: None,
+                                },
+                            )
+                        };
+                        let capture_agrees = capture_status_str == hook_status_str;
+
+                        // Log only on disagreement
+                        if !capture_agrees || ipc_agrees == Some(false) {
+                            let screen_context = if !content.is_empty() {
+                                let lines: Vec<&str> = content.lines().collect();
+                                let start = lines.len().saturating_sub(10);
+                                let tail = lines[start..].join("\n");
+                                let truncated = if tail.len() > 1000 {
+                                    tail[..tail.floor_char_boundary(1000)].to_string()
+                                } else {
+                                    tail
+                                };
+                                Some(truncated)
+                            } else {
+                                None
+                            };
+
+                            // Truncate tool_input to max 500 chars
+                            let hook_tool_input = hs.last_context.tool_input.as_ref().map(|v| {
+                                let s = v.to_string();
+                                if s.len() > 500 {
+                                    serde_json::Value::String(
+                                        s[..s.floor_char_boundary(500)].to_string(),
+                                    )
+                                } else {
+                                    v.clone()
+                                }
+                            });
+
+                            let ts = SystemTime::now()
+                                .duration_since(UNIX_EPOCH)
+                                .unwrap_or_default()
+                                .as_millis() as u64;
+
+                            self.audit_logger.log(&AuditEvent::DetectionValidation {
+                                ts,
+                                pane_id: pane.pane_id.clone(),
+                                agent_type: agent_type.short_name().to_string(),
+                                hook_status: hook_status_str,
+                                hook_event,
+                                ipc_status: ipc_status_str,
+                                capture_status: capture_status_str,
+                                capture_reason,
+                                ipc_agrees,
+                                capture_agrees,
+                                hook_tool_input,
+                                hook_permission_mode: hs.last_context.permission_mode.clone(),
+                                screen_context,
+                            });
+                        }
+                    }
+
                     (status, None, Some(reason))
                 } else if let Some(ref ws) = wrap_state {
                     // Tier 2: IPC-based detection (existing logic)


### PR DESCRIPTION
## Summary

- Hook events serve as ground truth for agent status detection. When audit is enabled, the poller compares IPC and capture-pane results against hook status and logs disagreements as `DetectionValidation` events
- Add `HookContext` struct to preserve rich hook event metadata (event name, tool_input, permission_mode)
- Add `compute_validation_stats()` for per-status/per-rule accuracy analysis
- Zero cost when audit is disabled; disagreement-only logging prevents log bloat

## Design

### 3-tier detection with validation

```
Hook (ground truth) ──→ compare ──→ DetectionValidation (disagreement only)
                          ↑
IPC  (if available) ──────┘
capture-pane ─────────────┘
```

### capture-pane skip condition change

| Condition | Before | After |
|---|---|---|
| selected | ANSI capture | ANSI capture (unchanged) |
| non-selected + audit + hook | skip | **plain capture** (for validation) |
| non-selected + hook/IPC (no audit) | skip | skip (unchanged) |
| non-selected + capture-pane only | plain capture | plain capture (unchanged) |

### Early real-world results (16 events)

| Pattern | Count | Cause |
|---|---|---|
| hook=awaiting_approval, cap=processing | 11 | Title spinner lag after PermissionRequest |
| hook=idle, cap=processing | 3 | Title spinner lag after Stop |
| hook=processing, cap=idle | 1 | UserPromptSubmit before title update |
| hook=processing, cap=awaiting_approval | 1 | Previous approval prompt still on screen |

87.5% of disagreements from `title_braille_spinner_fast_path` rule — confirms timing gap between hook events and tmux title updates.

## Changed files

| File | Change |
|---|---|
| `hooks/types.rs` | `HookContext` struct, `last_context` field on `HookState` |
| `hooks/handler.rs` | Set `last_context` on all event paths, `build_context()` helper |
| `audit/events.rs` | `DetectionValidation` variant (13 fields, optional fields skipped when None) |
| `monitor/poller.rs` | Audit-aware capture-pane skip, Tier 1 validation logic |
| `audit/analyze.rs` | `ValidationSummary`, `StatusAccuracy`, `compute_validation_stats()`, match exhaustiveness |

## Test plan

- [x] `cargo test -p tmai-core` — 409 tests pass (10 new)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] `cargo run -- --audit --debug` — 16 DetectionValidation events confirmed in real environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 検出結果の検証統計機能を追加しました。異なる検出方法間の一致状況を追跡できます。
  * 検出の不一致を記録する新しい検証イベントを実装しました。
  * フック処理の文脈情報を保持するようにしました。
  * 監査機能による検証プロセスを強化し、詳細なログを出力するようにしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->