### PR TITLE
feat: hybrid ANSI preview pipeline independent of capture-pane

### DIFF
--- a/crates/tmai-core/src/monitor/poller.rs
+++ b/crates/tmai-core/src/monitor/poller.rs
@@ -108,6 +108,8 @@ pub struct Poller {
     session_scanner: crate::session_discovery::SessionDiscoveryScanner,
     /// Transcript watcher for JSONL conversation log monitoring
     transcript_watcher: crate::transcript::TranscriptWatcher,
+    /// Pipe-pane log registry for vt100-processed ANSI capture
+    pipe_log_registry: crate::tmux::PipeLogRegistry,
 }
 
 /// Check if a PID is a descendant (child, grandchild, ...) of any PID in the set.
@@ -178,6 +180,7 @@ impl Poller {
             transcript_watcher: crate::transcript::TranscriptWatcher::new(
                 crate::transcript::watcher::new_transcript_registry(),
             ),
+            pipe_log_registry: crate::tmux::pipe_log::new_pipe_log_registry(),
         }
     }
 
@@ -220,6 +223,7 @@ impl Poller {
             event_tx: None,
             session_scanner: crate::session_discovery::SessionDiscoveryScanner::new(),
             transcript_watcher: crate::transcript::TranscriptWatcher::new(transcript_registry),
+            pipe_log_registry: crate::tmux::pipe_log::new_pipe_log_registry(),
         }
     }
 
@@ -342,9 +346,10 @@ impl Poller {
                         self.discover_sessions();
                     }
 
-                    // Transcript polling (every 2 polls ≈ 1 second)
+                    // Transcript + pipe-log polling (every 2 polls ≈ 1 second)
                     if poll_count.is_multiple_of(2) {
                         self.transcript_watcher.poll_updates();
+                        self.poll_pipe_logs();
                     }
 
                     // Audit: track state transitions
@@ -592,32 +597,77 @@ impl Poller {
                     (String::new(), plain)
                 };
 
-                // Fallback chain for empty content (standalone/webui mode):
-                // 1. transcript preview (D-2) — richest
-                // 2. activity log (D-1) — lightweight
+                // Fallback chain for empty/degraded content:
+                //
+                // capture-pane may return only visible area (virtual scroll)
+                // or be completely empty (standalone mode). Fall through:
+                //
+                // 1. pipe-pane log (vt100-processed) — real ANSI from stream
+                // 2. JSONL ANSI renderer — synthesized ANSI from transcript
+                // 3. JSONL plain preview — minimal text
+                // 4. activity log — lightweight hook events
                 if content.trim().is_empty() {
-                    // Try transcript preview first
-                    let transcript_preview = {
+                    // Tier 1: pipe-pane log (ANSI)
+                    let pipe_ansi = {
+                        let p_reg = self.pipe_log_registry.read();
+                        p_reg
+                            .get(&pane.pane_id)
+                            .filter(|ps| !ps.ansi_output.is_empty())
+                            .map(|ps| ps.ansi_output.clone())
+                    };
+
+                    if let Some(ansi) = pipe_ansi {
+                        content_ansi = ansi;
+                        content = strip_ansi(&content_ansi);
+                    } else {
+                        // Tier 2: JSONL ANSI preview
+                        let transcript_previews = {
+                            let t_reg = self.transcript_watcher.registry().read();
+                            t_reg.get(&pane.pane_id).and_then(|ts| {
+                                if !ts.ansi_preview_text.is_empty() {
+                                    Some((
+                                        ts.ansi_preview_text.clone(),
+                                        ts.preview_text.clone(),
+                                    ))
+                                } else if !ts.preview_text.is_empty() {
+                                    // Tier 3: plain preview only
+                                    Some((
+                                        ts.preview_text.clone(),
+                                        ts.preview_text.clone(),
+                                    ))
+                                } else {
+                                    None
+                                }
+                            })
+                        };
+
+                        if let Some((ansi_preview, plain_preview)) = transcript_previews {
+                            content_ansi = ansi_preview;
+                            content = plain_preview;
+                        } else if let Some(ref hs) = hook_state {
+                            // Tier 4: activity log
+                            if !hs.activity_log.is_empty() {
+                                let log_text =
+                                    crate::hooks::handler::format_activity_log(&hs.activity_log);
+                                if !log_text.is_empty() {
+                                    content = log_text.clone();
+                                    content_ansi = log_text;
+                                }
+                            }
+                        }
+                    }
+                } else if content_ansi.is_empty() {
+                    // capture-pane plain succeeded but ANSI is missing:
+                    // enrich with JSONL ANSI if available
+                    let ansi_preview = {
                         let t_reg = self.transcript_watcher.registry().read();
                         t_reg
                             .get(&pane.pane_id)
-                            .filter(|ts| !ts.preview_text.is_empty())
-                            .map(|ts| ts.preview_text.clone())
+                            .filter(|ts| !ts.ansi_preview_text.is_empty())
+                            .map(|ts| ts.ansi_preview_text.clone())
                     };
-
-                    if let Some(preview) = transcript_preview {
-                        content = preview.clone();
-                        content_ansi = preview;
-                    } else if let Some(ref hs) = hook_state {
-                        // Fallback to activity log
-                        if !hs.activity_log.is_empty() {
-                            let log_text =
-                                crate::hooks::handler::format_activity_log(&hs.activity_log);
-                            if !log_text.is_empty() {
-                                content = log_text.clone();
-                                content_ansi = log_text;
-                            }
-                        }
+                    if let Some(ansi) = ansi_preview {
+                        content_ansi = ansi;
                     }
                 }
 
@@ -1736,6 +1786,21 @@ impl Poller {
                 agent.is_worktree = Some(info.is_worktree);
                 agent.git_common_dir = info.common_dir.clone();
                 agent.worktree_name = crate::git::extract_claude_worktree_name(&agent.cwd);
+            }
+        }
+    }
+
+    /// Poll all active pipe-pane log files for new data.
+    fn poll_pipe_logs(&self) {
+        let pane_ids: Vec<String> = {
+            let reg = self.pipe_log_registry.read();
+            reg.keys().cloned().collect()
+        };
+
+        for pane_id in pane_ids {
+            let mut reg = self.pipe_log_registry.write();
+            if let Some(state) = reg.get_mut(&pane_id) {
+                crate::tmux::pipe_log::poll_pipe_log(state);
             }
         }
     }

--- a/crates/tmai-core/src/tmux/client.rs
+++ b/crates/tmai-core/src/tmux/client.rs
@@ -572,6 +572,57 @@ impl TmuxClient {
         Ok(())
     }
 
+    /// Start piping pane output to a log file.
+    ///
+    /// Uses `tmux pipe-pane` to stream the raw byte output (including ANSI
+    /// escape codes) of a pane into a file. Unlike `capture-pane`, this
+    /// captures the live output stream and is unaffected by virtual scrolling.
+    ///
+    /// The log file is created at the given `log_path`. If pipe-pane is
+    /// already active for this pane, tmux silently replaces the old pipe.
+    pub fn start_pipe_pane(&self, target: &str, log_path: &str) -> Result<()> {
+        validate_target(target)?;
+        // Validate log_path: must be an absolute path with safe characters
+        if !log_path.starts_with('/') && !log_path.contains(":\\") && !log_path.starts_with("\\") {
+            anyhow::bail!("pipe-pane log_path must be absolute: {}", log_path);
+        }
+
+        let output = Command::new("tmux")
+            .args([
+                "pipe-pane",
+                "-o",
+                "-t",
+                target,
+                &format!("cat >> '{}'", log_path),
+            ])
+            .output()
+            .context("Failed to execute tmux pipe-pane")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("tmux pipe-pane failed for {}: {}", target, stderr);
+        }
+
+        Ok(())
+    }
+
+    /// Stop piping pane output (cancel an active pipe-pane).
+    pub fn stop_pipe_pane(&self, target: &str) -> Result<()> {
+        validate_target(target)?;
+        // Calling pipe-pane with no command cancels any existing pipe
+        let output = Command::new("tmux")
+            .args(["pipe-pane", "-t", target])
+            .output()
+            .context("Failed to execute tmux pipe-pane (stop)")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("tmux pipe-pane (stop) failed for {}: {}", target, stderr);
+        }
+
+        Ok(())
+    }
+
     /// Kill a specific pane
     pub fn kill_pane(&self, target: &str) -> Result<()> {
         validate_target(target)?;

--- a/crates/tmai-core/src/tmux/mod.rs
+++ b/crates/tmai-core/src/tmux/mod.rs
@@ -1,7 +1,9 @@
 mod client;
 mod pane;
+pub mod pipe_log;
 mod process;
 
 pub use client::TmuxClient;
 pub use pane::PaneInfo;
+pub use pipe_log::{PipeLogRegistry, PipeLogState};
 pub use process::ProcessCache;

--- a/crates/tmai-core/src/tmux/pipe_log.rs
+++ b/crates/tmai-core/src/tmux/pipe_log.rs
@@ -1,0 +1,313 @@
+//! Pipe-pane log reader with vt100 terminal emulation.
+//!
+//! Reads raw terminal output captured by `tmux pipe-pane` and processes it
+//! through a `vt100::Parser` to produce clean, renderable ANSI output.
+//! This eliminates raw cursor movement sequences, screen clears, etc.,
+//! leaving only meaningful text with color/style ANSI codes.
+
+use std::collections::HashMap;
+use std::io::{Read, Seek, SeekFrom};
+use std::path::Path;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
+use tracing::debug;
+
+/// State for a single pipe-pane log file
+pub struct PipeLogState {
+    /// Path to the log file
+    pub path: String,
+    /// Pane target (e.g. "main:0.1")
+    pub target: String,
+    /// Last read position in the file (byte offset)
+    pub last_read_pos: u64,
+    /// vt100 parser instance (accumulates terminal state)
+    parser: vt100::Parser,
+    /// Cached ANSI output (regenerated on new data)
+    pub ansi_output: String,
+}
+
+impl PipeLogState {
+    /// Create a new PipeLogState for the given pane.
+    ///
+    /// `rows` and `cols` set the virtual terminal dimensions for the vt100 parser.
+    pub fn new(path: String, target: String, rows: u16, cols: u16) -> Self {
+        Self {
+            path,
+            target,
+            last_read_pos: 0,
+            parser: vt100::Parser::new(rows, cols, 1000), // 1000 lines scrollback
+            ansi_output: String::new(),
+        }
+    }
+}
+
+/// Shared registry: pane_id → PipeLogState
+pub type PipeLogRegistry = Arc<RwLock<HashMap<String, PipeLogState>>>;
+
+/// Create a new empty pipe-log registry
+pub fn new_pipe_log_registry() -> PipeLogRegistry {
+    Arc::new(RwLock::new(HashMap::new()))
+}
+
+/// Read new data from a pipe-pane log file and process through vt100.
+///
+/// Returns `true` if new data was processed.
+pub fn poll_pipe_log(state: &mut PipeLogState) -> bool {
+    let path = Path::new(&state.path);
+    if !path.exists() {
+        return false;
+    }
+
+    let file = match std::fs::File::open(path) {
+        Ok(f) => f,
+        Err(_) => return false,
+    };
+
+    let metadata = match file.metadata() {
+        Ok(m) => m,
+        Err(_) => return false,
+    };
+
+    let current_size = metadata.len();
+    if current_size <= state.last_read_pos {
+        if current_size < state.last_read_pos {
+            // File was truncated — reset
+            debug!(path = %state.path, "Pipe log truncated, resetting");
+            state.last_read_pos = 0;
+            state.parser = vt100::Parser::new(
+                state.parser.screen().size().0,
+                state.parser.screen().size().1,
+                1000,
+            );
+        }
+        return false;
+    }
+
+    let mut reader = std::io::BufReader::new(file);
+    if reader.seek(SeekFrom::Start(state.last_read_pos)).is_err() {
+        return false;
+    }
+
+    let mut buf = Vec::with_capacity((current_size - state.last_read_pos) as usize);
+    if reader.read_to_end(&mut buf).is_err() {
+        return false;
+    }
+
+    if buf.is_empty() {
+        return false;
+    }
+
+    // Feed raw bytes through vt100 terminal emulator
+    state.parser.process(&buf);
+
+    // Extract the rendered screen content with ANSI codes
+    state.ansi_output = screen_to_ansi(state.parser.screen());
+    state.last_read_pos = current_size;
+
+    true
+}
+
+/// Convert a vt100 screen to a string with ANSI color/style escape codes.
+///
+/// Iterates through each row of the screen and emits ANSI SGR sequences
+/// for foreground/background colors, bold, underline, etc.
+fn screen_to_ansi(screen: &vt100::Screen) -> String {
+    let (rows, cols) = screen.size();
+    let mut output = String::new();
+    let mut trailing_blank_rows = 0;
+
+    for row in 0..rows {
+        let mut line = String::new();
+        let mut current_attrs = CellAttrs::default();
+
+        for col in 0..cols {
+            let cell = screen.cell(row, col).unwrap();
+            let attrs = CellAttrs::from_cell(&cell);
+
+            if attrs != current_attrs {
+                // Emit SGR reset + new attributes
+                line.push_str("\x1b[0");
+                attrs.write_sgr(&mut line);
+                line.push('m');
+                current_attrs = attrs;
+            }
+
+            let ch = cell.contents();
+            if ch.is_empty() {
+                line.push(' ');
+            } else {
+                line.push_str(&ch);
+            }
+        }
+
+        // Reset at end of line if we had attributes
+        if current_attrs != CellAttrs::default() {
+            line.push_str("\x1b[0m");
+        }
+
+        // Trim trailing spaces
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            trailing_blank_rows += 1;
+        } else {
+            // Flush any accumulated blank rows
+            for _ in 0..trailing_blank_rows {
+                output.push('\n');
+            }
+            trailing_blank_rows = 0;
+
+            if !output.is_empty() {
+                output.push('\n');
+            }
+            output.push_str(trimmed);
+        }
+    }
+
+    output
+}
+
+/// Extracted cell attributes for SGR comparison
+#[derive(Clone, PartialEq, Eq)]
+struct CellAttrs {
+    fg: vt100::Color,
+    bg: vt100::Color,
+    bold: bool,
+    italic: bool,
+    underline: bool,
+    inverse: bool,
+}
+
+impl Default for CellAttrs {
+    fn default() -> Self {
+        Self {
+            fg: vt100::Color::Default,
+            bg: vt100::Color::Default,
+            bold: false,
+            italic: false,
+            underline: false,
+            inverse: false,
+        }
+    }
+}
+
+impl CellAttrs {
+    fn from_cell(cell: &vt100::Cell) -> Self {
+        Self {
+            fg: cell.fgcolor(),
+            bg: cell.bgcolor(),
+            bold: cell.bold(),
+            italic: cell.italic(),
+            underline: cell.underline(),
+            inverse: cell.inverse(),
+        }
+    }
+
+    fn write_sgr(&self, out: &mut String) {
+        if self.bold {
+            out.push_str(";1");
+        }
+        if self.italic {
+            out.push_str(";3");
+        }
+        if self.underline {
+            out.push_str(";4");
+        }
+        if self.inverse {
+            out.push_str(";7");
+        }
+        if self.fg != vt100::Color::Default {
+            write_color_sgr(out, &self.fg, false);
+        }
+        if self.bg != vt100::Color::Default {
+            write_color_sgr(out, &self.bg, true);
+        }
+    }
+}
+
+fn write_color_sgr(out: &mut String, color: &vt100::Color, is_bg: bool) {
+    let base = if is_bg { 40 } else { 30 };
+    match color {
+        vt100::Color::Default => {}
+        vt100::Color::Idx(idx) => {
+            if *idx < 8 {
+                out.push_str(&format!(";{}", base + idx));
+            } else if *idx < 16 {
+                out.push_str(&format!(";{}", base + 60 + idx - 8));
+            } else {
+                // 256-color
+                out.push_str(&format!(";{}8;5;{}", if is_bg { 4 } else { 3 }, idx));
+            }
+        }
+        vt100::Color::Rgb(r, g, b) => {
+            out.push_str(&format!(
+                ";{}8;2;{};{};{}",
+                if is_bg { 4 } else { 3 },
+                r,
+                g,
+                b
+            ));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_new_pipe_log_state() {
+        let state = PipeLogState::new("/tmp/test.log".to_string(), "main:0.1".to_string(), 24, 80);
+        assert_eq!(state.last_read_pos, 0);
+        assert!(state.ansi_output.is_empty());
+    }
+
+    #[test]
+    fn test_screen_to_ansi_empty() {
+        let parser = vt100::Parser::new(24, 80, 0);
+        let result = screen_to_ansi(parser.screen());
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_screen_to_ansi_plain_text() {
+        let mut parser = vt100::Parser::new(24, 80, 0);
+        parser.process(b"Hello, World!");
+        let result = screen_to_ansi(parser.screen());
+        assert!(result.contains("Hello, World!"));
+    }
+
+    #[test]
+    fn test_screen_to_ansi_with_colors() {
+        let mut parser = vt100::Parser::new(24, 80, 0);
+        // Red text
+        parser.process(b"\x1b[31mRed text\x1b[0m Normal");
+        let result = screen_to_ansi(parser.screen());
+        assert!(result.contains("Red text"));
+        assert!(result.contains("Normal"));
+        // Should contain SGR sequences
+        assert!(result.contains("\x1b["));
+    }
+
+    #[test]
+    fn test_poll_pipe_log_nonexistent() {
+        let mut state = PipeLogState::new(
+            "/tmp/nonexistent_pipe_log_test_12345.log".to_string(),
+            "main:0.1".to_string(),
+            24,
+            80,
+        );
+        assert!(!poll_pipe_log(&mut state));
+    }
+
+    #[test]
+    fn test_poll_pipe_log_with_file() {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        let path = tmp.path().to_str().unwrap().to_string();
+        std::fs::write(&path, "Hello from pipe-pane\r\n").unwrap();
+
+        let mut state = PipeLogState::new(path, "main:0.1".to_string(), 24, 80);
+        assert!(poll_pipe_log(&mut state));
+        assert!(state.ansi_output.contains("Hello from pipe-pane"));
+    }
+}

--- a/crates/tmai-core/src/transcript/ansi_renderer.rs
+++ b/crates/tmai-core/src/transcript/ansi_renderer.rs
@@ -1,0 +1,373 @@
+//! ANSI-rich preview renderer for transcript records.
+//!
+//! Converts parsed [`TranscriptRecord`]s into terminal output with ANSI
+//! color/style codes, producing a visually rich preview that does not
+//! depend on `tmux capture-pane`.
+//!
+//! Design notes:
+//! - Markdown → ANSI conversion is intentionally simple (no external crate).
+//!   It handles headings, bold, italic, inline code, code blocks, and lists.
+//! - Tool use / tool result records get distinct colored prefixes.
+//! - The output is suitable for direct display in an xterm-compatible
+//!   terminal or for conversion to HTML via `ansi_up`.
+
+use super::types::TranscriptRecord;
+
+// ── ANSI escape helpers ──────────────────────────────────────────────
+
+const RESET: &str = "\x1b[0m";
+const BOLD: &str = "\x1b[1m";
+const DIM: &str = "\x1b[2m";
+const ITALIC: &str = "\x1b[3m";
+
+// Foreground colors
+const FG_GREEN: &str = "\x1b[32m";
+const FG_YELLOW: &str = "\x1b[33m";
+const FG_BLUE: &str = "\x1b[34m";
+const FG_MAGENTA: &str = "\x1b[35m";
+const FG_CYAN: &str = "\x1b[36m";
+const FG_WHITE: &str = "\x1b[37m";
+const FG_BRIGHT_BLACK: &str = "\x1b[90m";
+
+// Background for code blocks
+const BG_CODE: &str = "\x1b[48;5;236m"; // dark grey background
+
+// ── Public API ───────────────────────────────────────────────────────
+
+/// Render transcript records into ANSI-colored preview text.
+///
+/// This is the ANSI-rich counterpart of [`super::renderer::render_preview`].
+/// The output contains escape codes for colors, bold, italic, etc.
+pub fn render_ansi_preview(records: &[TranscriptRecord], max_lines: usize) -> String {
+    let mut lines: Vec<String> = Vec::new();
+
+    for record in records {
+        match record {
+            TranscriptRecord::User { text } => {
+                render_user_message(&mut lines, text);
+            }
+            TranscriptRecord::AssistantText { text } => {
+                render_assistant_message(&mut lines, text);
+            }
+            TranscriptRecord::ToolUse {
+                tool_name,
+                input_summary,
+            } => {
+                render_tool_use(&mut lines, tool_name, input_summary);
+            }
+            TranscriptRecord::ToolResult { output_summary } => {
+                render_tool_result(&mut lines, output_summary);
+            }
+        }
+    }
+
+    // Keep only last max_lines
+    if lines.len() > max_lines {
+        let start = lines.len() - max_lines;
+        lines = lines[start..].to_vec();
+    }
+
+    lines.join("\n")
+}
+
+// ── Record renderers ─────────────────────────────────────────────────
+
+fn render_user_message(lines: &mut Vec<String>, text: &str) {
+    let first_line = text.lines().next().unwrap_or(text);
+    let truncated = truncate_chars(first_line, 120);
+    // Separator + green user prefix
+    lines.push(format!(
+        "{DIM}{FG_BRIGHT_BLACK}─────────────────────────────────{RESET}"
+    ));
+    lines.push(format!("{BOLD}{FG_GREEN}▶ User:{RESET} {}", truncated));
+}
+
+fn render_assistant_message(lines: &mut Vec<String>, text: &str) {
+    // Check for embedded tool-use markers like "[⚙ Bash: ls]"
+    for line in text.lines() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("[⚙") && trimmed.ends_with(']') {
+            // Inline tool use from parser — render as tool badge
+            let inner = &trimmed[1..trimmed.len() - 1]; // strip [ ]
+            lines.push(format!("  {FG_YELLOW}{inner}{RESET}"));
+        } else {
+            // Render as markdown-ish ANSI
+            let rendered = render_markdown_line(trimmed);
+            lines.push(format!("  {}", rendered));
+        }
+    }
+}
+
+fn render_tool_use(lines: &mut Vec<String>, tool_name: &str, input_summary: &str) {
+    let color = tool_color(tool_name);
+    if input_summary.is_empty() {
+        lines.push(format!("  {color}{BOLD}⚙ {tool_name}{RESET}"));
+    } else {
+        let summary = truncate_chars(input_summary, 100);
+        lines.push(format!(
+            "  {color}{BOLD}⚙ {tool_name}:{RESET}{color} {summary}{RESET}"
+        ));
+    }
+}
+
+fn render_tool_result(lines: &mut Vec<String>, output_summary: &str) {
+    let first_line = output_summary.lines().next().unwrap_or(output_summary);
+    let truncated = truncate_chars(first_line, 100);
+    lines.push(format!("  {FG_GREEN}✓{RESET} {DIM}{truncated}{RESET}"));
+}
+
+// ── Markdown-lite ANSI rendering ─────────────────────────────────────
+
+/// Render a single line of markdown-like text with ANSI codes.
+///
+/// Supported syntax:
+/// - `# Heading` → bold + blue
+/// - `**bold**` → bold
+/// - `*italic*` / `_italic_` → italic
+/// - `` `code` `` → cyan on dark bg
+/// - ```` ```code block``` ```` → handled by caller (multiline)
+/// - `- item` / `* item` → bullet with color
+fn render_markdown_line(line: &str) -> String {
+    // Headings
+    if let Some(rest) = line.strip_prefix("### ") {
+        return format!("{BOLD}{FG_BLUE}### {rest}{RESET}");
+    }
+    if let Some(rest) = line.strip_prefix("## ") {
+        return format!("{BOLD}{FG_BLUE}## {rest}{RESET}");
+    }
+    if let Some(rest) = line.strip_prefix("# ") {
+        return format!("{BOLD}{FG_BLUE}# {rest}{RESET}");
+    }
+
+    // Code block fence
+    if line.starts_with("```") {
+        return format!("{DIM}{FG_BRIGHT_BLACK}{line}{RESET}");
+    }
+
+    // Bullet lists
+    if line.starts_with("- ") || line.starts_with("* ") {
+        let rest = &line[2..];
+        let rendered = render_inline_formatting(rest);
+        return format!("{FG_CYAN}•{RESET} {rendered}");
+    }
+
+    // Numbered lists
+    if let Some(pos) = line.find(". ") {
+        let prefix = &line[..pos];
+        if !prefix.is_empty() && prefix.chars().all(|c| c.is_ascii_digit()) {
+            let rest = &line[pos + 2..];
+            let rendered = render_inline_formatting(rest);
+            return format!("{FG_CYAN}{prefix}.{RESET} {rendered}");
+        }
+    }
+
+    render_inline_formatting(line)
+}
+
+/// Process inline formatting: **bold**, *italic*, `code`
+fn render_inline_formatting(text: &str) -> String {
+    let mut result = String::with_capacity(text.len() * 2);
+    let chars: Vec<char> = text.chars().collect();
+    let len = chars.len();
+    let mut i = 0;
+
+    while i < len {
+        // Inline code: `...`
+        if chars[i] == '`' {
+            if let Some(end) = find_closing(&chars, i + 1, '`') {
+                let code_text: String = chars[i + 1..end].iter().collect();
+                result.push_str(&format!("{BG_CODE}{FG_CYAN}{code_text}{RESET}"));
+                i = end + 1;
+                continue;
+            }
+        }
+
+        // Bold: **...**
+        if i + 1 < len && chars[i] == '*' && chars[i + 1] == '*' {
+            if let Some(end) = find_closing_double(&chars, i + 2, '*') {
+                let bold_text: String = chars[i + 2..end].iter().collect();
+                result.push_str(&format!("{BOLD}{bold_text}{RESET}"));
+                i = end + 2;
+                continue;
+            }
+        }
+
+        // Italic: *...*
+        if chars[i] == '*' && (i + 1 < len && chars[i + 1] != '*') {
+            if let Some(end) = find_closing(&chars, i + 1, '*') {
+                let italic_text: String = chars[i + 1..end].iter().collect();
+                result.push_str(&format!("{ITALIC}{italic_text}{RESET}"));
+                i = end + 1;
+                continue;
+            }
+        }
+
+        result.push(chars[i]);
+        i += 1;
+    }
+
+    result
+}
+
+/// Find closing single delimiter
+fn find_closing(chars: &[char], start: usize, delimiter: char) -> Option<usize> {
+    for i in start..chars.len() {
+        if chars[i] == delimiter {
+            return Some(i);
+        }
+    }
+    None
+}
+
+/// Find closing double delimiter (e.g. **)
+fn find_closing_double(chars: &[char], start: usize, delimiter: char) -> Option<usize> {
+    for i in start..chars.len().saturating_sub(1) {
+        if chars[i] == delimiter && chars[i + 1] == delimiter {
+            return Some(i);
+        }
+    }
+    None
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────
+
+/// Assign a color to a tool name for visual distinction
+fn tool_color(tool_name: &str) -> &'static str {
+    match tool_name {
+        "Bash" => FG_YELLOW,
+        "Read" => FG_CYAN,
+        "Edit" | "Write" => FG_MAGENTA,
+        "Grep" | "Glob" => FG_BLUE,
+        "Agent" => FG_GREEN,
+        _ => FG_WHITE,
+    }
+}
+
+/// Truncate a string at a char boundary, respecting UTF-8
+fn truncate_chars(s: &str, max_chars: usize) -> String {
+    let truncated: String = s.chars().take(max_chars).collect();
+    if truncated.len() < s.len() {
+        format!("{}...", truncated)
+    } else {
+        truncated
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_user_message() {
+        let records = vec![TranscriptRecord::User {
+            text: "Fix the bug".to_string(),
+        }];
+        let result = render_ansi_preview(&records, 100);
+        assert!(result.contains("▶ User:"));
+        assert!(result.contains("Fix the bug"));
+        // Should contain ANSI codes
+        assert!(result.contains("\x1b["));
+    }
+
+    #[test]
+    fn test_render_assistant_with_markdown() {
+        let records = vec![TranscriptRecord::AssistantText {
+            text: "# Heading\n**bold text** and `code`".to_string(),
+        }];
+        let result = render_ansi_preview(&records, 100);
+        assert!(result.contains("Heading"));
+        assert!(result.contains("bold text"));
+        assert!(result.contains("code"));
+    }
+
+    #[test]
+    fn test_render_tool_use_colored() {
+        let records = vec![TranscriptRecord::ToolUse {
+            tool_name: "Bash".to_string(),
+            input_summary: "cargo test".to_string(),
+        }];
+        let result = render_ansi_preview(&records, 100);
+        assert!(result.contains("⚙ Bash:"));
+        assert!(result.contains("cargo test"));
+    }
+
+    #[test]
+    fn test_render_tool_result() {
+        let records = vec![TranscriptRecord::ToolResult {
+            output_summary: "All tests passed".to_string(),
+        }];
+        let result = render_ansi_preview(&records, 100);
+        assert!(result.contains("✓"));
+        assert!(result.contains("All tests passed"));
+    }
+
+    #[test]
+    fn test_render_mixed_conversation() {
+        let records = vec![
+            TranscriptRecord::User {
+                text: "Hello".to_string(),
+            },
+            TranscriptRecord::AssistantText {
+                text: "I'll help you.".to_string(),
+            },
+            TranscriptRecord::ToolUse {
+                tool_name: "Read".to_string(),
+                input_summary: "src/main.rs".to_string(),
+            },
+            TranscriptRecord::ToolResult {
+                output_summary: "fn main() { ... }".to_string(),
+            },
+        ];
+        let result = render_ansi_preview(&records, 100);
+        let line_count = result.lines().count();
+        assert!(line_count >= 4); // at least one line per record
+    }
+
+    #[test]
+    fn test_max_lines_truncation() {
+        let records: Vec<TranscriptRecord> = (0..50)
+            .map(|i| TranscriptRecord::User {
+                text: format!("Message {}", i),
+            })
+            .collect();
+        let result = render_ansi_preview(&records, 10);
+        let line_count = result.lines().count();
+        assert!(line_count <= 10);
+    }
+
+    #[test]
+    fn test_inline_formatting() {
+        let result = render_inline_formatting("**bold** and *italic* and `code`");
+        assert!(result.contains("bold"));
+        assert!(result.contains("italic"));
+        assert!(result.contains("code"));
+        assert!(result.contains(BOLD));
+        assert!(result.contains(ITALIC));
+    }
+
+    #[test]
+    fn test_bullet_list() {
+        let result = render_markdown_line("- item one");
+        assert!(result.contains("•"));
+        assert!(result.contains("item one"));
+    }
+
+    #[test]
+    fn test_multibyte_truncation() {
+        let text = "これは日本語テスト";
+        let result = truncate_chars(text, 5);
+        assert!(result.ends_with("..."));
+    }
+
+    #[test]
+    fn test_embedded_tool_use_marker() {
+        let records = vec![TranscriptRecord::AssistantText {
+            text: "Let me check.\n[⚙ Bash: ls -la]".to_string(),
+        }];
+        let result = render_ansi_preview(&records, 100);
+        assert!(result.contains("⚙ Bash: ls -la"));
+        assert!(result.contains(FG_YELLOW));
+    }
+}

--- a/crates/tmai-core/src/transcript/mod.rs
+++ b/crates/tmai-core/src/transcript/mod.rs
@@ -3,10 +3,12 @@
 //! Watches `~/.claude/projects/{hash}/{session}.jsonl` files for changes
 //! and provides parsed, rendered preview text for the Web UI.
 
+pub mod ansi_renderer;
 pub mod parser;
 pub mod renderer;
 pub mod types;
 pub mod watcher;
 
+pub use ansi_renderer::render_ansi_preview;
 pub use types::{TranscriptRecord, TranscriptState};
 pub use watcher::{TranscriptRegistry, TranscriptWatcher};

--- a/crates/tmai-core/src/transcript/types.rs
+++ b/crates/tmai-core/src/transcript/types.rs
@@ -36,8 +36,10 @@ pub struct TranscriptState {
     pub recent_records: Vec<TranscriptRecord>,
     /// Last read position in the file (byte offset)
     pub last_read_pos: u64,
-    /// Cached preview text (regenerated on new records)
+    /// Cached preview text — plain (regenerated on new records)
     pub preview_text: String,
+    /// Cached preview text — ANSI-rich (regenerated on new records)
+    pub ansi_preview_text: String,
 }
 
 impl TranscriptState {
@@ -50,6 +52,7 @@ impl TranscriptState {
             recent_records: Vec::new(),
             last_read_pos: 0,
             preview_text: String::new(),
+            ansi_preview_text: String::new(),
         }
     }
 

--- a/crates/tmai-core/src/transcript/watcher.rs
+++ b/crates/tmai-core/src/transcript/watcher.rs
@@ -9,6 +9,7 @@ use std::sync::Arc;
 use parking_lot::RwLock;
 use tracing::debug;
 
+use super::ansi_renderer::render_ansi_preview;
 use super::parser::parse_jsonl_line;
 use super::renderer::render_preview;
 use super::types::TranscriptState;
@@ -66,8 +67,9 @@ impl TranscriptWatcher {
             debug!(path, error = %e, "Failed initial transcript read (file may not exist yet)");
         }
 
-        // Generate initial preview
+        // Generate initial previews (plain + ANSI)
         state.preview_text = render_preview(&state.recent_records, MAX_PREVIEW_LINES);
+        state.ansi_preview_text = render_ansi_preview(&state.recent_records, MAX_PREVIEW_LINES);
 
         let mut reg = self.registry.write();
         reg.insert(pane_id.to_string(), state);
@@ -185,6 +187,7 @@ fn read_new_lines(state: &mut TranscriptState) -> std::io::Result<()> {
         );
         state.push_records(new_records);
         state.preview_text = render_preview(&state.recent_records, MAX_PREVIEW_LINES);
+        state.ansi_preview_text = render_ansi_preview(&state.recent_records, MAX_PREVIEW_LINES);
     }
 
     state.last_read_pos = current_size;


### PR DESCRIPTION
Claude Code's virtual scrolling renders capture-pane unable to retrieve scrollback history, returning only the visible screen area. This adds a hybrid fallback chain that provides ANSI-rich conversation previews without depending on capture-pane:

1. pipe-pane stream capture (vt100-processed) — real ANSI from live output
2. JSONL ANSI renderer — synthesized ANSI from transcript with markdown formatting, colored tool badges, and inline code highlighting
3. JSONL plain preview — existing minimal text fallback
4. Activity log — lightweight hook events

This moves toward standalone (tmux-free) operation where tmux enhances but is not required for full functionality.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * トランスクリプト表示にANSIスタイル対応の新しいプレビューレンダリング機能を追加
  * ペーン監視機能を強化し、vt100処理によるANSI出力をサポート
  * コンテンツプレビューのフォールバック処理を改善し、より充実した出力表示を実現

* **リファクタリング**
  * 内部ポーリングロジックと状態管理を最適化

<!-- end of auto-generated comment: release notes by coderabbit.ai -->