### PR TITLE
fix: resolve HTTP hook 415 errors and correct timeout unit

### DIFF
--- a/crates/tmai-app/src/hooks_server.rs
+++ b/crates/tmai-app/src/hooks_server.rs
@@ -2,6 +2,7 @@
 // Receives hook events from Claude Code via POST /hooks/event
 
 use axum::{
+    body::Bytes,
     extract::{Json, State},
     http::StatusCode,
     routing::post,
@@ -33,11 +34,14 @@ pub struct HookServerState {
 }
 
 /// Handle incoming hook event
+///
+/// Accepts raw bytes instead of `Json<T>` to avoid 415 errors when
+/// Claude Code's HTTP hooks don't send `Content-Type: application/json`.
 #[allow(dead_code)]
 pub async fn handle_hook_event(
     State(state): State<HookServerState>,
     headers: axum::http::HeaderMap,
-    Json(payload): Json<Value>,
+    body: Bytes,
 ) -> Result<Json<Value>, StatusCode> {
     // Validate token
     let token = headers
@@ -48,6 +52,9 @@ pub async fn handle_hook_event(
     if token != state.token {
         return Err(StatusCode::UNAUTHORIZED);
     }
+
+    // Parse JSON payload manually (Content-Type agnostic)
+    let payload: Value = serde_json::from_slice(&body).map_err(|_| StatusCode::BAD_REQUEST)?;
 
     // Process hook event (delegate to core)
     tracing::debug!("Hook event received: {:?}", payload);

--- a/src/init.rs
+++ b/src/init.rs
@@ -80,10 +80,10 @@ fn claude_settings_path() -> Result<PathBuf> {
     Ok(home.join(".claude").join("settings.json"))
 }
 
-/// Connection timeout for HTTP hooks in milliseconds.
+/// Connection timeout for HTTP hooks in seconds.
 /// Short timeout prevents Claude Code from stalling when tmai is not running.
 /// 2 seconds is more than enough for localhost connections.
-const HOOK_TIMEOUT_MS: u64 = 2000;
+const HOOK_TIMEOUT_SECS: u64 = 2;
 
 /// Build a tmai hook entry for a given event (new wrapper format)
 ///
@@ -107,7 +107,7 @@ fn build_hook_entry(event: &str, token: &str, port: u16, include_tmux_pane: bool
         json!(format!("http://localhost:{}/hooks/event", port)),
     );
     hook.insert("headers".to_string(), json!(headers));
-    hook.insert("timeout".to_string(), json!(HOOK_TIMEOUT_MS));
+    hook.insert("timeout".to_string(), json!(HOOK_TIMEOUT_SECS));
     if include_tmux_pane {
         hook.insert("allowedEnvVars".to_string(), json!(["TMUX_PANE"]));
     }
@@ -511,7 +511,7 @@ mod tests {
         assert_eq!(hooks[0]["headers"]["Authorization"], "Bearer test-token");
         assert_eq!(hooks[0]["headers"]["X-Tmai-Pane-Id"], "$TMUX_PANE");
         assert_eq!(hooks[0]["statusMessage"], "tmai: PreToolUse");
-        assert_eq!(hooks[0]["timeout"], HOOK_TIMEOUT_MS);
+        assert_eq!(hooks[0]["timeout"], HOOK_TIMEOUT_SECS);
     }
 
     #[test]

--- a/src/web/hooks.rs
+++ b/src/web/hooks.rs
@@ -6,6 +6,7 @@
 //! Uses a separate auth token from the main web API (hooks_token).
 
 use axum::{
+    body::Bytes,
     extract::State,
     http::{HeaderMap, StatusCode},
     response::IntoResponse,
@@ -36,6 +37,9 @@ struct HookEventResponse {
 
 /// POST /hooks/event — receive a hook event from Claude Code
 ///
+/// Accepts raw bytes instead of axum's `Json` extractor to avoid 415 errors
+/// when Claude Code's HTTP hooks don't send `Content-Type: application/json`.
+///
 /// Returns structured JSON responses for events that support it:
 /// - **PreToolUse**: `hookSpecificOutput.permissionDecision` for auto-approval
 /// - **TeammateIdle/TaskCompleted**: `continue` + `stopReason` for stop control
@@ -43,8 +47,18 @@ struct HookEventResponse {
 pub async fn hook_event(
     State(core): State<Arc<TmaiCore>>,
     headers: HeaderMap,
-    Json(payload): Json<HookEventPayload>,
+    body: Bytes,
 ) -> impl IntoResponse {
+    let payload: HookEventPayload = match serde_json::from_slice(&body) {
+        Ok(p) => p,
+        Err(e) => {
+            debug!("Hook event rejected: invalid JSON payload: {}", e);
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": "invalid JSON"})),
+            );
+        }
+    };
     // Validate hook token from Authorization header
     let token_valid = headers
         .get("authorization")


### PR DESCRIPTION
## Summary
- Hook endpoints used axum's `Json` extractor which requires `Content-Type: application/json`. Claude Code's HTTP hooks don't always send this header, causing **415 Unsupported Media Type** on every hook event (visible as `PostToolUse:Read hook error` etc.)
- Fix by accepting raw `Bytes` and deserializing manually in both `src/web/hooks.rs` and `crates/tmai-app/src/hooks_server.rs`
- Fix `timeout` unit: was `2000` (intended as ms) but Claude Code interprets the field as **seconds**, making it ~33 minutes instead of 2s

## Test plan
- [x] `cargo check` passes
- [x] `cargo test --lib -- init::tests` — 16 tests pass
- [ ] Run `tmai init --force` to regenerate settings with corrected timeout
- [ ] Verify no more `hook error` messages in Claude Code status line

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * Webhookハンドラーが`Content-Type`ヘッダーへの依存を排除し、より柔軟なリクエスト形式に対応するようになりました。
  * 無効なJSONペイロードに対して、より詳細なエラー応答が返されるようになりました。
  * Webhookのタイムアウト設定の精度が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->