### PR TITLE
fix: use straight lines instead of curves for PR base dashed lines in git panel

### DIFF
--- a/crates/tmai-app/web/src/components/worktree/graph/LaneGraph.tsx
+++ b/crates/tmai-app/web/src/components/worktree/graph/LaneGraph.tsx
@@ -264,9 +264,8 @@ export function LaneGraph({
 
             const color = pr.is_draft ? "rgb(161,161,170)" : "rgb(74,222,128)";
 
-            // Curved path for visual clarity
-            const midY = (fromY + toY) / 2;
-            const d = `M ${fromX} ${fromY} C ${fromX} ${midY}, ${toX} ${midY}, ${toX} ${toY}`;
+            // Straight line path for consistency with other connections
+            const d = `M ${fromX} ${fromY} L ${toX} ${toY}`;
 
             // Arrowhead pointing at target lane header
             const arrowSize = 4;


### PR DESCRIPTION
## Summary
- Replace cubic bezier curve (`C` command) with straight line (`L` command) for PR merge-target dashed arrows in LaneGraph
- Ensures visual consistency with all other connection lines (fork/merge/lane vertical/fold) which use straight `<line>` elements

Closes #144

## Test plan
- [ ] Open WebUI with a repo that has open PRs
- [ ] Verify PR base dashed lines render as straight lines, not curves
- [ ] Verify arrowheads still point correctly at target lane headers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **スタイル**
  * ブランチマージターゲット接続パスのビジュアルを改善しました。グラフの接続表示が曲線から直線に変更され、より明確な表示になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->