### PR TITLE
fix: remove false focus ring from conversation panel when right panel has focus

### DIFF
--- a/crates/tmai-app/web/src/components/agent/PreviewPanel.tsx
+++ b/crates/tmai-app/web/src/components/agent/PreviewPanel.tsx
@@ -490,12 +490,6 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
       className={`relative flex flex-1 flex-col overflow-hidden bg-[#0c0c0c] outline-none ${
         focused && hasDomFocus ? "ring-1 ring-cyan-500/30 ring-inset" : ""
       }`}
-      onClick={() => {
-        // Restore input mode when clicking anywhere in the panel after losing focus
-        if (!hasDomFocus) {
-          enterInputMode();
-        }
-      }}
     >
       <div
         role="log"
@@ -507,8 +501,9 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
           if (focused) enterSelectMode();
         }}
         onMouseUp={() => {
-          // If no text was selected (just a click), return to input mode
-          if (!focused) {
+          // If no text was selected (just a click), return to input mode.
+          // Also handles re-focus when clicking back from the right panel.
+          if (!focused || !hasDomFocus) {
             const sel = window.getSelection();
             if (!sel || sel.toString().length === 0) {
               enterInputMode();


### PR DESCRIPTION
## Summary
- Split-paneレイアウトで右パネル(git/markdown)にフォーカスが移った際、左の会話パネルのフォーカスリング(cyan枠)とカーソルオーバーレイを非表示にする
- `focusin`/`focusout` イベントで実際のDOMフォーカスを追跡し、`hasDomFocus` 状態と `focused`(input mode) の両方が真の時のみフォーカス表示
- 左パネルをクリックすると入力モードが復活

## Test plan
- [ ] Split-paneビューで右パネル(Git/Docs)をクリック → 左パネルのcyan枠が消えること
- [ ] 左パネルのカーソルオーバーレイも非表示になること
- [ ] 左パネルをクリック → cyan枠とカーソルが復活すること
- [ ] Select mode(テキスト選択)は従来通り動作すること
- [ ] エージェント切替時にフォーカスがリセットされること

Closes #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)