### PR TITLE
fix: cursor overlay misalignment when tmux panes are horizontally split

### DIFF
--- a/crates/tmai-app/web/src/components/agent/PreviewPanel.tsx
+++ b/crates/tmai-app/web/src/components/agent/PreviewPanel.tsx
@@ -367,9 +367,11 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
     if (!cursorPos || !showCursor) return base;
 
     const lines = base.split("\n");
-    if (cursorPos.y >= lines.length) return base;
+    if (lines.length === 0) return base;
+    // Clamp cursor_y to content bounds instead of giving up
+    const clampedY = Math.min(cursorPos.y, lines.length - 1);
 
-    const line = lines[cursorPos.y];
+    const line = lines[clampedY];
     let col = 0; // column count (full-width chars = 2)
     let inTag = false;
     let insertAt = line.length;
@@ -406,7 +408,7 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
 
     const marker =
       '<span data-tmai-cursor="1" style="display:inline-block;width:0;height:0;vertical-align:top;overflow:hidden"></span>';
-    lines[cursorPos.y] = line.slice(0, insertAt) + marker + line.slice(insertAt);
+    lines[clampedY] = line.slice(0, insertAt) + marker + line.slice(insertAt);
     return lines.join("\n");
   }, [ansi, content, cols, cursorPos, showCursor]);
   const html = htmlWithCursor;

--- a/crates/tmai-core/src/review/service.rs
+++ b/crates/tmai-core/src/review/service.rs
@@ -190,9 +190,9 @@ pub fn launch_review(
     let safe_branch = sanitize_name(request.branch.as_deref().unwrap_or("unknown"));
     let output_file = review_output_dir()?.join(format!("{safe_branch}.md"));
 
-    // Split the source agent's pane for the review (auto-closes when done)
+    // Split the source agent's pane for the review with tiled layout
     let review_target = tmux
-        .split_window(&request.target, &request.cwd)
+        .split_window_tiled(&request.target, &request.cwd)
         .context("Failed to split pane for review")?;
 
     // Build feedback target if auto_feedback is enabled

--- a/crates/tmai-core/src/runtime/mod.rs
+++ b/crates/tmai-core/src/runtime/mod.rs
@@ -103,6 +103,22 @@ pub trait RuntimeAdapter: Send + Sync {
         anyhow::bail!("window splitting not supported by {} runtime", self.name())
     }
 
+    /// Split a window and apply tiled layout for balanced pane sizes.
+    fn split_window_tiled(&self, session: &str, cwd: &str) -> Result<String> {
+        // Default: fall back to regular split_window
+        self.split_window(session, cwd)
+    }
+
+    /// Apply a layout to the window containing the target (e.g. "tiled").
+    fn select_layout(&self, _target: &str, _layout: &str) -> Result<()> {
+        Ok(()) // no-op for runtimes that don't support layouts
+    }
+
+    /// Count panes in the window containing the target.
+    fn count_panes(&self, _target: &str) -> Result<usize> {
+        Ok(0)
+    }
+
     /// Run a command in a pane (send text + Enter).
     fn run_command(&self, _target: &str, _command: &str) -> Result<()> {
         anyhow::bail!("command execution not supported by {} runtime", self.name())

--- a/crates/tmai-core/src/runtime/tmux_adapter.rs
+++ b/crates/tmai-core/src/runtime/tmux_adapter.rs
@@ -101,6 +101,18 @@ impl RuntimeAdapter for TmuxAdapter {
         self.client.split_window(session, cwd)
     }
 
+    fn split_window_tiled(&self, session: &str, cwd: &str) -> Result<String> {
+        self.client.split_window_tiled(session, cwd)
+    }
+
+    fn select_layout(&self, target: &str, layout: &str) -> Result<()> {
+        self.client.select_layout(target, layout)
+    }
+
+    fn count_panes(&self, target: &str) -> Result<usize> {
+        self.client.count_panes(target)
+    }
+
     fn run_command(&self, target: &str, command: &str) -> Result<()> {
         self.client.run_command(target, command)
     }

--- a/crates/tmai-core/src/tmux/client.rs
+++ b/crates/tmai-core/src/tmux/client.rs
@@ -498,6 +498,45 @@ impl TmuxClient {
         Ok(target)
     }
 
+    /// Split a window and apply tiled layout to distribute panes evenly.
+    /// Returns the new pane's target identifier (session:window.pane).
+    pub fn split_window_tiled(&self, session: &str, cwd: &str) -> Result<String> {
+        let target = self.split_window(session, cwd)?;
+        // Apply tiled layout so panes get balanced rows and columns
+        let _ = self.select_layout(session, "tiled");
+        Ok(target)
+    }
+
+    /// Apply a tmux layout to a window (e.g. "tiled", "even-horizontal", "even-vertical").
+    pub fn select_layout(&self, target: &str, layout: &str) -> Result<()> {
+        let output = Command::new("tmux")
+            .args(["select-layout", "-t", target, layout])
+            .output()
+            .context("Failed to execute tmux select-layout")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("tmux select-layout failed: {}", stderr);
+        }
+        Ok(())
+    }
+
+    /// Count the number of panes in the window containing the target pane.
+    pub fn count_panes(&self, target: &str) -> Result<usize> {
+        let output = Command::new("tmux")
+            .args(["list-panes", "-t", target])
+            .output()
+            .context("Failed to execute tmux list-panes")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("tmux list-panes failed: {}", stderr);
+        }
+
+        let text = String::from_utf8_lossy(&output.stdout);
+        Ok(text.lines().filter(|l| !l.is_empty()).count())
+    }
+
     /// Run a command in a specific pane
     pub fn run_command(&self, target: &str, command: &str) -> Result<()> {
         validate_target(target)?;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -2350,12 +2350,12 @@ impl App {
                 }
             },
             PlacementType::SplitPane => {
-                // Use target_pane (currently selected pane) for splitting
+                // Use target_pane (currently selected pane) for splitting with tiled layout
                 let pane = target_pane.unwrap_or_else(|| session.clone());
                 match self
                     .command_sender
                     .runtime()
-                    .split_window(&pane, &directory)
+                    .split_window_tiled(&pane, &directory)
                 {
                     Ok(t) => t,
                     Err(e) => {

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -458,23 +458,31 @@ pub async fn get_preview(
         }
     };
 
-    // Try capture-pane with ANSI colors first (via tmux target)
+    // Try capture-pane with ANSI colors first (via tmux target).
+    // Query cursor BEFORE capture to reduce race conditions: if new content
+    // appears between the two calls, the cursor position still references a
+    // valid line in the (larger) captured output.
     if let Some(ref target) = agent_target {
         if let Some(cmd) = core.raw_command_sender() {
+            // Pre-query cursor position
+            let pre_cursor = if show_cursor {
+                let cursor_result = cmd.runtime().get_cursor_position(target);
+                tracing::debug!("cursor query for {}: {:?}", target, cursor_result);
+                cursor_result.ok().flatten()
+            } else {
+                None
+            };
+
             if let Ok(content) = cmd.runtime().capture_pane_full(target) {
                 if !content.trim().is_empty() {
                     let lines = content.lines().count();
-                    // Query cursor position from runtime (tmux or IPC)
-                    let (cursor_x, cursor_y) = if show_cursor {
-                        let cursor_result = cmd.runtime().get_cursor_position(target);
-                        tracing::debug!("cursor query for {}: {:?}", target, cursor_result);
-                        cursor_result
-                            .ok()
-                            .flatten()
-                            .map(|(x, y)| (Some(x), Some(y)))
-                            .unwrap_or((None, None))
-                    } else {
-                        (None, None)
+                    // Clamp cursor_y to captured content bounds
+                    let (cursor_x, cursor_y) = match pre_cursor {
+                        Some((x, y)) if lines > 0 => {
+                            let clamped_y = y.min((lines - 1) as u32);
+                            (Some(x), Some(clamped_y))
+                        }
+                        _ => (None, None),
                     };
                     return Ok(Json(PreviewResponse {
                         content,
@@ -1344,8 +1352,8 @@ async fn spawn_in_tmux(
     // Reuse existing window with the same name, or create a new one
     let pane_target = find_tmux_window(&session_name, &window_name)
         .and_then(|target| {
-            // Split existing window to add a pane
-            tmux.split_window(&target, &req.cwd).ok()
+            // Split existing window with tiled layout for balanced pane sizes
+            tmux.split_window_tiled(&target, &req.cwd).ok()
         })
         .or_else(|| {
             // No existing window — create a new one


### PR DESCRIPTION
## Summary

- tmuxペイン分割後に `select-layout tiled` を自動適用し、ペインを格子状に均等配置。水平分割のみで行数が半減していく問題を解消
- カーソル位置クエリをキャプチャ**前**に実行し、レース条件によるズレを緩和
- バックエンド・フロントエンド両方で `cursor_y` をコンテンツ行数にクランプし、範囲外アクセスを防止

## Test plan

- [x] `cargo check` — コンパイル確認
- [x] `cargo test` — 全99テスト通過
- [x] `cargo fmt --check` / `cargo clippy` — pre-commit hook通過
- [ ] 手動テスト: 3-4エージェント起動時にペインがtiled配置になること確認
- [ ] カーソルオーバーレイが正しい位置に表示されること確認

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * プレビューパネルのカーソル位置がコンテンツ範囲外にある場合の処理を改善しました。

* **機能改善**
  * ウィンドウ分割時のレイアウトをタイル状に変更し、より効率的なペイン配置を実現しました。
  * プレビュー表示時のカーソル位置追跡の精度を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->