### PR TITLE
fix: hot-reload settings after PUT /api/settings/* updates

### DIFF
--- a/crates/tmai-core/src/api/core.rs
+++ b/crates/tmai-core/src/api/core.rs
@@ -5,6 +5,7 @@
 
 use std::sync::Arc;
 
+use parking_lot::RwLock;
 use tokio::sync::broadcast;
 
 use crate::audit::helper::AuditHelper;
@@ -30,8 +31,8 @@ pub struct TmaiCore {
     state: SharedState,
     /// Unified command sender (IPC + tmux fallback)
     command_sender: Option<Arc<CommandSender>>,
-    /// Application settings
-    settings: Arc<Settings>,
+    /// Application settings (hot-reloadable via `reload_settings()`)
+    settings: RwLock<Arc<Settings>>,
     /// IPC server for PTY wrapper communication
     ipc_server: Option<Arc<IpcServer>>,
     /// Broadcast sender for core events
@@ -70,7 +71,7 @@ impl TmaiCore {
         Self {
             state,
             command_sender,
-            settings,
+            settings: RwLock::new(settings),
             ipc_server,
             event_tx,
             audit_helper,
@@ -104,9 +105,30 @@ impl TmaiCore {
         self.command_sender.as_ref()
     }
 
-    /// Access application settings (read-only)
-    pub fn settings(&self) -> &Settings {
-        &self.settings
+    /// Access application settings (read-only snapshot)
+    ///
+    /// Returns a cheap `Arc` clone. The underlying settings can be
+    /// hot-reloaded via [`reload_settings()`](Self::reload_settings).
+    pub fn settings(&self) -> Arc<Settings> {
+        self.settings.read().clone()
+    }
+
+    /// Re-read `config.toml` and replace the live settings.
+    ///
+    /// Called after PUT `/api/settings/*` handlers persist changes to disk.
+    /// Returns `true` if the reload succeeded.
+    pub fn reload_settings(&self) -> bool {
+        match Settings::load(None) {
+            Ok(new_settings) => {
+                *self.settings.write() = Arc::new(new_settings);
+                tracing::debug!("Settings reloaded from config.toml");
+                true
+            }
+            Err(e) => {
+                tracing::warn!(%e, "Failed to reload settings from config.toml");
+                false
+            }
+        }
     }
 
     /// Access the IPC server (if configured)
@@ -168,6 +190,12 @@ impl TmaiCore {
     /// Access the runtime adapter (if set)
     pub fn runtime(&self) -> Option<&Arc<dyn RuntimeAdapter>> {
         self.runtime.as_ref()
+    }
+
+    /// Direct write access to settings (for testing)
+    #[cfg(test)]
+    pub(crate) fn settings_mut(&self) -> parking_lot::RwLockWriteGuard<'_, Arc<Settings>> {
+        self.settings.write()
     }
 
     /// Validate a hook authentication token (constant-time comparison)
@@ -274,5 +302,46 @@ mod tests {
 
         assert!(core.validate_hook_token("test-token-123"));
         assert!(!core.validate_hook_token("wrong-token"));
+    }
+
+    #[test]
+    fn test_settings_returns_arc_clone() {
+        let mut custom = Settings::default();
+        custom.poll_interval_ms = 1234;
+        let core = crate::api::TmaiCoreBuilder::new(custom).build();
+
+        let s1 = core.settings();
+        let s2 = core.settings();
+        assert_eq!(s1.poll_interval_ms, 1234);
+        assert_eq!(s2.poll_interval_ms, 1234);
+        // Both should point to the same underlying allocation
+        assert!(Arc::ptr_eq(&s1, &s2));
+    }
+
+    #[test]
+    fn test_reload_settings_with_tempdir() {
+        // Create a temp config file with a custom poll_interval_ms
+        let dir = tempfile::tempdir().unwrap();
+        let config_path = dir.path().join("config.toml");
+        std::fs::write(&config_path, "poll_interval_ms = 999\n").unwrap();
+
+        let initial = Settings::load(Some(&config_path)).unwrap();
+        assert_eq!(initial.poll_interval_ms, 999);
+
+        let core = crate::api::TmaiCoreBuilder::new(initial).build();
+        assert_eq!(core.settings().poll_interval_ms, 999);
+
+        // Modify config on disk
+        std::fs::write(&config_path, "poll_interval_ms = 2000\n").unwrap();
+
+        // reload_settings() reads from the default config path, not our temp file,
+        // so we test the mechanism indirectly: verify settings() returns an Arc
+        // and that the RwLock swap works by calling the internal write path.
+        {
+            let new_settings = Settings::load(Some(&config_path)).unwrap();
+            assert_eq!(new_settings.poll_interval_ms, 2000);
+            *core.settings_mut() = Arc::new(new_settings);
+        }
+        assert_eq!(core.settings().poll_interval_ms, 2000);
     }
 }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -443,7 +443,7 @@ pub async fn get_preview(
     State(core): State<Arc<TmaiCore>>,
     Path(id): Path<String>,
 ) -> Result<Json<PreviewResponse>, StatusCode> {
-    let show_cursor = read_show_cursor();
+    let show_cursor = core.settings().web.show_cursor;
 
     // Look up agent target for capture-pane (id may differ from tmux target)
     let (agent_target, agent_content, agent_cursor) = {
@@ -1006,6 +1006,9 @@ pub async fn update_spawn_settings(
         }
     }
 
+    // Reload live settings from config.toml
+    core.reload_settings();
+
     tracing::info!(
         "Spawn settings updated: use_tmux_window={} window_name={:?}",
         req.use_tmux_window,
@@ -1091,6 +1094,7 @@ pub async fn get_auto_approve_settings(
 
 /// PUT /api/settings/auto-approve — update auto-approve settings (persisted to config.toml)
 pub async fn update_auto_approve_settings(
+    State(core): State<Arc<TmaiCore>>,
     Json(req): Json<UpdateAutoApproveRequest>,
 ) -> Json<serde_json::Value> {
     // Persist mode change (normalize to lowercase for serde compat)
@@ -1161,7 +1165,10 @@ pub async fn update_auto_approve_settings(
         tracing::info!("Auto-approve rules updated (restart to apply)");
     }
 
-    Json(serde_json::json!({"ok": true, "restart_required": true}))
+    // Reload live settings from config.toml
+    core.reload_settings();
+
+    Json(serde_json::json!({"ok": true}))
 }
 
 // =========================================================
@@ -2208,6 +2215,7 @@ pub async fn get_usage_settings(State(core): State<Arc<TmaiCore>>) -> Json<Usage
 
 /// PUT /api/settings/usage — update usage settings and persist
 pub async fn update_usage_settings(
+    State(core): State<Arc<TmaiCore>>,
     Json(req): Json<UsageSettingsRequest>,
 ) -> Json<serde_json::Value> {
     if let Some(enabled) = req.enabled {
@@ -2224,6 +2232,10 @@ pub async fn update_usage_settings(
             toml_edit::Value::from(interval as i64),
         );
     }
+
+    // Reload live settings from config.toml
+    core.reload_settings();
+
     Json(serde_json::json!({"ok": true}))
 }
 
@@ -2596,22 +2608,18 @@ pub struct PreviewSettingsRequest {
     pub show_cursor: Option<bool>,
 }
 
-/// Read show_cursor from config file (reflects latest saved value)
-fn read_show_cursor() -> bool {
-    tmai_core::config::Settings::load(None)
-        .map(|s| s.web.show_cursor)
-        .unwrap_or(true)
-}
-
 /// GET /api/settings/preview
-pub async fn get_preview_settings() -> Json<PreviewSettingsResponse> {
+pub async fn get_preview_settings(
+    State(core): State<Arc<TmaiCore>>,
+) -> Json<PreviewSettingsResponse> {
     Json(PreviewSettingsResponse {
-        show_cursor: read_show_cursor(),
+        show_cursor: core.settings().web.show_cursor,
     })
 }
 
 /// PUT /api/settings/preview — update preview settings and persist
 pub async fn update_preview_settings(
+    State(core): State<Arc<TmaiCore>>,
     Json(req): Json<PreviewSettingsRequest>,
 ) -> Json<serde_json::Value> {
     if let Some(v) = req.show_cursor {
@@ -2621,6 +2629,10 @@ pub async fn update_preview_settings(
             toml_edit::Value::from(v),
         );
     }
+
+    // Reload live settings from config.toml
+    core.reload_settings();
+
     Json(serde_json::json!({"ok": true}))
 }
 


### PR DESCRIPTION
## Summary
- `TmaiCore.settings`を`Arc<Settings>`から`RwLock<Arc<Settings>>`に変更し、ランタイム中のホットリロードを可能に
- 4つのPUT settings handler（spawn, auto-approve, usage, preview）全てで`save_toml_value()`後に`reload_settings()`を呼出
- preview GETの`read_show_cursor()`ワークアラウンド（毎回ファイル再読み込み）を除去し、`core.settings()`に統一

Closes #120

## Test plan
- [x] `cargo test` 99テスト全通過
- [x] `cargo clippy` 警告なし
- [ ] WebUIからsettings変更→GET確認で即時反映されること
- [ ] auto-approveのmode変更が再起動なしで反映されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 設定をリアルタイムでリロード可能に。アプリケーション再起動なしに変更が即座に反映されます。

* **改善**
  * 設定の読み込みパフォーマンスを最適化しました。メモリ内キャッシュから設定を取得するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->