### PR TITLE
fix: keep issues tab stable when spawning worktree from git panel

### DIFF
--- a/crates/tmai-app/web/src/components/worktree/BranchGraph.tsx
+++ b/crates/tmai-app/web/src/components/worktree/BranchGraph.tsx
@@ -329,14 +329,12 @@ export function BranchGraph({
     return () => clearInterval(interval);
   }, [projectPath]);
 
-  // Handle start-work completion: switch back to graph, refresh, select new branch
+  // Handle start-work completion: refresh data in background, stay on current tab
   const handleStartWorkDone = useCallback(
-    (worktreeName: string) => {
-      setShowIssues(false);
-      setSelectedIssue(null);
+    (_worktreeName: string) => {
+      // Don't switch tabs or clear selection — keep the issues panel stable.
+      // The ActionPanel will auto-detect the matching worktree and show its status.
       refreshBranches();
-      // Select the new branch after data refreshes
-      setTimeout(() => setSelectedNode(worktreeName), 500);
     },
     [refreshBranches],
   );


### PR DESCRIPTION
## Summary
- Remove tab-switching (`setShowIssues(false)`) and state reset (`setSelectedIssue(null)`) from `handleStartWorkDone` callback in BranchGraph
- The git panel now stays on the issues tab after worktree spawn, eliminating both the split-pane layout flicker and the tab reset
- ActionPanel's existing `matchingWorktree` logic auto-detects the new worktree and shows its status naturally

Closes #147

## Test plan
- [ ] Open split-pane view with git panel on issues tab
- [ ] Spawn a worktree from an issue (Create & Resolve)
- [ ] Verify: split-pane layout remains stable (no fullscreen flash)
- [ ] Verify: git panel stays on issues tab
- [ ] Verify: ActionPanel shows "Worktree Exists" / "Agent In Progress" for the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)