### PR TITLE
feat: Git panel CI status, Issues panel, and worktree-from-issue

### DIFF
--- a/crates/tmai-app/web/src/components/worktree/ActionPanel.tsx
+++ b/crates/tmai-app/web/src/components/worktree/ActionPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useConfirm } from "@/components/layout/ConfirmDialog";
 import {
   api,
@@ -7,7 +7,7 @@ import {
   type IssueInfo,
   type PrInfo,
 } from "@/lib/api";
-import { extractIssueNumbers, extractIssueRefs } from "@/lib/issue-utils";
+import { extractIssueNumbers, extractIssueRefs, issueToWorktreeName } from "@/lib/issue-utils";
 import { CreateWorktreeForm } from "./CreateWorktreeForm";
 import type { DetailView } from "./DetailPanel";
 import type { BranchNode } from "./graph/types";
@@ -25,6 +25,11 @@ interface ActionPanelProps {
   onSelectNode: (name: string | null) => void;
   onFocusAgent: (target: string) => void;
   onOpenDetail: (view: DetailView | null) => void;
+  // Issue mode (when Issues tab is active)
+  issueMode?: boolean;
+  selectedIssue?: IssueInfo | null;
+  defaultBranch?: string;
+  onStartWorkDone?: (worktreeName: string) => void;
 }
 
 // Right-side action panel for selected branch
@@ -41,6 +46,10 @@ export function ActionPanel({
   onSelectNode,
   onFocusAgent,
   onOpenDetail,
+  issueMode,
+  selectedIssue,
+  defaultBranch,
+  onStartWorkDone,
 }: ActionPanelProps) {
   const [actionBusy, setActionBusy] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -50,11 +59,17 @@ export function ActionPanel({
   const [ciSummary, setCiSummary] = useState<CiSummary | null>(null);
   const [ciLoading, setCiLoading] = useState(false);
   const [ciExpanded, setCiExpanded] = useState(false);
+  const [rerunBusy, setRerunBusy] = useState(false);
   const [branchDiffStat, setBranchDiffStat] = useState<{
     files_changed: number;
     insertions: number;
     deletions: number;
   } | null>(null);
+  // Issue start-work form state
+  const [startWorkName, setStartWorkName] = useState("");
+  const [startWorkBusy, setStartWorkBusy] = useState(false);
+  const [startWorkError, setStartWorkError] = useState<string | null>(null);
+  const startWorkInputRef = useRef<HTMLInputElement>(null);
 
   // Reset all ephemeral state when branch changes
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional reset on branch name change
@@ -74,10 +89,27 @@ export function ActionPanel({
     setCiLoading(true);
     api
       .listChecks(projectPath, activeNode.name)
-      .then(setCiSummary)
+      .then((data) => {
+        setCiSummary(data);
+        // Auto-expand CI checks when there are failures
+        if (data && data.rollup === "FAILURE") {
+          setCiExpanded(true);
+        }
+      })
       .catch(() => setCiSummary(null))
       .finally(() => setCiLoading(false));
   }, [activeNode.name, projectPath]);
+
+  // Pre-fill start-work name when issue selection changes
+  useEffect(() => {
+    if (selectedIssue) {
+      setStartWorkName(issueToWorktreeName(selectedIssue));
+      setStartWorkError(null);
+      setStartWorkBusy(false);
+      // Focus the input after render
+      setTimeout(() => startWorkInputRef.current?.focus(), 50);
+    }
+  }, [selectedIssue]);
 
   // Fetch diff stat vs parent branch when branch changes (for non-main branches without worktree diffSummary)
   useEffect(() => {
@@ -196,6 +228,154 @@ export function ActionPanel({
   const handleWorktreeCancel = useCallback(() => {
     setShowNewWorktree(false);
   }, []);
+
+  // Re-run failed CI checks
+  const handleRerunFailed = useCallback(async () => {
+    if (!ciSummary || rerunBusy) return;
+    const failedRunIds = ciSummary.checks
+      .filter((c) => c.conclusion === "failure" && c.run_id != null)
+      .map((c) => c.run_id as number);
+    if (failedRunIds.length === 0) return;
+    setRerunBusy(true);
+    try {
+      await Promise.all(failedRunIds.map((id) => api.rerunFailedChecks(projectPath, id)));
+      // Re-fetch CI after a short delay for status to update
+      setTimeout(() => {
+        api
+          .listChecks(projectPath, activeNode.name)
+          .then((data) => {
+            setCiSummary(data);
+            if (data && data.rollup === "FAILURE") setCiExpanded(true);
+          })
+          .catch(() => {});
+      }, 2000);
+    } catch {
+      setActionError("Failed to re-run checks");
+    } finally {
+      setRerunBusy(false);
+    }
+  }, [ciSummary, rerunBusy, projectPath, activeNode.name]);
+
+  // Start work on an issue: create worktree + launch agent
+  const handleStartWork = useCallback(async () => {
+    if (!selectedIssue || startWorkBusy || !startWorkName.trim()) return;
+    const trimmed = startWorkName.trim();
+    if (!/^[a-zA-Z0-9_-]+$/.test(trimmed) || trimmed.length > 64) {
+      setStartWorkError("a-z, 0-9, -, _ only (max 64)");
+      return;
+    }
+    setStartWorkBusy(true);
+    setStartWorkError(null);
+    try {
+      const base = defaultBranch ?? "main";
+      await api.spawnWorktree({ name: trimmed, cwd: projectPath, base_branch: base });
+      // Auto-launch agent with issue context
+      try {
+        await api.launchWorktreeAgent(projectPath, trimmed);
+      } catch {
+        // Worktree created but agent launch failed — still consider success
+      }
+      onStartWorkDone?.(trimmed);
+    } catch (e) {
+      setStartWorkError(e instanceof Error ? e.message : "Failed to create worktree");
+    } finally {
+      setStartWorkBusy(false);
+    }
+  }, [selectedIssue, startWorkBusy, startWorkName, defaultBranch, projectPath, onStartWorkDone]);
+
+  // Issue mode: show issue details + start work form
+  if (issueMode) {
+    return (
+      <div className="w-80 shrink-0 overflow-y-auto border-l border-white/5 bg-black/20">
+        <div className="p-4">
+          {selectedIssue ? (
+            <>
+              {/* Issue header */}
+              <div className="mb-4">
+                <div className="flex items-center gap-2">
+                  <span className="text-lg font-semibold text-green-400">
+                    #{selectedIssue.number}
+                  </span>
+                  <a
+                    href={selectedIssue.url}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-[10px] text-zinc-500 hover:text-zinc-300"
+                  >
+                    open in GitHub
+                  </a>
+                </div>
+                <h3 className="mt-1 text-sm font-medium text-zinc-100">{selectedIssue.title}</h3>
+                {/* Labels */}
+                {selectedIssue.labels.length > 0 && (
+                  <div className="mt-2 flex flex-wrap gap-1">
+                    {selectedIssue.labels.map((label) => (
+                      <span
+                        key={label.name}
+                        className="rounded-full px-1.5 py-0.5 text-[10px]"
+                        style={{
+                          backgroundColor: `#${label.color}22`,
+                          color: `#${label.color}`,
+                        }}
+                      >
+                        {label.name}
+                      </span>
+                    ))}
+                  </div>
+                )}
+                {/* Assignees */}
+                {selectedIssue.assignees.length > 0 && (
+                  <div className="mt-2 text-[11px] text-zinc-500">
+                    Assigned: {selectedIssue.assignees.join(", ")}
+                  </div>
+                )}
+              </div>
+
+              {/* Start Work form */}
+              <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3">
+                <div className="mb-2 text-[11px] font-medium text-emerald-400">Start Work</div>
+                <div className="mb-1.5 text-[11px] text-zinc-500">
+                  base: <span className="text-emerald-400">{defaultBranch ?? "main"}</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <input
+                    ref={startWorkInputRef}
+                    type="text"
+                    value={startWorkName}
+                    onChange={(e) => {
+                      setStartWorkName(e.target.value);
+                      setStartWorkError(null);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleStartWork();
+                    }}
+                    placeholder="worktree name"
+                    className="flex-1 rounded bg-black/30 px-2 py-1.5 text-xs text-zinc-200 placeholder-zinc-600 outline-none ring-1 ring-emerald-500/30 focus:ring-emerald-500/60"
+                  />
+                </div>
+                <div className="mt-1 text-[10px] text-zinc-600">
+                  Creates worktree + launches agent
+                </div>
+                {startWorkError && (
+                  <div className="mt-1 text-[10px] text-red-400">{startWorkError}</div>
+                )}
+                <button
+                  type="button"
+                  onClick={handleStartWork}
+                  disabled={!startWorkName.trim() || startWorkBusy}
+                  className="mt-2 w-full rounded-lg bg-emerald-500/20 px-3 py-2 text-xs font-medium text-emerald-400 transition-colors hover:bg-emerald-500/30 disabled:opacity-40"
+                >
+                  {startWorkBusy ? "Creating..." : "Create & Launch Agent"}
+                </button>
+              </div>
+            </>
+          ) : (
+            <div className="text-sm text-zinc-500">Select an issue to start work</div>
+          )}
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="w-80 shrink-0 overflow-y-auto border-l border-white/5 bg-black/20">
@@ -444,6 +624,19 @@ export function ActionPanel({
                   })}
                 </div>
               )}
+              {/* Re-run failed checks button */}
+              {ciExpanded &&
+                ciSummary.rollup === "FAILURE" &&
+                ciSummary.checks.some((c) => c.conclusion === "failure" && c.run_id != null) && (
+                  <button
+                    type="button"
+                    onClick={handleRerunFailed}
+                    disabled={rerunBusy}
+                    className="mt-1.5 w-full rounded bg-red-500/10 px-2 py-1 text-[11px] text-red-400 transition-colors hover:bg-red-500/20 disabled:opacity-50"
+                  >
+                    {rerunBusy ? "Re-running..." : "Re-run failed checks"}
+                  </button>
+                )}
             </div>
           )}
           {ciSummary &&

--- a/crates/tmai-app/web/src/components/worktree/BranchGraph.tsx
+++ b/crates/tmai-app/web/src/components/worktree/BranchGraph.tsx
@@ -14,6 +14,7 @@ import { DetailPanel, type DetailView } from "./DetailPanel";
 import { LaneGraph } from "./graph/LaneGraph";
 import { computeLayout } from "./graph/layout";
 import type { BranchNode } from "./graph/types";
+import { IssuesPanel } from "./IssuesPanel";
 
 interface BranchGraphProps {
   projectPath: string;
@@ -54,6 +55,8 @@ export function BranchGraph({
   const [issues, setIssues] = useState<IssueInfo[]>([]);
   const [graphLimit, setGraphLimit] = useState(200);
   const [detailView, setDetailView] = useState<DetailView | null>(null);
+  const [showIssues, setShowIssues] = useState(false);
+  const [selectedIssue, setSelectedIssue] = useState<IssueInfo | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
   const savedScrollTop = useRef<number | null>(null);
 
@@ -300,6 +303,18 @@ export function BranchGraph({
     return () => clearInterval(interval);
   }, [projectPath]);
 
+  // Handle start-work completion: switch back to graph, refresh, select new branch
+  const handleStartWorkDone = useCallback(
+    (worktreeName: string) => {
+      setShowIssues(false);
+      setSelectedIssue(null);
+      refreshBranches();
+      // Select the new branch after data refreshes
+      setTimeout(() => setSelectedNode(worktreeName), 500);
+    },
+    [refreshBranches],
+  );
+
   if (loading) {
     return (
       <div className="flex flex-1 items-center justify-center text-sm text-zinc-500">
@@ -330,17 +345,45 @@ export function BranchGraph({
             <path d="M4 6 C4 8, 8 8, 12 8" stroke="currentColor" strokeWidth="1.5" fill="none" />
           </svg>
           <h2 className="text-lg font-semibold text-zinc-100">{projectName}</h2>
+          {/* Tab switcher */}
+          <div className="flex gap-1 rounded-lg bg-white/5 p-0.5">
+            <button
+              type="button"
+              onClick={() => {
+                setShowIssues(false);
+                setSelectedIssue(null);
+              }}
+              className={`rounded-md px-2.5 py-1 text-xs transition-colors ${
+                !showIssues ? "bg-white/10 text-zinc-200" : "text-zinc-500 hover:text-zinc-300"
+              }`}
+            >
+              Branches
+            </button>
+            <button
+              type="button"
+              onClick={() => setShowIssues(true)}
+              className={`rounded-md px-2.5 py-1 text-xs transition-colors ${
+                showIssues ? "bg-white/10 text-zinc-200" : "text-zinc-500 hover:text-zinc-300"
+              }`}
+            >
+              Issues{issues.length > 0 ? ` (${issues.length})` : ""}
+            </button>
+          </div>
           <span className="text-xs text-zinc-500">
-            {branchCount} branch{branchCount !== 1 ? "es" : ""}
-            {(() => {
-              const wtCount = projectWorktrees.filter((w) => !w.is_main).length;
-              if (wtCount === 0) return null;
-              return ` (${wtCount} worktree${wtCount !== 1 ? "s" : ""})`;
-            })()}
-            {graphData && (
+            {!showIssues && (
               <>
-                {" \u00B7 "}
-                {graphData.commits.length} commit{graphData.commits.length !== 1 ? "s" : ""}
+                {branchCount} branch{branchCount !== 1 ? "es" : ""}
+                {(() => {
+                  const wtCount = projectWorktrees.filter((w) => !w.is_main).length;
+                  if (wtCount === 0) return null;
+                  return ` (${wtCount} worktree${wtCount !== 1 ? "s" : ""})`;
+                })()}
+                {graphData && (
+                  <>
+                    {" \u00B7 "}
+                    {graphData.commits.length} commit{graphData.commits.length !== 1 ? "s" : ""}
+                  </>
+                )}
               </>
             )}
           </span>
@@ -366,115 +409,148 @@ export function BranchGraph({
       </div>
 
       <div className="flex flex-1 overflow-hidden">
-        {/* Graph canvas */}
-        <div ref={scrollRef} className="flex-1 overflow-auto p-6">
-          {layout && layout.lanes.length > 0 ? (
-            <LaneGraph
-              layout={layout}
-              selectedBranch={selectedNode}
-              repoPath={projectPath}
-              defaultBranch={branches?.default_branch ?? "main"}
-              collapsedLanes={collapsedLanes}
-              prMap={prMap}
-              onSelectBranch={selectBranch}
-              onToggleCollapse={toggleCollapse}
+        {showIssues ? (
+          <>
+            {/* Issues list (replaces graph) */}
+            <IssuesPanel
+              issues={issues}
+              selectedIssue={selectedIssue}
+              onSelectIssue={setSelectedIssue}
             />
-          ) : (
-            <div className="flex items-center justify-center py-20 text-sm text-zinc-500">
-              {graphData?.commits.length === 0
-                ? "No commits found"
-                : "Only the default branch exists"}
+
+            {/* Action panel in issue mode */}
+            <ActionPanel
+              activeNode={activeNode ?? nodes[0]}
+              branches={branches}
+              projectPath={projectPath}
+              nodeDepth={nodeDepth}
+              branchDepthWarning={BRANCH_DEPTH_WARNING}
+              prInfo={undefined}
+              targetPrs={[]}
+              issues={issues}
+              onRefresh={refreshBranches}
+              onSelectNode={setSelectedNode}
+              onFocusAgent={onFocusAgent}
+              onOpenDetail={setDetailView}
+              issueMode
+              selectedIssue={selectedIssue}
+              defaultBranch={branches?.default_branch ?? "main"}
+              onStartWorkDone={handleStartWorkDone}
+            />
+          </>
+        ) : (
+          <>
+            {/* Graph canvas */}
+            <div ref={scrollRef} className="flex-1 overflow-auto p-6">
+              {layout && layout.lanes.length > 0 ? (
+                <LaneGraph
+                  layout={layout}
+                  selectedBranch={selectedNode}
+                  repoPath={projectPath}
+                  defaultBranch={branches?.default_branch ?? "main"}
+                  collapsedLanes={collapsedLanes}
+                  prMap={prMap}
+                  onSelectBranch={selectBranch}
+                  onToggleCollapse={toggleCollapse}
+                />
+              ) : (
+                <div className="flex items-center justify-center py-20 text-sm text-zinc-500">
+                  {graphData?.commits.length === 0
+                    ? "No commits found"
+                    : "Only the default branch exists"}
+                </div>
+              )}
+
+              {/* Truncation indicator */}
+              {graphData && graphData.commits.length >= graphLimit && (
+                <div className="mt-4 flex justify-center">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      savedScrollTop.current = scrollRef.current?.scrollTop ?? null;
+                      setGraphLimit((prev) => prev + 200);
+                    }}
+                    className="rounded-lg bg-white/5 px-4 py-2 text-xs text-zinc-400 transition-colors hover:bg-white/10 hover:text-zinc-200"
+                  >
+                    Load more commits ({graphLimit} shown)
+                  </button>
+                </div>
+              )}
+
+              {/* Inactive branches (not shown in graph) */}
+              {nodes.filter(
+                (n) =>
+                  !n.isMain &&
+                  !n.isWorktree &&
+                  !n.hasAgent &&
+                  !n.isDirty &&
+                  n.ahead === 0 &&
+                  !n.isCurrent,
+              ).length > 0 && (
+                <div className="mt-6 border-t border-white/5 pt-4">
+                  <div className="mb-2 text-[11px] text-zinc-600">Inactive branches</div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {nodes
+                      .filter(
+                        (n) =>
+                          !n.isMain &&
+                          !n.isWorktree &&
+                          !n.hasAgent &&
+                          !n.isDirty &&
+                          n.ahead === 0 &&
+                          !n.isCurrent,
+                      )
+                      .map((n) => (
+                        <button
+                          type="button"
+                          key={n.name}
+                          onClick={() => selectBranch(n.name)}
+                          className={`rounded-md px-2 py-1 text-[11px] transition-colors ${
+                            selectedNode === n.name
+                              ? "bg-cyan-500/15 text-cyan-400"
+                              : "bg-white/5 text-zinc-500 hover:bg-white/10 hover:text-zinc-300"
+                          }`}
+                        >
+                          {n.name}
+                          {n.behind > 0 && (
+                            <span className="ml-1 text-[10px] text-red-400">{n.behind}\u2193</span>
+                          )}
+                        </button>
+                      ))}
+                  </div>
+                </div>
+              )}
             </div>
-          )}
 
-          {/* Truncation indicator */}
-          {graphData && graphData.commits.length >= graphLimit && (
-            <div className="mt-4 flex justify-center">
-              <button
-                type="button"
-                onClick={() => {
-                  savedScrollTop.current = scrollRef.current?.scrollTop ?? null;
-                  setGraphLimit((prev) => prev + 200);
-                }}
-                className="rounded-lg bg-white/5 px-4 py-2 text-xs text-zinc-400 transition-colors hover:bg-white/10 hover:text-zinc-200"
-              >
-                Load more commits ({graphLimit} shown)
-              </button>
-            </div>
-          )}
+            {/* Detail panel (middle, conditional) */}
+            {detailView && activeNode && (
+              <DetailPanel
+                view={detailView}
+                projectPath={projectPath}
+                activeNode={activeNode}
+                branches={branches}
+                onClose={() => setDetailView(null)}
+              />
+            )}
 
-          {/* Inactive branches (not shown in graph) */}
-          {nodes.filter(
-            (n) =>
-              !n.isMain &&
-              !n.isWorktree &&
-              !n.hasAgent &&
-              !n.isDirty &&
-              n.ahead === 0 &&
-              !n.isCurrent,
-          ).length > 0 && (
-            <div className="mt-6 border-t border-white/5 pt-4">
-              <div className="mb-2 text-[11px] text-zinc-600">Inactive branches</div>
-              <div className="flex flex-wrap gap-1.5">
-                {nodes
-                  .filter(
-                    (n) =>
-                      !n.isMain &&
-                      !n.isWorktree &&
-                      !n.hasAgent &&
-                      !n.isDirty &&
-                      n.ahead === 0 &&
-                      !n.isCurrent,
-                  )
-                  .map((n) => (
-                    <button
-                      type="button"
-                      key={n.name}
-                      onClick={() => selectBranch(n.name)}
-                      className={`rounded-md px-2 py-1 text-[11px] transition-colors ${
-                        selectedNode === n.name
-                          ? "bg-cyan-500/15 text-cyan-400"
-                          : "bg-white/5 text-zinc-500 hover:bg-white/10 hover:text-zinc-300"
-                      }`}
-                    >
-                      {n.name}
-                      {n.behind > 0 && (
-                        <span className="ml-1 text-[10px] text-red-400">{n.behind}\u2193</span>
-                      )}
-                    </button>
-                  ))}
-              </div>
-            </div>
-          )}
-        </div>
-
-        {/* Detail panel (middle, conditional) */}
-        {detailView && activeNode && (
-          <DetailPanel
-            view={detailView}
-            projectPath={projectPath}
-            activeNode={activeNode}
-            branches={branches}
-            onClose={() => setDetailView(null)}
-          />
-        )}
-
-        {/* Action panel (right side) */}
-        {activeNode && (
-          <ActionPanel
-            activeNode={activeNode}
-            branches={branches}
-            projectPath={projectPath}
-            nodeDepth={nodeDepth}
-            branchDepthWarning={BRANCH_DEPTH_WARNING}
-            prInfo={prMap[activeNode.name]}
-            targetPrs={targetPrMap[activeNode.name] ?? []}
-            issues={issues}
-            onRefresh={refreshBranches}
-            onSelectNode={setSelectedNode}
-            onFocusAgent={onFocusAgent}
-            onOpenDetail={setDetailView}
-          />
+            {/* Action panel (right side) */}
+            {activeNode && (
+              <ActionPanel
+                activeNode={activeNode}
+                branches={branches}
+                projectPath={projectPath}
+                nodeDepth={nodeDepth}
+                branchDepthWarning={BRANCH_DEPTH_WARNING}
+                prInfo={prMap[activeNode.name]}
+                targetPrs={targetPrMap[activeNode.name] ?? []}
+                issues={issues}
+                onRefresh={refreshBranches}
+                onSelectNode={setSelectedNode}
+                onFocusAgent={onFocusAgent}
+                onOpenDetail={setDetailView}
+              />
+            )}
+          </>
         )}
       </div>
     </div>

--- a/crates/tmai-app/web/src/components/worktree/IssuesPanel.tsx
+++ b/crates/tmai-app/web/src/components/worktree/IssuesPanel.tsx
@@ -1,0 +1,158 @@
+import { useMemo, useState } from "react";
+import type { IssueInfo } from "@/lib/api";
+
+interface IssuesPanelProps {
+  issues: IssueInfo[];
+  selectedIssue: IssueInfo | null;
+  onSelectIssue: (issue: IssueInfo | null) => void;
+}
+
+// Issues list panel — replaces the graph area when Issues tab is active
+export function IssuesPanel({ issues, selectedIssue, onSelectIssue }: IssuesPanelProps) {
+  const [searchQuery, setSearchQuery] = useState("");
+  const [selectedLabels, setSelectedLabels] = useState<Set<string>>(new Set());
+
+  // Collect all unique labels for filter chips
+  const allLabels = useMemo(() => {
+    const labelMap = new Map<string, { name: string; color: string }>();
+    for (const issue of issues) {
+      for (const label of issue.labels) {
+        if (!labelMap.has(label.name)) {
+          labelMap.set(label.name, label);
+        }
+      }
+    }
+    return Array.from(labelMap.values());
+  }, [issues]);
+
+  // Filter issues by search query and selected labels
+  const filteredIssues = useMemo(() => {
+    return issues.filter((issue) => {
+      // Text filter
+      if (searchQuery) {
+        const q = searchQuery.toLowerCase();
+        const matchesText =
+          issue.title.toLowerCase().includes(q) || issue.number.toString().includes(q);
+        if (!matchesText) return false;
+      }
+      // Label filter
+      if (selectedLabels.size > 0) {
+        const hasLabel = issue.labels.some((l) => selectedLabels.has(l.name));
+        if (!hasLabel) return false;
+      }
+      return true;
+    });
+  }, [issues, searchQuery, selectedLabels]);
+
+  // Toggle a label filter
+  const toggleLabel = (name: string) => {
+    setSelectedLabels((prev) => {
+      const next = new Set(prev);
+      if (next.has(name)) {
+        next.delete(name);
+      } else {
+        next.add(name);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <div className="flex-1 overflow-auto p-6">
+      {/* Search and filters */}
+      <div className="mb-4">
+        <input
+          type="text"
+          value={searchQuery}
+          onChange={(e) => setSearchQuery(e.target.value)}
+          placeholder="Search issues..."
+          className="w-full rounded-lg bg-white/5 px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 outline-none ring-1 ring-white/10 transition-colors focus:ring-white/20"
+        />
+        {allLabels.length > 0 && (
+          <div className="mt-2 flex flex-wrap gap-1.5">
+            {allLabels.map((label) => (
+              <button
+                key={label.name}
+                type="button"
+                onClick={() => toggleLabel(label.name)}
+                className="rounded-full px-2 py-0.5 text-[11px] transition-opacity"
+                style={{
+                  backgroundColor: selectedLabels.has(label.name)
+                    ? `#${label.color}33`
+                    : `#${label.color}15`,
+                  color: `#${label.color}`,
+                  opacity: selectedLabels.size > 0 && !selectedLabels.has(label.name) ? 0.5 : 1,
+                }}
+              >
+                {label.name}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      {/* Issue count */}
+      <div className="mb-3 text-[11px] text-zinc-500">
+        {filteredIssues.length} issue{filteredIssues.length !== 1 ? "s" : ""}
+        {filteredIssues.length !== issues.length ? ` (${issues.length} total)` : ""}
+      </div>
+
+      {/* Issue list */}
+      {filteredIssues.length === 0 ? (
+        <div className="flex items-center justify-center py-20 text-sm text-zinc-500">
+          {issues.length === 0 ? "No open issues" : "No issues match filters"}
+        </div>
+      ) : (
+        <div className="flex flex-col gap-2">
+          {filteredIssues.map((issue) => {
+            const isSelected = selectedIssue?.number === issue.number;
+            return (
+              <button
+                type="button"
+                key={issue.number}
+                onClick={() => onSelectIssue(isSelected ? null : issue)}
+                className={`rounded-lg border p-3 text-left transition-colors ${
+                  isSelected
+                    ? "border-cyan-500/30 bg-cyan-500/[0.06]"
+                    : "border-white/5 bg-white/[0.02] hover:bg-white/[0.05]"
+                }`}
+              >
+                <div className="flex items-start gap-2">
+                  <span className="shrink-0 text-sm font-medium text-green-400">
+                    #{issue.number}
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <div className="text-sm text-zinc-200">{issue.title}</div>
+                    {/* Labels */}
+                    {issue.labels.length > 0 && (
+                      <div className="mt-1.5 flex flex-wrap gap-1">
+                        {issue.labels.map((label) => (
+                          <span
+                            key={label.name}
+                            className="rounded-full px-1.5 py-0.5 text-[10px]"
+                            style={{
+                              backgroundColor: `#${label.color}22`,
+                              color: `#${label.color}`,
+                            }}
+                          >
+                            {label.name}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                    {/* Assignees */}
+                    {issue.assignees.length > 0 && (
+                      <div className="mt-1 text-[10px] text-zinc-500">
+                        {issue.assignees.join(", ")}
+                      </div>
+                    )}
+                  </div>
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/crates/tmai-app/web/src/lib/api-http.ts
+++ b/crates/tmai-app/web/src/lib/api-http.ts
@@ -424,6 +424,7 @@ export interface IssueInfo {
   state: string;
   url: string;
   labels: IssueLabel[];
+  assignees: string[];
 }
 
 export interface PrComment {
@@ -684,6 +685,11 @@ export const api = {
     apiFetch<CiFailureLog>(
       `/github/ci/failure-log?repo=${encodeURIComponent(repoPath)}&run_id=${runId}`,
     ),
+  rerunFailedChecks: (repoPath: string, runId: number) =>
+    apiFetch<{ status: string }>("/github/ci/rerun", {
+      method: "POST",
+      body: JSON.stringify({ repo: repoPath, run_id: runId }),
+    }),
   deleteBranch: (repoPath: string, branch: string, force?: boolean, deleteRemote?: boolean) =>
     apiFetch("/git/branches/delete", {
       method: "POST",

--- a/crates/tmai-app/web/src/lib/api-tauri.ts
+++ b/crates/tmai-app/web/src/lib/api-tauri.ts
@@ -122,6 +122,8 @@ export const api = {
   getPrMergeStatus: (repoPath: string, prNumber: number) =>
     httpApi.getPrMergeStatus(repoPath, prNumber),
   getCiFailureLog: (repoPath: string, runId: number) => httpApi.getCiFailureLog(repoPath, runId),
+  rerunFailedChecks: (repoPath: string, runId: number) =>
+    httpApi.rerunFailedChecks(repoPath, runId),
   deleteBranch: (repoPath: string, branch: string, force?: boolean, deleteRemote?: boolean) =>
     httpApi.deleteBranch(repoPath, branch, force, deleteRemote),
   createBranch: (repoPath: string, name: string, base?: string) =>

--- a/crates/tmai-app/web/src/lib/issue-utils.ts
+++ b/crates/tmai-app/web/src/lib/issue-utils.ts
@@ -10,6 +10,16 @@ export function extractIssueNumbers(branch: string): number[] {
   return nums;
 }
 
+/// Generate a worktree name from an issue (e.g., {number: 42, title: "Add login"} → "42-add-login")
+export function issueToWorktreeName(issue: { number: number; title: string }): string {
+  const slug = issue.title
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-|-$/g, "")
+    .slice(0, 50);
+  return slug ? `${issue.number}-${slug}` : `${issue.number}`;
+}
+
 /// Extract issue references from text (e.g., "Fixes #42", "closes #7", "resolves #123")
 export function extractIssueRefs(text: string): number[] {
   const nums: number[] = [];

--- a/crates/tmai-core/src/github/mod.rs
+++ b/crates/tmai-core/src/github/mod.rs
@@ -392,6 +392,13 @@ pub struct IssueInfo {
     pub state: String,
     pub url: String,
     pub labels: Vec<IssueLabel>,
+    pub assignees: Vec<String>,
+}
+
+/// Raw assignee from `gh issue list`
+#[derive(Debug, serde::Deserialize)]
+struct GhAssignee {
+    login: String,
 }
 
 /// Raw issue from `gh issue list`
@@ -402,6 +409,8 @@ struct GhIssueEntry {
     state: String,
     url: String,
     labels: Vec<IssueLabel>,
+    #[serde(default)]
+    assignees: Vec<GhAssignee>,
 }
 
 /// Fetch open issues for a repository using gh CLI (cached with 30s TTL)
@@ -425,7 +434,7 @@ pub async fn list_issues(repo_dir: &str) -> Option<Vec<IssueInfo>> {
                 "--state",
                 "open",
                 "--json",
-                "number,title,state,url,labels",
+                "number,title,state,url,labels,assignees",
                 "--limit",
                 "50",
             ])
@@ -450,6 +459,7 @@ pub async fn list_issues(repo_dir: &str) -> Option<Vec<IssueInfo>> {
             state: e.state,
             url: e.url,
             labels: e.labels,
+            assignees: e.assignees.into_iter().map(|a| a.login).collect(),
         })
         .collect();
 
@@ -784,6 +794,28 @@ pub async fn get_ci_failure_log(repo_dir: &str, run_id: u64) -> Option<CiFailure
         run_id,
         log_text: text,
     })
+}
+
+/// Re-run failed jobs for a CI workflow run
+///
+/// Uses `gh run rerun <run_id> --failed` to re-trigger only failed jobs.
+pub async fn rerun_failed_checks(repo_dir: &str, run_id: u64) -> Option<()> {
+    let output = tokio::time::timeout(
+        GH_TIMEOUT,
+        Command::new("gh")
+            .args(["run", "rerun", &run_id.to_string(), "--failed"])
+            .current_dir(repo_dir)
+            .output(),
+    )
+    .await
+    .ok()
+    .and_then(|r| r.ok())?;
+
+    if output.status.success() {
+        Some(())
+    } else {
+        None
+    }
 }
 
 /// Extract issue numbers from a branch name

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -2330,6 +2330,26 @@ pub async fn get_pr_merge_status(
         .map(Json)
 }
 
+/// POST /api/github/ci/rerun — re-run failed CI checks
+pub async fn rerun_failed_checks(
+    Json(body): Json<CiLogParams>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    let repo_dir = tmai_core::git::strip_git_suffix(&body.repo);
+    if !std::path::Path::new(repo_dir).is_dir() {
+        return Err(json_error(StatusCode::NOT_FOUND, "Repository not found"));
+    }
+
+    tmai_core::github::rerun_failed_checks(repo_dir, body.run_id)
+        .await
+        .ok_or_else(|| {
+            json_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to re-run checks (may lack actions:write permission)",
+            )
+        })
+        .map(|()| Json(serde_json::json!({"status": "ok"})))
+}
+
 /// GET /api/github/ci/failure-log — fetch failure log for a CI run
 pub async fn get_ci_failure_log(
     axum::extract::Query(params): axum::extract::Query<CiLogParams>,

--- a/src/web/server.rs
+++ b/src/web/server.rs
@@ -101,6 +101,7 @@ impl WebServer {
             .route("/github/pr/files", get(api::get_pr_files))
             .route("/github/pr/merge-status", get(api::get_pr_merge_status))
             .route("/github/ci/failure-log", get(api::get_ci_failure_log))
+            .route("/github/ci/rerun", post(api::rerun_failed_checks))
             .route("/git/merge", post(api::git_merge))
             .route("/projects", get(api::get_projects).post(api::add_project))
             .route("/projects/remove", post(api::remove_project))


### PR DESCRIPTION
## Summary

- CI checks auto-expand on failure, add "Re-run failed checks" button
- New IssuesPanel with search/label filters, replacing graph via tab switcher
- Start Work from issue: auto-generates worktree name, creates worktree + launches agent
- Extend IssueInfo with assignees field

Closes #115

## Test plan

- [ ] CI checks display in ActionPanel with pass/fail/pending icons
- [ ] Failed checks auto-expand and show "Re-run" button
- [ ] Issues tab shows open issues with search and label filtering
- [ ] "Start Work" from issue creates worktree with correct branch name
- [ ] `cargo test` / `cargo clippy` pass
- [ ] `pnpm lint` / `tsc --noEmit` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Issues パネルを追加しました。タイトル・番号・ラベルでイシューを検索・フィルタリングできます。
  * イシューから直接ワークツリーを作成・起動できるようになりました。
  * 失敗した CI チェックを再実行できるようになりました。
  * イシューに割り当てられたメンバー情報を表示するようにしました。
  * ブランチビューと Issues ビューを切り替えるタブを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->