### PR TITLE
fix: make with_preview_height() actually use the parameter

### DIFF
--- a/src/ui/layout.rs
+++ b/src/ui/layout.rs
@@ -87,10 +87,11 @@ impl Layout {
         }
     }
 
-    /// Create a layout with custom preview height (now used as session list width)
-    pub fn with_preview_height(mut self, _height_pct: u16) -> Self {
-        // Keep default width for now
-        self.session_list_width_pct = 35;
+    /// Create a layout with custom preview size (percentage of space for the preview panel)
+    pub fn with_preview_height(mut self, preview_pct: u16) -> Self {
+        let preview_pct = preview_pct.clamp(10, 90);
+        self.session_list_width_pct = 100 - preview_pct;
+        self.session_list_height_pct = 100 - preview_pct;
         self
     }
 


### PR DESCRIPTION
## Summary

- `with_preview_height()` was a no-op — it ignored the `_height_pct` parameter and hardcoded `session_list_width_pct = 35`
- Now clamps the input to 10–90% and sets both `session_list_width_pct` and `session_list_height_pct` accordingly

Split from #57 per reviewer request.

## Test plan

- [x] Verify `with_preview_height(70)` produces `session_list_width_pct = 30` and `session_list_height_pct = 30`
- [x] Verify clamping: values <10 and >90 are bounded
- [x] `cargo build` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
- プレビューパネルのサイズ設定が改善されました。プレビューパネルの高さを10～90%の範囲で正確に調整でき、レイアウト全体が適切に同期されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->