### PR TITLE
fix: add timeout to HTTP hooks preventing stall without tmai

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -80,6 +80,11 @@ fn claude_settings_path() -> Result<PathBuf> {
     Ok(home.join(".claude").join("settings.json"))
 }
 
+/// Connection timeout for HTTP hooks in milliseconds.
+/// Short timeout prevents Claude Code from stalling when tmai is not running.
+/// 2 seconds is more than enough for localhost connections.
+const HOOK_TIMEOUT_MS: u64 = 2000;
+
 /// Build a tmai hook entry for a given event (new wrapper format)
 fn build_hook_entry(event: &str, token: &str, port: u16) -> Value {
     json!({
@@ -90,6 +95,7 @@ fn build_hook_entry(event: &str, token: &str, port: u16) -> Value {
                 "Authorization": format!("Bearer {}", token),
                 "X-Tmai-Pane-Id": "$TMUX_PANE"
             },
+            "timeout": HOOK_TIMEOUT_MS,
             "allowedEnvVars": ["TMUX_PANE"],
             "statusMessage": format!("{}{}", TMAI_STATUS_PREFIX, event)
         }]
@@ -482,6 +488,7 @@ mod tests {
         assert_eq!(hooks[0]["headers"]["Authorization"], "Bearer test-token");
         assert_eq!(hooks[0]["headers"]["X-Tmai-Pane-Id"], "$TMUX_PANE");
         assert_eq!(hooks[0]["statusMessage"], "tmai: PreToolUse");
+        assert_eq!(hooks[0]["timeout"], HOOK_TIMEOUT_MS);
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- HTTP hooks に `timeout: 2000ms` を追加
- tmai未起動時、18個のhookが各~16秒のTCPタイムアウトを待ち、Claude Code起動に4分47秒かかっていた
- 2秒タイムアウトにより最悪でも36秒に短縮（localhost接続は正常時1ms未満）

## Test plan
- [x] `cargo test -p tmai --lib init::tests` — 15テスト全パス
- [x] `cargo clippy -- -D warnings` — pass
- [x] `cargo fmt --check` — pass
- [ ] `tmai init --force` で既存hookにtimeoutが反映されることを確認
- [ ] tmai未起動時に `time claude --print "hi"` が大幅に短縮されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * HTTPフックに2秒のタイムアウト機能を追加しました。これにより、フック処理の信頼性と安定性が向上します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->