### PR TITLE
feat: add context compaction tracking and subagent count from hook events

### DIFF
--- a/crates/tmai-core/src/agents/types.rs
+++ b/crates/tmai-core/src/agents/types.rs
@@ -521,6 +521,10 @@ pub struct MonitoredAgent {
     pub git_common_dir: Option<String>,
     /// Worktree name extracted from `.claude/worktrees/{name}` in cwd
     pub worktree_name: Option<String>,
+    /// Number of active subagents (from hook SubagentStart/Stop tracking)
+    pub active_subagents: u32,
+    /// Number of context compactions in this session (from hook PreCompact tracking)
+    pub compaction_count: u32,
 }
 
 impl MonitoredAgent {
@@ -566,6 +570,8 @@ impl MonitoredAgent {
             auto_approve_phase: None,
             git_common_dir: None,
             worktree_name: None,
+            active_subagents: 0,
+            compaction_count: 0,
         }
     }
 

--- a/crates/tmai-core/src/api/events.rs
+++ b/crates/tmai-core/src/api/events.rs
@@ -111,6 +111,14 @@ pub enum CoreEvent {
         last_assistant_message: Option<String>,
     },
 
+    /// Context compaction started (PreCompact hook event)
+    ContextCompacting {
+        /// Agent target ID
+        target: String,
+        /// How many compactions have occurred in this session
+        compaction_count: u32,
+    },
+
     /// An agent completed work and is ready for fresh-session review
     ReviewReady {
         /// Review request with context for launching a review session

--- a/crates/tmai-core/src/api/types.rs
+++ b/crates/tmai-core/src/api/types.rs
@@ -121,6 +121,17 @@ pub struct AgentSnapshot {
     /// Agent definition info from `.claude/agents/*.md`
     #[serde(skip_serializing_if = "Option::is_none")]
     pub agent_definition: Option<AgentDefinitionInfo>,
+    /// Number of active subagents (from hook SubagentStart/Stop tracking)
+    #[serde(skip_serializing_if = "is_zero")]
+    pub active_subagents: u32,
+    /// Number of context compactions in this session (from hook PreCompact tracking)
+    #[serde(skip_serializing_if = "is_zero")]
+    pub compaction_count: u32,
+}
+
+/// Helper for skip_serializing_if on u32
+fn is_zero(v: &u32) -> bool {
+    *v == 0
 }
 
 /// Summary of an agent definition for API consumers
@@ -185,6 +196,8 @@ impl AgentSnapshot {
             worktree_name: agent.worktree_name.clone(),
             display_name: agent.display_name(),
             agent_definition: None,
+            active_subagents: agent.active_subagents,
+            compaction_count: agent.compaction_count,
         }
     }
 

--- a/crates/tmai-core/src/hooks/handler.rs
+++ b/crates/tmai-core/src/hooks/handler.rs
@@ -163,8 +163,8 @@ pub fn handle_hook_event(
             None
         }
 
-        event_names::SUBAGENT_START | event_names::SUBAGENT_STOP => {
-            // Touch the hook state to keep it fresh, agent is processing
+        event_names::SUBAGENT_START => {
+            // Increment active subagent count, agent is processing
             update_status(
                 hook_registry,
                 pane_id,
@@ -172,6 +172,26 @@ pub fn handle_hook_event(
                 HookStatus::Processing,
                 None,
             );
+            let mut reg = hook_registry.write();
+            if let Some(state) = reg.get_mut(pane_id) {
+                state.active_subagents = state.active_subagents.saturating_add(1);
+            }
+            None
+        }
+
+        event_names::SUBAGENT_STOP => {
+            // Decrement active subagent count, agent is still processing
+            update_status(
+                hook_registry,
+                pane_id,
+                payload,
+                HookStatus::Processing,
+                None,
+            );
+            let mut reg = hook_registry.write();
+            if let Some(state) = reg.get_mut(pane_id) {
+                state.active_subagents = state.active_subagents.saturating_sub(1);
+            }
             None
         }
 
@@ -262,15 +282,24 @@ pub fn handle_hook_event(
         }
 
         event_names::PRE_COMPACT => {
-            // Context compaction starting — maintain Processing, touch timestamp
+            // Context compaction starting — set Compacting status, increment counter
             let ctx = build_context(payload);
-            let mut reg = hook_registry.write();
-            if let Some(state) = reg.get_mut(pane_id) {
-                state.status = HookStatus::Processing;
-                state.last_context = ctx;
-                state.touch();
-            }
-            None
+            let count = {
+                let mut reg = hook_registry.write();
+                if let Some(state) = reg.get_mut(pane_id) {
+                    state.status = HookStatus::Compacting;
+                    state.compaction_count = state.compaction_count.saturating_add(1);
+                    state.last_context = ctx;
+                    state.touch();
+                    state.compaction_count
+                } else {
+                    1
+                }
+            };
+            Some(CoreEvent::ContextCompacting {
+                target: pane_id.to_string(),
+                compaction_count: count,
+            })
         }
 
         event_names::INSTRUCTIONS_LOADED => {
@@ -905,7 +934,7 @@ mod tests {
     }
 
     #[test]
-    fn test_pre_compact_maintains_processing() {
+    fn test_pre_compact_sets_compacting_and_emits_event() {
         let registry = new_hook_registry();
         let map = new_session_pane_map();
 
@@ -913,10 +942,49 @@ mod tests {
         handle_hook_event(&make_payload("UserPromptSubmit"), "5", &registry, &map);
 
         let event = handle_hook_event(&make_payload("PreCompact"), "5", &registry, &map);
-        assert!(event.is_none());
+        assert!(matches!(
+            event,
+            Some(CoreEvent::ContextCompacting {
+                compaction_count: 1,
+                ..
+            })
+        ));
 
         let reg = registry.read();
-        assert_eq!(reg.get("5").unwrap().status, HookStatus::Processing);
+        assert_eq!(reg.get("5").unwrap().status, HookStatus::Compacting);
+        assert_eq!(reg.get("5").unwrap().compaction_count, 1);
+    }
+
+    #[test]
+    fn test_pre_compact_increments_compaction_count() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        handle_hook_event(&make_payload("SessionStart"), "5", &registry, &map);
+
+        // First compaction
+        handle_hook_event(&make_payload("PreCompact"), "5", &registry, &map);
+        {
+            let reg = registry.read();
+            assert_eq!(reg.get("5").unwrap().compaction_count, 1);
+        }
+
+        // Resume processing
+        handle_hook_event(&make_payload("UserPromptSubmit"), "5", &registry, &map);
+
+        // Second compaction
+        let event = handle_hook_event(&make_payload("PreCompact"), "5", &registry, &map);
+        if let Some(CoreEvent::ContextCompacting {
+            compaction_count, ..
+        }) = event
+        {
+            assert_eq!(compaction_count, 2);
+        } else {
+            panic!("Expected ContextCompacting event");
+        }
+
+        let reg = registry.read();
+        assert_eq!(reg.get("5").unwrap().compaction_count, 2);
     }
 
     #[test]
@@ -1083,6 +1151,85 @@ mod tests {
         assert!(
             reg.get("5").unwrap().worktree.is_none(),
             "WorktreeRemove should clear worktree info"
+        );
+    }
+
+    #[test]
+    fn test_subagent_start_increments_count() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        handle_hook_event(&make_payload("SessionStart"), "5", &registry, &map);
+
+        // Start two subagents
+        handle_hook_event(&make_payload("SubagentStart"), "5", &registry, &map);
+        {
+            let reg = registry.read();
+            assert_eq!(reg.get("5").unwrap().active_subagents, 1);
+        }
+
+        handle_hook_event(&make_payload("SubagentStart"), "5", &registry, &map);
+        {
+            let reg = registry.read();
+            assert_eq!(reg.get("5").unwrap().active_subagents, 2);
+        }
+
+        // Stop one subagent
+        handle_hook_event(&make_payload("SubagentStop"), "5", &registry, &map);
+        {
+            let reg = registry.read();
+            assert_eq!(reg.get("5").unwrap().active_subagents, 1);
+        }
+
+        // Stop the last subagent
+        handle_hook_event(&make_payload("SubagentStop"), "5", &registry, &map);
+        let reg = registry.read();
+        assert_eq!(reg.get("5").unwrap().active_subagents, 0);
+    }
+
+    #[test]
+    fn test_subagent_stop_does_not_underflow() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        handle_hook_event(&make_payload("SessionStart"), "5", &registry, &map);
+
+        // Stop without matching start should not underflow
+        handle_hook_event(&make_payload("SubagentStop"), "5", &registry, &map);
+        let reg = registry.read();
+        assert_eq!(
+            reg.get("5").unwrap().active_subagents,
+            0,
+            "SubagentStop should not underflow below 0"
+        );
+    }
+
+    #[test]
+    fn test_compaction_count_resets_on_new_session() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        handle_hook_event(&make_payload("SessionStart"), "5", &registry, &map);
+        handle_hook_event(&make_payload("PreCompact"), "5", &registry, &map);
+        {
+            let reg = registry.read();
+            assert_eq!(reg.get("5").unwrap().compaction_count, 1);
+        }
+
+        // Session end + new session start resets counters
+        handle_hook_event(&make_payload("SessionEnd"), "5", &registry, &map);
+        handle_hook_event(&make_payload("SessionStart"), "5", &registry, &map);
+
+        let reg = registry.read();
+        assert_eq!(
+            reg.get("5").unwrap().compaction_count,
+            0,
+            "New session should reset compaction count"
+        );
+        assert_eq!(
+            reg.get("5").unwrap().active_subagents,
+            0,
+            "New session should reset subagent count"
         );
     }
 }

--- a/crates/tmai-core/src/hooks/types.rs
+++ b/crates/tmai-core/src/hooks/types.rs
@@ -158,6 +158,8 @@ pub enum HookStatus {
     Idle,
     /// Agent is awaiting user approval (permission prompt)
     AwaitingApproval,
+    /// Agent is compacting context (after PreCompact)
+    Compacting,
 }
 
 /// Rich context from a hook event (for audit validation)
@@ -188,6 +190,10 @@ pub struct HookState {
     pub last_context: HookContext,
     /// Worktree information (if running in `--worktree` session)
     pub worktree: Option<WorktreeInfo>,
+    /// Number of active subagents (incremented on SubagentStart, decremented on SubagentStop)
+    pub active_subagents: u32,
+    /// Number of context compactions in this session (incremented on PreCompact)
+    pub compaction_count: u32,
 }
 
 impl HookState {
@@ -201,6 +207,8 @@ impl HookState {
             last_event_at: current_time_millis(),
             last_context: HookContext::default(),
             worktree: None,
+            active_subagents: 0,
+            compaction_count: 0,
         }
     }
 

--- a/crates/tmai-core/src/monitor/poller.rs
+++ b/crates/tmai-core/src/monitor/poller.rs
@@ -594,6 +594,12 @@ impl Poller {
                     _ => {}
                 }
 
+                // Propagate hook-tracked metrics (subagent count, compaction count)
+                if let Some(hs) = hook_state.as_ref() {
+                    agent.active_subagents = hs.active_subagents;
+                    agent.compaction_count = hs.compaction_count;
+                }
+
                 agents.push(agent);
             }
         }
@@ -1672,6 +1678,9 @@ fn hook_state_to_agent_status(hs: &crate::hooks::types::HookState) -> AgentStatu
                 }
             }
         }
+        HookStatus::Compacting => AgentStatus::Processing {
+            activity: "Compacting context…".to_string(),
+        },
     }
 }
 
@@ -1867,5 +1876,25 @@ mod tests {
                 ref details,
             } if choices.is_empty() && details.is_empty()
         ));
+    }
+
+    /// hook_state_to_agent_status maps Compacting to Processing with activity
+    #[test]
+    fn test_hook_state_to_agent_status_compacting() {
+        use crate::hooks::types::{HookState, HookStatus};
+        let mut hs = HookState::new("s1".into(), None);
+        hs.status = HookStatus::Compacting;
+
+        let status = hook_state_to_agent_status(&hs);
+        match status {
+            AgentStatus::Processing { ref activity } => {
+                assert!(
+                    activity.contains("Compacting"),
+                    "Compacting status should produce 'Compacting' activity, got: {}",
+                    activity
+                );
+            }
+            _ => panic!("Expected Processing status, got {:?}", status),
+        }
     }
 }

--- a/crates/tmai-core/src/state/store.rs
+++ b/crates/tmai-core/src/state/store.rs
@@ -611,6 +611,9 @@ impl AppState {
                 existing.is_worktree = agent.is_worktree;
                 existing.git_common_dir = agent.git_common_dir;
                 existing.worktree_name = agent.worktree_name;
+                // Hook-tracked metrics
+                existing.active_subagents = agent.active_subagents;
+                existing.compaction_count = agent.compaction_count;
                 // Preserve auto_approve_phase from service, but clear it when
                 // agent is no longer awaiting approval (state has transitioned)
                 if !matches!(

--- a/src/ui/components/session_list.rs
+++ b/src/ui/components/session_list.rs
@@ -533,6 +533,22 @@ impl SessionList {
             ));
         }
 
+        // 3b) Compaction count (shown when context has been compacted at least once)
+        if agent.compaction_count > 0 {
+            line1_spans.push(Span::styled(
+                format!("  \u{267B}\u{FE0E}{}x", agent.compaction_count),
+                Style::default().fg(Color::DarkGray),
+            ));
+        }
+
+        // 3c) Active subagent count
+        if agent.active_subagents > 0 {
+            line1_spans.push(Span::styled(
+                format!("  \u{2442}{}", agent.active_subagents),
+                Style::default().fg(Color::Cyan),
+            ));
+        }
+
         // 4) Status label (auto-approve phase aware)
         let status_label = match (&agent.status, &agent.auto_approve_phase) {
             (

--- a/src/web/events.rs
+++ b/src/web/events.rs
@@ -124,6 +124,18 @@ pub async fn events(State(core): State<Arc<TmaiCore>>) -> impl IntoResponse {
                                 return;
                             }
                         }
+                        Ok(CoreEvent::ContextCompacting { target, compaction_count }) => {
+                            let data = serde_json::json!({
+                                "target": target,
+                                "compaction_count": compaction_count,
+                            });
+                            let event = Event::default()
+                                .event("context_compacting")
+                                .data(data.to_string());
+                            if tx.send(Ok(event)).await.is_err() {
+                                return;
+                            }
+                        }
                         Ok(CoreEvent::ConfigChanged { .. })
                         | Ok(CoreEvent::WorktreeCreated { .. })
                         | Ok(CoreEvent::WorktreeRemoved { .. })


### PR DESCRIPTION
## Summary
- Track context compaction count and active subagent count per agent via Claude Code hook events (v2.1.63+)
- Add `HookStatus::Compacting` state for `PreCompact` events, mapping to "Compacting context…" activity display
- Track `SubagentStart`/`SubagentStop` events with saturating increment/decrement
- Display compaction count (♻Nx) and active subagents (⑂N) in TUI session list
- Emit `CoreEvent::ContextCompacting` and SSE `context_compacting` event for web clients

## Context
With Opus 1M context now default for Max/Team/Enterprise plans (v2.1.75), context consumption visibility becomes critical. The compaction threshold is fixed at 150K tokens, meaning compaction fires at just 15% usage on 1M — making compaction count a key metric for understanding context health.

## Test plan
- [x] `test_pre_compact_sets_compacting_and_emits_event` — Compacting status + event emission
- [x] `test_pre_compact_increments_compaction_count` — Counter increments across multiple compactions
- [x] `test_subagent_start_increments_count` — Subagent lifecycle tracking
- [x] `test_subagent_stop_does_not_underflow` — Saturating subtraction safety
- [x] `test_compaction_count_resets_on_new_session` — Session boundary reset
- [x] `test_hook_state_to_agent_status_compacting` — Status mapping
- [x] All 479 core tests + 90 bin tests passing
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * エージェントごとに「アクティブなサブエージェント数」と「コンテキスト圧縮回数」を追跡・保持するようになりました。
  * セッション一覧の行に圧縮回数（⌁x）とアクティブサブエージェント数（␂x）のインライン表示を追加。
  * コンテキスト圧縮の進行を示す「圧縮中」ステータスとリアルタイム通知（イベント）が届くようになりました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->