### PR TITLE
feat: split-pane layout — conversation left, git/markdown right

### DIFF
--- a/crates/tmai-app/web/src/App.tsx
+++ b/crates/tmai-app/web/src/App.tsx
@@ -3,6 +3,7 @@ import { AgentActions } from "@/components/agent/AgentActions";
 import { AgentList } from "@/components/agent/AgentList";
 import { PreviewPanel } from "@/components/agent/PreviewPanel";
 import { HelpOverlay } from "@/components/layout/HelpOverlay";
+import { SplitPaneLayout } from "@/components/layout/SplitPaneLayout";
 import { StatusBar } from "@/components/layout/StatusBar";
 import { ToastContainer, useToast } from "@/components/layout/ToastContainer";
 import { MarkdownPanel } from "@/components/markdown/MarkdownPanel";
@@ -15,6 +16,7 @@ import { BranchGraph } from "@/components/worktree/BranchGraph";
 import { WorktreePanel } from "@/components/worktree/WorktreePanel";
 import { useAgents } from "@/hooks/useAgents";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
+import { useSplitPane } from "@/hooks/useSplitPane";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { api, isAiAgent, type Selection } from "@/lib/api";
 
@@ -29,6 +31,19 @@ export function App() {
   const [showSettings, setShowSettings] = useState(false);
   const [showSecurity, setShowSecurity] = useState(false);
   const [showHelp, setShowHelp] = useState(false);
+  const [rightPanelTab, setRightPanelTab] = useState<"git" | "markdown">("git");
+
+  // Split-pane layout state
+  const {
+    splitRatio,
+    splitEnabled,
+    setSplitEnabled,
+    isDragging,
+    isNarrowScreen,
+    containerRef,
+    onDividerMouseDown,
+    onDividerDoubleClick,
+  } = useSplitPane();
 
   // Fetch registered projects on mount and on demand
   const refreshProjects = useCallback(() => {
@@ -103,6 +118,18 @@ export function App() {
   // Derive selectedTarget string for components that need it
   const selectedTarget = selection?.type === "agent" ? selection.id : null;
 
+  // Derive project context from selected agent for split view
+  const agentProjectPath = selectedAgent?.git_common_dir ?? null;
+  const agentProjectName = agentProjectPath
+    ? (agentProjectPath
+        .replace(/\/\.git\/?$/, "")
+        .replace(/\/+$/, "")
+        .split("/")
+        .pop() ?? agentProjectPath)
+    : null;
+  const showSplitView =
+    selection?.type === "agent" && agentProjectPath !== null && splitEnabled && !isNarrowScreen;
+
   // Keyboard shortcuts handlers
   useKeyboardShortcuts([
     {
@@ -129,6 +156,11 @@ export function App() {
           toast.info("Previous project");
         }
       },
+    },
+    {
+      keys: ["\\"],
+      description: "Toggle split view",
+      handler: () => setSplitEnabled(!splitEnabled),
     },
     {
       keys: ["]"],
@@ -245,6 +277,51 @@ export function App() {
               }}
             />
           </div>
+        ) : showSplitView && selectedAgent && agentProjectPath && agentProjectName ? (
+          <SplitPaneLayout
+            left={
+              <div className="flex flex-1 flex-col overflow-hidden">
+                <AgentActions agent={selectedAgent} passthrough />
+                {sessionId ? (
+                  <div key={sessionId} className="flex-1 overflow-hidden animate-fade-in">
+                    <TerminalPanel sessionId={sessionId} />
+                  </div>
+                ) : (
+                  <div
+                    key={selectedAgent.id}
+                    className="flex flex-1 flex-col overflow-hidden animate-fade-in"
+                  >
+                    <PreviewPanel agentId={selectedAgent.id} />
+                  </div>
+                )}
+              </div>
+            }
+            right={
+              rightPanelTab === "git" ? (
+                <BranchGraph
+                  key={agentProjectPath}
+                  projectPath={agentProjectPath}
+                  projectName={agentProjectName}
+                  worktrees={worktrees}
+                  agents={aiAgents}
+                  onFocusAgent={handleSelectAgent}
+                />
+              ) : (
+                <MarkdownPanel
+                  key={agentProjectPath}
+                  projectPath={agentProjectPath}
+                  projectName={agentProjectName}
+                />
+              )
+            }
+            rightTab={rightPanelTab}
+            onTabChange={setRightPanelTab}
+            splitRatio={splitRatio}
+            isDragging={isDragging}
+            containerRef={containerRef}
+            onDividerMouseDown={onDividerMouseDown}
+            onDividerDoubleClick={onDividerDoubleClick}
+          />
         ) : (
           <div className="flex flex-1 flex-col overflow-hidden">
             {selectedAgent && <AgentActions agent={selectedAgent} passthrough />}

--- a/crates/tmai-app/web/src/components/layout/HelpOverlay.tsx
+++ b/crates/tmai-app/web/src/components/layout/HelpOverlay.tsx
@@ -13,6 +13,7 @@ export function HelpOverlay({ isOpen, onClose }: HelpOverlayProps) {
       category: "Navigation",
       items: [
         { key: "?", description: "Toggle this help menu" },
+        { key: "\\", description: "Toggle split view" },
         { key: "[", description: "Previous project" },
         { key: "]", description: "Next project" },
         { key: "/", description: "Focus project search" },

--- a/crates/tmai-app/web/src/components/layout/SplitPaneLayout.tsx
+++ b/crates/tmai-app/web/src/components/layout/SplitPaneLayout.tsx
@@ -1,0 +1,118 @@
+import type { ReactNode, RefObject } from "react";
+
+type RightTab = "git" | "markdown";
+
+interface SplitPaneLayoutProps {
+  left: ReactNode;
+  right: ReactNode;
+  rightTab: RightTab;
+  onTabChange: (tab: RightTab) => void;
+  /** Split ratio 0.0–1.0 (fraction assigned to left pane) */
+  splitRatio: number;
+  isDragging: boolean;
+  containerRef: RefObject<HTMLDivElement | null>;
+  onDividerMouseDown: (e: React.MouseEvent) => void;
+  onDividerDoubleClick: () => void;
+}
+
+// Convert split ratio (0–1) to ARIA percentage (0–100)
+function ratioToPercent(ratio: number): number {
+  return Math.round(ratio * 100);
+}
+
+// Tab button for the right panel header
+function TabButton({
+  active,
+  onClick,
+  children,
+}: {
+  active: boolean;
+  onClick: () => void;
+  children: ReactNode;
+}) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
+        active
+          ? "bg-white/10 text-cyan-400"
+          : "text-zinc-500 hover:bg-white/[0.05] hover:text-zinc-300"
+      }`}
+    >
+      {children}
+    </button>
+  );
+}
+
+// Split-pane layout: left panel + draggable divider + right panel with tab bar
+export function SplitPaneLayout({
+  left,
+  right,
+  rightTab,
+  onTabChange,
+  splitRatio,
+  isDragging,
+  containerRef,
+  onDividerMouseDown,
+  onDividerDoubleClick,
+}: SplitPaneLayoutProps) {
+  const leftPercent = `${(splitRatio * 100).toFixed(2)}%`;
+  const rightPercent = `${((1 - splitRatio) * 100).toFixed(2)}%`;
+
+  return (
+    <div
+      ref={containerRef}
+      className={`flex h-full flex-1 overflow-hidden ${isDragging ? "select-none" : ""}`}
+    >
+      {/* Left pane: conversation / agent */}
+      <div className="flex flex-col overflow-hidden" style={{ width: leftPercent }}>
+        {left}
+      </div>
+
+      {/* Divider — draggable split handle */}
+      {/* biome-ignore lint/a11y/useSemanticElements: <hr> cannot serve as a draggable split handle */}
+      <div
+        role="separator"
+        tabIndex={0}
+        aria-valuenow={ratioToPercent(splitRatio)}
+        aria-valuemin={20}
+        aria-valuemax={80}
+        aria-label="Resize split pane"
+        className="group relative flex shrink-0 cursor-col-resize items-center justify-center"
+        style={{ width: "5px" }}
+        onMouseDown={onDividerMouseDown}
+        onDoubleClick={onDividerDoubleClick}
+      >
+        {/* Visible line */}
+        <div
+          className={`h-full w-px transition-colors ${
+            isDragging ? "bg-cyan-500/50" : "bg-white/[0.06] group-hover:bg-cyan-500/30"
+          }`}
+        />
+        {/* Drag handle dots (visible on hover) */}
+        <div className="absolute flex flex-col gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+          <div className="h-1 w-1 rounded-full bg-zinc-500" />
+          <div className="h-1 w-1 rounded-full bg-zinc-500" />
+          <div className="h-1 w-1 rounded-full bg-zinc-500" />
+        </div>
+      </div>
+
+      {/* Right pane: git / markdown tabs */}
+      <div className="flex flex-col overflow-hidden" style={{ width: rightPercent }}>
+        {/* Tab bar */}
+        <div className="flex shrink-0 items-center gap-1 border-b border-white/[0.06] px-3 py-1.5">
+          <TabButton active={rightTab === "git"} onClick={() => onTabChange("git")}>
+            Git
+          </TabButton>
+          <TabButton active={rightTab === "markdown"} onClick={() => onTabChange("markdown")}>
+            Docs
+          </TabButton>
+        </div>
+
+        {/* Tab content */}
+        <div className="flex flex-1 flex-col overflow-hidden">{right}</div>
+      </div>
+    </div>
+  );
+}

--- a/crates/tmai-app/web/src/hooks/useKeyboardShortcuts.ts
+++ b/crates/tmai-app/web/src/hooks/useKeyboardShortcuts.ts
@@ -5,6 +5,7 @@ export const KEYBOARD_SHORTCUTS = {
   helpToggle: "?",
   settingsToggle: "s",
   securityToggle: "sec",
+  splitToggle: "\\",
   projectNext: "]",
   projectPrev: "[",
   agentKill: "k",

--- a/crates/tmai-app/web/src/hooks/useSplitPane.ts
+++ b/crates/tmai-app/web/src/hooks/useSplitPane.ts
@@ -1,0 +1,144 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+const STORAGE_KEY_RATIO = "tmai:split-ratio";
+const STORAGE_KEY_ENABLED = "tmai:split-enabled";
+const DEFAULT_RATIO = 0.5;
+const MIN_RATIO = 0.2;
+const MAX_RATIO = 0.8;
+const NARROW_BREAKPOINT = "(min-width: 1024px)";
+
+// Read a number from localStorage with a fallback default
+function readStoredNumber(key: string, fallback: number): number {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    const parsed = Number.parseFloat(raw);
+    return Number.isFinite(parsed) ? parsed : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+// Read a boolean from localStorage with a fallback default
+function readStoredBool(key: string, fallback: boolean): boolean {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    return raw === "true";
+  } catch {
+    return fallback;
+  }
+}
+
+export interface UseSplitPaneResult {
+  splitRatio: number;
+  splitEnabled: boolean;
+  setSplitEnabled: (enabled: boolean) => void;
+  isDragging: boolean;
+  isNarrowScreen: boolean;
+  containerRef: React.RefObject<HTMLDivElement | null>;
+  onDividerMouseDown: (e: React.MouseEvent) => void;
+  onDividerDoubleClick: () => void;
+}
+
+// Manage split-pane layout state: drag ratio, enabled toggle, narrow-screen detection
+export function useSplitPane(): UseSplitPaneResult {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [splitRatio, setSplitRatio] = useState(() => {
+    const stored = readStoredNumber(STORAGE_KEY_RATIO, DEFAULT_RATIO);
+    return Math.max(MIN_RATIO, Math.min(MAX_RATIO, stored));
+  });
+  const [splitEnabled, setSplitEnabledRaw] = useState(() =>
+    readStoredBool(STORAGE_KEY_ENABLED, true),
+  );
+  const [isDragging, setIsDragging] = useState(false);
+  const [isNarrowScreen, setIsNarrowScreen] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return !window.matchMedia(NARROW_BREAKPOINT).matches;
+  });
+
+  // Persist splitEnabled to localStorage
+  const setSplitEnabled = useCallback((enabled: boolean) => {
+    setSplitEnabledRaw(enabled);
+    try {
+      localStorage.setItem(STORAGE_KEY_ENABLED, String(enabled));
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  // Track narrow screen via matchMedia
+  useEffect(() => {
+    const mql = window.matchMedia(NARROW_BREAKPOINT);
+    const handler = (e: MediaQueryListEvent) => setIsNarrowScreen(!e.matches);
+    mql.addEventListener("change", handler);
+    return () => mql.removeEventListener("change", handler);
+  }, []);
+
+  // Divider mousedown handler
+  const onDividerMouseDown = useCallback((e: React.MouseEvent) => {
+    e.preventDefault();
+    setIsDragging(true);
+  }, []);
+
+  // Double-click divider to reset to 50/50
+  const onDividerDoubleClick = useCallback(() => {
+    setSplitRatio(DEFAULT_RATIO);
+    try {
+      localStorage.setItem(STORAGE_KEY_RATIO, String(DEFAULT_RATIO));
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  // Handle drag: mousemove + mouseup on document
+  const splitRatioRef = useRef(splitRatio);
+  splitRatioRef.current = splitRatio;
+
+  useEffect(() => {
+    if (!isDragging) return;
+
+    const handleMouseMove = (e: MouseEvent) => {
+      const container = containerRef.current;
+      if (!container) return;
+      const rect = container.getBoundingClientRect();
+      const ratio = (e.clientX - rect.left) / rect.width;
+      setSplitRatio(Math.max(MIN_RATIO, Math.min(MAX_RATIO, ratio)));
+    };
+
+    const handleMouseUp = () => {
+      setIsDragging(false);
+      // Persist final ratio
+      try {
+        localStorage.setItem(STORAGE_KEY_RATIO, String(splitRatioRef.current));
+      } catch {
+        // ignore
+      }
+      // Notify xterm.js and other ResizeObserver-based components
+      window.dispatchEvent(new Event("resize"));
+    };
+
+    document.body.style.cursor = "col-resize";
+    document.body.style.userSelect = "none";
+    document.addEventListener("mousemove", handleMouseMove);
+    document.addEventListener("mouseup", handleMouseUp);
+
+    return () => {
+      document.body.style.cursor = "";
+      document.body.style.userSelect = "";
+      document.removeEventListener("mousemove", handleMouseMove);
+      document.removeEventListener("mouseup", handleMouseUp);
+    };
+  }, [isDragging]);
+
+  return {
+    splitRatio,
+    splitEnabled,
+    setSplitEnabled,
+    isDragging,
+    isNarrowScreen,
+    containerRef,
+    onDividerMouseDown,
+    onDividerDoubleClick,
+  };
+}


### PR DESCRIPTION
## Summary
- エージェント選択時に左右分割レイアウトを表示（左=会話/ターミナル、右=Git/Docsタブ切り替え）
- ドラッグ可能なディバイダで分割比率を調整（localStorageに永続化、ダブルクリックで50%リセット）
- `\` キーで分割表示トグル、狭い画面（<1024px）では従来のタブ切り替えにフォールバック

## New files
- `useSplitPane.ts` — ドラッグ比率・有効/無効・画面幅検知を管理するhook
- `SplitPaneLayout.tsx` — 左右分割レイアウト + ディバイダ + 右パネルタブバー

## Test plan
- [ ] エージェント選択時（git_common_dirあり）に分割表示されること
- [ ] ディバイダのドラッグで比率変更、リロード後も維持されること
- [ ] `\` キーで分割トグルが効くこと
- [ ] ウィンドウ幅 < 1024px でフォールバック（従来の単一パネル表示）
- [ ] project/markdown 直接選択はフルワイド表示のまま
- [ ] ディバイダのダブルクリックで50%リセット

Closes #125

🤖 Generated with [Claude Code](https://claude.com/claude-code)