### PR TITLE
feat: show remote-only branches in git panel

### DIFF
--- a/crates/tmai-app/web/src/components/worktree/ActionPanel.tsx
+++ b/crates/tmai-app/web/src/components/worktree/ActionPanel.tsx
@@ -183,6 +183,26 @@ export function ActionPanel({
     }
   }, [actionBusy, projectPath, activeNode.name, forceDelete, focusAfterDelete, onRefresh]);
 
+  // Checkout a remote-only branch (creates local tracking branch)
+  const handleCheckoutRemote = useCallback(async () => {
+    if (actionBusy) return;
+    setActionBusy(true);
+    setActionError(null);
+    try {
+      // Extract short name from "origin/branch-name"
+      const shortName = activeNode.name.includes("/")
+        ? activeNode.name.split("/").slice(1).join("/")
+        : activeNode.name;
+      await api.checkoutBranch(projectPath, shortName);
+      onRefresh();
+      onSelectNode(shortName);
+    } catch (e) {
+      setActionError(e instanceof Error ? e.message : "Failed to checkout branch");
+    } finally {
+      setActionBusy(false);
+    }
+  }, [actionBusy, projectPath, activeNode.name, onRefresh, onSelectNode]);
+
   // Resolve the base branch for merge/PR operations
   const baseBranch = activeNode.parent ?? branches?.default_branch ?? "main";
 
@@ -818,8 +838,20 @@ export function ActionPanel({
             </button>
           )}
 
+          {/* Remote-only branch actions */}
+          {activeNode.isRemoteOnly && (
+            <button
+              type="button"
+              onClick={handleCheckoutRemote}
+              disabled={actionBusy}
+              className="w-full rounded-lg bg-purple-500/15 px-3 py-2 text-left text-xs font-medium text-purple-400 transition-colors hover:bg-purple-500/25 disabled:opacity-50"
+            >
+              {actionBusy ? "Checking out..." : "Checkout (Create Local Branch)"}
+            </button>
+          )}
+
           {/* Non-main branch/worktree actions (unified) */}
-          {!activeNode.isMain && (
+          {!activeNode.isMain && !activeNode.isRemoteOnly && (
             <>
               {/* Focus Agent (worktree or any branch with agent) */}
               {activeNode.agentTarget ? (

--- a/crates/tmai-app/web/src/components/worktree/BranchGraph.tsx
+++ b/crates/tmai-app/web/src/components/worktree/BranchGraph.tsx
@@ -156,6 +156,7 @@ export function BranchGraph({
       ahead: 0,
       behind: 0,
       remote: rtMap[defaultBranch] ?? null,
+      isRemoteOnly: false,
     });
 
     for (const wt of projectWorktrees) {
@@ -177,6 +178,7 @@ export function BranchGraph({
         ahead: ab?.[0] ?? 0,
         behind: ab?.[1] ?? 0,
         remote: rtMap[branchName] ?? null,
+        isRemoteOnly: false,
       });
     }
 
@@ -201,8 +203,32 @@ export function BranchGraph({
             ahead: ab?.[0] ?? 0,
             behind: ab?.[1] ?? 0,
             remote: rtMap[b] ?? null,
+            isRemoteOnly: false,
           });
         }
+      }
+    }
+
+    // Add remote-only branches (no local counterpart)
+    if (branches?.remote_only_branches) {
+      for (const rb of branches.remote_only_branches) {
+        result.push({
+          name: rb,
+          parent: defaultBranch,
+          isWorktree: false,
+          isMain: false,
+          isCurrent: false,
+          isDirty: false,
+          hasAgent: false,
+          agentTarget: null,
+          agentStatus: null,
+          diffSummary: null,
+          worktree: null,
+          ahead: 0,
+          behind: 0,
+          remote: null,
+          isRemoteOnly: true,
+        });
       }
     }
 
@@ -482,6 +508,7 @@ export function BranchGraph({
                 (n) =>
                   !n.isMain &&
                   !n.isWorktree &&
+                  !n.isRemoteOnly &&
                   !n.hasAgent &&
                   !n.isDirty &&
                   n.ahead === 0 &&
@@ -495,6 +522,7 @@ export function BranchGraph({
                         (n) =>
                           !n.isMain &&
                           !n.isWorktree &&
+                          !n.isRemoteOnly &&
                           !n.hasAgent &&
                           !n.isDirty &&
                           n.ahead === 0 &&
@@ -515,6 +543,32 @@ export function BranchGraph({
                           {n.behind > 0 && (
                             <span className="ml-1 text-[10px] text-red-400">{n.behind}\u2193</span>
                           )}
+                        </button>
+                      ))}
+                  </div>
+                </div>
+              )}
+
+              {/* Remote-only branches (no local counterpart) */}
+              {nodes.filter((n) => n.isRemoteOnly).length > 0 && (
+                <div className="mt-6 border-t border-white/5 pt-4">
+                  <div className="mb-2 text-[11px] text-zinc-600">Remote branches</div>
+                  <div className="flex flex-wrap gap-1.5">
+                    {nodes
+                      .filter((n) => n.isRemoteOnly)
+                      .map((n) => (
+                        <button
+                          type="button"
+                          key={n.name}
+                          onClick={() => selectBranch(n.name)}
+                          className={`rounded-md px-2 py-1 text-[11px] transition-colors ${
+                            selectedNode === n.name
+                              ? "bg-purple-500/15 text-purple-400"
+                              : "bg-white/5 text-zinc-500 hover:bg-white/10 hover:text-zinc-300"
+                          }`}
+                        >
+                          <span className="mr-1 text-[10px] text-purple-500/60">remote</span>
+                          {n.name}
                         </button>
                       ))}
                   </div>

--- a/crates/tmai-app/web/src/components/worktree/graph/types.ts
+++ b/crates/tmai-app/web/src/components/worktree/graph/types.ts
@@ -66,6 +66,7 @@ export interface BranchNode {
   ahead: number;
   behind: number;
   remote: RemoteTrackingInfo | null;
+  isRemoteOnly: boolean;
 }
 
 export interface GraphCommit {

--- a/crates/tmai-app/web/src/lib/api-http.ts
+++ b/crates/tmai-app/web/src/lib/api-http.ts
@@ -365,6 +365,7 @@ export interface BranchListResponse {
   parents: Record<string, string>;
   ahead_behind: Record<string, [number, number]>;
   remote_tracking: Record<string, RemoteTrackingInfo>;
+  remote_only_branches: string[];
   last_fetch: number | null;
 }
 

--- a/crates/tmai-core/src/git/mod.rs
+++ b/crates/tmai-core/src/git/mod.rs
@@ -403,6 +403,9 @@ pub struct BranchListResult {
     /// Remote tracking info per branch
     #[serde(default)]
     pub remote_tracking: HashMap<String, RemoteTrackingInfo>,
+    /// Remote-only branches (no local counterpart), e.g., "origin/fix-hook-script"
+    #[serde(default)]
+    pub remote_only_branches: Vec<String>,
     /// Last fetch timestamp (Unix seconds), None if never fetched
     pub last_fetch: Option<u64>,
 }
@@ -464,6 +467,9 @@ pub async fn list_branches(repo_dir: &str) -> Option<BranchListResult> {
     // Compute remote tracking info
     let remote_tracking = fetch_remote_tracking(repo_dir).await;
 
+    // Get remote-only branches (no local counterpart)
+    let remote_only_branches = fetch_remote_only_branches(repo_dir, &branches).await;
+
     // Get last fetch timestamp
     let last_fetch = fetch_head_time(repo_dir);
 
@@ -474,6 +480,7 @@ pub async fn list_branches(repo_dir: &str) -> Option<BranchListResult> {
         parents,
         ahead_behind: ab_map,
         remote_tracking,
+        remote_only_branches,
         last_fetch,
     })
 }
@@ -534,6 +541,45 @@ async fn fetch_remote_tracking(repo_dir: &str) -> HashMap<String, RemoteTracking
     }
 
     result
+}
+
+/// Fetch remote branches that have no local counterpart
+///
+/// Returns short names like "origin/fix-hook-script", excluding HEAD and
+/// branches that match any local branch name.
+async fn fetch_remote_only_branches(repo_dir: &str, local_branches: &[String]) -> Vec<String> {
+    let output = tokio::time::timeout(
+        GIT_TIMEOUT,
+        Command::new("git")
+            .args(["-C", repo_dir, "branch", "-r", "--format=%(refname:short)"])
+            .output(),
+    )
+    .await
+    .ok()
+    .and_then(|r| r.ok());
+
+    let Some(output) = output else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+
+    let local_set: std::collections::HashSet<&str> =
+        local_branches.iter().map(|s| s.as_str()).collect();
+
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|s| s.trim().to_string())
+        .filter(|s| {
+            if s.is_empty() || s.contains("->") {
+                return false;
+            }
+            // Extract short name after "origin/" (or any remote prefix)
+            let short = s.split('/').skip(1).collect::<Vec<_>>().join("/");
+            !local_set.contains(short.as_str())
+        })
+        .collect()
 }
 
 /// Parse git upstream:track format


### PR DESCRIPTION
## Summary
- リモート専用ブランチ（ローカルに対応がないもの）をgitパネルに表示
- グラフ下部に紫色の「Remote branches」セクションとして一���表示
- 選択すると「Checkout (Create Local Branch)」ボタンでローカル追跡ブランチを作成可能

## Changes
- **Backend**: `BranchListResult`に`remote_only_branches`フィールド追加、`git branch -r`でリモートブランチ取得
- **Frontend**: `BranchNode.isRemoteOnly`追加、Remote branchesセクション表示、ActionPanelにCheckoutアクション追加

## Test plan
- [ ] リモートにのみ存在するブランチがgitパネル下部に表示される
- [ ] リモートブランチをクリックして選択できる
- [ ] 「Checkout」ボタンでロ��カルブランチが作成される
- [ ] ローカルにも存在するブランチはRemoteセクションに重複表示されない
- [ ] `cargo test` / `cargo clippy` / TypeScript型チェック通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * リモートのみのブランチ（ローカルトラッキングブランチが存在しないリモートブランチ）を表示できるようになりました。ユーザーは新しい「リモートブランチ」セクションからリモートブランチを選択し、ローカルブランチとしてチェックアウトできます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->