### PR TITLE
fix: prevent AskUserQuestion from being auto-approved

### DIFF
--- a/crates/tmai-core/src/auto_approve/service.rs
+++ b/crates/tmai-core/src/auto_approve/service.rs
@@ -500,6 +500,12 @@ fn is_genuine_user_question(approval_type: &ApprovalType) -> bool {
                 return true;
             }
 
+            // Empty choices = hook-based detection without choice info → genuine
+            // Hook detection only knows tool_name, not the actual choices
+            if choices.is_empty() {
+                return true;
+            }
+
             // Standard permission prompts have choices that are all variations of Yes/No
             // e.g., ["Yes", "Yes, and always allow...", "No"]
             // Genuine questions have choices like ["Option A", "Option B", "Other"]
@@ -649,6 +655,17 @@ mod tests {
         // Non-UserQuestion types are never genuine user questions
         assert!(!is_genuine_user_question(&ApprovalType::FileEdit));
         assert!(!is_genuine_user_question(&ApprovalType::ShellCommand));
+    }
+
+    #[test]
+    fn test_is_genuine_user_question_empty_choices() {
+        // Empty choices from hook-based detection → genuine (requires human judgment)
+        let approval = ApprovalType::UserQuestion {
+            choices: vec![],
+            multi_select: false,
+            cursor_position: 0,
+        };
+        assert!(is_genuine_user_question(&approval));
     }
 
     #[test]

--- a/crates/tmai-core/src/monitor/poller.rs
+++ b/crates/tmai-core/src/monitor/poller.rs
@@ -1547,9 +1547,22 @@ fn hook_state_to_agent_status(hs: &crate::hooks::types::HookState) -> AgentStatu
         HookStatus::Idle => AgentStatus::Idle,
         HookStatus::AwaitingApproval => {
             let tool_info = hs.last_tool.clone().unwrap_or_default();
-            AgentStatus::AwaitingApproval {
-                approval_type: ApprovalType::Other("Approval".to_string()),
-                details: tool_info,
+            // AskUserQuestion requires human judgment — map to UserQuestion type
+            // so auto_approve's is_genuine_user_question filter can block it
+            if tool_info == "AskUserQuestion" {
+                AgentStatus::AwaitingApproval {
+                    approval_type: ApprovalType::UserQuestion {
+                        choices: vec![],
+                        multi_select: false,
+                        cursor_position: 0,
+                    },
+                    details: String::new(),
+                }
+            } else {
+                AgentStatus::AwaitingApproval {
+                    approval_type: ApprovalType::Other("Approval".to_string()),
+                    details: tool_info,
+                }
             }
         }
     }
@@ -1725,6 +1738,27 @@ mod tests {
                 approval_type: ApprovalType::Other(_),
                 details,
             } if details == "Bash"
+        ));
+    }
+
+    #[test]
+    fn test_hook_state_to_agent_status_awaiting_approval_ask_user_question() {
+        use crate::hooks::types::{HookState, HookStatus};
+        let mut hs = HookState::new("s1".into(), None);
+        hs.status = HookStatus::AwaitingApproval;
+        hs.last_tool = Some("AskUserQuestion".to_string());
+
+        let status = hook_state_to_agent_status(&hs);
+        assert!(matches!(
+            status,
+            AgentStatus::AwaitingApproval {
+                approval_type: ApprovalType::UserQuestion {
+                    ref choices,
+                    multi_select: false,
+                    cursor_position: 0,
+                },
+                ref details,
+            } if choices.is_empty() && details.is_empty()
         ));
     }
 }


### PR DESCRIPTION
## Summary
- Hook経由の検出で `AskUserQuestion` が `ApprovalType::Other("Approval")` に変換され、`is_genuine_user_question` フィルターをバイパスして自動承認されてしまう問題を修正
- `hook_state_to_agent_status` で `AskUserQuestion` を `ApprovalType::UserQuestion` に正しくマッピング
- `is_genuine_user_question` で空 choices（Hook経由検出）を genuine として扱うガード追加

## Test plan
- [x] `cargo test -p tmai-core -- hook_state_to_agent_status` (6 tests pass)
- [x] `cargo test -p tmai-core -- is_genuine_user_question` (6 tests pass)
- [x] `cargo clippy -- -D warnings` (no warnings)
- [x] `cargo fmt --check` (no issues)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 承認プロセス内でユーザーへの質問型リクエストの処理を改善しました。選択肢が存在しないケースについて、より正確に人間による判断が必要であることを認識するようになります。

* **テスト**
  * 改善された処理ロジックの動作を検証するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->