### PR TITLE
feat: context-aware action buttons based on branch state

### DIFF
--- a/crates/tmai-app/web/src/components/worktree/ActionPanel.tsx
+++ b/crates/tmai-app/web/src/components/worktree/ActionPanel.tsx
@@ -9,6 +9,7 @@ import {
   type WorktreeSnapshot,
 } from "@/lib/api";
 import { extractIssueNumbers, extractIssueRefs, issueToWorktreeName } from "@/lib/issue-utils";
+import { branchStateBadgeClass, branchStateLabel, deriveBranchState } from "./branch-state";
 import { CreateWorktreeForm } from "./CreateWorktreeForm";
 import type { DetailView } from "./DetailPanel";
 import type { BranchNode } from "./graph/types";
@@ -549,6 +550,17 @@ export function ActionPanel({
             {activeNode.isDirty && (
               <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-amber-400">modified</span>
             )}
+            {/* Branch lifecycle state badge */}
+            {(() => {
+              const state = deriveBranchState(activeNode, prInfo);
+              const label = branchStateLabel(state);
+              if (!label) return null;
+              return (
+                <span className={`rounded px-1.5 py-0.5 ${branchStateBadgeClass(state)}`}>
+                  {label}
+                </span>
+              );
+            })()}
           </div>
           {(() => {
             const ds = activeNode.diffSummary ?? branchDiffStat;
@@ -805,169 +817,232 @@ export function ActionPanel({
             </button>
           )}
 
-          {/* Non-main branch/worktree actions (unified) */}
-          {!activeNode.isMain && !activeNode.isRemoteOnly && (
-            <>
-              {/* Focus Agent (worktree or any branch with agent) */}
-              {activeNode.agentTarget ? (
-                <button
-                  type="button"
-                  onClick={() => {
-                    if (activeNode.agentTarget) onFocusAgent(activeNode.agentTarget);
-                  }}
-                  className="w-full rounded-lg bg-cyan-500/15 px-3 py-2 text-left text-xs font-medium text-cyan-400 transition-colors hover:bg-cyan-500/25"
-                >
-                  Focus Agent
-                </button>
-              ) : (
-                activeNode.isWorktree &&
-                activeNode.worktree && (
-                  <button
-                    type="button"
-                    onClick={() => confirmIfAgentActive("Launch agent", handleLaunchAgent)}
-                    disabled={actionBusy}
-                    className="w-full rounded-lg bg-cyan-500/15 px-3 py-2 text-left text-xs font-medium text-cyan-400 transition-colors hover:bg-cyan-500/25 disabled:opacity-50"
-                  >
-                    {actionBusy ? "Launching..." : "Launch Agent"}
-                  </button>
-                )
-              )}
+          {/* Non-main branch/worktree actions (context-aware by branch state) */}
+          {!activeNode.isMain &&
+            !activeNode.isRemoteOnly &&
+            (() => {
+              const branchState = deriveBranchState(activeNode, prInfo);
+              const isMerged = branchState === "merged";
+              const isStale = branchState === "stale";
+              const hasOpenPr = branchState === "has-open-pr";
 
-              {/* Merge into parent / Create PR */}
-              {activeNode.ahead > 0 && (
+              return (
                 <>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      confirmIfAgentActive("Merge", () =>
-                        delegateToAi(
-                          prInfo
-                            ? `Merge PR #${prInfo.number}. First run 'gh pr view ${prInfo.number} --json baseRefName -q .baseRefName' to verify base is '${baseBranch}'. If base matches, run 'gh pr merge ${prInfo.number} --squash --delete-branch'. If base does NOT match, STOP and report the mismatch — do not merge.`
-                            : `Merge branch '${activeNode.name}' into '${baseBranch}'. First check 'gh pr list --head ${activeNode.name} --base ${baseBranch}'. If PR exists and its base is '${baseBranch}', run 'gh pr merge <number> --squash --delete-branch'. If no PR, run 'git checkout ${baseBranch} && git merge ${activeNode.name}'. Do not merge into any branch other than '${baseBranch}'.`,
-                        ),
-                      )
-                    }
-                    disabled={actionBusy}
-                    className="w-full rounded-lg bg-purple-500/15 px-3 py-2 text-left text-xs font-medium text-purple-400 transition-colors hover:bg-purple-500/25 disabled:opacity-50"
-                  >
-                    {prInfo
-                      ? `AI Merge PR #${prInfo.number} into ${baseBranch}`
-                      : `AI Merge into ${baseBranch}`}
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() =>
-                      delegateToAi(
-                        `Run 'gh pr create --base ${baseBranch} --head ${activeNode.name}' to create a PR. Generate a title and description summarizing the changes. Do not merge anything.`,
-                      )
-                    }
-                    disabled={actionBusy}
-                    className="w-full rounded-lg bg-blue-500/15 px-3 py-2 text-left text-xs font-medium text-blue-400 transition-colors hover:bg-blue-500/25 disabled:opacity-50"
-                  >
-                    AI Create PR → {baseBranch}
-                  </button>
-                </>
-              )}
-
-              {/* Behind warning */}
-              {activeNode.behind > 0 && (
-                <div className="rounded-lg bg-amber-500/10 px-3 py-2 text-xs text-amber-400">
-                  {activeNode.behind} commit
-                  {activeNode.behind !== 1 ? "s" : ""} behind {baseBranch}
-                </div>
-              )}
-
-              {/* Move to Worktree (only for current non-worktree branches) */}
-              {!activeNode.isWorktree && activeNode.isCurrent && (
-                <button
-                  type="button"
-                  onClick={() => confirmIfAgentActive("Move", handleMoveToWorktree)}
-                  disabled={actionBusy}
-                  className="w-full rounded-lg bg-amber-500/15 px-3 py-2 text-left text-xs font-medium text-amber-400 transition-colors hover:bg-amber-500/25 disabled:opacity-50"
-                >
-                  {actionBusy ? "Moving..." : "Move to Worktree"}
-                </button>
-              )}
-
-              {/* Create worktree (only for non-worktree branches) */}
-              {!activeNode.isWorktree &&
-                (!showNewWorktree ? (
-                  <button
-                    type="button"
-                    onClick={() => setShowNewWorktree(true)}
-                    className="w-full rounded-lg bg-emerald-500/15 px-3 py-2 text-left text-xs font-medium text-emerald-400 transition-colors hover:bg-emerald-500/25"
-                  >
-                    Create Worktree
-                  </button>
-                ) : (
-                  <CreateWorktreeForm
-                    baseBranch={activeNode.name}
-                    depth={nodeDepth.get(activeNode.name) ?? 0}
-                    depthWarning={branchDepthWarning}
-                    projectPath={projectPath}
-                    onCreated={handleWorktreeCreated}
-                    onCancel={handleWorktreeCancel}
-                  />
-                ))}
-
-              {/* Delete */}
-              <hr className="border-white/5" />
-              {!confirmDelete ? (
-                <button
-                  type="button"
-                  onClick={() => confirmIfAgentActive("Delete", () => setConfirmDelete(true))}
-                  disabled={!activeNode.isWorktree && activeNode.isCurrent}
-                  className="w-full rounded-lg bg-red-500/10 px-3 py-2 text-left text-xs text-red-400 transition-colors hover:bg-red-500/20 disabled:opacity-30"
-                >
-                  Delete {activeNode.isWorktree ? "Worktree" : "Branch"}
-                </button>
-              ) : (
-                <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-2">
-                  <label className="flex items-center gap-1.5 text-[11px] text-zinc-400">
-                    <input
-                      type="checkbox"
-                      checked={forceDelete}
-                      onChange={(e) => setForceDelete(e.target.checked)}
-                      className="accent-red-500"
-                    />
-                    Force delete{!activeNode.isWorktree ? " (unmerged)" : ""}
-                  </label>
-                  {!activeNode.isWorktree && activeNode.remote && (
-                    <label className="mt-1 flex items-center gap-1.5 text-[11px] text-zinc-400">
-                      <input
-                        type="checkbox"
-                        checked={deleteRemote}
-                        onChange={(e) => setDeleteRemote(e.target.checked)}
-                        className="accent-red-500"
-                      />
-                      Also delete remote branch
-                    </label>
+                  {/* Merged branch guidance */}
+                  {isMerged && (
+                    <div className="rounded-lg bg-purple-500/10 px-3 py-2 text-xs text-purple-400">
+                      This branch has been merged. You can safely delete it.
+                    </div>
                   )}
-                  <div className="mt-2 flex gap-2">
+
+                  {/* Stale branch guidance */}
+                  {isStale && (
+                    <div className="rounded-lg bg-amber-500/10 px-3 py-2 text-xs text-amber-400">
+                      {activeNode.behind} commit
+                      {activeNode.behind !== 1 ? "s" : ""} behind {baseBranch} — pull or rebase
+                      before resuming work.
+                    </div>
+                  )}
+
+                  {/* View PR link — prominent for open PR state */}
+                  {hasOpenPr && prInfo && (
+                    <a
+                      href={prInfo.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block w-full rounded-lg bg-blue-500/15 px-3 py-2 text-left text-xs font-medium text-blue-400 transition-colors hover:bg-blue-500/25"
+                    >
+                      View PR #{prInfo.number} on GitHub
+                    </a>
+                  )}
+
+                  {/* Focus Agent / Launch Agent — hidden for merged, disabled for stale */}
+                  {!isMerged &&
+                    (activeNode.agentTarget ? (
+                      <button
+                        type="button"
+                        onClick={() => {
+                          if (activeNode.agentTarget) onFocusAgent(activeNode.agentTarget);
+                        }}
+                        disabled={isStale}
+                        className="w-full rounded-lg bg-cyan-500/15 px-3 py-2 text-left text-xs font-medium text-cyan-400 transition-colors hover:bg-cyan-500/25 disabled:opacity-30"
+                        title={isStale ? "Pull from main before focusing agent" : undefined}
+                      >
+                        Focus Agent
+                      </button>
+                    ) : (
+                      activeNode.isWorktree &&
+                      activeNode.worktree && (
+                        <button
+                          type="button"
+                          onClick={() => confirmIfAgentActive("Launch agent", handleLaunchAgent)}
+                          disabled={actionBusy || isStale}
+                          className="w-full rounded-lg bg-cyan-500/15 px-3 py-2 text-left text-xs font-medium text-cyan-400 transition-colors hover:bg-cyan-500/25 disabled:opacity-30"
+                          title={isStale ? "Pull from main before launching agent" : undefined}
+                        >
+                          {actionBusy ? "Launching..." : "Launch Agent"}
+                        </button>
+                      )
+                    ))}
+
+                  {/* Merge into parent / Create PR — hidden for merged and open-PR, disabled for stale */}
+                  {!isMerged && !hasOpenPr && activeNode.ahead > 0 && (
+                    <>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          confirmIfAgentActive("Merge", () =>
+                            delegateToAi(
+                              prInfo
+                                ? `Merge PR #${prInfo.number}. First run 'gh pr view ${prInfo.number} --json baseRefName -q .baseRefName' to verify base is '${baseBranch}'. If base matches, run 'gh pr merge ${prInfo.number} --squash --delete-branch'. If base does NOT match, STOP and report the mismatch — do not merge.`
+                                : `Merge branch '${activeNode.name}' into '${baseBranch}'. First check 'gh pr list --head ${activeNode.name} --base ${baseBranch}'. If PR exists and its base is '${baseBranch}', run 'gh pr merge <number> --squash --delete-branch'. If no PR, run 'git checkout ${baseBranch} && git merge ${activeNode.name}'. Do not merge into any branch other than '${baseBranch}'.`,
+                            ),
+                          )
+                        }
+                        disabled={actionBusy || isStale}
+                        className="w-full rounded-lg bg-purple-500/15 px-3 py-2 text-left text-xs font-medium text-purple-400 transition-colors hover:bg-purple-500/25 disabled:opacity-30"
+                        title={isStale ? "Pull from main before merging" : undefined}
+                      >
+                        {prInfo
+                          ? `AI Merge PR #${prInfo.number} into ${baseBranch}`
+                          : `AI Merge into ${baseBranch}`}
+                      </button>
+                      <button
+                        type="button"
+                        onClick={() =>
+                          delegateToAi(
+                            `Run 'gh pr create --base ${baseBranch} --head ${activeNode.name}' to create a PR. Generate a title and description summarizing the changes. Do not merge anything.`,
+                          )
+                        }
+                        disabled={actionBusy || isStale}
+                        className="w-full rounded-lg bg-blue-500/15 px-3 py-2 text-left text-xs font-medium text-blue-400 transition-colors hover:bg-blue-500/25 disabled:opacity-30"
+                        title={isStale ? "Pull from main before creating PR" : undefined}
+                      >
+                        AI Create PR → {baseBranch}
+                      </button>
+                    </>
+                  )}
+
+                  {/* Behind warning — shown for non-merged branches (prominent in stale already handled above) */}
+                  {!isMerged && !isStale && activeNode.behind > 0 && (
+                    <div className="rounded-lg bg-amber-500/10 px-3 py-2 text-xs text-amber-400">
+                      {activeNode.behind} commit
+                      {activeNode.behind !== 1 ? "s" : ""} behind {baseBranch}
+                    </div>
+                  )}
+
+                  {/* Move to Worktree — hidden for merged branches */}
+                  {!isMerged && !activeNode.isWorktree && activeNode.isCurrent && (
                     <button
                       type="button"
-                      onClick={activeNode.isWorktree ? handleDeleteWorktree : handleDeleteBranch}
+                      onClick={() => confirmIfAgentActive("Move", handleMoveToWorktree)}
                       disabled={actionBusy}
-                      className="rounded bg-red-500/20 px-2 py-1 text-xs text-red-400 hover:bg-red-500/30 disabled:opacity-50"
+                      className="w-full rounded-lg bg-amber-500/15 px-3 py-2 text-left text-xs font-medium text-amber-400 transition-colors hover:bg-amber-500/25 disabled:opacity-50"
                     >
-                      {actionBusy ? "..." : "Confirm"}
+                      {actionBusy ? "Moving..." : "Move to Worktree"}
                     </button>
+                  )}
+
+                  {/* Create worktree — hidden for merged branches */}
+                  {!isMerged &&
+                    !activeNode.isWorktree &&
+                    (!showNewWorktree ? (
+                      <button
+                        type="button"
+                        onClick={() => setShowNewWorktree(true)}
+                        className="w-full rounded-lg bg-emerald-500/15 px-3 py-2 text-left text-xs font-medium text-emerald-400 transition-colors hover:bg-emerald-500/25"
+                      >
+                        Create Worktree
+                      </button>
+                    ) : (
+                      <CreateWorktreeForm
+                        baseBranch={activeNode.name}
+                        depth={nodeDepth.get(activeNode.name) ?? 0}
+                        depthWarning={branchDepthWarning}
+                        projectPath={projectPath}
+                        onCreated={handleWorktreeCreated}
+                        onCancel={handleWorktreeCancel}
+                      />
+                    ))}
+
+                  {/* Delete — primary for merged, confirmation-gated for open PR */}
+                  <hr className="border-white/5" />
+                  {!confirmDelete ? (
                     <button
                       type="button"
-                      onClick={() => {
-                        setConfirmDelete(false);
-                        setForceDelete(false);
-                        setDeleteRemote(true);
-                      }}
-                      className="text-xs text-zinc-500 hover:text-zinc-300"
+                      onClick={() =>
+                        hasOpenPr
+                          ? confirmIfAgentActive("Delete (PR is open)", () =>
+                              setConfirmDelete(true),
+                            )
+                          : confirmIfAgentActive("Delete", () => setConfirmDelete(true))
+                      }
+                      disabled={!activeNode.isWorktree && activeNode.isCurrent}
+                      className={`w-full rounded-lg px-3 py-2 text-left text-xs transition-colors disabled:opacity-30 ${
+                        isMerged
+                          ? "bg-red-500/20 font-medium text-red-400 hover:bg-red-500/30"
+                          : "bg-red-500/10 text-red-400 hover:bg-red-500/20"
+                      }`}
                     >
-                      Cancel
+                      {isMerged
+                        ? `Delete ${activeNode.isWorktree ? "Worktree" : "Branch"} (merged)`
+                        : `Delete ${activeNode.isWorktree ? "Worktree" : "Branch"}`}
                     </button>
-                  </div>
-                </div>
-              )}
-            </>
-          )}
+                  ) : (
+                    <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-2">
+                      {hasOpenPr && (
+                        <div className="mb-2 text-[11px] text-amber-400">
+                          Warning: PR #{prInfo?.number} is still open
+                        </div>
+                      )}
+                      <label className="flex items-center gap-1.5 text-[11px] text-zinc-400">
+                        <input
+                          type="checkbox"
+                          checked={forceDelete}
+                          onChange={(e) => setForceDelete(e.target.checked)}
+                          className="accent-red-500"
+                        />
+                        Force delete{!activeNode.isWorktree ? " (unmerged)" : ""}
+                      </label>
+                      {!activeNode.isWorktree && activeNode.remote && (
+                        <label className="mt-1 flex items-center gap-1.5 text-[11px] text-zinc-400">
+                          <input
+                            type="checkbox"
+                            checked={deleteRemote}
+                            onChange={(e) => setDeleteRemote(e.target.checked)}
+                            className="accent-red-500"
+                          />
+                          Also delete remote branch
+                        </label>
+                      )}
+                      <div className="mt-2 flex gap-2">
+                        <button
+                          type="button"
+                          onClick={
+                            activeNode.isWorktree ? handleDeleteWorktree : handleDeleteBranch
+                          }
+                          disabled={actionBusy}
+                          className="rounded bg-red-500/20 px-2 py-1 text-xs text-red-400 hover:bg-red-500/30 disabled:opacity-50"
+                        >
+                          {actionBusy ? "..." : "Confirm"}
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            setConfirmDelete(false);
+                            setForceDelete(false);
+                            setDeleteRemote(true);
+                          }}
+                          className="text-xs text-zinc-500 hover:text-zinc-300"
+                        >
+                          Cancel
+                        </button>
+                      </div>
+                    </div>
+                  )}
+                </>
+              );
+            })()}
 
           {/* Main branch actions */}
           {activeNode.isMain &&

--- a/crates/tmai-app/web/src/components/worktree/__tests__/branch-state.test.ts
+++ b/crates/tmai-app/web/src/components/worktree/__tests__/branch-state.test.ts
@@ -1,0 +1,138 @@
+import { describe, expect, it } from "vitest";
+import type { PrInfo } from "@/lib/api";
+import { branchStateBadgeClass, branchStateLabel, deriveBranchState } from "../branch-state";
+import type { BranchNode } from "../graph/types";
+
+// Helper to create a minimal BranchNode with overrides
+function makeNode(overrides: Partial<BranchNode> = {}): BranchNode {
+  return {
+    name: "feat/test",
+    parent: "main",
+    isWorktree: false,
+    isMain: false,
+    isCurrent: false,
+    isDirty: false,
+    hasAgent: false,
+    agentTarget: null,
+    agentStatus: null,
+    diffSummary: null,
+    worktree: null,
+    ahead: 0,
+    behind: 0,
+    remote: null,
+    isRemoteOnly: false,
+    ...overrides,
+  };
+}
+
+// Helper to create a minimal PrInfo with overrides
+function makePr(overrides: Partial<PrInfo> = {}): PrInfo {
+  return {
+    number: 42,
+    title: "Test PR",
+    state: "open",
+    head_branch: "feat/test",
+    head_sha: "abc123",
+    base_branch: "main",
+    url: "https://github.com/test/repo/pull/42",
+    review_decision: null,
+    check_status: null,
+    is_draft: false,
+    additions: 10,
+    deletions: 5,
+    comments: 0,
+    reviews: 0,
+    ...overrides,
+  };
+}
+
+describe("deriveBranchState", () => {
+  it("returns 'merged' when PR state is merged", () => {
+    const node = makeNode({ ahead: 0, behind: 0 });
+    const pr = makePr({ state: "merged", merge_commit_sha: "def456" });
+    expect(deriveBranchState(node, pr)).toBe("merged");
+  });
+
+  it("returns 'merged' even if branch has agent (merged takes priority)", () => {
+    const node = makeNode({ hasAgent: true });
+    const pr = makePr({ state: "merged" });
+    expect(deriveBranchState(node, pr)).toBe("merged");
+  });
+
+  it("returns 'merged' even if branch is behind (merged takes priority)", () => {
+    const node = makeNode({ behind: 3, ahead: 0 });
+    const pr = makePr({ state: "merged" });
+    expect(deriveBranchState(node, pr)).toBe("merged");
+  });
+
+  it("returns 'has-open-pr' when PR state is open", () => {
+    const node = makeNode({ ahead: 2 });
+    const pr = makePr({ state: "open" });
+    expect(deriveBranchState(node, pr)).toBe("has-open-pr");
+  });
+
+  it("returns 'has-open-pr' even if agent is active (open-pr takes priority over active)", () => {
+    const node = makeNode({ hasAgent: true, ahead: 1 });
+    const pr = makePr({ state: "open" });
+    expect(deriveBranchState(node, pr)).toBe("has-open-pr");
+  });
+
+  it("returns 'active' when agent is running and no PR", () => {
+    const node = makeNode({ hasAgent: true, agentTarget: "claude", agentStatus: "in-progress" });
+    expect(deriveBranchState(node)).toBe("active");
+  });
+
+  it("returns 'active' when agent is running and PR is closed (not merged)", () => {
+    const node = makeNode({ hasAgent: true });
+    const pr = makePr({ state: "closed" });
+    expect(deriveBranchState(node, pr)).toBe("active");
+  });
+
+  it("returns 'stale' when behind main with no agent and no new commits", () => {
+    const node = makeNode({ behind: 5, ahead: 0, hasAgent: false });
+    expect(deriveBranchState(node)).toBe("stale");
+  });
+
+  it("returns 'default' when behind but has commits ahead (not stale)", () => {
+    const node = makeNode({ behind: 2, ahead: 3, hasAgent: false });
+    expect(deriveBranchState(node)).toBe("default");
+  });
+
+  it("returns 'default' for a normal working branch", () => {
+    const node = makeNode({ ahead: 1, behind: 0 });
+    expect(deriveBranchState(node)).toBe("default");
+  });
+
+  it("returns 'default' when no PR and no agent and not behind", () => {
+    const node = makeNode();
+    expect(deriveBranchState(node)).toBe("default");
+  });
+
+  it("returns 'default' when prInfo is undefined", () => {
+    const node = makeNode({ ahead: 2 });
+    expect(deriveBranchState(node, undefined)).toBe("default");
+  });
+});
+
+describe("branchStateLabel", () => {
+  it("returns correct labels", () => {
+    expect(branchStateLabel("merged")).toBe("Merged");
+    expect(branchStateLabel("has-open-pr")).toBe("PR Open");
+    expect(branchStateLabel("active")).toBe("Active");
+    expect(branchStateLabel("stale")).toBe("Stale");
+    expect(branchStateLabel("default")).toBe("");
+  });
+});
+
+describe("branchStateBadgeClass", () => {
+  it("returns non-empty classes for non-default states", () => {
+    expect(branchStateBadgeClass("merged")).toContain("purple");
+    expect(branchStateBadgeClass("has-open-pr")).toContain("blue");
+    expect(branchStateBadgeClass("active")).toContain("cyan");
+    expect(branchStateBadgeClass("stale")).toContain("amber");
+  });
+
+  it("returns empty string for default state", () => {
+    expect(branchStateBadgeClass("default")).toBe("");
+  });
+});

--- a/crates/tmai-app/web/src/components/worktree/branch-state.ts
+++ b/crates/tmai-app/web/src/components/worktree/branch-state.ts
@@ -1,0 +1,58 @@
+import type { PrInfo } from "@/lib/api";
+import type { BranchNode } from "./graph/types";
+
+/**
+ * Represents the lifecycle state of a branch, used to determine
+ * which action buttons are relevant in the ActionPanel.
+ */
+export type BranchState = "merged" | "has-open-pr" | "active" | "stale" | "default";
+
+/** Derive the lifecycle state of a branch from its node data and optional PR info. */
+export function deriveBranchState(node: BranchNode, prInfo?: PrInfo): BranchState {
+  // 1. Merged — PR exists and is merged
+  if (prInfo?.state === "merged") return "merged";
+
+  // 2. Has open PR — PR exists and is open
+  if (prInfo?.state === "open") return "has-open-pr";
+
+  // 3. Active — agent is currently running on this branch
+  if (node.hasAgent) return "active";
+
+  // 4. Stale — behind parent, no agent, no new work (ahead === 0)
+  if (node.behind > 0 && !node.hasAgent && node.ahead === 0) return "stale";
+
+  // 5. Default — normal working branch
+  return "default";
+}
+
+/** Human-readable label for a branch state badge. */
+export function branchStateLabel(state: BranchState): string {
+  switch (state) {
+    case "merged":
+      return "Merged";
+    case "has-open-pr":
+      return "PR Open";
+    case "active":
+      return "Active";
+    case "stale":
+      return "Stale";
+    case "default":
+      return "";
+  }
+}
+
+/** Tailwind classes for the branch state badge. */
+export function branchStateBadgeClass(state: BranchState): string {
+  switch (state) {
+    case "merged":
+      return "bg-purple-500/15 text-purple-400";
+    case "has-open-pr":
+      return "bg-blue-500/15 text-blue-400";
+    case "active":
+      return "bg-cyan-500/15 text-cyan-400";
+    case "stale":
+      return "bg-amber-500/15 text-amber-400";
+    case "default":
+      return "";
+  }
+}


### PR DESCRIPTION
## Summary

- Introduce `BranchState` type (`merged` | `has-open-pr` | `active` | `stale` | `default`) with priority-based derivation from branch node data and PR info
- Refactor ActionPanel to show only relevant actions per branch lifecycle state:
  - **Merged**: Delete button promoted as primary action, workflow buttons (agent, PR, worktree) hidden
  - **Stale**: Agent/PR/merge actions disabled with tooltip guidance to pull from main first
  - **Open PR**: View PR link shown prominently, Create PR hidden, Delete requires confirmation warning
  - **Active**: Full action set available
- Add branch state badge in the panel header (Merged, PR Open, Active, Stale)
- Add unit tests for `deriveBranchState()` covering all state transitions and priority rules

## Test plan

- [x] `vitest run` — 19 tests pass (including 12 new branch-state tests)
- [x] `tsc --noEmit` — no type errors
- [x] `biome check` — no errors
- [ ] Manual: select merged branch → only Delete + View Diff shown, "Merged" badge visible
- [ ] Manual: select stale branch → behind warning prominent, agent/PR buttons disabled with tooltips
- [ ] Manual: select branch with open PR → "View PR" link prominent, no "Create PR" button
- [ ] Manual: select active branch → full action set available

Closes #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ブランチのライフサイクル状態（マージ済み、ステール、オープンPRなど）をUIバッジで表示
  * ブランチの状態に応じてアクションボタンを動的に調整
  * PR がオープンの場合、GitHub への直接リンクを表示

* **Tests**
  * ブランチ状態ロジックの包括的なテストスイートを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->