### PR TITLE
fix: update picomatch to 4.0.4 (Dependabot alert #6)

### DIFF
--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -2140,9 +2140,9 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.3.tgz",
-      "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
       "engines": {


### PR DESCRIPTION
## Summary
- `web/package-lock.json` の picomatch を 4.0.3 → 4.0.4 に更新
- Dependabot alert #6: "Picomatch: Method Injection in POSIX Character Classes causes incorrect Glob Matching" を解消

## glib alert (#7) について
glib 0.18.5 → 0.20.0 へのアップグレードは不可。Tauri v2 の GTK 系依存（atk, gtk, webkit2gtk 等）が全て `glib ^0.18` を要求しており、Tauri 側の対応待ち。アラートは dismiss 予定。

🤖 Generated with [Claude Code](https://claude.com/claude-code)