### PR TITLE
fix: wezterm spawn 2-pane issue and simplify README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -92,19 +92,8 @@ cargo fmt --check             # フォーマットチェック（CI同等）
 10. ReviewService起動（設定有効時、AgentStopped → 自動レビュー）
 11. `app.run()` でTUIイベントループ開始
 
-## Issues / TODO
+## Known Limitations
 
 ### Passthrough Mode Cursor Position
 
-tmuxペインとプレビューの幅が異なり、折り返し位置がずれてカーソル位置が一致しない。
-
-### Focus to Another Session (`f` key)
-
-`switch-client`を使うとtmai自体のクライアントが切り替わる問題（SSH経由で顕著）。
-
-## Known Bugs
-
-### wezTerm SSH Domain: New AI Session Creation
-
-`wezterm cli spawn`が2ペイン構成になる。回避策: 空シェルペインを手動で閉じる。
-該当: `crates/tmai-core/src/tmux/client.rs` の `open_session_in_wezterm_tab()`
+プレビューペインはボーダー分（2列）実tmuxペインより狭いため、折り返し位置がずれてカーソル位置が一致しない。設計上の制約。緩和策: Tab/Shift+Tabで分割比率を調整、または`line_wrap = true`を設定。

--- a/crates/tmai-core/src/tmux/client.rs
+++ b/crates/tmai-core/src/tmux/client.rs
@@ -325,13 +325,14 @@ impl TmuxClient {
             None => return,
         };
 
-        // Spawn a new wezterm tab (in current window) attached to the tmux session
+        // Spawn a new wezterm tab attached to the tmux session
         let _ = Command::new("wezterm")
             .args([
                 "cli",
                 "spawn",
                 "--window-id",
                 &window_id,
+                "--new-window",
                 "--",
                 "tmux",
                 "attach",


### PR DESCRIPTION
## Summary

- **wezterm 2ペイン問題修正**: `wezterm cli spawn` に `--new-window` フラグを追加。`--window-id` のみだと新ペイン（split）が作成される仕様だったため、新タブが正しく開かれるように修正
- **README簡潔化**: 250行→90行。Configuration/WSL/PTY詳細をdoc/へ移動、Featuresを9項目に集約

## Test plan

- [ ] wezterm環境で `n` キーによる新セッション作成が新タブで開くことを確認
- [ ] `cargo clippy -- -D warnings` パス済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)