### PR TITLE
feat: send_prompt API/MCP for queuing prompts to idle/stopped agents (#225)

### DIFF
--- a/crates/tmai-app/web/src/lib/api-http.ts
+++ b/crates/tmai-app/web/src/lib/api-http.ts
@@ -629,6 +629,14 @@ export const api = {
       method: "POST",
       body: JSON.stringify({ text }),
     }),
+  sendPrompt: (target: string, prompt: string) =>
+    apiFetch<{ status: string; action: string; queue_size: number }>(
+      `/agents/${encodeURIComponent(target)}/prompt`,
+      {
+        method: "POST",
+        body: JSON.stringify({ prompt }),
+      },
+    ),
   sendKey: (target: string, key: string) =>
     apiFetch(`/agents/${encodeURIComponent(target)}/key`, {
       method: "POST",

--- a/crates/tmai-app/web/src/lib/api-tauri.ts
+++ b/crates/tmai-app/web/src/lib/api-tauri.ts
@@ -71,6 +71,8 @@ export const api = {
     return await httpApi.sendText(target, text);
   },
 
+  sendPrompt: (target: string, prompt: string) => httpApi.sendPrompt(target, prompt),
+
   sendKey: async (target: string, key: string) => {
     try {
       if (await isInTauri()) {

--- a/crates/tmai-core/src/api/actions.rs
+++ b/crates/tmai-core/src/api/actions.rs
@@ -7,10 +7,13 @@ use crate::agents::{AgentStatus, ApprovalType};
 use crate::detectors::get_detector;
 
 use super::core::TmaiCore;
-use super::types::ApiError;
+use super::types::{ApiError, SendPromptResult};
 
 /// Maximum text length for send_text
 const MAX_TEXT_LENGTH: usize = 1024;
+
+/// Maximum number of queued prompts per agent
+const MAX_PROMPT_QUEUE_SIZE: usize = 5;
 
 /// Allowed special key names for send_key
 const ALLOWED_KEYS: &[&str] = &[
@@ -285,6 +288,84 @@ impl TmaiCore {
             .maybe_emit_input(target, "input_text", "api_input", None);
 
         Ok(())
+    }
+
+    /// Send a prompt to an agent with status-aware behavior.
+    ///
+    /// - **Idle**: sends the prompt immediately (text + Enter).
+    /// - **Offline** (stopped): sends the prompt to restart the agent.
+    /// - **Processing**: queues the prompt (max 5); delivered when agent becomes Idle.
+    /// - **Other** (AwaitingApproval, Error, Unknown): queues like Processing.
+    ///
+    /// Returns a JSON-serializable status indicating the action taken.
+    pub async fn send_prompt(
+        &self,
+        target: &str,
+        prompt: &str,
+    ) -> Result<SendPromptResult, ApiError> {
+        if prompt.chars().count() > MAX_TEXT_LENGTH {
+            return Err(ApiError::InvalidInput {
+                message: format!(
+                    "Prompt exceeds maximum length of {} characters",
+                    MAX_TEXT_LENGTH
+                ),
+            });
+        }
+
+        let (status, is_virtual) = {
+            let state = self.state().read();
+            match state.agents.get(target) {
+                Some(a) => (a.status.clone(), a.is_virtual),
+                None => {
+                    return Err(ApiError::AgentNotFound {
+                        target: target.to_string(),
+                    })
+                }
+            }
+        };
+
+        if is_virtual {
+            return Err(ApiError::VirtualAgent {
+                target: target.to_string(),
+            });
+        }
+
+        match status {
+            AgentStatus::Idle | AgentStatus::Offline => {
+                // Send immediately — Idle agents accept input; Offline panes may restart
+                self.send_text(target, prompt).await?;
+                let action = if status.is_idle() {
+                    "sent"
+                } else {
+                    "sent_restart"
+                };
+                Ok(SendPromptResult {
+                    action: action.to_string(),
+                    queue_size: 0,
+                })
+            }
+            _ => {
+                // Processing, AwaitingApproval, Error, Unknown — queue the prompt
+                let queue_size = {
+                    let mut state = self.state().write();
+                    let queue = state.prompt_queue.entry(target.to_string()).or_default();
+                    if queue.len() >= MAX_PROMPT_QUEUE_SIZE {
+                        return Err(ApiError::InvalidInput {
+                            message: format!(
+                                "Prompt queue full (max {} per agent)",
+                                MAX_PROMPT_QUEUE_SIZE
+                            ),
+                        });
+                    }
+                    queue.push_back(prompt.to_string());
+                    queue.len()
+                };
+                Ok(SendPromptResult {
+                    action: "queued".to_string(),
+                    queue_size,
+                })
+            }
+        }
     }
 
     /// Send a special key to an agent (whitelist-validated).
@@ -1261,6 +1342,7 @@ mod tests {
                 }),
                 is_dirty: Some(false),
                 diff_summary: None,
+                agent_pending: false,
             }],
         }];
     }
@@ -1316,5 +1398,182 @@ mod tests {
             ),
             "Should not block deletion when no agent is running"
         );
+    }
+
+    // =========================================================
+    // send_prompt tests
+    // =========================================================
+
+    #[tokio::test]
+    async fn test_send_prompt_queues_when_processing() {
+        let agent = test_agent(
+            "test:0.0",
+            AgentStatus::Processing {
+                activity: "thinking".to_string(),
+            },
+        );
+        let core = make_core_with_agents(vec![agent]);
+
+        // send_prompt should queue (no command sender, but queue is written before send)
+        let result = core.send_prompt("test:0.0", "do something").await;
+        assert!(result.is_ok());
+        let r = result.unwrap();
+        assert_eq!(r.action, "queued");
+        assert_eq!(r.queue_size, 1);
+
+        // Verify queue state
+        let state = core.state().read();
+        let q = state.prompt_queue.get("test:0.0").unwrap();
+        assert_eq!(q.len(), 1);
+        assert_eq!(q[0], "do something");
+    }
+
+    #[tokio::test]
+    async fn test_send_prompt_queue_overflow() {
+        let agent = test_agent(
+            "test:0.0",
+            AgentStatus::Processing {
+                activity: "thinking".to_string(),
+            },
+        );
+        let core = make_core_with_agents(vec![agent]);
+
+        // Fill up the queue (MAX_PROMPT_QUEUE_SIZE = 5)
+        for i in 0..5 {
+            let result = core.send_prompt("test:0.0", &format!("prompt {}", i)).await;
+            assert!(result.is_ok());
+            assert_eq!(result.unwrap().queue_size, i + 1);
+        }
+
+        // 6th prompt should fail
+        let result = core.send_prompt("test:0.0", "overflow").await;
+        assert!(result.is_err());
+        match result {
+            Err(ApiError::InvalidInput { message }) => {
+                assert!(message.contains("queue full"));
+            }
+            other => panic!("Expected InvalidInput, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_prompt_idle_sends_immediately() {
+        let agent = test_agent("test:0.0", AgentStatus::Idle);
+        let core = make_core_with_agents(vec![agent]);
+
+        // Idle agent — send_prompt tries to send immediately.
+        // Without a CommandSender, it will fail at the send_text level, not the queue level.
+        let result = core.send_prompt("test:0.0", "hello").await;
+        // Should fail because no CommandSender, not because of queueing
+        assert!(result.is_err());
+        match result {
+            Err(ApiError::NoCommandSender) => {} // expected
+            other => panic!("Expected NoCommandSender, got {:?}", other),
+        }
+
+        // Queue should remain empty (not queued)
+        let state = core.state().read();
+        assert!(state.prompt_queue.get("test:0.0").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_send_prompt_offline_sends_immediately() {
+        let agent = test_agent("test:0.0", AgentStatus::Offline);
+        let core = make_core_with_agents(vec![agent]);
+
+        // Offline agent — should try to send immediately (restart)
+        let result = core.send_prompt("test:0.0", "restart prompt").await;
+        assert!(result.is_err());
+        match result {
+            Err(ApiError::NoCommandSender) => {} // expected without tmux
+            other => panic!("Expected NoCommandSender, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_prompt_not_found() {
+        let core = make_core_with_agents(vec![]);
+
+        let result = core.send_prompt("nonexistent", "hello").await;
+        assert!(result.is_err());
+        match result {
+            Err(ApiError::AgentNotFound { target }) => {
+                assert_eq!(target, "nonexistent");
+            }
+            other => panic!("Expected AgentNotFound, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_prompt_virtual_agent() {
+        let mut agent = test_agent("test:0.0", AgentStatus::Idle);
+        agent.is_virtual = true;
+        let core = make_core_with_agents(vec![agent]);
+
+        let result = core.send_prompt("test:0.0", "hello").await;
+        assert!(result.is_err());
+        match result {
+            Err(ApiError::VirtualAgent { .. }) => {} // expected
+            other => panic!("Expected VirtualAgent, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_prompt_too_long() {
+        let agent = test_agent("test:0.0", AgentStatus::Idle);
+        let core = make_core_with_agents(vec![agent]);
+
+        let long_text = "a".repeat(MAX_TEXT_LENGTH + 1);
+        let result = core.send_prompt("test:0.0", &long_text).await;
+        assert!(result.is_err());
+        match result {
+            Err(ApiError::InvalidInput { message }) => {
+                assert!(message.contains("maximum length"));
+            }
+            other => panic!("Expected InvalidInput, got {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_send_prompt_queues_when_awaiting_approval() {
+        let agent = test_agent(
+            "test:0.0",
+            AgentStatus::AwaitingApproval {
+                approval_type: ApprovalType::McpTool,
+                details: "read file".to_string(),
+            },
+        );
+        let core = make_core_with_agents(vec![agent]);
+
+        let result = core.send_prompt("test:0.0", "after approval").await;
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().action, "queued");
+    }
+
+    #[test]
+    fn test_prompt_queue_drain() {
+        // Test the drain behavior by directly manipulating AppState
+        let state = AppState::shared();
+        {
+            let mut s = state.write();
+            let mut q = std::collections::VecDeque::new();
+            q.push_back("first".to_string());
+            q.push_back("second".to_string());
+            s.prompt_queue.insert("agent1".to_string(), q);
+        }
+
+        // Pop front (simulating what the poller does)
+        let prompt = {
+            let mut s = state.write();
+            s.prompt_queue.get_mut("agent1").and_then(|q| q.pop_front())
+        };
+        assert_eq!(prompt, Some("first".to_string()));
+
+        // Verify second is still there
+        let remaining = {
+            let s = state.read();
+            s.prompt_queue.get("agent1").unwrap().len()
+        };
+        assert_eq!(remaining, 1);
     }
 }

--- a/crates/tmai-core/src/api/events.rs
+++ b/crates/tmai-core/src/api/events.rs
@@ -170,6 +170,14 @@ pub enum CoreEvent {
         error: String,
     },
 
+    /// A queued prompt is ready to be delivered (agent transitioned to Idle)
+    PromptReady {
+        /// Agent target ID
+        target: String,
+        /// The prompt text to send
+        prompt: String,
+    },
+
     /// Usage data was updated (after a fetch cycle)
     UsageUpdated,
 

--- a/crates/tmai-core/src/api/mod.rs
+++ b/crates/tmai-core/src/api/mod.rs
@@ -31,7 +31,9 @@ pub mod types;
 pub use builder::TmaiCoreBuilder;
 pub use core::TmaiCore;
 pub use events::CoreEvent;
-pub use types::{AgentSnapshot, ApiError, TeamSummary, TeamTaskInfo, WorktreeSnapshot};
+pub use types::{
+    AgentSnapshot, ApiError, SendPromptResult, TeamSummary, TeamTaskInfo, WorktreeSnapshot,
+};
 
 // Re-export for web/api.rs usage
 pub use actions::has_checkbox_format;

--- a/crates/tmai-core/src/api/types.rs
+++ b/crates/tmai-core/src/api/types.rs
@@ -52,6 +52,15 @@ pub enum ApiError {
 /// Owned snapshot of a `MonitoredAgent`, returned by query methods.
 ///
 /// All string fields are cloned out of the locked state so that callers
+/// Result of a send_prompt operation
+#[derive(Debug, Clone, Serialize)]
+pub struct SendPromptResult {
+    /// Action taken: "sent", "sent_restart", or "queued"
+    pub action: String,
+    /// Current queue size for this agent (0 if sent immediately)
+    pub queue_size: usize,
+}
+
 /// never need to hold a read lock beyond the query call.
 #[derive(Debug, Clone, Serialize)]
 pub struct AgentSnapshot {

--- a/crates/tmai-core/src/monitor/poller.rs
+++ b/crates/tmai-core/src/monitor/poller.rs
@@ -1500,6 +1500,7 @@ impl Poller {
                 // Emit TeammateIdle when a team member transitions to idle
                 if current_status_name == "idle" && committed_status != "idle" {
                     self.emit_teammate_idle(agent);
+                    self.drain_prompt_queue(&agent.target);
                 }
 
                 self.previous_statuses.insert(
@@ -1552,6 +1553,7 @@ impl Poller {
                         // Emit TeammateIdle when a team member transitions to idle
                         if current_status_name == "idle" && committed_status != "idle" {
                             self.emit_teammate_idle(agent);
+                            self.drain_prompt_queue(&agent.target);
                         }
 
                         self.previous_statuses.insert(
@@ -1637,6 +1639,37 @@ impl Poller {
                     target: agent.target.clone(),
                     team_name: team_info.team_name.clone(),
                     member_name: team_info.member_name.clone(),
+                });
+            }
+        }
+    }
+
+    /// Drain one prompt from the queue for an agent that just became Idle.
+    ///
+    /// Pops the front prompt from `AppState::prompt_queue` and emits a
+    /// `CoreEvent::PromptReady` event so that the main loop can deliver it.
+    fn drain_prompt_queue(&self, target: &str) {
+        let prompt = {
+            let mut state = self.state.write();
+            state
+                .prompt_queue
+                .get_mut(target)
+                .and_then(|q| q.pop_front())
+        };
+        if let Some(prompt) = prompt {
+            // Clean up empty queues
+            {
+                let mut state = self.state.write();
+                if let Some(q) = state.prompt_queue.get(target) {
+                    if q.is_empty() {
+                        state.prompt_queue.remove(target);
+                    }
+                }
+            }
+            if let Some(ref tx) = self.event_tx {
+                let _ = tx.send(CoreEvent::PromptReady {
+                    target: target.to_string(),
+                    prompt,
                 });
             }
         }

--- a/crates/tmai-core/src/state/store.rs
+++ b/crates/tmai-core/src/state/store.rs
@@ -498,6 +498,11 @@ pub struct AppState {
     /// Key: worktree path, Value: spawn timestamp.
     /// Prevents deletion during the window between spawn and agent detection.
     pub pending_agent_worktrees: HashMap<String, std::time::Instant>,
+
+    /// Prompt queue for agents that are currently Processing.
+    /// Key: agent target ID, Value: queued prompts (max 5 per agent).
+    /// Drained by the poller when the agent transitions to Idle.
+    pub prompt_queue: HashMap<String, std::collections::VecDeque<String>>,
 }
 
 impl AppState {
@@ -538,6 +543,7 @@ impl AppState {
             spawn_in_tmux: false,
             spawn_tmux_window_name: "tmai-agents".to_string(),
             pending_agent_worktrees: HashMap::new(),
+            prompt_queue: HashMap::new(),
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -417,6 +417,22 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
     // Run poller in background
     let mut poll_rx = poller.start();
 
+    // Background task: deliver queued prompts when agents become idle
+    {
+        let core = core.clone();
+        let mut event_rx = core.subscribe();
+        tokio::spawn(async move {
+            while let Ok(event) = event_rx.recv().await {
+                if let tmai_core::api::CoreEvent::PromptReady { target, prompt } = event {
+                    tracing::info!("Delivering queued prompt to agent {}", target);
+                    if let Err(e) = core.send_text(&target, &prompt).await {
+                        tracing::warn!("Failed to deliver queued prompt to {}: {}", target, e);
+                    }
+                }
+            }
+        });
+    }
+
     // Interval for syncing PTY session liveness with agent status
     let mut pty_sync_interval = tokio::time::interval(std::time::Duration::from_secs(2));
     pty_sync_interval.tick().await; // skip first tick

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -48,6 +48,14 @@ pub struct SendTextParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SendPromptParams {
+    /// Agent ID
+    pub id: String,
+    /// Prompt text to send to the agent
+    pub prompt: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SendKeyParams {
     /// Agent ID
     pub id: String,
@@ -203,6 +211,38 @@ impl TmaiMcpServer {
             &serde_json::json!({"text": p.text}),
         ) {
             Ok(()) => format!("Sent text to agent {}", p.id),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Send a prompt to an agent with status-aware delivery. If the agent is idle, the prompt is
+    /// sent immediately. If the agent is processing, the prompt is queued (max 5) and delivered
+    /// automatically when the agent becomes idle. If the agent is stopped/offline, the prompt is
+    /// sent to restart it.
+    #[tool(description = "Send a prompt to an agent (queues if busy, delivers when idle)")]
+    fn send_prompt(&self, Parameters(p): Parameters<SendPromptParams>) -> String {
+        match self.client.post::<serde_json::Value>(
+            &format!("/agents/{}/prompt", p.id),
+            &serde_json::json!({"prompt": p.prompt}),
+        ) {
+            Ok(data) => {
+                let action = data
+                    .get("action")
+                    .and_then(|v| v.as_str())
+                    .unwrap_or("unknown");
+                let queue_size = data.get("queue_size").and_then(|v| v.as_u64()).unwrap_or(0);
+                match action {
+                    "sent" => format!("Prompt sent to agent {} (idle)", p.id),
+                    "sent_restart" => {
+                        format!("Prompt sent to agent {} (restarting from stopped)", p.id)
+                    }
+                    "queued" => format!(
+                        "Prompt queued for agent {} (queue position: {})",
+                        p.id, queue_size
+                    ),
+                    _ => format!("Prompt action '{}' for agent {}", action, p.id),
+                }
+            }
             Err(e) => format!("Error: {e}"),
         }
     }

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -459,6 +459,21 @@ impl App {
                             let mut state = self.state.write();
                             state.set_notification(format!("Setup failed [{}]: {}", branch, error));
                         }
+                        tmai_core::api::CoreEvent::PromptReady { target, prompt } => {
+                            if let Some(ref core) = self.core {
+                                let core = core.clone();
+                                tokio::spawn(async move {
+                                    tracing::info!("Delivering queued prompt to agent {}", target);
+                                    if let Err(e) = core.send_text(&target, &prompt).await {
+                                        tracing::warn!(
+                                            "Failed to deliver queued prompt to {}: {}",
+                                            target,
+                                            e
+                                        );
+                                    }
+                                });
+                            }
+                        }
                         _ => {} // Other events handled elsewhere
                     }
                 }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -123,6 +123,12 @@ pub struct PassthroughRequest {
     pub key: Option<String>,
 }
 
+/// Prompt request body
+#[derive(Debug, Deserialize)]
+pub struct PromptRequest {
+    pub prompt: String,
+}
+
 /// Per-agent auto-approve override request
 #[derive(Debug, Deserialize)]
 pub struct AutoApproveOverrideRequest {
@@ -347,6 +353,22 @@ pub async fn send_text(
         .map(|()| Json(serde_json::json!({"status": "ok"})))
         .map_err(|e| {
             tracing::warn!("API: input failed agent_id={}: {}", id, e);
+            api_error_to_http(e)
+        })
+}
+
+/// Send a prompt to an agent with status-aware behavior (queue if Processing)
+pub async fn send_prompt(
+    State(core): State<Arc<TmaiCore>>,
+    Path(id): Path<String>,
+    Json(req): Json<PromptRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    tracing::info!("API: send_prompt agent_id={}", id);
+    core.send_prompt(&id, &req.prompt)
+        .await
+        .map(|result| Json(serde_json::json!({"status": "ok", "action": result.action, "queue_size": result.queue_size})))
+        .map_err(|e| {
+            tracing::warn!("API: send_prompt failed agent_id={}: {}", id, e);
             api_error_to_http(e)
         })
 }

--- a/src/web/events.rs
+++ b/src/web/events.rs
@@ -244,8 +244,10 @@ pub async fn events(State(core): State<Arc<TmaiCore>>) -> impl IntoResponse {
                         | Ok(CoreEvent::InstructionsLoaded { .. })
                         | Ok(CoreEvent::ReviewReady { .. })
                         | Ok(CoreEvent::WorktreeSetupCompleted { .. })
-                        | Ok(CoreEvent::WorktreeSetupFailed { .. }) => {
-                            // Future: forward to SSE subscribers if needed
+                        | Ok(CoreEvent::WorktreeSetupFailed { .. })
+                        | Ok(CoreEvent::PromptReady { .. }) => {
+                            // PromptReady is handled by the background prompt delivery task.
+                            // Other events: forward to SSE subscribers in the future if needed.
                         }
                         Ok(CoreEvent::ReviewLaunched { source_target, review_target }) => {
                             let data = serde_json::json!({

--- a/src/web/server.rs
+++ b/src/web/server.rs
@@ -74,6 +74,7 @@ impl WebServer {
             .route("/agents/{id}/select", post(api::select_choice))
             .route("/agents/{id}/submit", post(api::submit_selection))
             .route("/agents/{id}/input", post(api::send_text))
+            .route("/agents/{id}/prompt", post(api::send_prompt))
             .route("/agents/{id}/key", post(api::send_key))
             .route("/agents/{id}/auto-approve", put(api::set_auto_approve))
             .route("/agents/{id}/kill", post(api::kill_agent))


### PR DESCRIPTION
## Summary
- Add `POST /api/agents/{id}/prompt` endpoint with status-aware delivery: sends immediately to idle/offline agents, queues (max 5) for processing agents
- Add `send_prompt` MCP tool for orchestrator use with human-readable responses
- Add `TmaiCore::send_prompt` method, `prompt_queue` in AppState, and `CoreEvent::PromptReady` for poller-driven queue drain on idle transition
- Add `sendPrompt` to frontend API clients (api-http.ts, api-tauri.ts)
- Add 9 unit tests covering queue, overflow, status routing, validation

## Behavior
| Agent Status | Action |
|---|---|
| Idle | Send immediately (text + Enter) |
| Offline (stopped) | Send immediately (restarts agent) |
| Processing / AwaitingApproval / Error | Queue (max 5, FIFO) |

Queued prompts are drained one-at-a-time when the poller commits an idle transition, via `CoreEvent::PromptReady` → background delivery task.

## Test plan
- [x] `cargo test -- send_prompt prompt_queue prompt_drain` — 9 tests pass
- [x] `cargo test` — 108 tests pass
- [x] `cargo clippy` — clean
- [x] `cargo fmt` — clean

Closes #225

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エージェントへのプロンプト送信機能を追加しました。
  * エージェントが処理中の場合、プロンプトは自動的にキューイングされます（最大5件まで）。
  * キューはエージェントがアイドル状態になると自動的に処理されます。Web API、UI、MCPツール経由で利用可能です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->