### PR TITLE
feat: PTY stdin injection for web-only mode input (Phase E)

### DIFF
--- a/crates/tmai-core/src/command_sender.rs
+++ b/crates/tmai-core/src/command_sender.rs
@@ -1,15 +1,17 @@
 use anyhow::Result;
 use std::sync::Arc;
 
+use crate::hooks::registry::HookRegistry;
 use crate::ipc::server::IpcServer;
 use crate::runtime::RuntimeAdapter;
 use crate::state::SharedState;
 
-/// Unified command sender that tries IPC first, falls back to runtime adapter
+/// Unified command sender with 3-tier fallback: IPC → PTY inject → RuntimeAdapter
 pub struct CommandSender {
     ipc_server: Option<Arc<IpcServer>>,
     runtime: Arc<dyn RuntimeAdapter>,
     app_state: SharedState,
+    hook_registry: Option<HookRegistry>,
 }
 
 impl CommandSender {
@@ -23,11 +25,19 @@ impl CommandSender {
             ipc_server,
             runtime,
             app_state,
+            hook_registry: None,
         }
     }
 
-    /// Send keys via IPC if connected, otherwise via runtime adapter
+    /// Attach a HookRegistry for PTY injection (Tier 2) PID resolution
+    pub fn with_hook_registry(mut self, registry: HookRegistry) -> Self {
+        self.hook_registry = Some(registry);
+        self
+    }
+
+    /// Send keys via IPC → PTY inject → runtime adapter
     pub fn send_keys(&self, target: &str, keys: &str) -> Result<()> {
+        // Tier 1: IPC
         if let Some(ref ipc) = self.ipc_server {
             if let Some(pane_id) = self.get_pane_id_for_target(target) {
                 if ipc.try_send_keys(&pane_id, keys, false) {
@@ -35,11 +45,19 @@ impl CommandSender {
                 }
             }
         }
+        // Tier 2: PTY injection via /proc/{pid}/fd/0
+        if let Some(pid) = self.resolve_pid_for_target(target) {
+            if pid > 0 && crate::pty_inject::inject_text(pid, keys).is_ok() {
+                return Ok(());
+            }
+        }
+        // Tier 3: RuntimeAdapter (tmux send-keys / standalone error)
         self.runtime.send_keys(target, keys)
     }
 
-    /// Send literal keys via IPC if connected, otherwise via runtime adapter
+    /// Send literal keys via IPC → PTY inject → runtime adapter
     pub fn send_keys_literal(&self, target: &str, keys: &str) -> Result<()> {
+        // Tier 1: IPC
         if let Some(ref ipc) = self.ipc_server {
             if let Some(pane_id) = self.get_pane_id_for_target(target) {
                 if ipc.try_send_keys(&pane_id, keys, true) {
@@ -47,11 +65,19 @@ impl CommandSender {
                 }
             }
         }
+        // Tier 2: PTY injection (literal text, no key-name conversion)
+        if let Some(pid) = self.resolve_pid_for_target(target) {
+            if pid > 0 && crate::pty_inject::inject_text_literal(pid, keys).is_ok() {
+                return Ok(());
+            }
+        }
+        // Tier 3: RuntimeAdapter
         self.runtime.send_keys_literal(target, keys)
     }
 
-    /// Send text + Enter via IPC if connected, otherwise via runtime adapter
+    /// Send text + Enter via IPC → PTY inject → runtime adapter
     pub fn send_text_and_enter(&self, target: &str, text: &str) -> Result<()> {
+        // Tier 1: IPC
         if let Some(ref ipc) = self.ipc_server {
             if let Some(pane_id) = self.get_pane_id_for_target(target) {
                 if ipc.try_send_keys_and_enter(&pane_id, text) {
@@ -59,6 +85,13 @@ impl CommandSender {
                 }
             }
         }
+        // Tier 2: PTY injection (text + Enter)
+        if let Some(pid) = self.resolve_pid_for_target(target) {
+            if pid > 0 && crate::pty_inject::inject_text_and_enter(pid, text).is_ok() {
+                return Ok(());
+            }
+        }
+        // Tier 3: RuntimeAdapter
         self.runtime.send_text_and_enter(target, text)
     }
 
@@ -76,5 +109,33 @@ impl CommandSender {
     fn get_pane_id_for_target(&self, target: &str) -> Option<String> {
         let state = self.app_state.read();
         state.target_to_pane_id.get(target).cloned()
+    }
+
+    /// Resolve the PID for a target agent via HookRegistry or AppState
+    fn resolve_pid_for_target(&self, target: &str) -> Option<u32> {
+        // Try HookRegistry: target → pane_id → HookState.pid
+        if let Some(ref registry) = self.hook_registry {
+            let pane_id = {
+                let state = self.app_state.read();
+                state.target_to_pane_id.get(target).cloned()
+            };
+            if let Some(pane_id) = pane_id {
+                let reg = registry.read();
+                if let Some(hook_state) = reg.get(&pane_id) {
+                    if let Some(pid) = hook_state.pid {
+                        return Some(pid);
+                    }
+                }
+            }
+        }
+
+        // Fallback: check MonitoredAgent.pid in AppState
+        let state = self.app_state.read();
+        for agent in state.agents.values() {
+            if agent.target == target && agent.pid > 0 {
+                return Some(agent.pid);
+            }
+        }
+        None
     }
 }

--- a/crates/tmai-core/src/hooks/handler.rs
+++ b/crates/tmai-core/src/hooks/handler.rs
@@ -42,6 +42,11 @@ pub fn handle_hook_event(
             state.last_context = build_context(payload);
             state.worktree = payload.worktree.clone();
             save_transcript_path(&mut state, payload);
+            // Resolve PID from session files for PTY injection
+            state.pid = crate::session_discovery::resolve_pid_for_session(&payload.session_id);
+            if let Some(pid) = state.pid {
+                debug!(pid, session_id = %payload.session_id, "Resolved PID for session");
+            }
             let mut reg = hook_registry.write();
             reg.insert(pane_id.to_string(), state);
             None
@@ -576,6 +581,10 @@ fn update_status(
         if payload.worktree.is_some() && state.worktree.is_none() {
             state.worktree = payload.worktree.clone();
         }
+        // Resolve PID if not yet known (fallback for late discovery)
+        if state.pid.is_none() && !payload.session_id.is_empty() {
+            state.pid = crate::session_discovery::resolve_pid_for_session(&payload.session_id);
+        }
         save_transcript_path(state, payload);
         state.last_context = build_context(payload);
         state.touch();
@@ -585,6 +594,8 @@ fn update_status(
         state.status = status;
         state.last_tool = tool_name;
         state.worktree = payload.worktree.clone();
+        // Resolve PID for new entry
+        state.pid = crate::session_discovery::resolve_pid_for_session(&payload.session_id);
         save_transcript_path(&mut state, payload);
         state.last_context = build_context(payload);
         reg.insert(pane_id.to_string(), state);

--- a/crates/tmai-core/src/hooks/types.rs
+++ b/crates/tmai-core/src/hooks/types.rs
@@ -218,6 +218,8 @@ pub struct HookState {
     pub transcript_path: Option<String>,
     /// Recent tool activity log for preview display
     pub activity_log: Vec<ToolActivity>,
+    /// Process ID of the Claude Code instance (for PTY injection)
+    pub pid: Option<u32>,
 }
 
 impl HookState {
@@ -235,6 +237,7 @@ impl HookState {
             compaction_count: 0,
             transcript_path: None,
             activity_log: Vec::new(),
+            pid: None,
         }
     }
 

--- a/crates/tmai-core/src/ipc/client.rs
+++ b/crates/tmai-core/src/ipc/client.rs
@@ -236,32 +236,8 @@ impl IpcClient {
     }
 }
 
-/// Convert tmux key name to bytes for PTY input
-fn tmux_key_to_bytes(key: &str) -> Vec<u8> {
-    match key {
-        "Enter" => vec![b'\r'],
-        "Space" => vec![b' '],
-        "BSpace" => vec![0x7f],
-        "Tab" => vec![b'\t'],
-        "Escape" | "Esc" => vec![0x1b],
-        "Up" => vec![0x1b, b'[', b'A'],
-        "Down" => vec![0x1b, b'[', b'B'],
-        "Right" => vec![0x1b, b'[', b'C'],
-        "Left" => vec![0x1b, b'[', b'D'],
-        "Home" => vec![0x1b, b'[', b'H'],
-        "End" => vec![0x1b, b'[', b'F'],
-        "PPage" => vec![0x1b, b'[', b'5', b'~'],
-        "NPage" => vec![0x1b, b'[', b'6', b'~'],
-        "DC" => vec![0x1b, b'[', b'3', b'~'],
-        s if s.starts_with("C-") && s.len() == 3 => {
-            // Control character via bitmask: C-a/C-A = 0x01, C-@ = 0x00, C-[ = 0x1b
-            let c = s.as_bytes()[2];
-            vec![c & 0x1f]
-        }
-        // For literal text like "y"
-        other => other.as_bytes().to_vec(),
-    }
-}
+/// Re-export shared key conversion utility
+use crate::utils::keys::tmux_key_to_bytes;
 
 #[cfg(test)]
 mod tests {

--- a/crates/tmai-core/src/lib.rs
+++ b/crates/tmai-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod git;
 pub mod hooks;
 pub mod ipc;
 pub mod monitor;
+pub mod pty_inject;
 pub mod review;
 pub mod runtime;
 pub mod security;

--- a/crates/tmai-core/src/monitor/poller.rs
+++ b/crates/tmai-core/src/monitor/poller.rs
@@ -343,7 +343,7 @@ impl Poller {
                         pane_id: (*pane_id).clone(),
                         window_name: "claude".to_string(),
                         command: "claude".to_string(),
-                        pid: 0,
+                        pid: hook_state.pid.unwrap_or(0),
                         title: String::new(),
                         cwd,
                     });
@@ -1523,6 +1523,7 @@ impl Poller {
             // Register in HookRegistry so the synthesize logic picks it up
             let mut state = HookState::new(session.session_id.clone(), Some(session.cwd.clone()));
             state.transcript_path = session.transcript_path;
+            state.pid = Some(session.pid);
             let mut reg = self.hook_registry.write();
             reg.insert(pane_id.clone(), state);
             tracing::info!(

--- a/crates/tmai-core/src/pty_inject.rs
+++ b/crates/tmai-core/src/pty_inject.rs
@@ -1,0 +1,64 @@
+//! PTY stdin injection via `/proc/{pid}/fd/0`.
+//!
+//! Writes keystrokes directly to a Claude Code process's PTY stdin,
+//! enabling input delivery in web-only mode without tmux or IPC.
+
+use std::fs::OpenOptions;
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use tracing::debug;
+
+use crate::utils::keys::tmux_key_to_bytes;
+
+/// Inject raw bytes into a process's PTY stdin via `/proc/{pid}/fd/0`
+pub fn inject_keys(pid: u32, data: &[u8]) -> Result<()> {
+    let fd_path = format!("/proc/{}/fd/0", pid);
+    let mut file = OpenOptions::new()
+        .write(true)
+        .open(&fd_path)
+        .with_context(|| format!("Failed to open {} for PTY injection", fd_path))?;
+    file.write_all(data)
+        .with_context(|| format!("Failed to write to {}", fd_path))?;
+    file.flush()?;
+    debug!(pid, bytes = data.len(), "PTY inject: wrote bytes");
+    Ok(())
+}
+
+/// Inject tmux-style key names (e.g., "y", "Enter") into a process's PTY stdin
+pub fn inject_text(pid: u32, keys: &str) -> Result<()> {
+    let data = tmux_key_to_bytes(keys);
+    inject_keys(pid, &data)
+}
+
+/// Inject literal text (no key-name conversion) into a process's PTY stdin
+pub fn inject_text_literal(pid: u32, text: &str) -> Result<()> {
+    inject_keys(pid, text.as_bytes())
+}
+
+/// Inject literal text followed by Enter into a process's PTY stdin
+pub fn inject_text_and_enter(pid: u32, text: &str) -> Result<()> {
+    let mut data = text.as_bytes().to_vec();
+    data.push(b'\r');
+    inject_keys(pid, &data)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_inject_keys_nonexistent_pid() {
+        // Should fail gracefully for a non-existent PID
+        let result = inject_keys(999_999_999, b"test");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_inject_text_converts_key_names() {
+        // Verify key conversion happens (we can't inject into a real process in unit tests,
+        // so we just check that the function properly fails for non-existent PID)
+        let result = inject_text(999_999_999, "Enter");
+        assert!(result.is_err());
+    }
+}

--- a/crates/tmai-core/src/session_discovery/mod.rs
+++ b/crates/tmai-core/src/session_discovery/mod.rs
@@ -6,5 +6,5 @@
 pub mod scanner;
 pub mod types;
 
-pub use scanner::SessionDiscoveryScanner;
+pub use scanner::{resolve_pid_for_session, SessionDiscoveryScanner};
 pub use types::DiscoveredSession;

--- a/crates/tmai-core/src/session_discovery/scanner.rs
+++ b/crates/tmai-core/src/session_discovery/scanner.rs
@@ -164,6 +164,34 @@ fn derive_transcript_path(cwd: &str, session_id: &str) -> Option<String> {
     }
 }
 
+/// Resolve the PID for a given Claude Code session_id by scanning session files.
+///
+/// Walks `~/.claude/sessions/*.json`, finds the entry whose `session_id` matches,
+/// and returns the PID if the process is still alive.
+pub fn resolve_pid_for_session(session_id: &str) -> Option<u32> {
+    let sessions_dir = dirs::home_dir()?.join(".claude").join("sessions");
+    let entries = std::fs::read_dir(&sessions_dir).ok()?;
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        let content = match std::fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let session: ClaudeSessionFile = match serde_json::from_str(&content) {
+            Ok(s) => s,
+            Err(_) => continue,
+        };
+        if session.session_id == session_id && is_pid_alive(session.pid) {
+            return Some(session.pid);
+        }
+    }
+    None
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/tmai-core/src/utils/keys.rs
+++ b/crates/tmai-core/src/utils/keys.rs
@@ -1,0 +1,45 @@
+//! Shared key conversion utilities for tmux key names to PTY bytes.
+
+/// Convert tmux key name to bytes for PTY input
+pub fn tmux_key_to_bytes(key: &str) -> Vec<u8> {
+    match key {
+        "Enter" => vec![b'\r'],
+        "Space" => vec![b' '],
+        "BSpace" => vec![0x7f],
+        "Tab" => vec![b'\t'],
+        "Escape" | "Esc" => vec![0x1b],
+        "Up" => vec![0x1b, b'[', b'A'],
+        "Down" => vec![0x1b, b'[', b'B'],
+        "Right" => vec![0x1b, b'[', b'C'],
+        "Left" => vec![0x1b, b'[', b'D'],
+        "Home" => vec![0x1b, b'[', b'H'],
+        "End" => vec![0x1b, b'[', b'F'],
+        "PPage" => vec![0x1b, b'[', b'5', b'~'],
+        "NPage" => vec![0x1b, b'[', b'6', b'~'],
+        "DC" => vec![0x1b, b'[', b'3', b'~'],
+        s if s.starts_with("C-") && s.len() == 3 => {
+            // Control character via bitmask: C-a/C-A = 0x01, C-@ = 0x00, C-[ = 0x1b
+            let c = s.as_bytes()[2];
+            vec![c & 0x1f]
+        }
+        // For literal text like "y"
+        other => other.as_bytes().to_vec(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_tmux_key_to_bytes() {
+        assert_eq!(tmux_key_to_bytes("Enter"), vec![b'\r']);
+        assert_eq!(tmux_key_to_bytes("Space"), vec![b' ']);
+        assert_eq!(tmux_key_to_bytes("Up"), vec![0x1b, b'[', b'A']);
+        assert_eq!(tmux_key_to_bytes("C-c"), vec![3]); // 0x03
+        assert_eq!(tmux_key_to_bytes("C-A"), vec![1]); // uppercase: same as C-a
+        assert_eq!(tmux_key_to_bytes("C-@"), vec![0]); // NUL
+        assert_eq!(tmux_key_to_bytes("C-["), vec![0x1b]); // ESC
+        assert_eq!(tmux_key_to_bytes("y"), vec![b'y']);
+    }
+}

--- a/crates/tmai-core/src/utils/mod.rs
+++ b/crates/tmai-core/src/utils/mod.rs
@@ -1,1 +1,2 @@
+pub mod keys;
 pub mod namegen;

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,16 +118,16 @@ async fn main() -> Result<()> {
 
     // Build TmaiCore facade (shared between Web and TUI for event broadcasting)
     let app_state = app.shared_state();
-    let core_cmd_sender = Arc::new(CommandSender::new(
-        Some(ipc_server.clone()),
-        runtime.clone(),
-        app_state.clone(),
-    ));
 
     // Create hook registry and load hook token
     let hook_registry = tmai_core::hooks::new_hook_registry();
     let session_pane_map = tmai_core::hooks::new_session_pane_map();
     let hook_token = tmai::init::load_hook_token();
+
+    let core_cmd_sender = Arc::new(
+        CommandSender::new(Some(ipc_server.clone()), runtime.clone(), app_state.clone())
+            .with_hook_registry(hook_registry.clone()),
+    );
 
     let mut core_builder = TmaiCoreBuilder::new(settings.clone())
         .with_state(app_state.clone())
@@ -217,7 +217,8 @@ async fn main() -> Result<()> {
                 Some(ipc_server.clone()),
                 runtime.clone(),
                 app.shared_state(),
-            ),
+            )
+            .with_hook_registry(core.hook_registry().clone()),
             audit_tx,
         );
         service.start();
@@ -248,15 +249,14 @@ async fn run_web_only_mode(settings: Settings) -> Result<()> {
         s.show_activity_name = settings.ui.show_activity_name;
     }
 
-    // Create command sender (IPC-primary, runtime fallback will error in standalone)
-    let cmd_sender = Arc::new(CommandSender::new(
-        Some(ipc_server.clone()),
-        runtime.clone(),
-        state.clone(),
-    ));
-
     // Create hook registry and load token
     let hook_registry = tmai_core::hooks::new_hook_registry();
+
+    // Create command sender (IPC → PTY inject → standalone error)
+    let cmd_sender = Arc::new(
+        CommandSender::new(Some(ipc_server.clone()), runtime.clone(), state.clone())
+            .with_hook_registry(hook_registry.clone()),
+    );
     let session_pane_map = tmai_core::hooks::new_session_pane_map();
     let hook_token = tmai::init::load_hook_token();
 


### PR DESCRIPTION
## Summary
- `--web-only` モードで WebUI の入力機能（承認・テキスト入力・プロンプト送信）を有効化
- `CommandSender` に3層フォールバック（IPC → PTY inject → RuntimeAdapter）を実装
- `/proc/{pid}/fd/0` 経由の PTY stdin 注入で Claude Code プロセスへキーストロークを送信
- Session Discovery + Hook イベントから PID を解決し `HookState.pid` に保持

## Changes
- **`pty_inject.rs`** (新規): `/proc/{pid}/fd/0` への書き込みで PTY stdin 注入
- **`utils/keys.rs`** (新規): `tmux_key_to_bytes()` を `ipc/client.rs` から共有ユーティリティ化
- **`command_sender.rs`**: Tier 2 PTY injection 追加、`with_hook_registry()` で PID 解決
- **`hooks/types.rs`**: `HookState.pid: Option<u32>` フィールド追加
- **`hooks/handler.rs`**: SessionStart/update_status で `resolve_pid_for_session()` 呼出
- **`session_discovery/scanner.rs`**: `resolve_pid_for_session()` 関数追加
- **`monitor/poller.rs`**: discover_sessions + PaneInfo 合成時に PID を反映
- **`main.rs`**: 全 CommandSender に hook_registry を配線

## Test plan
- [x] `cargo test` — 90 tests passed
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] 手動検証: `cargo run -- --web-only --debug` → Claude Code (hooks設定済み) 起動 → WebUI で Approve/Send 操作

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * コマンド送信に3段階のフォールバック（IPC → PTY注入 → ランタイム）を追加
  * PTY注入による直接入力送信とキー変換ユーティリティを提供
  * フックレジストリ連携および関連の公開APIを追加

* **改善**
  * セッション情報からのプロセスID自動解決を追加し検出精度を向上
  * セッション検出でプロセス生存確認を行うように強化

* **テスト**
  * PTY注入とキー変換に関する単体テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->