### PR TITLE
fix: increase transcript record limit for full session scrollback

### DIFF
--- a/crates/tmai-core/src/transcript/types.rs
+++ b/crates/tmai-core/src/transcript/types.rs
@@ -19,8 +19,9 @@ pub enum TranscriptRecord {
     ToolResult { output_summary: String },
 }
 
-/// Maximum number of recent records to retain per transcript
-pub const MAX_RECENT_RECORDS: usize = 50;
+/// Maximum number of recent records to retain per transcript.
+/// Set high to preserve full session history for hybrid scrollback preview.
+pub const MAX_RECENT_RECORDS: usize = 10_000;
 
 /// Tracked state for a single transcript file
 #[derive(Debug, Clone)]
@@ -73,7 +74,7 @@ mod tests {
             "sess".to_string(),
             "5".to_string(),
         );
-        let records: Vec<TranscriptRecord> = (0..60)
+        let records: Vec<TranscriptRecord> = (0..10_050)
             .map(|i| TranscriptRecord::User {
                 text: format!("msg {}", i),
             })


### PR DESCRIPTION
## Summary
- `MAX_RECENT_RECORDS` was 50, far too few for the hybrid scrollback preview to reach session start
- Increased to 10,000 to preserve full conversation history
- Hybrid scrollback (#177) depends on this to enable scrolling back through the entire session

## Test plan
- [x] `cargo test -p tmai-core transcript` passes
- [ ] Manual: verify scrolling back to session start works in WebUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 会話履歴の保持上限を拡大し、より長い会話履歴を管理・参照できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->