### PR TITLE
feat: integrate PermissionDenied hook event into audit system

### DIFF
--- a/crates/tmai-core/src/api/core.rs
+++ b/crates/tmai-core/src/api/core.rs
@@ -168,8 +168,8 @@ impl TmaiCore {
         self.command_sender.as_ref()
     }
 
-    /// Borrow the audit helper (for action modules)
-    pub(crate) fn audit_helper(&self) -> &AuditHelper {
+    /// Borrow the audit helper (for action modules and hook handlers)
+    pub fn audit_helper(&self) -> &AuditHelper {
         &self.audit_helper
     }
 

--- a/crates/tmai-core/src/audit/analyze.rs
+++ b/crates/tmai-core/src/audit/analyze.rs
@@ -310,6 +310,7 @@ fn event_ts(event: &AuditEvent) -> u64 {
         | AuditEvent::AgentDisappeared { ts, .. }
         | AuditEvent::AutoApproveJudgment { ts, .. }
         | AuditEvent::DetectionValidation { ts, .. }
+        | AuditEvent::PermissionDenied { ts, .. }
         | AuditEvent::UserInputDuringProcessing { ts, .. } => *ts,
     }
 }
@@ -323,6 +324,7 @@ fn event_type_name(event: &AuditEvent) -> &'static str {
         AuditEvent::AgentDisappeared { .. } => "AgentDisappeared",
         AuditEvent::AutoApproveJudgment { .. } => "AutoApproveJudgment",
         AuditEvent::DetectionValidation { .. } => "DetectionValidation",
+        AuditEvent::PermissionDenied { .. } => "PermissionDenied",
         AuditEvent::UserInputDuringProcessing { .. } => "UserInputDuringProcessing",
     }
 }
@@ -336,6 +338,7 @@ fn event_agent_type(event: &AuditEvent) -> &str {
         | AuditEvent::AgentDisappeared { agent_type, .. }
         | AuditEvent::AutoApproveJudgment { agent_type, .. }
         | AuditEvent::DetectionValidation { agent_type, .. }
+        | AuditEvent::PermissionDenied { agent_type, .. }
         | AuditEvent::UserInputDuringProcessing { agent_type, .. } => agent_type,
     }
 }
@@ -606,6 +609,28 @@ mod tests {
         assert_eq!(summary.total, 1);
         assert_eq!(summary.ipc_total, 1);
         assert_eq!(summary.ipc_agreement_count, 1);
+    }
+
+    #[test]
+    fn test_compute_stats_includes_permission_denied() {
+        let events = vec![
+            AuditEvent::PermissionDenied {
+                ts: 5000,
+                pane_id: "1".to_string(),
+                agent_type: "ClaudeCode".to_string(),
+                tool_name: Some("Bash".to_string()),
+                tool_input: Some(serde_json::json!({"command": "rm -rf /"})),
+                permission_mode: Some("default".to_string()),
+            },
+            state_changed(1000, "rule_a", DetectionConfidence::High),
+        ];
+
+        let stats = compute_stats(&events);
+        assert_eq!(stats.total_events, 2);
+        assert_eq!(stats.by_event_type["PermissionDenied"], 1);
+        assert_eq!(stats.by_event_type["StateChanged"], 1);
+        assert_eq!(stats.ts_min, Some(1000));
+        assert_eq!(stats.ts_max, Some(5000));
     }
 
     #[test]

--- a/crates/tmai-core/src/audit/events.rs
+++ b/crates/tmai-core/src/audit/events.rs
@@ -108,6 +108,21 @@ pub enum AuditEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         screen_context: Option<String>,
     },
+    /// User denied a permission request from Claude Code
+    PermissionDenied {
+        ts: u64,
+        pane_id: String,
+        agent_type: String,
+        /// Tool that was denied (e.g., "Bash", "Edit")
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_name: Option<String>,
+        /// Tool input parameters at the time of denial
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        tool_input: Option<serde_json::Value>,
+        /// Permission mode (e.g., "default", "plan")
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        permission_mode: Option<String>,
+    },
     /// User sent input while agent was detected as Processing
     /// (possible false negative — detection may have missed an approval prompt)
     UserInputDuringProcessing {
@@ -234,6 +249,74 @@ mod tests {
             assert_eq!(capture_status, "processing");
         } else {
             panic!("Expected DetectionValidation");
+        }
+    }
+
+    #[test]
+    fn test_permission_denied_serde_roundtrip() {
+        let event = AuditEvent::PermissionDenied {
+            ts: 1234567890,
+            pane_id: "5".to_string(),
+            agent_type: "ClaudeCode".to_string(),
+            tool_name: Some("Bash".to_string()),
+            tool_input: Some(serde_json::json!({"command": "rm -rf /"})),
+            permission_mode: Some("default".to_string()),
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        assert!(json.contains("\"event\":\"PermissionDenied\""));
+
+        let deserialized: AuditEvent = serde_json::from_str(&json).unwrap();
+        if let AuditEvent::PermissionDenied {
+            ts,
+            pane_id,
+            agent_type,
+            tool_name,
+            tool_input,
+            permission_mode,
+        } = deserialized
+        {
+            assert_eq!(ts, 1234567890);
+            assert_eq!(pane_id, "5");
+            assert_eq!(agent_type, "ClaudeCode");
+            assert_eq!(tool_name.as_deref(), Some("Bash"));
+            assert!(tool_input.is_some());
+            assert_eq!(permission_mode.as_deref(), Some("default"));
+        } else {
+            panic!("Expected PermissionDenied");
+        }
+    }
+
+    #[test]
+    fn test_permission_denied_serde_minimal() {
+        let event = AuditEvent::PermissionDenied {
+            ts: 100,
+            pane_id: "1".to_string(),
+            agent_type: "ClaudeCode".to_string(),
+            tool_name: None,
+            tool_input: None,
+            permission_mode: None,
+        };
+
+        let json = serde_json::to_string(&event).unwrap();
+        // Optional None fields should be omitted
+        assert!(!json.contains("tool_name"));
+        assert!(!json.contains("tool_input"));
+        assert!(!json.contains("permission_mode"));
+
+        let deserialized: AuditEvent = serde_json::from_str(&json).unwrap();
+        if let AuditEvent::PermissionDenied {
+            tool_name,
+            tool_input,
+            permission_mode,
+            ..
+        } = deserialized
+        {
+            assert!(tool_name.is_none());
+            assert!(tool_input.is_none());
+            assert!(permission_mode.is_none());
+        } else {
+            panic!("Expected PermissionDenied");
         }
     }
 }

--- a/crates/tmai-core/src/audit/helper.rs
+++ b/crates/tmai-core/src/audit/helper.rs
@@ -109,6 +109,34 @@ impl AuditHelper {
         });
     }
 
+    /// Emit a PermissionDenied audit event when the user denies a tool permission
+    pub fn emit_permission_denied(
+        &self,
+        pane_id: &str,
+        agent_type: &str,
+        tool_name: Option<String>,
+        tool_input: Option<serde_json::Value>,
+        permission_mode: Option<String>,
+    ) {
+        let Some(ref tx) = self.tx else {
+            return;
+        };
+
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_millis() as u64;
+
+        let _ = tx.send(AuditEvent::PermissionDenied {
+            ts,
+            pane_id: pane_id.to_string(),
+            agent_type: agent_type.to_string(),
+            tool_name,
+            tool_input,
+            permission_mode,
+        });
+    }
+
     /// Resolve pane_id from target using AppState mapping
     fn resolve_pane_id(&self, target: &str) -> String {
         let state = self.app_state.read();

--- a/crates/tmai-core/src/hooks/handler.rs
+++ b/crates/tmai-core/src/hooks/handler.rs
@@ -168,6 +168,18 @@ pub fn handle_hook_event(
             None
         }
 
+        event_names::PERMISSION_DENIED => {
+            // Permission was denied by the user; agent returns to processing
+            update_status(
+                hook_registry,
+                pane_id,
+                payload,
+                HookStatus::Processing,
+                payload.tool_name.clone().filter(|t| !t.is_empty()),
+            );
+            None
+        }
+
         event_names::STOP => {
             // Clear last_tool on stop (session returns to idle)
             let ctx = build_context(payload);
@@ -1007,6 +1019,68 @@ mod tests {
         let state = reg.get("5").unwrap();
         assert_eq!(state.status, HookStatus::AwaitingApproval);
         assert_eq!(state.last_tool.as_deref(), Some("Bash"));
+    }
+
+    #[test]
+    fn test_permission_denied_sets_processing() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        handle_hook_event(&make_payload("SessionStart"), "5", &registry, &map);
+        // First set AwaitingApproval via PermissionRequest
+        handle_hook_event(
+            &make_payload_with_tool("PermissionRequest", "Bash"),
+            "5",
+            &registry,
+            &map,
+        );
+        {
+            let reg = registry.read();
+            assert_eq!(reg.get("5").unwrap().status, HookStatus::AwaitingApproval);
+        }
+
+        // PermissionDenied should transition back to Processing
+        handle_hook_event(
+            &make_payload_with_tool("PermissionDenied", "Bash"),
+            "5",
+            &registry,
+            &map,
+        );
+
+        let reg = registry.read();
+        let state = reg.get("5").unwrap();
+        assert_eq!(state.status, HookStatus::Processing);
+        assert_eq!(state.last_tool.as_deref(), Some("Bash"));
+    }
+
+    #[test]
+    fn test_permission_denied_context_preserved() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        handle_hook_event(&make_payload("SessionStart"), "5", &registry, &map);
+
+        let payload: HookEventPayload = serde_json::from_value(serde_json::json!({
+            "hook_event_name": "PermissionDenied",
+            "session_id": "test-session",
+            "cwd": "/tmp/test",
+            "tool_name": "Edit",
+            "tool_input": {"file_path": "/etc/passwd"},
+            "permission_mode": "default"
+        }))
+        .unwrap();
+
+        handle_hook_event(&payload, "5", &registry, &map);
+
+        let reg = registry.read();
+        let state = reg.get("5").unwrap();
+        assert_eq!(state.status, HookStatus::Processing);
+        assert_eq!(state.last_tool.as_deref(), Some("Edit"));
+        assert_eq!(state.last_context.event_name, "PermissionDenied");
+        assert_eq!(
+            state.last_context.permission_mode.as_deref(),
+            Some("default")
+        );
     }
 
     /// UserPromptSubmit clears last_tool from previous cycle

--- a/crates/tmai-core/src/hooks/types.rs
+++ b/crates/tmai-core/src/hooks/types.rs
@@ -27,6 +27,7 @@ pub mod event_names {
     pub const PRE_COMPACT: &str = "PreCompact";
     pub const POST_TOOL_USE_FAILURE: &str = "PostToolUseFailure";
     pub const INSTRUCTIONS_LOADED: &str = "InstructionsLoaded";
+    pub const PERMISSION_DENIED: &str = "PermissionDenied";
 }
 
 /// Worktree information attached to hook events in `--worktree` sessions
@@ -704,6 +705,25 @@ mod tests {
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
         assert_eq!(payload.hook_event_name, "PermissionRequest");
         assert_eq!(payload.tool_name.as_deref(), Some("Bash"));
+        let tool_input = payload.tool_input.unwrap();
+        assert_eq!(tool_input["command"], "rm -rf /tmp/build");
+    }
+
+    /// PermissionDenied payload with tool_name and tool_input
+    #[test]
+    fn test_hook_event_payload_deserialize_permission_denied() {
+        let json = r#"{
+            "hook_event_name": "PermissionDenied",
+            "session_id": "sess-1",
+            "cwd": "/tmp",
+            "permission_mode": "default",
+            "tool_name": "Bash",
+            "tool_input": {"command": "rm -rf /tmp/build"}
+        }"#;
+        let payload: HookEventPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.hook_event_name, "PermissionDenied");
+        assert_eq!(payload.tool_name.as_deref(), Some("Bash"));
+        assert_eq!(payload.permission_mode.as_deref(), Some("default"));
         let tool_input = payload.tool_input.unwrap();
         assert_eq!(tool_input["command"], "rm -rf /tmp/build");
     }

--- a/src/web/hooks.rs
+++ b/src/web/hooks.rs
@@ -125,6 +125,17 @@ pub async fn hook_event(
         let _ = core.event_sender().send(event);
     }
 
+    // Emit PermissionDenied audit event when a permission is denied
+    if event_name == "PermissionDenied" {
+        core.audit_helper().emit_permission_denied(
+            &pane_id,
+            "ClaudeCode",
+            payload.tool_name.clone(),
+            payload.tool_input.clone(),
+            payload.permission_mode.clone(),
+        );
+    }
+
     // Notify subscribers that agent state may have changed
     core.notify_agents_updated();
 


### PR DESCRIPTION
## Summary
- Add `PermissionDenied` hook event handling: when a user denies a Claude Code permission request, the hook handler transitions the agent back to `Processing` status
- Add `PermissionDenied` variant to `AuditEvent` enum with tool_name, tool_input, and permission_mode fields
- Emit `PermissionDenied` audit events from the web hooks endpoint for security review and observability
- Make `audit_helper()` public on `TmaiCore` so the bin crate can emit audit events

Closes #174

## Test plan
- [x] Unit test: `PermissionDenied` hook payload deserialization (`types.rs`)
- [x] Unit test: `PermissionDenied` handler sets status to `Processing` (`handler.rs`)
- [x] Unit test: `PermissionDenied` context (tool_name, permission_mode) preserved (`handler.rs`)
- [x] Unit test: `PermissionDenied` audit event serde roundtrip — full and minimal (`events.rs`)
- [x] Unit test: `PermissionDenied` counted in `compute_stats` (`analyze.rs`)
- [x] `cargo test`, `cargo clippy -- -D warnings`, `cargo fmt --check` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 権限拒否イベントの監査ログ記録機能を追加。ツール実行時に権限が拒否された場合、タイムスタンプ、パネルID、エージェント情報などの詳細が監査ログに記録されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->