### PR TITLE
fix: worktree delete fails for .git/.claude/worktrees/ path

### DIFF
--- a/crates/tmai-core/src/worktree/ops.rs
+++ b/crates/tmai-core/src/worktree/ops.rs
@@ -96,14 +96,26 @@ pub async fn delete_worktree(req: &WorktreeDeleteRequest) -> Result<(), Worktree
         return Err(WorktreeOpsError::InvalidName(req.worktree_name.clone()));
     }
 
-    let worktree_dir = Path::new(&req.repo_path)
-        .join(".claude")
-        .join("worktrees")
-        .join(&req.worktree_name);
-
-    if !worktree_dir.exists() {
-        return Err(WorktreeOpsError::NotFound(req.worktree_name.clone()));
-    }
+    // Try both `<repo>/.claude/worktrees/<name>` and `<repo>/.git/.claude/worktrees/<name>`
+    // Claude Code may create worktrees under `.git/.claude/worktrees/`
+    let worktree_dir = {
+        let primary = Path::new(&req.repo_path)
+            .join(".claude")
+            .join("worktrees")
+            .join(&req.worktree_name);
+        if primary.exists() {
+            primary
+        } else {
+            let fallback = Path::new(&req.repo_path)
+                .join(".git/.claude/worktrees")
+                .join(&req.worktree_name);
+            if fallback.exists() {
+                fallback
+            } else {
+                return Err(WorktreeOpsError::NotFound(req.worktree_name.clone()));
+            }
+        }
+    };
 
     // Check for uncommitted changes unless force
     if !req.force {


### PR DESCRIPTION
## Summary
- Worktree delete API returned NotFound when the worktree lived under `.git/.claude/worktrees/` instead of `.claude/worktrees/`
- Claude Code creates worktrees in the `.git/` variant; `delete_worktree` only checked the non-`.git/` path
- Now falls back to `.git/.claude/worktrees/{name}` when the primary path doesn't exist

## Test plan
- [ ] Create a worktree via "Create & Resolve" → verify it can be deleted from UI
- [ ] Existing worktrees under `.git/.claude/worktrees/` can be deleted
- [ ] `cargo test -p tmai-core worktree` passes (37 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)