### PR TITLE
fix: auto-fetch usage stats on startup when enabled in settings

### DIFF
--- a/crates/tmai-app/src/main.rs
+++ b/crates/tmai-app/src/main.rs
@@ -41,6 +41,9 @@ async fn main() {
             let settings = Settings::default();
             let core = Arc::new(TmaiCoreBuilder::new(settings).build());
 
+            // Auto-fetch usage stats if enabled in settings
+            core.start_initial_usage_fetch();
+
             // Start event bridge
             let _event_bridge = events::start_event_bridge(core.clone(), app.app_handle().clone());
 

--- a/crates/tmai-core/src/api/actions.rs
+++ b/crates/tmai-core/src/api/actions.rs
@@ -697,6 +697,15 @@ impl TmaiCore {
         });
     }
 
+    /// Auto-fetch usage on startup if enabled in settings.
+    pub fn start_initial_usage_fetch(&self) {
+        let settings = self.settings();
+        if settings.usage.enabled {
+            tracing::info!("Usage monitoring enabled — starting initial fetch");
+            self.fetch_usage();
+        }
+    }
+
     /// Kill a specific agent (PTY session or tmux pane)
     pub fn kill_pane(&self, target: &str) -> Result<(), ApiError> {
         // Validate agent exists and is not virtual
@@ -1096,5 +1105,31 @@ mod tests {
         // Agent exists but not in multi-select state — idempotent Ok
         let result = core.submit_selection("main:0.0", &[1]);
         assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_initial_usage_fetch_sets_fetching_when_enabled() {
+        let mut settings = Settings::default();
+        settings.usage.enabled = true;
+        let state = AppState::shared();
+        let core = TmaiCoreBuilder::new(settings)
+            .with_state(state.clone())
+            .build();
+        // Should set fetching=true since usage is enabled
+        core.start_initial_usage_fetch();
+        assert!(state.read().usage.fetching);
+    }
+
+    #[test]
+    fn test_initial_usage_fetch_noop_when_disabled() {
+        let mut settings = Settings::default();
+        settings.usage.enabled = false;
+        let state = AppState::shared();
+        let core = TmaiCoreBuilder::new(settings)
+            .with_state(state.clone())
+            .build();
+        core.start_initial_usage_fetch();
+        // Should not set fetching since usage is disabled
+        assert!(!state.read().usage.fetching);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -164,6 +164,9 @@ async fn run_tmux_mode(settings: Settings, _cli: Config) -> Result<()> {
 
     let core = Arc::new(core_builder.build());
 
+    // Auto-fetch usage stats if enabled in settings
+    core.start_initial_usage_fetch();
+
     // Share core with App for event broadcasting
     app.set_core(core.clone());
 
@@ -309,6 +312,9 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
     }
 
     let core = Arc::new(core_builder.build());
+
+    // Auto-fetch usage stats if enabled in settings
+    core.start_initial_usage_fetch();
 
     // Start web server (required for WebUI mode)
     if !settings.web.enabled {


### PR DESCRIPTION
## Summary
- Add `start_initial_usage_fetch()` to `TmaiCore` that triggers `fetch_usage()` when `usage.enabled = true`
- Call it in all three startup paths: TUI mode, WebUI mode, and Tauri app
- Add unit tests for both enabled and disabled cases

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)