### PR TITLE
feat: click-to-copy commit SHA in git panel

### DIFF
--- a/crates/tmai-app/web/src/components/worktree/CommitLog.tsx
+++ b/crates/tmai-app/web/src/components/worktree/CommitLog.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { api } from "@/lib/api";
+import { CopyableSha } from "./CopyableSha";
 
 interface CommitData {
   sha: string;
@@ -55,7 +56,7 @@ export function CommitLog({ repoPath, base, branch, count }: CommitLogProps) {
                 onClick={() => setExpandedSha((prev) => (prev === c.sha ? null : c.sha))}
                 className="flex w-full items-baseline gap-2 py-1 text-left hover:bg-white/[0.03] rounded px-1 -mx-1 transition-colors"
               >
-                <span className="shrink-0 font-mono text-[10px] text-cyan-600">{c.sha}</span>
+                <CopyableSha sha={c.sha} className="text-[10px] text-cyan-600" />
                 <span className="text-[11px] text-zinc-400 truncate">{c.subject}</span>
               </button>
               {expandedSha === c.sha && (

--- a/crates/tmai-app/web/src/components/worktree/CopyableSha.tsx
+++ b/crates/tmai-app/web/src/components/worktree/CopyableSha.tsx
@@ -1,0 +1,42 @@
+import { useCallback, useRef, useState } from "react";
+
+interface CopyableShaProps {
+  /** Full commit SHA (will be copied to clipboard) */
+  sha: string;
+  /** Number of characters to display (default: 7) */
+  displayLength?: number;
+  /** Additional CSS classes for the container */
+  className?: string;
+  /** Inline styles for the text span */
+  style?: React.CSSProperties;
+}
+
+// Clickable SHA label that copies full SHA to clipboard with brief visual feedback
+export function CopyableSha({ sha, displayLength = 7, className = "", style }: CopyableShaProps) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleClick = useCallback(
+    (e: React.MouseEvent) => {
+      e.stopPropagation();
+      navigator.clipboard.writeText(sha).then(() => {
+        if (timerRef.current) clearTimeout(timerRef.current);
+        setCopied(true);
+        timerRef.current = setTimeout(() => setCopied(false), 1200);
+      });
+    },
+    [sha],
+  );
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      title={copied ? "Copied!" : `Click to copy ${sha}`}
+      className={`shrink-0 cursor-pointer font-mono transition-colors ${className}`}
+      style={style}
+    >
+      {copied ? "Copied!" : sha.slice(0, displayLength)}
+    </button>
+  );
+}

--- a/crates/tmai-app/web/src/components/worktree/__tests__/copyable-sha.test.ts
+++ b/crates/tmai-app/web/src/components/worktree/__tests__/copyable-sha.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from "vitest";
+
+// Unit tests for CopyableSha display logic (clipboard interaction is tested via browser)
+describe("CopyableSha display logic", () => {
+  const fullSha = "abc1234567890def1234567890abcdef12345678";
+
+  it("slices SHA to 7 characters by default", () => {
+    const displayLength = 7;
+    expect(fullSha.slice(0, displayLength)).toBe("abc1234");
+  });
+
+  it("slices SHA to custom display length", () => {
+    const displayLength = 12;
+    expect(fullSha.slice(0, displayLength)).toBe("abc123456789");
+  });
+
+  it("shows full SHA when displayLength equals SHA length", () => {
+    const displayLength = 40;
+    expect(fullSha.slice(0, displayLength)).toBe(fullSha);
+  });
+
+  it("handles short SHA gracefully (no padding)", () => {
+    const shortSha = "abc12";
+    const displayLength = 7;
+    expect(shortSha.slice(0, displayLength)).toBe("abc12");
+  });
+});

--- a/crates/tmai-app/web/src/components/worktree/graph/LaneGraph.tsx
+++ b/crates/tmai-app/web/src/components/worktree/graph/LaneGraph.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api, type PrInfo } from "@/lib/api";
+import { CopyableSha } from "../CopyableSha";
 import { laneBgColor, laneColor, laneDimColor } from "./colors";
 import { BRANCH_R, COMMIT_R, LEFT_PAD, ROW_H } from "./layout";
 import type { LaneLayout } from "./types";
@@ -553,15 +554,14 @@ export function LaneGraph({
               onMouseLeave={() => setHoveredSha(null)}
               onClick={() => handleCommitClick(row.sha, row.lane)}
             >
-              {/* SHA */}
-              <span
-                className="shrink-0 font-mono text-[10px]"
+              {/* SHA (click to copy) */}
+              <CopyableSha
+                sha={row.sha}
+                className="text-[10px]"
                 style={{
                   color: isHovered || isExpanded ? "rgb(34,211,238)" : "rgba(34,211,238,0.35)",
                 }}
-              >
-                {row.sha.slice(0, 7)}
-              </span>
+              />
 
               {/* Subject */}
               <span
@@ -664,9 +664,11 @@ export function LaneGraph({
         >
           <div className="p-3">
             <div className="flex items-center justify-between gap-3">
-              <span className="font-mono text-[11px] text-cyan-400 select-all">
-                {commitDetail?.sha ?? expandedRow.sha}
-              </span>
+              <CopyableSha
+                sha={commitDetail?.sha ?? expandedRow.sha}
+                displayLength={40}
+                className="text-[11px] text-cyan-400"
+              />
               <button
                 type="button"
                 onClick={() => {

--- a/crates/tmai-core/src/git/mod.rs
+++ b/crates/tmai-core/src/git/mod.rs
@@ -997,7 +997,7 @@ pub async fn log_commits(
                 "-C",
                 repo_dir,
                 "log",
-                "--format=%h\t%s\t%b%x1e",
+                "--format=%H\t%s\t%b%x1e",
                 &format!("--max-count={}", max_count),
                 &format!("{}..{}", base, branch),
             ])


### PR DESCRIPTION
## Summary

- Add `CopyableSha` reusable component with clipboard copy and brief "Copied!" visual feedback
- Integrate into LaneGraph commit rows, detail overlay, and CommitLog
- Backend `git_log` now returns full SHA (`%H`) instead of abbreviated (`%h`) so full SHA is available for copying

Closes #162

## Test plan

- [ ] Click SHA in LaneGraph commit row → full SHA copied to clipboard, text flashes "Copied!"
- [ ] Click SHA in commit detail overlay → same behavior
- [ ] Click SHA in CommitLog → same behavior
- [ ] 7-char display unchanged in commit rows; full SHA shown in detail overlay
- [ ] Unit tests pass (`vitest run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * コミットSHAの表示にコピー機能を追加。SHAをクリックするとクリップボードにコピーでき、完了時に一時的なフィードバックが表示されます。

* **Tests**
  * コミットSHA表示機能のテストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->