### PR TITLE
feat: support Claude Code v2.1.69+ hook fields and events

### DIFF
--- a/crates/tmai-core/src/api/events.rs
+++ b/crates/tmai-core/src/api/events.rs
@@ -8,6 +8,7 @@
 
 use tokio::sync::broadcast;
 
+use crate::hooks::WorktreeInfo;
 use crate::review::ReviewRequest;
 
 use super::core::TmaiCore;
@@ -80,10 +81,22 @@ pub enum CoreEvent {
     WorktreeCreated {
         /// Agent target ID
         target: String,
+        /// Worktree details (name, path, branch, original_repo)
+        worktree: Option<WorktreeInfo>,
     },
 
     /// A git worktree was removed
     WorktreeRemoved {
+        /// Agent target ID
+        target: String,
+        /// Worktree details (name, path, branch, original_repo)
+        worktree: Option<WorktreeInfo>,
+    },
+
+    /// CLAUDE.md or `.claude/rules/*.md` files were loaded into context
+    ///
+    /// Added in Claude Code v2.1.69. Fires when instruction files are loaded.
+    InstructionsLoaded {
         /// Agent target ID
         target: String,
     },

--- a/crates/tmai-core/src/hooks/handler.rs
+++ b/crates/tmai-core/src/hooks/handler.rs
@@ -37,6 +37,7 @@ pub fn handle_hook_event(
         event_names::SESSION_START => {
             let mut state = HookState::new(payload.session_id.clone(), payload.cwd.clone());
             state.last_context = build_context(payload);
+            state.worktree = payload.worktree.clone();
             let mut reg = hook_registry.write();
             reg.insert(pane_id.to_string(), state);
             None
@@ -221,7 +222,8 @@ pub fn handle_hook_event(
         }
 
         event_names::WORKTREE_CREATE => {
-            // Worktree created — set Processing, emit event
+            // Worktree created — set Processing, store worktree info, emit event
+            let worktree_info = payload.worktree.clone();
             update_status(
                 hook_registry,
                 pane_id,
@@ -229,21 +231,33 @@ pub fn handle_hook_event(
                 HookStatus::Processing,
                 None,
             );
+            // Store worktree info in HookState
+            if worktree_info.is_some() {
+                let mut reg = hook_registry.write();
+                if let Some(state) = reg.get_mut(pane_id) {
+                    state.worktree = worktree_info.clone();
+                }
+            }
             Some(CoreEvent::WorktreeCreated {
                 target: pane_id.to_string(),
+                worktree: worktree_info,
             })
         }
 
         event_names::WORKTREE_REMOVE => {
-            // Worktree removed — touch timestamp, emit event
+            // Worktree removed — touch timestamp, emit event with worktree info
+            let worktree_info = payload.worktree.clone();
             let ctx = build_context(payload);
             let mut reg = hook_registry.write();
             if let Some(state) = reg.get_mut(pane_id) {
                 state.last_context = ctx;
                 state.touch();
+                // Clear worktree info on removal
+                state.worktree = None;
             }
             Some(CoreEvent::WorktreeRemoved {
                 target: pane_id.to_string(),
+                worktree: worktree_info,
             })
         }
 
@@ -257,6 +271,19 @@ pub fn handle_hook_event(
                 state.touch();
             }
             None
+        }
+
+        event_names::INSTRUCTIONS_LOADED => {
+            // CLAUDE.md or rules files loaded — touch timestamp, emit event
+            let ctx = build_context(payload);
+            let mut reg = hook_registry.write();
+            if let Some(state) = reg.get_mut(pane_id) {
+                state.last_context = ctx;
+                state.touch();
+            }
+            Some(CoreEvent::InstructionsLoaded {
+                target: pane_id.to_string(),
+            })
         }
 
         event_names::POST_TOOL_USE_FAILURE => {
@@ -351,6 +378,10 @@ fn update_status(
         if payload.cwd.is_some() {
             state.cwd = payload.cwd.clone();
         }
+        // Update worktree info if provided (first event with worktree in non-SessionStart path)
+        if payload.worktree.is_some() && state.worktree.is_none() {
+            state.worktree = payload.worktree.clone();
+        }
         state.last_context = build_context(payload);
         state.touch();
     } else {
@@ -358,6 +389,7 @@ fn update_status(
         let mut state = HookState::new(payload.session_id.clone(), payload.cwd.clone());
         state.status = status;
         state.last_tool = tool_name;
+        state.worktree = payload.worktree.clone();
         state.last_context = build_context(payload);
         reg.insert(pane_id.to_string(), state);
     }
@@ -936,6 +968,121 @@ mod tests {
         assert_eq!(
             state.last_context.permission_mode.as_deref(),
             Some("dontAsk")
+        );
+    }
+
+    #[test]
+    fn test_instructions_loaded_emits_event_and_touches() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        handle_hook_event(&make_payload("SessionStart"), "5", &registry, &map);
+
+        let event = handle_hook_event(&make_payload("InstructionsLoaded"), "5", &registry, &map);
+        assert!(matches!(event, Some(CoreEvent::InstructionsLoaded { .. })));
+        if let Some(CoreEvent::InstructionsLoaded { target }) = event {
+            assert_eq!(target, "5");
+        }
+
+        // Status should remain Idle (no state change)
+        let reg = registry.read();
+        assert_eq!(reg.get("5").unwrap().status, HookStatus::Idle);
+    }
+
+    #[test]
+    fn test_session_start_stores_worktree_info() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        let payload: HookEventPayload = serde_json::from_value(serde_json::json!({
+            "hook_event_name": "SessionStart",
+            "session_id": "wt-session",
+            "cwd": "/home/user/worktrees/feat-auth",
+            "worktree": {
+                "name": "feat-auth",
+                "path": "/home/user/worktrees/feat-auth",
+                "branch": "feat/auth",
+                "original_repo": "/home/user/project"
+            }
+        }))
+        .unwrap();
+
+        handle_hook_event(&payload, "10", &registry, &map);
+
+        let reg = registry.read();
+        let state = reg.get("10").unwrap();
+        let wt = state.worktree.as_ref().unwrap();
+        assert_eq!(wt.name.as_deref(), Some("feat-auth"));
+        assert_eq!(wt.branch.as_deref(), Some("feat/auth"));
+        assert_eq!(wt.original_repo.as_deref(), Some("/home/user/project"));
+    }
+
+    #[test]
+    fn test_worktree_create_includes_worktree_info_in_event() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        handle_hook_event(&make_payload("SessionStart"), "5", &registry, &map);
+
+        let payload: HookEventPayload = serde_json::from_value(serde_json::json!({
+            "hook_event_name": "WorktreeCreate",
+            "session_id": "test-session",
+            "cwd": "/home/user/worktrees/fix-bug",
+            "worktree": {
+                "name": "fix-bug",
+                "path": "/home/user/worktrees/fix-bug",
+                "branch": "fix/bug-123"
+            }
+        }))
+        .unwrap();
+
+        let event = handle_hook_event(&payload, "5", &registry, &map);
+        if let Some(CoreEvent::WorktreeCreated { target, worktree }) = event {
+            assert_eq!(target, "5");
+            let wt = worktree.unwrap();
+            assert_eq!(wt.name.as_deref(), Some("fix-bug"));
+            assert_eq!(wt.branch.as_deref(), Some("fix/bug-123"));
+        } else {
+            panic!("Expected WorktreeCreated event");
+        }
+
+        // Verify worktree info stored in HookState
+        let reg = registry.read();
+        let state = reg.get("5").unwrap();
+        assert!(state.worktree.is_some());
+    }
+
+    #[test]
+    fn test_worktree_remove_clears_worktree_info() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        // Start with worktree info
+        let start_payload: HookEventPayload = serde_json::from_value(serde_json::json!({
+            "hook_event_name": "SessionStart",
+            "session_id": "wt-session",
+            "cwd": "/home/user/worktrees/feat",
+            "worktree": {
+                "name": "feat",
+                "path": "/home/user/worktrees/feat",
+                "branch": "feat/x"
+            }
+        }))
+        .unwrap();
+        handle_hook_event(&start_payload, "5", &registry, &map);
+
+        {
+            let reg = registry.read();
+            assert!(reg.get("5").unwrap().worktree.is_some());
+        }
+
+        // Remove worktree
+        handle_hook_event(&make_payload("WorktreeRemove"), "5", &registry, &map);
+
+        let reg = registry.read();
+        assert!(
+            reg.get("5").unwrap().worktree.is_none(),
+            "WorktreeRemove should clear worktree info"
         );
     }
 }

--- a/crates/tmai-core/src/hooks/mod.rs
+++ b/crates/tmai-core/src/hooks/mod.rs
@@ -13,4 +13,4 @@ pub mod registry;
 pub mod types;
 
 pub use registry::{new_hook_registry, new_session_pane_map, HookRegistry, SessionPaneMap};
-pub use types::{HookEventPayload, HookState, HookStatus};
+pub use types::{HookEventPayload, HookState, HookStatus, WorktreeInfo};

--- a/crates/tmai-core/src/hooks/types.rs
+++ b/crates/tmai-core/src/hooks/types.rs
@@ -26,6 +26,27 @@ pub mod event_names {
     pub const WORKTREE_REMOVE: &str = "WorktreeRemove";
     pub const PRE_COMPACT: &str = "PreCompact";
     pub const POST_TOOL_USE_FAILURE: &str = "PostToolUseFailure";
+    pub const INSTRUCTIONS_LOADED: &str = "InstructionsLoaded";
+}
+
+/// Worktree information attached to hook events in `--worktree` sessions
+///
+/// Contains name, path, branch, and the original repo directory.
+/// Added in Claude Code v2.1.69.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+pub struct WorktreeInfo {
+    /// Worktree name (e.g., "feat-auth")
+    #[serde(default)]
+    pub name: Option<String>,
+    /// Worktree filesystem path
+    #[serde(default)]
+    pub path: Option<String>,
+    /// Branch checked out in the worktree
+    #[serde(default)]
+    pub branch: Option<String>,
+    /// Original (main) repository directory
+    #[serde(default)]
+    pub original_repo: Option<String>,
 }
 
 /// POST body from a Claude Code HTTP hook
@@ -118,6 +139,11 @@ pub struct HookEventPayload {
     #[serde(default)]
     pub file_path: Option<String>,
 
+    /// Worktree information (present when running in `--worktree` session)
+    /// Added in Claude Code v2.1.69.
+    #[serde(default)]
+    pub worktree: Option<WorktreeInfo>,
+
     /// Additional fields not explicitly modeled
     #[serde(flatten)]
     pub extra: HashMap<String, serde_json::Value>,
@@ -160,6 +186,8 @@ pub struct HookState {
     pub last_event_at: u64,
     /// Rich context from the last hook event (for audit validation)
     pub last_context: HookContext,
+    /// Worktree information (if running in `--worktree` session)
+    pub worktree: Option<WorktreeInfo>,
 }
 
 impl HookState {
@@ -172,6 +200,7 @@ impl HookState {
             cwd,
             last_event_at: current_time_millis(),
             last_context: HookContext::default(),
+            worktree: None,
         }
     }
 
@@ -399,6 +428,55 @@ mod tests {
         assert!(payload.tool_name.is_none());
         assert!(payload.stop_hook_active.is_none());
         assert!(payload.teammate_name.is_none());
+    }
+
+    /// InstructionsLoaded payload (fires when CLAUDE.md or rules files are loaded)
+    #[test]
+    fn test_hook_event_payload_deserialize_instructions_loaded() {
+        let json = r#"{
+            "hook_event_name": "InstructionsLoaded",
+            "session_id": "sess-1",
+            "cwd": "/home/user/project"
+        }"#;
+        let payload: HookEventPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.hook_event_name, "InstructionsLoaded");
+        assert_eq!(payload.cwd.as_deref(), Some("/home/user/project"));
+    }
+
+    /// Payload with worktree info (present in --worktree sessions)
+    #[test]
+    fn test_hook_event_payload_deserialize_with_worktree() {
+        let json = r#"{
+            "hook_event_name": "PreToolUse",
+            "session_id": "sess-1",
+            "cwd": "/home/user/worktrees/feat-auth",
+            "tool_name": "Bash",
+            "worktree": {
+                "name": "feat-auth",
+                "path": "/home/user/worktrees/feat-auth",
+                "branch": "feat/auth",
+                "original_repo": "/home/user/project"
+            }
+        }"#;
+        let payload: HookEventPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.hook_event_name, "PreToolUse");
+        let wt = payload.worktree.as_ref().unwrap();
+        assert_eq!(wt.name.as_deref(), Some("feat-auth"));
+        assert_eq!(wt.path.as_deref(), Some("/home/user/worktrees/feat-auth"));
+        assert_eq!(wt.branch.as_deref(), Some("feat/auth"));
+        assert_eq!(wt.original_repo.as_deref(), Some("/home/user/project"));
+    }
+
+    /// Payload without worktree field (non-worktree session)
+    #[test]
+    fn test_hook_event_payload_deserialize_without_worktree() {
+        let json = r#"{
+            "hook_event_name": "PreToolUse",
+            "session_id": "sess-1",
+            "tool_name": "Bash"
+        }"#;
+        let payload: HookEventPayload = serde_json::from_str(json).unwrap();
+        assert!(payload.worktree.is_none());
     }
 
     /// PermissionRequest payload with tool_name and tool_input

--- a/src/web/events.rs
+++ b/src/web/events.rs
@@ -128,6 +128,7 @@ pub async fn events(State(core): State<Arc<TmaiCore>>) -> impl IntoResponse {
                         | Ok(CoreEvent::WorktreeCreated { .. })
                         | Ok(CoreEvent::WorktreeRemoved { .. })
                         | Ok(CoreEvent::AgentStopped { .. })
+                        | Ok(CoreEvent::InstructionsLoaded { .. })
                         | Ok(CoreEvent::ReviewReady { .. }) => {
                             // Future: forward to SSE subscribers if needed
                         }

--- a/src/web/hooks.rs
+++ b/src/web/hooks.rs
@@ -11,7 +11,7 @@ use axum::{
     response::IntoResponse,
     Json,
 };
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
@@ -19,7 +19,25 @@ use tmai_core::api::{CoreEvent, TmaiCore};
 use tmai_core::hooks::handler::{handle_hook_event, resolve_pane_id};
 use tmai_core::hooks::HookEventPayload;
 
+/// Response body for hook events that support stop control
+///
+/// Claude Code v2.1.69+ supports `{"continue": false, "stopReason": "..."}` responses
+/// for TeammateIdle and TaskCompleted events, allowing tmai to stop teammates.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct HookEventResponse {
+    /// Whether the teammate should continue (true) or stop (false)
+    #[serde(rename = "continue")]
+    should_continue: bool,
+    /// Reason for stopping (only meaningful when should_continue is false)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stop_reason: Option<String>,
+}
+
 /// POST /hooks/event — receive a hook event from Claude Code
+///
+/// Returns 200 OK for most events. For TeammateIdle/TaskCompleted events,
+/// returns a JSON body that can control whether the teammate continues.
 pub async fn hook_event(
     State(core): State<Arc<TmaiCore>>,
     headers: HeaderMap,
@@ -35,7 +53,7 @@ pub async fn hook_event(
 
     if !token_valid {
         debug!("Hook event rejected: invalid or missing token");
-        return StatusCode::UNAUTHORIZED;
+        return (StatusCode::UNAUTHORIZED, Json(serde_json::Value::Null));
     }
 
     // Extract pane_id from X-Tmai-Pane-Id header
@@ -58,9 +76,12 @@ pub async fn hook_event(
                 "Could not resolve pane_id for hook event"
             );
             // Still return 200 to not block Claude Code
-            return StatusCode::OK;
+            return (StatusCode::OK, Json(serde_json::Value::Null));
         }
     };
+
+    // Check if this is a teammate event that supports stop control
+    let event_name = payload.hook_event_name.clone();
 
     // Process the hook event
     let core_event = handle_hook_event(
@@ -78,7 +99,20 @@ pub async fn hook_event(
     // Notify subscribers that agent state may have changed
     core.notify_agents_updated();
 
-    StatusCode::OK
+    // For TeammateIdle/TaskCompleted, return JSON body for stop control.
+    // Default: continue=true (don't stop). Future: configurable stop logic.
+    if event_name == "TeammateIdle" || event_name == "TaskCompleted" {
+        let response = HookEventResponse {
+            should_continue: true,
+            stop_reason: None,
+        };
+        (
+            StatusCode::OK,
+            Json(serde_json::to_value(response).unwrap_or(serde_json::Value::Null)),
+        )
+    } else {
+        (StatusCode::OK, Json(serde_json::Value::Null))
+    }
 }
 
 /// Payload for review completion notification


### PR DESCRIPTION
## Summary
- **InstructionsLoaded** イベント追加 — CLAUDE.mdやrulesファイル読み込み時に発火する新hookイベントに対応
- **WorktreeInfo** struct追加 — `--worktree`セッションのhookイベントに含まれるworktree情報（name, path, branch, original_repo）を解析・保持
- **TeammateIdle/TaskCompleted 停止制御レスポンス** — Claude Code v2.1.69+で追加された`{"continue": false, "stopReason": "..."}`レスポンス形式に対応（デフォルト: continue=true）

## Test plan
- [x] InstructionsLoadedイベントの処理とCoreEvent emit
- [x] WorktreeInfo のデシリアライズ（あり/なし両方）
- [x] SessionStartでworktree情報がHookStateに保存される
- [x] WorktreeCreateイベントでworktree情報がCoreEventに含まれる
- [x] WorktreeRemoveでworktree情報がクリアされる
- [x] 全535テスト合格、clippy/fmt クリーン

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 命令ファイル読み込みイベント追跡機能を追加
  * ワークツリー操作時のメタデータ情報を強化

* **テスト**
  * 新しいイベント処理とワークツリーデータ伝播の包括的なテストカバレッジを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->