### PR TITLE
chore: normalize trailing newline in CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -652,3 +652,4 @@ Initial public release on crates.io.
 - Real-time pane preview
 - Approval/rejection key shortcuts
 - AskUserQuestion selection support
+


### PR DESCRIPTION
## Summary
- CHANGELOG.mdの末尾にtrailing newlineを追加（ファイルフォーマット正規化）

## Test plan
- [x] 変更内容がCHANGELOG.mdの末尾空行追加のみであること確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)