### PR TITLE
feat: include issue context in spawn_worktree MCP tool (#222)

### DIFF
--- a/crates/tmai-core/src/api/actions.rs
+++ b/crates/tmai-core/src/api/actions.rs
@@ -1261,6 +1261,7 @@ mod tests {
                 }),
                 is_dirty: Some(false),
                 diff_summary: None,
+                agent_pending: false,
             }],
         }];
     }

--- a/crates/tmai-core/src/utils/namegen.rs
+++ b/crates/tmai-core/src/utils/namegen.rs
@@ -269,6 +269,57 @@ pub fn generate_unique_name(existing: &[String]) -> String {
     format!("{}-{}", name, ts)
 }
 
+/// Convert a title string into a valid branch-name slug.
+///
+/// Rules: lowercase, replace non-alphanumeric runs with `-`, strip leading/trailing
+/// hyphens, and truncate to `max_len` on a word boundary.
+///
+/// # Examples
+///
+/// ```
+/// let slug = tmai_core::utils::namegen::slugify_for_branch("feat: Spawn Worktree Issue Number!", 50);
+/// assert_eq!(slug, "feat-spawn-worktree-issue-number");
+/// ```
+pub fn slugify_for_branch(title: &str, max_len: usize) -> String {
+    // Lowercase and replace any non-alphanumeric character run with a single hyphen
+    let slug: String = title
+        .to_lowercase()
+        .chars()
+        .map(|c| if c.is_ascii_alphanumeric() { c } else { '-' })
+        .collect();
+
+    // Collapse consecutive hyphens and trim leading/trailing hyphens
+    let mut result = String::with_capacity(slug.len());
+    let mut prev_hyphen = true; // treat start as hyphen to strip leading
+    for c in slug.chars() {
+        if c == '-' {
+            if !prev_hyphen {
+                result.push('-');
+            }
+            prev_hyphen = true;
+        } else {
+            result.push(c);
+            prev_hyphen = false;
+        }
+    }
+    // Trim trailing hyphen
+    while result.ends_with('-') {
+        result.pop();
+    }
+
+    // Truncate to max_len on a hyphen boundary if possible
+    if result.len() > max_len {
+        let truncated = &result[..max_len];
+        if let Some(last_hyphen) = truncated.rfind('-') {
+            result = truncated[..last_hyphen].to_string();
+        } else {
+            result = truncated.to_string();
+        }
+    }
+
+    result
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -325,5 +376,51 @@ mod tests {
         let existing: Vec<String> = vec![];
         let name = generate_unique_name(&existing);
         assert!(name.contains('-'), "Name should contain a hyphen separator");
+    }
+
+    #[test]
+    fn test_slugify_basic() {
+        assert_eq!(
+            slugify_for_branch("feat: Spawn Worktree Issue Number!", 50),
+            "feat-spawn-worktree-issue-number"
+        );
+    }
+
+    #[test]
+    fn test_slugify_special_characters() {
+        assert_eq!(
+            slugify_for_branch("Add `issue_number` param to spawn_worktree MCP tool", 60),
+            "add-issue-number-param-to-spawn-worktree-mcp-tool"
+        );
+    }
+
+    #[test]
+    fn test_slugify_truncation() {
+        let slug = slugify_for_branch(
+            "this is a very long title that should be truncated properly at word boundary",
+            30,
+        );
+        assert!(
+            slug.len() <= 30,
+            "Slug should be at most 30 chars, got {}: {}",
+            slug.len(),
+            slug
+        );
+        assert!(!slug.ends_with('-'), "Slug should not end with hyphen");
+    }
+
+    #[test]
+    fn test_slugify_leading_trailing_hyphens() {
+        assert_eq!(slugify_for_branch("---hello---", 50), "hello");
+    }
+
+    #[test]
+    fn test_slugify_empty() {
+        assert_eq!(slugify_for_branch("", 50), "");
+    }
+
+    #[test]
+    fn test_slugify_consecutive_specials() {
+        assert_eq!(slugify_for_branch("a!!!b###c", 50), "a-b-c");
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -99,8 +99,13 @@ pub struct SpawnAgentParams {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SpawnWorktreeParams {
-    /// Worktree name
-    pub name: String,
+    /// Worktree name (optional if issue_number is provided — auto-generated from issue title)
+    #[serde(default)]
+    pub name: Option<String>,
+    /// GitHub issue number. When provided: auto-generates worktree name from issue title
+    /// (if name is omitted) and composes a resolve prompt with the issue context.
+    #[serde(default)]
+    pub issue_number: Option<u64>,
     /// Repository path (optional, defaults to cwd or first registered project)
     #[serde(default)]
     pub repo: Option<String>,
@@ -267,13 +272,24 @@ impl TmaiMcpServer {
     }
 
     /// Create a new git worktree and spawn an AI agent in it. Ideal for isolated feature work.
+    /// When issue_number is provided, the worktree name is auto-generated from the issue title
+    /// and a resolve prompt with issue context is composed automatically.
     #[tool(description = "Create a worktree and spawn an agent in it")]
     fn spawn_worktree(&self, Parameters(p): Parameters<SpawnWorktreeParams>) -> String {
+        if p.name.is_none() && p.issue_number.is_none() {
+            return "Error: either 'name' or 'issue_number' must be provided".to_string();
+        }
         let cwd = match self.client.resolve_repo(&p.repo) {
             Ok(r) => r,
             Err(e) => return format!("Error: {e}"),
         };
-        let mut body = serde_json::json!({"name": p.name, "cwd": cwd});
+        let mut body = serde_json::json!({"cwd": cwd});
+        if let Some(name) = &p.name {
+            body["name"] = serde_json::json!(name);
+        }
+        if let Some(issue_number) = p.issue_number {
+            body["issue_number"] = serde_json::json!(issue_number);
+        }
         if let Some(base) = &p.base_branch {
             body["base_branch"] = serde_json::json!(base);
         }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -2172,8 +2172,13 @@ pub async fn git_merge(
 /// Request body for worktree spawn
 #[derive(Debug, Deserialize)]
 pub struct WorktreeSpawnRequest {
-    /// Worktree name (also used as branch name)
-    pub name: String,
+    /// Worktree name (optional if issue_number is provided — auto-generated from issue title)
+    #[serde(default)]
+    pub name: Option<String>,
+    /// GitHub issue number. When set, fetches issue title/body to auto-generate the
+    /// worktree name (if not given) and compose a resolve prompt with issue context.
+    #[serde(default)]
+    pub issue_number: Option<u64>,
     /// Repository path
     pub cwd: String,
     /// Base branch to create worktree from (defaults to current HEAD)
@@ -2201,19 +2206,21 @@ pub async fn spawn_worktree(
         ));
     }
 
+    // Resolve worktree name and initial prompt from issue context if provided
+    let (resolved_name, resolved_prompt) = resolve_issue_context(&req).await?;
+
     // Validate worktree name
-    if !tmai_core::git::is_valid_worktree_name(&req.name) {
+    if !tmai_core::git::is_valid_worktree_name(&resolved_name) {
         return Err(json_error(
             StatusCode::BAD_REQUEST,
-            &format!("Invalid worktree name: {}", req.name),
+            &format!("Invalid worktree name: {}", resolved_name),
         ));
     }
 
     // Create git worktree using tmai-core
-    // Directory and branch both use the user-provided name (consistent with PATH 1)
     let wt_req = tmai_core::worktree::WorktreeCreateRequest {
         repo_path: req.cwd.clone(),
-        branch_name: req.name.clone(),
+        branch_name: resolved_name.clone(),
         dir_name: None,
         base_branch: req.base_branch.clone(),
     };
@@ -2224,15 +2231,16 @@ pub async fn spawn_worktree(
 
     tracing::info!(
         "API: created worktree '{}' at {} (branch: {})",
-        req.name,
+        resolved_name,
         wt_result.path,
         wt_result.branch
     );
 
-    // Build args — pass initial prompt as first positional argument if provided
-    let args = match req.initial_prompt {
-        Some(ref prompt) if !prompt.is_empty() => vec![prompt.clone()],
-        _ => vec![],
+    // Build args — pass resolved prompt as first positional argument if provided
+    let args = if !resolved_prompt.is_empty() {
+        vec![resolved_prompt]
+    } else {
+        vec![]
     };
 
     // Spawn claude in the worktree directory
@@ -2275,6 +2283,77 @@ pub async fn spawn_worktree(
     }
 
     result
+}
+
+/// Resolve worktree name and initial prompt from issue context.
+///
+/// When `issue_number` is provided, fetches the issue via `gh` and:
+/// - auto-generates a worktree name from `{issue_number}-{slugified-title}` if `name` is absent
+/// - composes an initial prompt with the issue context (title + body) if `initial_prompt` is absent
+async fn resolve_issue_context(
+    req: &WorktreeSpawnRequest,
+) -> Result<(String, String), (StatusCode, Json<serde_json::Value>)> {
+    match req.issue_number {
+        Some(issue_number) => {
+            let issue = tmai_core::github::get_issue_detail(&req.cwd, issue_number)
+                .await
+                .ok_or_else(|| {
+                    json_error(
+                        StatusCode::BAD_REQUEST,
+                        &format!("Failed to fetch GitHub issue #{issue_number}. Is `gh` authenticated and is this a GitHub repository?"),
+                    )
+                })?;
+
+            // Auto-generate name: {issue_number}-{slugified-title}
+            let name = match &req.name {
+                Some(n) if !n.is_empty() => n.clone(),
+                _ => {
+                    // Max slug portion: 64 (worktree name limit) - issue_number digits - 1 (hyphen)
+                    let prefix = format!("{}-", issue_number);
+                    let max_slug = 64_usize.saturating_sub(prefix.len());
+                    let slug =
+                        tmai_core::utils::namegen::slugify_for_branch(&issue.title, max_slug);
+                    if slug.is_empty() {
+                        return Err(json_error(
+                            StatusCode::BAD_REQUEST,
+                            &format!("Could not generate valid worktree name from issue #{issue_number} title"),
+                        ));
+                    }
+                    format!("{prefix}{slug}")
+                }
+            };
+
+            // Compose initial prompt with issue context if not explicitly provided
+            let prompt = match &req.initial_prompt {
+                Some(p) if !p.is_empty() => p.clone(),
+                _ => {
+                    let body_section = if issue.body.is_empty() {
+                        String::new()
+                    } else {
+                        format!("\n\n## Issue Body\n{}", issue.body)
+                    };
+                    format!(
+                        "Resolve GitHub issue #{number}: {title}{body}\n\nCreate PR: \"{title} (#{number})\"",
+                        number = issue_number,
+                        title = issue.title,
+                        body = body_section,
+                    )
+                }
+            };
+
+            Ok((name, prompt))
+        }
+        None => {
+            let name = req.name.clone().ok_or_else(|| {
+                json_error(
+                    StatusCode::BAD_REQUEST,
+                    "Either 'name' or 'issue_number' must be provided",
+                )
+            })?;
+            let prompt = req.initial_prompt.clone().unwrap_or_default();
+            Ok((name, prompt))
+        }
+    }
 }
 
 // =========================================================


### PR DESCRIPTION
## Summary
- Add optional `issue_number` parameter to the `spawn_worktree` MCP tool and web API endpoint
- When `issue_number` is provided, auto-generates worktree name as `{issue_number}-{slugified-title}` (if `name` not given) and composes a resolve prompt with the issue context (title + body)
- Add `slugify_for_branch()` utility function with comprehensive tests

## Test plan
- [x] `slugify_for_branch` unit tests pass (11 tests including edge cases)
- [ ] Manual test: `spawn_worktree` with `issue_number` only — should auto-generate name and prompt
- [ ] Manual test: `spawn_worktree` with both `issue_number` and `name` — should use provided name
- [ ] Manual test: `spawn_worktree` with neither `name` nor `issue_number` — should return error
- [ ] Manual test: `spawn_worktree` with invalid issue number — should return error about `gh` auth

Closes #222

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * GitHub課題番号を使用したワークツリーの作成が可能になりました。課題のタイトルから自動的にワークツリー名が生成されます。
  * 課題の内容から初期プロンプトが自動で構成されるようになりました。

* **テスト**
  * テストヘルパーのワークツリー状態初期化を改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->