### PR TITLE
fix: change tool_response type from String to Value to fix hook errors

### DIFF
--- a/crates/tmai-core/src/hooks/handler.rs
+++ b/crates/tmai-core/src/hooks/handler.rs
@@ -108,8 +108,14 @@ pub fn handle_hook_event(
             let input_summary = summarize_tool_input(&tool_name, payload.tool_input.as_ref());
             let response_summary = payload
                 .tool_response
-                .as_deref()
-                .map(|s| truncate_string(s, 200))
+                .as_ref()
+                .map(|v| {
+                    let s = v
+                        .as_str()
+                        .map(String::from)
+                        .unwrap_or_else(|| v.to_string());
+                    truncate_string(&s, 200)
+                })
                 .unwrap_or_default();
             let activity = ToolActivity {
                 tool_name,

--- a/crates/tmai-core/src/hooks/types.rs
+++ b/crates/tmai-core/src/hooks/types.rs
@@ -84,8 +84,10 @@ pub struct HookEventPayload {
     pub tool_input: Option<serde_json::Value>,
 
     /// Tool response/output (for PostToolUse)
+    /// Claude Code v2.1.87+ sends this as an object (e.g., {"stdout":"...","exitCode":0}),
+    /// not a plain string.
     #[serde(default)]
-    pub tool_response: Option<String>,
+    pub tool_response: Option<serde_json::Value>,
 
     /// Whether a stop hook is already active (for Stop / SubagentStop)
     #[serde(default)]


### PR DESCRIPTION
## Summary
- `HookEventPayload.tool_response` の型を `Option<String>` → `Option<serde_json::Value>` に変更
- Claude Code v2.1.87+ が `tool_response` をオブジェクト（`{"stdout":"...","exitCode":0}` 等）として送信するため、String 型ではデシリアライズ失敗 → 400 Bad Request → 全 PostToolUse で "hook error" 表示

## Root Cause
```
[DEBUG] Hook PostToolUse:Bash (PostToolUse) error:
HTTP 400 from http://localhost:9876/hooks/event
```

## Test plan
- [x] 既存テスト（文字列の tool_response）がパスすることを確認
- [ ] `tmai` 再起動後、PostToolUse で "hook error" が消えることを確認

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

**改善**
* ツール実行レスポンスの処理を拡張し、構造化JSON形式を含むより多くのレスポンス形式に対応するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->