### PR TITLE
fix: read full session transcript on initial load for scrollback

### DIFF
--- a/crates/tmai-core/src/transcript/watcher.rs
+++ b/crates/tmai-core/src/transcript/watcher.rs
@@ -24,8 +24,9 @@ pub fn new_transcript_registry() -> TranscriptRegistry {
 /// Maximum preview lines to render
 const MAX_PREVIEW_LINES: usize = 80;
 
-/// Number of tail lines to read on initial file open
-const INITIAL_TAIL_LINES: usize = 100;
+/// Number of tail lines to read on initial file open.
+/// Set high to load full session history for hybrid scrollback preview.
+const INITIAL_TAIL_LINES: usize = 50_000;
 
 /// Transcript watcher that monitors JSONL files for changes
 pub struct TranscriptWatcher {


### PR DESCRIPTION
## Summary
- `INITIAL_TAIL_LINES` was 100, limiting the initial JSONL read to the last 100 lines
- Combined with the previous `MAX_RECENT_RECORDS=50` fix (#179), this was the second bottleneck preventing full session scrollback
- Increased to 50,000 to effectively load the entire session on startup

## Test plan
- [x] `cargo test -p tmai-core transcript` passes
- [ ] Manual: verify scrolling back to session start works in WebUI

🤖 Generated with [Claude Code](https://claude.com/claude-code)