### PR TITLE
feat: press Enter to switch from select mode to input mode

### DIFF
--- a/crates/tmai-app/web/src/components/agent/PreviewPanel.tsx
+++ b/crates/tmai-app/web/src/components/agent/PreviewPanel.tsx
@@ -263,6 +263,21 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
     };
   }, []);
 
+  // In select mode, listen for Enter key on the container to switch to input mode
+  useEffect(() => {
+    if (focused) return;
+    const container = containerRef.current;
+    if (!container) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        enterInputMode();
+      }
+    };
+    container.addEventListener("keydown", onKeyDown);
+    return () => container.removeEventListener("keydown", onKeyDown);
+  }, [focused, enterInputMode]);
+
   // Focus/blur the hidden input when mode changes
   useEffect(() => {
     if (focused) {
@@ -616,7 +631,7 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
         </button>
         <div className="flex-1" />
         <span className="text-[10px] text-zinc-600">
-          {focused ? "click to select" : "click ⌨ to input"}
+          {focused ? "click to select" : "Enter or click ⌨ to input"}
         </span>
       </div>
     </div>

--- a/crates/tmai-app/web/src/components/terminal/TerminalPanel.tsx
+++ b/crates/tmai-app/web/src/components/terminal/TerminalPanel.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useTerminal } from "@/hooks/useTerminal";
 import "@xterm/xterm/css/xterm.css";
 
@@ -26,6 +26,21 @@ export function TerminalPanel({ sessionId }: TerminalPanelProps) {
     setInputMode(false);
     setAttachable(false);
   }, [setAttachable]);
+
+  // In select mode, listen for Enter key on the container to switch to input mode
+  useEffect(() => {
+    if (inputMode) return;
+    const el = containerRef.current;
+    if (!el) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Enter") {
+        e.preventDefault();
+        enterInputMode();
+      }
+    };
+    el.addEventListener("keydown", onKeyDown);
+    return () => el.removeEventListener("keydown", onKeyDown);
+  }, [inputMode, enterInputMode]);
 
   return (
     <section className="relative flex h-full w-full flex-col">
@@ -81,7 +96,7 @@ export function TerminalPanel({ sessionId }: TerminalPanelProps) {
         </button>
         <div className="flex-1" />
         <span className="text-[10px] text-zinc-600">
-          {inputMode ? "click to select" : "click ⌨ to input"}
+          {inputMode ? "click to select" : "Enter or click ⌨ to input"}
         </span>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- Add Enter key listener in select mode to switch to input mode for both PreviewPanel and TerminalPanel
- Update footer hint text to indicate the Enter shortcut (`Enter or click ⌨ to input`)

## Test plan
- [ ] Open WebUI, select an agent in PreviewPanel
- [ ] Click to enter select mode (amber ring appears)
- [ ] Press Enter → verify it switches to input mode (cyan ring)
- [ ] Verify Enter in input mode still sends keystroke to agent (not intercepted)
- [ ] Repeat for TerminalPanel (xterm.js based)

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Enterキーを押すことで、エージェント・ターミナルパネルを入力モードに切り替えられるようになりました。

* **改善**
  * パネルのフッターヒント表示を「Enter or click ⌨ to input」に更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->