### PR TITLE
feat: add MCP server for programmatic agent orchestration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,6 +167,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -223,7 +234,7 @@ dependencies = [
  "log",
  "num-rational",
  "num-traits",
- "pastey",
+ "pastey 0.1.1",
  "rayon",
  "thiserror 2.0.18",
  "v_frame",
@@ -1520,12 +1531,28 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-channel"
-version = "0.3.31"
+name = "futures"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1580,6 +1607,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -3367,6 +3395,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35fb2e5f958ec131621fdd531e9fc186ed768cbe395337403ae56c17a74c68ec"
 
 [[package]]
+name = "pastey"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4314,6 +4348,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2231b2c085b371c01bc90c0e6c1cab8834711b6394533375bdbf870b0166d419"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "pastey 0.2.1",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36ea0e100fadf81be85d7ff70f86cd805c7572601d4ab2946207f36540854b43"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "rust-embed"
 version = "8.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4439,7 +4508,7 @@ checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
  "indexmap 1.9.3",
- "schemars_derive",
+ "schemars_derive 0.8.22",
  "serde",
  "serde_json",
  "url",
@@ -4464,8 +4533,10 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -4475,6 +4546,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5605,7 +5688,9 @@ dependencies = [
  "rand 0.10.0",
  "ratatui",
  "regex",
+ "rmcp",
  "rust-embed",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "temp-env",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -60,6 +60,8 @@ ureq = { version = "3", features = ["json"] }
 toml_edit = "0.25"
 bytes = "1"
 futures-util = "0.3"
+rmcp = { version = "1.3", features = ["server", "transport-io"] }
+schemars = "1.0"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/crates/tmai-core/src/config/settings.rs
+++ b/crates/tmai-core/src/config/settings.rs
@@ -74,6 +74,8 @@ pub enum Command {
     /// Bridge Codex CLI hook events to tmai (called by Codex, not by users)
     #[command(name = "codex-hook")]
     CodexHook,
+    /// Run MCP server on stdio (spawned by Claude Code as an MCP server)
+    Mcp,
     /// List all agents visible to tmai
     Agents,
     /// Get terminal output of another agent
@@ -171,6 +173,11 @@ impl Config {
     /// Check if running in codex-hook bridge mode
     pub fn is_codex_hook_mode(&self) -> bool {
         matches!(self.command, Some(Command::CodexHook))
+    }
+
+    /// Check if running in MCP server mode
+    pub fn is_mcp_mode(&self) -> bool {
+        matches!(self.command, Some(Command::Mcp))
     }
 
     /// Get audit subcommand

--- a/src/init.rs
+++ b/src/init.rs
@@ -327,6 +327,84 @@ fn merge_hooks(settings: &mut Value, token: &str, port: u16, include_tmux_pane: 
 }
 
 /// Remove tmai hooks from settings
+/// MCP server name in Claude Code settings
+const MCP_SERVER_NAME: &str = "tmai";
+
+/// Add tmai MCP server to Claude Code's mcpServers configuration.
+///
+/// Returns true if the entry was added or updated.
+fn merge_mcp_server(settings: &mut Value) -> bool {
+    if !settings.is_object() {
+        *settings = json!({});
+    }
+
+    let mcp_servers = settings
+        .as_object_mut()
+        .unwrap()
+        .entry("mcpServers")
+        .or_insert_with(|| json!({}));
+
+    if !mcp_servers.is_object() {
+        *mcp_servers = json!({});
+    }
+
+    let servers = mcp_servers.as_object_mut().unwrap();
+
+    // If a "tmai" entry exists that is NOT tmai-managed, don't overwrite it
+    if let Some(existing) = servers.get(MCP_SERVER_NAME) {
+        let is_managed = existing
+            .get("_tmai_managed")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false);
+        if !is_managed {
+            // User has their own "tmai" MCP server — leave it alone
+            return false;
+        }
+    }
+
+    // Resolve tmai binary path (use current executable path)
+    let tmai_command = std::env::current_exe()
+        .ok()
+        .and_then(|p| p.to_str().map(|s| s.to_string()))
+        .unwrap_or_else(|| "tmai".to_string());
+
+    let entry = json!({
+        "command": tmai_command,
+        "args": ["mcp"],
+        "_tmai_managed": true
+    });
+
+    servers.insert(MCP_SERVER_NAME.to_string(), entry);
+
+    true
+}
+
+/// Remove tmai MCP server from Claude Code settings.
+///
+/// Returns true if the entry was removed.
+fn remove_mcp_server(settings: &mut Value) -> bool {
+    let Some(mcp_servers) = settings
+        .get_mut("mcpServers")
+        .and_then(|s| s.as_object_mut())
+    else {
+        return false;
+    };
+
+    // Only remove if it's tmai-managed
+    if let Some(entry) = mcp_servers.get(MCP_SERVER_NAME) {
+        if entry
+            .get("_tmai_managed")
+            .and_then(|v| v.as_bool())
+            .unwrap_or(false)
+        {
+            mcp_servers.remove(MCP_SERVER_NAME);
+            return true;
+        }
+    }
+
+    false
+}
+
 fn remove_tmai_hooks(settings: &mut Value) -> usize {
     let Some(hooks) = settings.get_mut("hooks").and_then(|h| h.as_object_mut()) else {
         return 0;
@@ -365,6 +443,9 @@ pub fn run_uninit() -> Result<()> {
     // Remove tmai hooks
     let removed = remove_tmai_hooks(&mut settings);
 
+    // Remove tmai MCP server
+    let mcp_removed = remove_mcp_server(&mut settings);
+
     // Remove statusLine config if it points to our script
     let mut statusline_removed = false;
     if let Some(obj) = settings.as_object_mut() {
@@ -380,8 +461,8 @@ pub fn run_uninit() -> Result<()> {
         }
     }
 
-    if removed > 0 || statusline_removed {
-        // Write back settings if hooks or statusline were removed
+    if removed > 0 || statusline_removed || mcp_removed {
+        // Write back settings if anything was removed
         let formatted = serde_json::to_string_pretty(&settings)?;
         fs::write(&settings_path, formatted)
             .with_context(|| format!("Failed to write {}", settings_path.display()))?;
@@ -393,11 +474,14 @@ pub fn run_uninit() -> Result<()> {
                 settings_path.display()
             );
         }
+        if mcp_removed {
+            println!("Removed tmai MCP server from mcpServers");
+        }
         if statusline_removed {
             println!("Removed statusLine config from {}", settings_path.display());
         }
     } else {
-        println!("No tmai hook entries found in {}", settings_path.display());
+        println!("No tmai entries found in {}", settings_path.display());
     }
 
     // Remove statusline.sh script
@@ -460,6 +544,9 @@ pub fn run(force: bool) -> Result<()> {
     merge_statusline_config(&mut settings, &statusline_path);
     println!("Generated statusline script: {}", statusline_path.display());
 
+    // Step 3c: Add MCP server configuration
+    let mcp_added = merge_mcp_server(&mut settings);
+
     // Step 4: Write back settings
     if let Some(parent) = settings_path.parent() {
         fs::create_dir_all(parent)?;
@@ -473,6 +560,9 @@ pub fn run(force: bool) -> Result<()> {
         count,
         settings_path.display()
     );
+    if mcp_added {
+        println!("Added tmai MCP server to mcpServers");
+    }
     println!("\nSetup complete! tmai will now receive hook events from Claude Code.");
     println!(
         "Make sure to start tmai with web server enabled (port {}).",
@@ -955,5 +1045,97 @@ mod tests {
             stop[1]["hooks"][0]["headers"]["Authorization"],
             "Bearer new-token"
         );
+    }
+
+    #[test]
+    fn test_merge_mcp_server_empty_settings() {
+        let mut settings = json!({});
+        let added = merge_mcp_server(&mut settings);
+        assert!(added);
+
+        let mcp = settings["mcpServers"]["tmai"].as_object().unwrap();
+        assert!(mcp.contains_key("command"));
+        assert_eq!(mcp["args"], json!(["mcp"]));
+        assert_eq!(mcp["_tmai_managed"], json!(true));
+    }
+
+    #[test]
+    fn test_merge_mcp_server_preserves_others() {
+        let mut settings = json!({
+            "mcpServers": {
+                "other-server": {"command": "other", "args": []}
+            }
+        });
+        merge_mcp_server(&mut settings);
+
+        assert!(settings["mcpServers"]["other-server"].is_object());
+        assert!(settings["mcpServers"]["tmai"].is_object());
+    }
+
+    #[test]
+    fn test_remove_mcp_server() {
+        let mut settings = json!({
+            "mcpServers": {
+                "tmai": {"command": "tmai", "args": ["mcp"], "_tmai_managed": true},
+                "other": {"command": "other"}
+            }
+        });
+        let removed = remove_mcp_server(&mut settings);
+        assert!(removed);
+        assert!(!settings["mcpServers"]
+            .as_object()
+            .unwrap()
+            .contains_key("tmai"));
+        assert!(settings["mcpServers"]
+            .as_object()
+            .unwrap()
+            .contains_key("other"));
+    }
+
+    #[test]
+    fn test_remove_mcp_server_not_managed() {
+        let mut settings = json!({
+            "mcpServers": {
+                "tmai": {"command": "custom-tmai", "args": ["custom"]}
+            }
+        });
+        let removed = remove_mcp_server(&mut settings);
+        assert!(!removed);
+        // Should NOT remove user-defined tmai entry
+        assert!(settings["mcpServers"]
+            .as_object()
+            .unwrap()
+            .contains_key("tmai"));
+    }
+
+    #[test]
+    fn test_merge_mcp_server_skips_user_defined() {
+        let mut settings = json!({
+            "mcpServers": {
+                "tmai": {"command": "custom-tmai", "args": ["custom-arg"]}
+            }
+        });
+        let added = merge_mcp_server(&mut settings);
+        assert!(!added);
+        // Should NOT overwrite user-defined entry
+        assert_eq!(settings["mcpServers"]["tmai"]["command"], "custom-tmai");
+        assert_eq!(
+            settings["mcpServers"]["tmai"]["args"],
+            json!(["custom-arg"])
+        );
+    }
+
+    #[test]
+    fn test_merge_mcp_server_updates_managed() {
+        let mut settings = json!({
+            "mcpServers": {
+                "tmai": {"command": "old-path", "args": ["mcp"], "_tmai_managed": true}
+            }
+        });
+        let added = merge_mcp_server(&mut settings);
+        assert!(added);
+        // Should update the managed entry (new binary path)
+        assert_ne!(settings["mcpServers"]["tmai"]["command"], "old-path");
+        assert_eq!(settings["mcpServers"]["tmai"]["_tmai_managed"], true);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,6 @@ pub mod audit;
 pub mod codex_hook;
 pub mod demo;
 pub mod init;
+pub mod mcp;
 pub mod ui;
 pub mod web;

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,11 @@ async fn main() -> Result<()> {
         }
     }
 
+    // Check for MCP server subcommand (stdio transport, no logging to stdout)
+    if cli.is_mcp_mode() {
+        return tmai::mcp::run().await;
+    }
+
     // Check for codex-hook bridge subcommand (no logging, fast path)
     if cli.is_codex_hook_mode() {
         let settings = Settings::load(cli.config.as_ref()).unwrap_or_default();
@@ -185,8 +190,13 @@ async fn run_tmux_mode(settings: Settings, _cli: Config) -> Result<()> {
         }
 
         // Start web server in background
-        let web_server = WebServer::new(settings.clone(), core.clone(), token);
+        let web_server = WebServer::new(settings.clone(), core.clone(), token.clone());
         web_server.start();
+
+        // Write API connection info for MCP server
+        if let Err(e) = tmai::mcp::client::write_api_info(settings.web.port, &token) {
+            eprintln!("tmai: warning: failed to write API info: {e}");
+        }
     }
 
     // Start review service if enabled
@@ -339,6 +349,11 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
     let web_server = WebServer::new(settings.clone(), core.clone(), token.clone());
     web_server.start();
 
+    // Write API connection info for MCP server and other external tools
+    if let Err(e) = tmai::mcp::client::write_api_info(port, &token) {
+        eprintln!("tmai: warning: failed to write API info: {e}");
+    }
+
     let url = format!("http://localhost:{port}/?token={token}");
     eprintln!("tmai: web server running at {url}");
 
@@ -437,6 +452,9 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
             }
         }
     }
+
+    // Cleanup API connection info
+    tmai::mcp::client::remove_api_info();
 
     Ok(())
 }

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -1,0 +1,119 @@
+//! HTTP client for connecting to the running tmai instance's Web API.
+
+use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
+use std::path::PathBuf;
+
+/// Connection info for the tmai HTTP API
+#[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
+pub struct ApiConnectionInfo {
+    pub port: u16,
+    pub token: String,
+}
+
+/// Path to the runtime API connection file
+fn api_info_path() -> PathBuf {
+    tmai_core::ipc::protocol::state_dir().join("api.json")
+}
+
+/// Write API connection info (called by tmai when starting the web server)
+pub fn write_api_info(port: u16, token: &str) -> Result<()> {
+    let dir = tmai_core::ipc::protocol::state_dir();
+    std::fs::create_dir_all(&dir)
+        .with_context(|| format!("Failed to create state dir: {}", dir.display()))?;
+
+    let info = ApiConnectionInfo {
+        port,
+        token: token.to_string(),
+    };
+    let path = api_info_path();
+    let json = serde_json::to_string(&info)?;
+    std::fs::write(&path, &json)
+        .with_context(|| format!("Failed to write API info: {}", path.display()))?;
+
+    // Restrict permissions (token is sensitive)
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+    }
+
+    Ok(())
+}
+
+/// Remove API connection info (called on tmai shutdown)
+pub fn remove_api_info() {
+    let _ = std::fs::remove_file(api_info_path());
+}
+
+/// HTTP client for tmai's Web API
+#[derive(Debug, Clone)]
+pub struct TmaiHttpClient {
+    base_url: String,
+    token: String,
+}
+
+impl TmaiHttpClient {
+    /// Create a new client by reading the runtime API info file
+    pub fn from_runtime() -> Result<Self> {
+        let path = api_info_path();
+        let data = std::fs::read_to_string(&path)
+            .with_context(|| format!("tmai is not running (no API info at {})", path.display()))?;
+        let info: ApiConnectionInfo =
+            serde_json::from_str(&data).context("Invalid API info file")?;
+
+        Ok(Self {
+            base_url: format!("http://localhost:{}", info.port),
+            token: info.token,
+        })
+    }
+
+    /// Make a GET request to the tmai API
+    pub fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let url = format!("{}/api{}", self.base_url, path);
+        let resp: T = ureq::get(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .call()
+            .with_context(|| format!("GET {path} failed"))?
+            .body_mut()
+            .read_json()
+            .with_context(|| format!("Failed to parse response from {path}"))?;
+        Ok(resp)
+    }
+
+    /// Make a POST request to the tmai API with a JSON body
+    pub fn post<T: DeserializeOwned>(&self, path: &str, body: &serde_json::Value) -> Result<T> {
+        let url = format!("{}/api{}", self.base_url, path);
+        let resp: T = ureq::post(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .send_json(body)
+            .with_context(|| format!("POST {path} failed"))?
+            .body_mut()
+            .read_json()
+            .with_context(|| format!("Failed to parse response from {path}"))?;
+        Ok(resp)
+    }
+
+    /// Make a POST request that returns a simple status (no body parsing)
+    pub fn post_ok(&self, path: &str, body: &serde_json::Value) -> Result<()> {
+        let url = format!("{}/api{}", self.base_url, path);
+        ureq::post(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .send_json(body)
+            .with_context(|| format!("POST {path} failed"))?;
+        Ok(())
+    }
+
+    /// Make a GET request that returns raw text.
+    pub fn get_text(&self, path: &str) -> Result<String> {
+        let url = format!("{}/api{}", self.base_url, path);
+        let text = ureq::get(&url)
+            .header("Authorization", &format!("Bearer {}", self.token))
+            .call()
+            .with_context(|| format!("GET {path} failed"))?
+            .body_mut()
+            .read_to_string()
+            .with_context(|| format!("Failed to read response from {path}"))?;
+        Ok(text)
+    }
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,0 +1,14 @@
+//! MCP (Model Context Protocol) server for tmai.
+//!
+//! Exposes tmai's functionality as MCP tools, allowing AI agents (e.g., Claude Code)
+//! to programmatically control tmai — list agents, approve actions, send text,
+//! query GitHub state, and manage worktrees.
+//!
+//! Communication: stdio transport (spawned by Claude Code as an MCP server).
+//! The MCP server connects to the running tmai instance via its HTTP API.
+
+pub mod client;
+mod server;
+mod tools;
+
+pub use server::run;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,0 +1,45 @@
+//! MCP server entry point.
+//!
+//! Starts a stdio-based MCP server that connects to the running tmai instance.
+
+use anyhow::{Context, Result};
+use rmcp::model::{Implementation, ServerCapabilities, ServerInfo};
+use rmcp::serve_server;
+use rmcp::transport::io::stdio;
+use rmcp::ServerHandler;
+
+use super::client::TmaiHttpClient;
+use super::tools::TmaiMcpServer;
+
+/// MCP server handler implementation
+#[rmcp::tool_handler]
+impl ServerHandler for TmaiMcpServer {
+    fn get_info(&self) -> ServerInfo {
+        ServerInfo::new(ServerCapabilities::builder().enable_tools().build())
+            .with_server_info(Implementation::new("tmai", env!("CARGO_PKG_VERSION")))
+            .with_instructions(
+                "tmai MCP server — monitor and control AI coding agents. \
+                 Use list_agents to see all agents, approve to accept pending permissions, \
+                 send_text to inject prompts, and spawn_agent/spawn_worktree to start new agents.",
+            )
+    }
+}
+
+/// Run the MCP server on stdio
+pub async fn run() -> Result<()> {
+    // Connect to the running tmai instance
+    let client =
+        TmaiHttpClient::from_runtime().context("Cannot connect to tmai. Is tmai running?")?;
+
+    let server = TmaiMcpServer::new(client);
+
+    // Serve over stdio
+    let service = serve_server(server, stdio())
+        .await
+        .context("Failed to start MCP server")?;
+
+    // Wait until the client disconnects
+    service.waiting().await?;
+
+    Ok(())
+}

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1,0 +1,385 @@
+//! MCP tool definitions for tmai.
+//!
+//! Each tool wraps a call to the tmai HTTP API and returns the result
+//! as formatted text for the LLM consumer.
+
+use rmcp::handler::server::tool::ToolRouter;
+use rmcp::handler::server::wrapper::Parameters;
+use rmcp::{schemars, tool, tool_router};
+
+use super::client::TmaiHttpClient;
+
+/// tmai MCP Server — exposes agent management, GitHub, and worktree tools
+#[derive(Debug)]
+pub struct TmaiMcpServer {
+    pub tool_router: ToolRouter<Self>,
+    client: TmaiHttpClient,
+}
+
+impl TmaiMcpServer {
+    /// Create a new server connected to the running tmai instance
+    pub fn new(client: TmaiHttpClient) -> Self {
+        Self {
+            tool_router: Self::tool_router(),
+            client,
+        }
+    }
+}
+
+// =========================================================
+// Parameter types
+// =========================================================
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct EmptyParams {}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct AgentIdParams {
+    /// Agent ID (e.g., "main:0.0" or a PTY session ID)
+    pub id: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SendTextParams {
+    /// Agent ID
+    pub id: String,
+    /// Text to send to the agent
+    pub text: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SendKeyParams {
+    /// Agent ID
+    pub id: String,
+    /// Key name (Enter, Escape, Space, Up, Down, Left, Right, Tab, BTab, BSpace)
+    pub key: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SelectChoiceParams {
+    /// Agent ID
+    pub id: String,
+    /// Choice index (1-based)
+    pub index: u32,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct BranchParams {
+    /// Branch name
+    pub branch: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct PrNumberParams {
+    /// Pull request number
+    pub pr_number: u32,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SpawnAgentParams {
+    /// Working directory for the agent
+    pub directory: String,
+    /// Initial prompt to send after the agent starts (optional)
+    #[serde(default)]
+    pub prompt: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SpawnWorktreeParams {
+    /// Worktree name
+    pub name: String,
+    /// Base branch to fork from (defaults to main)
+    #[serde(default)]
+    pub base_branch: Option<String>,
+    /// Initial prompt to send after the agent starts (optional)
+    #[serde(default)]
+    pub prompt: Option<String>,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct WorktreePathParams {
+    /// Worktree path
+    pub path: String,
+}
+
+// =========================================================
+// Tool implementations
+// =========================================================
+
+#[tool_router]
+impl TmaiMcpServer {
+    // ----- Agent Queries -----
+
+    /// List all monitored AI agents with their current status, type, working directory, and detection source.
+    #[tool(description = "List all monitored AI agents with their status")]
+    fn list_agents(&self, Parameters(_): Parameters<EmptyParams>) -> String {
+        match self.client.get::<serde_json::Value>("/agents") {
+            Ok(agents) => format_json(&agents),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Get detailed information about a specific agent including its status, working directory, git branch, and connection channels.
+    #[tool(description = "Get detailed info about a specific agent")]
+    fn get_agent(&self, Parameters(p): Parameters<AgentIdParams>) -> String {
+        match self.client.get::<serde_json::Value>("/agents") {
+            Ok(data) => {
+                if let Some(agents) = data.as_array() {
+                    if let Some(agent) = agents.iter().find(|a| {
+                        a.get("id").and_then(|v| v.as_str()) == Some(&p.id)
+                            || a.get("pty_session_id").and_then(|v| v.as_str()) == Some(&p.id)
+                    }) {
+                        return format_json(agent);
+                    }
+                }
+                format!("Agent not found: {}", p.id)
+            }
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Get the plain-text terminal output of an agent. Useful for seeing what the agent is currently displaying.
+    #[tool(description = "Get the terminal output of an agent")]
+    fn get_agent_output(&self, Parameters(p): Parameters<AgentIdParams>) -> String {
+        match self.client.get_text(&format!("/agents/{}/output", p.id)) {
+            Ok(text) => text,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Get the conversation transcript of an agent (parsed from JSONL session log).
+    #[tool(description = "Get the conversation transcript of an agent")]
+    fn get_transcript(&self, Parameters(p): Parameters<AgentIdParams>) -> String {
+        match self
+            .client
+            .get::<serde_json::Value>(&format!("/agents/{}/transcript", p.id))
+        {
+            Ok(data) => format_json(&data),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    // ----- Agent Actions -----
+
+    /// Approve a pending permission request for an agent (equivalent to pressing 'y').
+    #[tool(description = "Approve a pending permission request for an agent")]
+    fn approve(&self, Parameters(p): Parameters<AgentIdParams>) -> String {
+        match self
+            .client
+            .post_ok(&format!("/agents/{}/approve", p.id), &serde_json::json!({}))
+        {
+            Ok(()) => format!("Approved agent {}", p.id),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Send text input to an agent (like typing in the terminal). Use this to send prompts or commands.
+    #[tool(description = "Send text input to an agent")]
+    fn send_text(&self, Parameters(p): Parameters<SendTextParams>) -> String {
+        match self.client.post_ok(
+            &format!("/agents/{}/input", p.id),
+            &serde_json::json!({"text": p.text}),
+        ) {
+            Ok(()) => format!("Sent text to agent {}", p.id),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Send a special key to an agent (Enter, Escape, Space, Up, Down, Left, Right, Tab).
+    #[tool(description = "Send a special key to an agent")]
+    fn send_key(&self, Parameters(p): Parameters<SendKeyParams>) -> String {
+        match self.client.post_ok(
+            &format!("/agents/{}/key", p.id),
+            &serde_json::json!({"key": p.key}),
+        ) {
+            Ok(()) => format!("Sent key '{}' to agent {}", p.key, p.id),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Select a numbered choice for an agent's AskUserQuestion prompt (1-based index).
+    #[tool(description = "Select a choice for an agent's question")]
+    fn select_choice(&self, Parameters(p): Parameters<SelectChoiceParams>) -> String {
+        match self.client.post_ok(
+            &format!("/agents/{}/select", p.id),
+            &serde_json::json!({"index": p.index}),
+        ) {
+            Ok(()) => format!("Selected choice {} for agent {}", p.index, p.id),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    // ----- Team Queries -----
+
+    /// List all Claude Code Agent Teams with their member count and task progress.
+    #[tool(description = "List all agent teams")]
+    fn list_teams(&self, Parameters(_): Parameters<EmptyParams>) -> String {
+        match self.client.get::<serde_json::Value>("/teams") {
+            Ok(teams) => format_json(&teams),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    // ----- Worktree Management -----
+
+    /// List all git worktrees with their linked agents, branch names, and diff statistics.
+    #[tool(description = "List all git worktrees")]
+    fn list_worktrees(&self, Parameters(_): Parameters<EmptyParams>) -> String {
+        match self.client.get::<serde_json::Value>("/worktrees") {
+            Ok(wt) => format_json(&wt),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Spawn a new AI agent (Claude Code) in a specified directory.
+    #[tool(description = "Spawn a new AI agent in a directory")]
+    fn spawn_agent(&self, Parameters(p): Parameters<SpawnAgentParams>) -> String {
+        let mut body = serde_json::json!({"directory": p.directory});
+        if let Some(prompt) = &p.prompt {
+            body["initial_prompt"] = serde_json::json!(prompt);
+        }
+        match self.client.post::<serde_json::Value>("/spawn", &body) {
+            Ok(data) => format_json(&data),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Create a new git worktree and spawn an AI agent in it. Ideal for isolated feature work.
+    #[tool(description = "Create a worktree and spawn an agent in it")]
+    fn spawn_worktree(&self, Parameters(p): Parameters<SpawnWorktreeParams>) -> String {
+        let mut body = serde_json::json!({"name": p.name});
+        if let Some(base) = &p.base_branch {
+            body["base_branch"] = serde_json::json!(base);
+        }
+        if let Some(prompt) = &p.prompt {
+            body["initial_prompt"] = serde_json::json!(prompt);
+        }
+        match self
+            .client
+            .post::<serde_json::Value>("/spawn/worktree", &body)
+        {
+            Ok(data) => format_json(&data),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Delete a git worktree.
+    #[tool(description = "Delete a git worktree")]
+    fn delete_worktree(&self, Parameters(p): Parameters<WorktreePathParams>) -> String {
+        match self
+            .client
+            .post_ok("/worktrees/delete", &serde_json::json!({"path": p.path}))
+        {
+            Ok(()) => format!("Deleted worktree: {}", p.path),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    // ----- GitHub -----
+
+    /// List open pull requests for the current repository with CI status and review state.
+    #[tool(description = "List open pull requests")]
+    fn list_prs(&self, Parameters(_): Parameters<EmptyParams>) -> String {
+        match self.client.get::<serde_json::Value>("/github/prs") {
+            Ok(prs) => format_json(&prs),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// List open issues for the current repository.
+    #[tool(description = "List open issues")]
+    fn list_issues(&self, Parameters(_): Parameters<EmptyParams>) -> String {
+        match self.client.get::<serde_json::Value>("/github/issues") {
+            Ok(issues) => format_json(&issues),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Get CI check results for a branch.
+    #[tool(description = "Get CI check results for a branch")]
+    fn get_ci_status(&self, Parameters(p): Parameters<BranchParams>) -> String {
+        match self
+            .client
+            .get::<serde_json::Value>(&format!("/github/checks?branch={}", p.branch))
+        {
+            Ok(checks) => format_json(&checks),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Get comments and reviews on a pull request.
+    #[tool(description = "Get PR comments and reviews")]
+    fn get_pr_comments(&self, Parameters(p): Parameters<PrNumberParams>) -> String {
+        match self
+            .client
+            .get::<serde_json::Value>(&format!("/github/pr/comments?pr={}", p.pr_number))
+        {
+            Ok(data) => format_json(&data),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Get the merge status of a pull request (mergeable, CI status, review decision).
+    #[tool(description = "Get PR merge status")]
+    fn get_pr_merge_status(&self, Parameters(p): Parameters<PrNumberParams>) -> String {
+        match self
+            .client
+            .get::<serde_json::Value>(&format!("/github/pr/merge-status?pr={}", p.pr_number))
+        {
+            Ok(data) => format_json(&data),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Get the CI failure log for debugging a failed check.
+    #[tool(description = "Get CI failure log for a branch")]
+    fn get_ci_failure_log(&self, Parameters(p): Parameters<BranchParams>) -> String {
+        match self
+            .client
+            .get_text(&format!("/github/ci/failure-log?branch={}", p.branch))
+        {
+            Ok(log) => log,
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Rerun failed CI checks for a branch.
+    #[tool(description = "Rerun failed CI checks")]
+    fn rerun_ci(&self, Parameters(p): Parameters<BranchParams>) -> String {
+        match self
+            .client
+            .post_ok("/github/ci/rerun", &serde_json::json!({"branch": p.branch}))
+        {
+            Ok(()) => format!("Rerunning failed checks for branch: {}", p.branch),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    // ----- Git -----
+
+    /// List git branches in the repository.
+    #[tool(description = "List git branches")]
+    fn list_branches(&self, Parameters(_): Parameters<EmptyParams>) -> String {
+        match self.client.get::<serde_json::Value>("/git/branches") {
+            Ok(branches) => format_json(&branches),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Get the diff statistics for a branch compared to its base.
+    #[tool(description = "Get diff stats for a branch")]
+    fn git_diff_stat(&self, Parameters(p): Parameters<BranchParams>) -> String {
+        match self
+            .client
+            .get::<serde_json::Value>(&format!("/git/diff-stat?branch={}", p.branch))
+        {
+            Ok(data) => format_json(&data),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+}
+
+/// Format JSON value as pretty-printed string
+fn format_json(value: &serde_json::Value) -> String {
+    serde_json::to_string_pretty(value).unwrap_or_else(|_| value.to_string())
+}


### PR DESCRIPTION
## Summary

- Add MCP (Model Context Protocol) server exposing 25 tools for programmatic tmai control
- `tmai mcp` subcommand runs stdio-based MCP server (spawned by Claude Code)
- `tmai init` / `tmai uninit` manage MCP server config in `~/.claude/settings.json`
- Runtime API info file (`$XDG_RUNTIME_DIR/tmai/api.json`) bridges MCP server → running tmai HTTP API

### MCP Tools (25)

| Category | Tools |
|----------|-------|
| Agent Queries | `list_agents`, `get_agent`, `get_agent_output`, `get_transcript` |
| Agent Actions | `approve`, `send_text`, `send_key`, `select_choice` |
| Teams | `list_teams` |
| Worktree | `list_worktrees`, `spawn_agent`, `spawn_worktree`, `delete_worktree` |
| GitHub | `list_prs`, `list_issues`, `get_ci_status`, `get_pr_comments`, `get_pr_merge_status`, `get_ci_failure_log`, `rerun_ci` |
| Git | `list_branches`, `git_diff_stat` |

### Architecture

```
Claude Code → spawns → tmai mcp (stdio MCP server)
                          ↓ HTTP + Bearer token
                     tmai (running instance)
                          ↓
                     TmaiCore Facade API
```

### Safety

- `tmai init` preserves user-defined MCP server entries (only manages `_tmai_managed: true` entries)
- `tmai uninit` only removes tmai-managed entries
- 6 new tests for MCP config merge/remove safety

## Test plan

- [x] `cargo test` — 105 tests pass (including 6 new MCP config tests)
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [ ] Manual: run `tmai init`, verify `mcpServers.tmai` added to `~/.claude/settings.json`
- [ ] Manual: run `tmai`, then `tmai mcp` in another terminal to verify connection
- [ ] Manual: run `tmai uninit`, verify MCP entry removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * MCP（Model Context Protocol）サーバーを追加。tmai の機能を MCP ツールとして公開し、外部アプリケーションからのアクセスを実現。
  * 初期化時に MCP サーバー設定を自動管理。アンイニシャライズ時に設定をクリーンアップ。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->