### PR TITLE
fix: fallback to cwd when git_common_dir is null for markdown panel

### DIFF
--- a/crates/tmai-app/web/src/App.tsx
+++ b/crates/tmai-app/web/src/App.tsx
@@ -119,7 +119,7 @@ export function App() {
   const selectedTarget = selection?.type === "agent" ? selection.id : null;
 
   // Derive project context from selected agent for split view
-  const agentProjectPath = selectedAgent?.git_common_dir ?? null;
+  const agentProjectPath = selectedAgent?.git_common_dir ?? selectedAgent?.cwd ?? null;
   const agentProjectName = agentProjectPath
     ? (agentProjectPath
         .replace(/\/\.git\/?$/, "")


### PR DESCRIPTION
## Summary
- Split-paneレイアウトでマークダウンパネルのルートパスが `git_common_dir` のみに依存していたため、Hook検出のみのエージェント等で `null` になりファイルツリーが表示されなかった
- `selectedAgent.cwd` をフォールバックとして追加

Closes #134

## Test plan
- [ ] `git_common_dir` が null のエージェントを選択し、split-paneでMarkdownタブのファイルツリーが表示されることを確認
- [ ] `git_common_dir` がある通常エージェントで既存動作に影響がないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * 特定の条件下で分割ビューパネルが表示されない問題を修正しました。ブランチグラフやマークダウンパネルなどの右/左分割パネルが、より多くのシナリオで正常にレンダリングされるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->