### PR TITLE
feat: sync sidebar icon state with active right pane panel

### DIFF
--- a/crates/tmai-app/web/src/App.tsx
+++ b/crates/tmai-app/web/src/App.tsx
@@ -99,22 +99,6 @@ export function App() {
     setShowSecurity(false);
   }, []);
 
-  // Select handler for worktrees (from BranchGraph click)
-
-  // Select handler for project branch graph
-  const handleSelectProject = useCallback((path: string, name: string) => {
-    setSelection({ type: "project", path, name });
-    setShowSettings(false);
-    setShowSecurity(false);
-  }, []);
-
-  // Select handler for project markdown viewer
-  const handleSelectMarkdown = useCallback((projectPath: string, projectName: string) => {
-    setSelection({ type: "markdown", projectPath, projectName });
-    setShowSettings(false);
-    setShowSecurity(false);
-  }, []);
-
   // Derive selectedTarget string for components that need it
   const selectedTarget = selection?.type === "agent" ? selection.id : null;
 
@@ -129,6 +113,52 @@ export function App() {
     : null;
   const showSplitView =
     selection?.type === "agent" && agentProjectPath !== null && splitEnabled && !isNarrowScreen;
+
+  // Select handler for project branch graph
+  const handleSelectProject = useCallback(
+    (path: string, name: string) => {
+      // In split-pane mode with matching project, switch tab instead of going fullscreen
+      if (splitEnabled && !isNarrowScreen && selection?.type === "agent" && agentProjectPath) {
+        const matchesAgent = path === agentProjectPath;
+        if (matchesAgent) {
+          if (rightPanelTab === "git") {
+            // Already showing git tab — toggle split view off
+            setSplitEnabled(false);
+          } else {
+            setRightPanelTab("git");
+          }
+          return;
+        }
+      }
+      setSelection({ type: "project", path, name });
+      setShowSettings(false);
+      setShowSecurity(false);
+    },
+    [splitEnabled, isNarrowScreen, selection, agentProjectPath, rightPanelTab, setSplitEnabled],
+  );
+
+  // Select handler for project markdown viewer
+  const handleSelectMarkdown = useCallback(
+    (projectPath: string, projectName: string) => {
+      // In split-pane mode with matching project, switch tab instead of going fullscreen
+      if (splitEnabled && !isNarrowScreen && selection?.type === "agent" && agentProjectPath) {
+        const matchesAgent = projectPath === agentProjectPath;
+        if (matchesAgent) {
+          if (rightPanelTab === "markdown") {
+            // Already showing markdown tab — toggle split view off
+            setSplitEnabled(false);
+          } else {
+            setRightPanelTab("markdown");
+          }
+          return;
+        }
+      }
+      setSelection({ type: "markdown", projectPath, projectName });
+      setShowSettings(false);
+      setShowSecurity(false);
+    },
+    [splitEnabled, isNarrowScreen, selection, agentProjectPath, rightPanelTab, setSplitEnabled],
+  );
 
   // Keyboard shortcuts handlers
   useKeyboardShortcuts([
@@ -221,6 +251,8 @@ export function App() {
           registeredProjects={registeredProjects}
           worktrees={worktrees}
           onSpawned={handleSpawned}
+          splitPaneProjectPath={showSplitView ? agentProjectPath : null}
+          splitPaneTab={showSplitView ? rightPanelTab : null}
         />
         <TerminalList
           terminals={terminals}

--- a/crates/tmai-app/web/src/components/agent/AgentList.tsx
+++ b/crates/tmai-app/web/src/components/agent/AgentList.tsx
@@ -17,6 +17,8 @@ interface AgentListProps {
   registeredProjects: string[];
   worktrees: WorktreeSnapshot[];
   onSpawned: (sessionId: string) => void;
+  splitPaneProjectPath: string | null;
+  splitPaneTab: "git" | "markdown" | null;
 }
 
 // Scrollable list of agents grouped by project and worktree
@@ -30,6 +32,8 @@ export function AgentList({
   registeredProjects,
   worktrees,
   onSpawned,
+  splitPaneProjectPath,
+  splitPaneTab,
 }: AgentListProps) {
   const projects = useMemo(
     () => groupByProject(agents, registeredProjects, worktrees),
@@ -67,6 +71,8 @@ export function AgentList({
           onSelectProject={onSelectProject}
           onSelectMarkdown={onSelectMarkdown}
           onSpawned={onSpawned}
+          splitPaneProjectPath={splitPaneProjectPath}
+          splitPaneTab={splitPaneTab}
         />
       ))}
     </div>

--- a/crates/tmai-app/web/src/components/project/ProjectGroup.tsx
+++ b/crates/tmai-app/web/src/components/project/ProjectGroup.tsx
@@ -12,6 +12,8 @@ interface ProjectGroupProps {
   onSelectProject: (path: string, name: string) => void;
   onSelectMarkdown: (projectPath: string, projectName: string) => void;
   onSpawned: (sessionId: string) => void;
+  splitPaneProjectPath: string | null;
+  splitPaneTab: "git" | "markdown" | null;
 }
 
 // Collapsible project group containing worktree sub-groups
@@ -22,6 +24,8 @@ export function ProjectGroup({
   onSelectProject,
   onSelectMarkdown,
   onSpawned,
+  splitPaneProjectPath,
+  splitPaneTab,
 }: ProjectGroupProps) {
   const [collapsed, setCollapsed] = useState(false);
   const [showSpawn, setShowSpawn] = useState(false);
@@ -49,9 +53,14 @@ export function ProjectGroup({
 
   // Derive selectedTarget for agent card highlighting
   const selectedTarget = selection?.type === "agent" ? selection.id : null;
-  const isProjectSelected = selection?.type === "project" && selection.path === project.path;
+  // Icon is active when shown fullscreen OR in split-pane right panel
+  const isSplitForThisProject = splitPaneProjectPath === project.path;
+  const isProjectSelected =
+    (selection?.type === "project" && selection.path === project.path) ||
+    (isSplitForThisProject && splitPaneTab === "git");
   const isMarkdownSelected =
-    selection?.type === "markdown" && selection.projectPath === project.path;
+    (selection?.type === "markdown" && selection.projectPath === project.path) ||
+    (isSplitForThisProject && splitPaneTab === "markdown");
 
   // Spawn an agent in a specific directory
   const confirm = useConfirm();


### PR DESCRIPTION
## Summary
- Sidebar git/markdown icons now highlight when their panel is active in the split-pane right panel, not just in fullscreen mode
- In split-pane mode, clicking a sidebar icon switches the right pane tab instead of opening fullscreen
- Clicking the already-active icon toggles split view off (close right pane)

Closes #145

## Test plan
- [ ] Select an agent with split-pane enabled (`\` shortcut) — verify git icon is highlighted in sidebar
- [ ] Click markdown icon — verify right pane switches to markdown tab, markdown icon highlights, git icon unhighlights
- [ ] Click highlighted markdown icon again — verify split view closes
- [ ] Click git/markdown icon for a **different** project — verify it still opens fullscreen (not split-pane)
- [ ] In non-split mode, verify icons still work as before (fullscreen)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 分割ビューモードでのプロジェクト選択動作を改善しました。エージェント選択中に分割ビューが有効な場合、プロジェクトをクリックするとフルスクリーン表示に切り替わるのではなく、右パネルのタブが直接更新されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->