### PR TITLE
chore: bump version to v0.11.0 (#59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.11.0] - 2026-03-02
+
+### Added
+- Hook-as-Teacher detection validation: use hook events as ground truth to measure IPC/capture-pane detection accuracy
+  - `DetectionValidation` audit event logged on disagreement between hook and IPC/capture-pane results
+  - `HookContext` preserves rich event context (event_name, tool_input, permission_mode) for analysis
+  - `compute_validation_stats()` for accuracy analysis by rule and status
+  - Non-selected panes run capture-pane for validation when audit is enabled
+
+### Dependencies
+- Bump chrono from 0.4.43 to 0.4.44
+- Bump nix from 0.31.1 to 0.31.2
+
 ## [0.10.3] - 2026-03-02
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,7 +2941,7 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tmai"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "ansi-to-tui",
  "anyhow",
@@ -2984,7 +2984,7 @@ dependencies = [
 
 [[package]]
 name = "tmai-core"
-version = "0.10.3"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [package]
 name = "tmai"
-version = "0.10.3"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.91"
 authors = ["TrustDelta"]
@@ -25,7 +25,7 @@ exclude = [
 ]
 
 [dependencies]
-tmai-core = { version = "0.10.3", path = "crates/tmai-core" }
+tmai-core = { version = "0.11.0", path = "crates/tmai-core" }
 ratatui = "0.30"
 crossterm = "0.29"
 tokio = { version = "1", features = ["full"] }

--- a/crates/tmai-core/Cargo.toml
+++ b/crates/tmai-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tmai-core"
-version = "0.10.3"
+version = "0.11.0"
 edition = "2021"
 rust-version = "1.91"
 authors = ["TrustDelta"]


### PR DESCRIPTION
## Summary
- Version bump to v0.11.0
- CHANGELOG updated

## Changes
### Added
- Hook-as-Teacher detection validation: use hook events as ground truth to measure IPC/capture-pane detection accuracy
  - `DetectionValidation` audit event logged on disagreement between hook and IPC/capture-pane results
  - `HookContext` preserves rich event context (event_name, tool_input, permission_mode) for analysis
  - `compute_validation_stats()` for accuracy analysis by rule and status
  - Non-selected panes run capture-pane for validation when audit is enabled

### Dependencies
- Bump chrono from 0.4.43 to 0.4.44
- Bump nix from 0.31.1 to 0.31.2

## Checklist
- [x] Version bumped in Cargo.toml and crates/tmai-core/Cargo.toml
- [x] CHANGELOG.md updated
- [x] Cargo.lock updated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート v0.11.0

* **新機能**
  * Hook-as-Teacherの検出検証機能を追加
  * グラウンドトゥルース検証に対応
  * コンテキスト情報を強化
  * 検証統計機能を追加
  * 非選択ペーンの検証動作に対応
  * 監査ログ機能を実装

<!-- end of auto-generated comment: release notes by coderabbit.ai -->