### PR TITLE
feat: integrate TaskCreated hook event for task monitoring

### DIFF
--- a/crates/tmai-core/src/api/events.rs
+++ b/crates/tmai-core/src/api/events.rs
@@ -58,6 +58,16 @@ pub enum CoreEvent {
         member_name: String,
     },
 
+    /// A new task was created
+    TaskCreated {
+        /// Team name
+        team_name: String,
+        /// Task ID
+        task_id: String,
+        /// Task subject
+        task_subject: String,
+    },
+
     /// A task was completed
     TaskCompleted {
         /// Team name

--- a/crates/tmai-core/src/hooks/handler.rs
+++ b/crates/tmai-core/src/hooks/handler.rs
@@ -285,6 +285,21 @@ pub fn handle_hook_event(
             }
         }
 
+        event_names::TASK_CREATED => {
+            let team_name = payload.team_name.clone().unwrap_or_default();
+            let task_id = payload.task_id.clone().unwrap_or_default();
+            let task_subject = payload.task_subject.clone().unwrap_or_default();
+            if !team_name.is_empty() && !task_id.is_empty() {
+                Some(CoreEvent::TaskCreated {
+                    team_name,
+                    task_id,
+                    task_subject,
+                })
+            } else {
+                None
+            }
+        }
+
         event_names::TASK_COMPLETED => {
             let team_name = payload.team_name.clone().unwrap_or_default();
             let task_id = payload.task_id.clone().unwrap_or_default();
@@ -952,6 +967,41 @@ mod tests {
 
         let event = handle_hook_event(&payload, "5", &registry, &map);
         assert!(matches!(event, Some(CoreEvent::TaskCompleted { .. })));
+    }
+
+    #[test]
+    fn test_task_created_emits_core_event() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        let payload: HookEventPayload = serde_json::from_value(serde_json::json!({
+            "hook_event_name": "TaskCreated",
+            "session_id": "s1",
+            "team_name": "my-team",
+            "task_id": "1",
+            "task_subject": "Implement feature"
+        }))
+        .unwrap();
+
+        let event = handle_hook_event(&payload, "5", &registry, &map);
+        assert!(matches!(event, Some(CoreEvent::TaskCreated { .. })));
+    }
+
+    #[test]
+    fn test_task_created_missing_fields_returns_none() {
+        let registry = new_hook_registry();
+        let map = new_session_pane_map();
+
+        let payload: HookEventPayload = serde_json::from_value(serde_json::json!({
+            "hook_event_name": "TaskCreated",
+            "session_id": "s1",
+            "team_name": "",
+            "task_id": ""
+        }))
+        .unwrap();
+
+        let event = handle_hook_event(&payload, "5", &registry, &map);
+        assert!(event.is_none());
     }
 
     #[test]

--- a/crates/tmai-core/src/hooks/types.rs
+++ b/crates/tmai-core/src/hooks/types.rs
@@ -19,6 +19,7 @@ pub mod event_names {
     pub const SUBAGENT_START: &str = "SubagentStart";
     pub const SUBAGENT_STOP: &str = "SubagentStop";
     pub const TEAMMATE_IDLE: &str = "TeammateIdle";
+    pub const TASK_CREATED: &str = "TaskCreated";
     pub const TASK_COMPLETED: &str = "TaskCompleted";
     pub const SESSION_END: &str = "SessionEnd";
     pub const CONFIG_CHANGE: &str = "ConfigChange";
@@ -621,6 +622,32 @@ mod tests {
             Some("Add login and signup endpoints")
         );
         assert_eq!(payload.teammate_name.as_deref(), Some("implementer"));
+    }
+
+    /// TaskCreated payload — fires when a background task is created
+    #[test]
+    fn test_hook_event_payload_deserialize_task_created() {
+        let json = r#"{
+            "hook_event_name": "TaskCreated",
+            "session_id": "sess-1",
+            "cwd": "/tmp",
+            "permission_mode": "default",
+            "task_id": "task-001",
+            "task_subject": "Implement feature",
+            "task_description": "Add login functionality",
+            "teammate_name": "implementer",
+            "team_name": "my-project"
+        }"#;
+        let payload: HookEventPayload = serde_json::from_str(json).unwrap();
+        assert_eq!(payload.hook_event_name, "TaskCreated");
+        assert_eq!(payload.task_id.as_deref(), Some("task-001"));
+        assert_eq!(payload.task_subject.as_deref(), Some("Implement feature"));
+        assert_eq!(
+            payload.task_description.as_deref(),
+            Some("Add login functionality")
+        );
+        assert_eq!(payload.teammate_name.as_deref(), Some("implementer"));
+        assert_eq!(payload.team_name.as_deref(), Some("my-project"));
     }
 
     /// SessionStart payload (minimal — only common fields)

--- a/src/init.rs
+++ b/src/init.rs
@@ -291,6 +291,7 @@ fn target_events() -> &'static [&'static str] {
         "SubagentStart",
         "SubagentStop",
         "TeammateIdle",
+        "TaskCreated",
         "TaskCompleted",
         "SessionEnd",
         "ConfigChange",
@@ -1083,8 +1084,8 @@ mod tests {
 
     #[test]
     fn test_target_events_count() {
-        // Should have 18 target events
-        assert_eq!(target_events().len(), 18);
+        // Should have 19 target events
+        assert_eq!(target_events().len(), 19);
     }
 
     #[test]

--- a/src/web/events.rs
+++ b/src/web/events.rs
@@ -129,6 +129,19 @@ pub async fn events(State(core): State<Arc<TmaiCore>>) -> impl IntoResponse {
                                 return;
                             }
                         }
+                        Ok(CoreEvent::TaskCreated { team_name, task_id, task_subject }) => {
+                            let data = serde_json::json!({
+                                "team_name": team_name,
+                                "task_id": task_id,
+                                "task_subject": task_subject,
+                            });
+                            let event = Event::default()
+                                .event("task_created")
+                                .data(data.to_string());
+                            if tx.send(Ok(event)).await.is_err() {
+                                return;
+                            }
+                        }
                         Ok(CoreEvent::TaskCompleted { team_name, task_id, task_subject }) => {
                             let data = serde_json::json!({
                                 "team_name": team_name,

--- a/src/web/hooks.rs
+++ b/src/web/hooks.rs
@@ -252,8 +252,8 @@ pub async fn hook_event(
             }
         }
 
-        // TeammateIdle/TaskCompleted: return stop control response
-        "TeammateIdle" | "TaskCompleted" => {
+        // TeammateIdle/TaskCreated/TaskCompleted: return stop control response
+        "TeammateIdle" | "TaskCreated" | "TaskCompleted" => {
             let response = HookEventResponse {
                 should_continue: true,
                 stop_reason: None,


### PR DESCRIPTION
## Summary

- Add `TaskCreated` hook event (Claude Code v2.1.86) for event-driven task awareness when background tasks are created
- Emit `CoreEvent::TaskCreated` via SSE for real-time frontend propagation
- Register `TaskCreated` in `target_events()` for automatic hook setup via `tmai init`

Closes #175

## Test plan

- [x] `test_hook_event_payload_deserialize_task_created` — payload deserialization
- [x] `test_task_created_emits_core_event` — handler emits correct CoreEvent
- [x] `test_task_created_missing_fields_returns_none` — empty fields return None
- [x] All 674 tmai-core tests pass
- [x] All 105 tmai bin tests pass
- [x] `cargo fmt --check` and `cargo clippy` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * タスク作成イベント通知機能を実装しました。タスクが作成されるとシステムがリアルタイムでイベントを発行し、関連情報がユーザーに通知されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->