### PR TITLE
fix: auto-force delete for squash-merged branches

### DIFF
--- a/crates/tmai-core/src/github/mod.rs
+++ b/crates/tmai-core/src/github/mod.rs
@@ -315,6 +315,37 @@ pub async fn list_merged_prs(
     Some(map)
 }
 
+/// Check if a specific branch has an associated merged PR.
+///
+/// Uses `gh pr list --state merged --head <branch>` to detect squash-merged
+/// branches that `git branch -d` would refuse to delete.
+/// Returns `true` if at least one merged PR exists for the given branch.
+pub async fn has_merged_pr(repo_dir: &str, branch: &str) -> bool {
+    let output = tokio::time::timeout(
+        GH_TIMEOUT,
+        Command::new("gh")
+            .args([
+                "pr", "list", "--state", "merged", "--head", branch, "--json", "number", "--limit",
+                "1",
+            ])
+            .current_dir(repo_dir)
+            .output(),
+    )
+    .await
+    .ok()
+    .and_then(|r| r.ok());
+
+    match output {
+        Some(o) if o.status.success() => {
+            // Parse JSON array — non-empty means at least one merged PR
+            serde_json::from_slice::<Vec<serde_json::Value>>(&o.stdout)
+                .map(|v| !v.is_empty())
+                .unwrap_or(false)
+        }
+        _ => false,
+    }
+}
+
 /// A single CI check / workflow run
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct CiCheck {
@@ -1112,6 +1143,24 @@ mod tests {
     fn test_parse_issue_detail_json_missing_required() {
         let json = serde_json::json!({"title": "no number"});
         assert!(parse_issue_detail_json(&json).is_none());
+    }
+
+    #[test]
+    fn test_has_merged_pr_json_parsing() {
+        // Non-empty array → branch has a merged PR
+        let non_empty = b"[{\"number\":42}]";
+        let parsed: Vec<serde_json::Value> = serde_json::from_slice(non_empty).unwrap();
+        assert!(!parsed.is_empty());
+
+        // Empty array → no merged PR
+        let empty = b"[]";
+        let parsed: Vec<serde_json::Value> = serde_json::from_slice(empty).unwrap();
+        assert!(parsed.is_empty());
+
+        // Invalid JSON → should not panic
+        let invalid = b"not json";
+        let result = serde_json::from_slice::<Vec<serde_json::Value>>(invalid);
+        assert!(result.is_err());
     }
 
     #[test]

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1930,6 +1930,10 @@ pub struct DeleteBranchRequest {
 }
 
 /// Delete a local git branch
+///
+/// When force is not requested, automatically uses force-delete (`-D`) for
+/// branches whose PR has been squash-merged — `git branch -d` would reject
+/// them because the original commits don't exist on the target branch.
 pub async fn delete_branch(
     Json(req): Json<DeleteBranchRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
@@ -1942,7 +1946,15 @@ pub async fn delete_branch(
         return Err(json_error(StatusCode::NOT_FOUND, "Repository not found"));
     }
 
-    tmai_core::git::delete_branch(repo_dir, &req.branch, req.force, req.delete_remote)
+    // Auto-force for squash-merged branches: git branch -d fails because the
+    // original commits don't appear in the target branch after squash merge.
+    let force = if req.force {
+        true
+    } else {
+        tmai_core::github::has_merged_pr(repo_dir, &req.branch).await
+    };
+
+    tmai_core::git::delete_branch(repo_dir, &req.branch, force, req.delete_remote)
         .await
         .map(|()| Json(serde_json::json!({"status": "ok"})))
         .map_err(|e| json_error(StatusCode::BAD_REQUEST, &e))


### PR DESCRIPTION
## Summary

- Add `has_merged_pr()` to `github/mod.rs` — lightweight check via `gh pr list --state merged --head <branch>`
- Update `delete_branch` API handler to auto-detect squash-merged branches and use `git branch -D` instead of `-d`
- Add unit test for the merged PR JSON parsing logic

Closes #192

## Test plan

- [ ] Delete a branch whose PR was squash-merged **without** checking "Force delete" — should succeed
- [ ] Delete an unmerged branch without force — should still fail with the expected error
- [ ] Delete a branch with force checkbox — should work as before
- [ ] `cargo test -p tmai-core -- github::tests` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  - ブランチ削除時にスクイズマージされたプルリクエストを自動検出し、強制削除を適用するよう改善しました。これにより、通常の削除では失敗していたブランチも確実に削除できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->