### PR TITLE
feat: auto-rebase stale PRs after merge (#224)

### DIFF
--- a/crates/tmai-core/src/api/events.rs
+++ b/crates/tmai-core/src/api/events.rs
@@ -191,6 +191,24 @@ pub enum CoreEvent {
         tool_name: String,
     },
 
+    /// A worktree branch was successfully rebased onto the default branch
+    RebaseSucceeded {
+        /// Branch that was rebased
+        branch: String,
+        /// Worktree path
+        worktree_path: String,
+    },
+
+    /// A worktree branch rebase failed due to conflicts
+    RebaseConflict {
+        /// Branch that had conflicts
+        branch: String,
+        /// Worktree path
+        worktree_path: String,
+        /// Error details
+        error: String,
+    },
+
     /// A deferred tool call was resolved (approved/denied)
     ToolCallResolved {
         /// Unique deferred call ID

--- a/crates/tmai-core/src/config/settings.rs
+++ b/crates/tmai-core/src/config/settings.rs
@@ -278,6 +278,10 @@ pub struct Settings {
     #[serde(default)]
     pub worktree: WorktreeSettings,
 
+    /// Workflow automation settings
+    #[serde(default)]
+    pub workflow: WorkflowSettings,
+
     /// Agent spawn settings
     #[serde(default)]
     pub spawn: SpawnSettings,
@@ -791,6 +795,15 @@ impl Default for WorktreeSettings {
     }
 }
 
+/// Workflow automation settings
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct WorkflowSettings {
+    /// Automatically rebase open worktree branches onto main after a PR merge
+    /// (default: false)
+    #[serde(default)]
+    pub auto_rebase_on_merge: bool,
+}
+
 /// Agent spawn settings (how new agents are started from the Web UI)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SpawnSettings {
@@ -858,6 +871,7 @@ impl Default for Settings {
             review: ReviewSettings::default(),
             codex_ws: CodexWsSettings::default(),
             worktree: WorktreeSettings::default(),
+            workflow: WorkflowSettings::default(),
             spawn: SpawnSettings::default(),
             projects: Vec::new(),
             webui: true,

--- a/crates/tmai-core/src/git/mod.rs
+++ b/crates/tmai-core/src/git/mod.rs
@@ -1456,6 +1456,247 @@ pub async fn ahead_behind(repo_dir: &str, branch: &str, base: &str) -> Option<(u
     }
 }
 
+/// Resolve the SHA of origin/<default_branch> HEAD (from local refs, no fetch).
+pub async fn resolve_remote_head(repo_dir: &str) -> Option<String> {
+    let default_branch = detect_default_branch(repo_dir).await?;
+    let remote_ref = format!("origin/{}", default_branch);
+
+    let output = tokio::time::timeout(
+        GIT_TIMEOUT,
+        Command::new("git")
+            .args(["-C", repo_dir, "rev-parse", &remote_ref])
+            .output(),
+    )
+    .await
+    .ok()?
+    .ok()?;
+
+    if !output.status.success() {
+        return None;
+    }
+
+    let sha = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if sha.is_empty() {
+        None
+    } else {
+        Some(sha)
+    }
+}
+
+// ── Auto-rebase service ──────────────────────────────────────────────
+
+/// Result of a single branch rebase attempt
+#[derive(Debug, Clone)]
+pub struct RebaseResult {
+    /// Branch name that was rebased
+    pub branch: String,
+    /// Worktree path
+    pub worktree_path: String,
+    /// Whether the rebase succeeded (clean rebase + force-push)
+    pub success: bool,
+    /// Error message if rebase failed (e.g., conflicts)
+    pub error: Option<String>,
+}
+
+/// Rebase all tmai-managed worktree branches onto the default branch after a merge.
+///
+/// Only rebases branches that:
+/// - Live in a `.claude/worktrees/` directory (tmai-managed)
+/// - Have their PR base branch set to the default branch (e.g., main)
+/// - Are behind the default branch
+///
+/// For each eligible branch: fetch, rebase onto default, force-push if clean.
+/// Returns a list of results for each attempted rebase.
+pub async fn rebase_worktree_branches(
+    repo_dir: &str,
+    open_prs: &std::collections::HashMap<String, crate::github::PrInfo>,
+) -> Vec<RebaseResult> {
+    let default_branch = match detect_default_branch(repo_dir).await {
+        Some(b) => b,
+        None => return Vec::new(),
+    };
+
+    // Fetch latest from remote first
+    let _ = tokio::time::timeout(
+        Duration::from_secs(30),
+        Command::new("git")
+            .args(["-C", repo_dir, "fetch", "origin", &default_branch])
+            .output(),
+    )
+    .await;
+
+    let worktrees = list_worktrees(repo_dir).await;
+    let mut results = Vec::new();
+
+    for wt in &worktrees {
+        // Skip main worktree and bare repos
+        if wt.is_main || wt.is_bare {
+            continue;
+        }
+
+        // Only rebase tmai-managed worktrees (under .claude/worktrees/)
+        if extract_claude_worktree_name(&wt.path).is_none() {
+            continue;
+        }
+
+        let branch = match &wt.branch {
+            Some(b) => b.clone(),
+            None => continue, // detached HEAD
+        };
+
+        // Skip if no open PR for this branch
+        let pr = match open_prs.get(&branch) {
+            Some(pr) => pr,
+            None => continue,
+        };
+
+        // Only rebase branches whose PR targets the default branch
+        if pr.base_branch != default_branch {
+            continue;
+        }
+
+        // Check if branch is behind default
+        let behind =
+            match ahead_behind(&wt.path, &branch, &format!("origin/{}", default_branch)).await {
+                Some((_, behind)) if behind > 0 => behind,
+                _ => continue, // up-to-date or error
+            };
+
+        tracing::info!(
+            branch = %branch,
+            behind = behind,
+            worktree = %wt.path,
+            "auto-rebasing worktree branch onto {}",
+            default_branch
+        );
+
+        let result = rebase_single_branch(&wt.path, &branch, &default_branch).await;
+        results.push(result);
+    }
+
+    results
+}
+
+/// Rebase a single branch in its worktree onto origin/<default_branch>.
+/// If clean, force-push. If conflicts, abort rebase and report.
+async fn rebase_single_branch(
+    worktree_path: &str,
+    branch: &str,
+    default_branch: &str,
+) -> RebaseResult {
+    let target = format!("origin/{}", default_branch);
+
+    // Run git rebase
+    let rebase_output = tokio::time::timeout(
+        Duration::from_secs(60),
+        Command::new("git")
+            .args(["-C", worktree_path, "rebase", &target])
+            .output(),
+    )
+    .await;
+
+    let rebase_ok = match &rebase_output {
+        Ok(Ok(o)) => o.status.success(),
+        _ => false,
+    };
+
+    if !rebase_ok {
+        // Abort the failed rebase
+        let _ = tokio::time::timeout(
+            Duration::from_secs(10),
+            Command::new("git")
+                .args(["-C", worktree_path, "rebase", "--abort"])
+                .output(),
+        )
+        .await;
+
+        let error_msg = match rebase_output {
+            Ok(Ok(o)) => {
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                let stdout = String::from_utf8_lossy(&o.stdout);
+                format!("{}\n{}", stdout.trim(), stderr.trim())
+                    .trim()
+                    .to_string()
+            }
+            Ok(Err(e)) => format!("Failed to run git: {}", e),
+            Err(_) => "Git rebase timed out".to_string(),
+        };
+
+        tracing::warn!(
+            branch = %branch,
+            worktree = %worktree_path,
+            error = %error_msg,
+            "rebase conflict, aborted"
+        );
+
+        return RebaseResult {
+            branch: branch.to_string(),
+            worktree_path: worktree_path.to_string(),
+            success: false,
+            error: Some(error_msg),
+        };
+    }
+
+    // Force-push the rebased branch
+    let push_output = tokio::time::timeout(
+        Duration::from_secs(30),
+        Command::new("git")
+            .args([
+                "-C",
+                worktree_path,
+                "push",
+                "--force-with-lease",
+                "origin",
+                branch,
+            ])
+            .output(),
+    )
+    .await;
+
+    let push_ok = match &push_output {
+        Ok(Ok(o)) => o.status.success(),
+        _ => false,
+    };
+
+    if !push_ok {
+        let error_msg = match push_output {
+            Ok(Ok(o)) => {
+                let stderr = String::from_utf8_lossy(&o.stderr);
+                format!("force-push failed: {}", stderr.trim())
+            }
+            Ok(Err(e)) => format!("Failed to run git push: {}", e),
+            Err(_) => "Git push timed out".to_string(),
+        };
+
+        tracing::warn!(
+            branch = %branch,
+            worktree = %worktree_path,
+            error = %error_msg,
+            "rebase succeeded but push failed"
+        );
+
+        return RebaseResult {
+            branch: branch.to_string(),
+            worktree_path: worktree_path.to_string(),
+            success: false,
+            error: Some(error_msg),
+        };
+    }
+
+    tracing::info!(
+        branch = %branch,
+        worktree = %worktree_path,
+        "rebase + force-push succeeded"
+    );
+
+    RebaseResult {
+        branch: branch.to_string(),
+        worktree_path: worktree_path.to_string(),
+        success: true,
+        error: None,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1833,5 +2074,50 @@ branch refs/heads/main
         )
         .await;
         assert_eq!(parent, "main");
+    }
+
+    #[tokio::test]
+    async fn test_resolve_remote_head_invalid_dir() {
+        let result = resolve_remote_head("/nonexistent/path").await;
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_rebase_worktree_branches_no_worktrees() {
+        // With an invalid repo dir, rebase should return empty
+        let prs = std::collections::HashMap::new();
+        let results = rebase_worktree_branches("/nonexistent/path", &prs).await;
+        assert!(results.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_rebase_worktree_branches_empty_prs() {
+        // Even with a valid repo, no open PRs means nothing to rebase
+        let repo = env!("CARGO_MANIFEST_DIR");
+        let prs = std::collections::HashMap::new();
+        let results = rebase_worktree_branches(repo, &prs).await;
+        assert!(results.is_empty());
+    }
+
+    #[test]
+    fn test_rebase_result_fields() {
+        let result = RebaseResult {
+            branch: "feat-x".to_string(),
+            worktree_path: "/tmp/wt".to_string(),
+            success: true,
+            error: None,
+        };
+        assert!(result.success);
+        assert!(result.error.is_none());
+        assert_eq!(result.branch, "feat-x");
+
+        let fail_result = RebaseResult {
+            branch: "feat-y".to_string(),
+            worktree_path: "/tmp/wt2".to_string(),
+            success: false,
+            error: Some("CONFLICT in file.rs".to_string()),
+        };
+        assert!(!fail_result.success);
+        assert!(fail_result.error.unwrap().contains("CONFLICT"));
     }
 }

--- a/crates/tmai-core/src/monitor/poller.rs
+++ b/crates/tmai-core/src/monitor/poller.rs
@@ -108,6 +108,9 @@ pub struct Poller {
     session_scanner: crate::session_discovery::SessionDiscoveryScanner,
     /// Transcript watcher for JSONL conversation log monitoring
     transcript_watcher: crate::transcript::TranscriptWatcher,
+    /// Tracks the last known HEAD sha per repo for auto-rebase merge detection.
+    /// Key: repo root path, Value: SHA of origin/<default_branch> HEAD.
+    last_default_branch_head: HashMap<String, String>,
 }
 
 /// Check if a PID is a descendant (child, grandchild, ...) of any PID in the set.
@@ -178,6 +181,7 @@ impl Poller {
             transcript_watcher: crate::transcript::TranscriptWatcher::new(
                 crate::transcript::watcher::new_transcript_registry(),
             ),
+            last_default_branch_head: HashMap::new(),
         }
     }
 
@@ -220,6 +224,7 @@ impl Poller {
             event_tx: None,
             session_scanner: crate::session_discovery::SessionDiscoveryScanner::new(),
             transcript_watcher: crate::transcript::TranscriptWatcher::new(transcript_registry),
+            last_default_branch_head: HashMap::new(),
         }
     }
 
@@ -335,6 +340,12 @@ impl Poller {
                     // Worktree scan (every 30 polls, offset from git scan)
                     if poll_count % 30 == 5 {
                         self.scan_worktrees(&agents).await;
+                    }
+
+                    // Auto-rebase check (every 60 polls ≈ 30 seconds)
+                    if self.settings.workflow.auto_rebase_on_merge && poll_count.is_multiple_of(60)
+                    {
+                        self.check_and_rebase(&agents).await;
                     }
 
                     // Session discovery (every 10 polls ≈ 5 seconds)
@@ -2129,6 +2140,88 @@ impl Poller {
             .retain(|_, spawned_at| spawned_at.elapsed().as_secs() < PENDING_AGENT_GRACE_SECS);
 
         state.worktree_info = result;
+    }
+
+    /// Check if the default branch HEAD advanced (indicating a merge) and trigger
+    /// auto-rebase on all tmai-managed worktree branches.
+    async fn check_and_rebase(&mut self, agents: &[MonitoredAgent]) {
+        use crate::git;
+
+        // Collect unique repo roots from agents
+        let mut repo_roots: HashSet<String> = HashSet::new();
+        for agent in agents {
+            if agent.is_virtual {
+                continue;
+            }
+            if let Some(ref common_dir) = agent.git_common_dir {
+                let root = common_dir
+                    .strip_suffix("/.git")
+                    .unwrap_or(common_dir)
+                    .to_string();
+                repo_roots.insert(root);
+            }
+        }
+        // Also include registered projects
+        {
+            let state = self.state.read();
+            for project_path in &state.registered_projects {
+                repo_roots.insert(project_path.clone());
+            }
+        }
+
+        for repo_root in &repo_roots {
+            // Resolve current HEAD of origin/<default_branch>
+            let head_sha = match git::resolve_remote_head(repo_root).await {
+                Some(sha) => sha,
+                None => continue,
+            };
+
+            let prev_sha = self.last_default_branch_head.get(repo_root).cloned();
+            self.last_default_branch_head
+                .insert(repo_root.clone(), head_sha.clone());
+
+            // Only trigger rebase when the HEAD actually changed (not on first poll)
+            let changed = match prev_sha {
+                Some(prev) => prev != head_sha,
+                None => false, // first observation, just record
+            };
+
+            if !changed {
+                continue;
+            }
+
+            tracing::info!(
+                repo = %repo_root,
+                new_head = %head_sha,
+                "default branch HEAD advanced, triggering auto-rebase"
+            );
+
+            // Fetch open PRs to filter branches by base
+            let open_prs = match crate::github::list_open_prs(repo_root).await {
+                Some(prs) => prs,
+                None => continue,
+            };
+
+            let results = git::rebase_worktree_branches(repo_root, &open_prs).await;
+
+            // Emit events for each result
+            if let Some(ref tx) = self.event_tx {
+                for result in results {
+                    if result.success {
+                        let _ = tx.send(CoreEvent::RebaseSucceeded {
+                            branch: result.branch,
+                            worktree_path: result.worktree_path,
+                        });
+                    } else {
+                        let _ = tx.send(CoreEvent::RebaseConflict {
+                            branch: result.branch,
+                            worktree_path: result.worktree_path,
+                            error: result.error.unwrap_or_default(),
+                        });
+                    }
+                }
+            }
+        }
     }
 
     /// Cleanup the process cache

--- a/src/web/events.rs
+++ b/src/web/events.rs
@@ -240,6 +240,31 @@ pub async fn events(State(core): State<Arc<TmaiCore>>) -> impl IntoResponse {
                                 return;
                             }
                         }
+                        Ok(CoreEvent::RebaseSucceeded { branch, worktree_path }) => {
+                            let data = serde_json::json!({
+                                "branch": branch,
+                                "worktree_path": worktree_path,
+                            });
+                            let event = Event::default()
+                                .event("rebase_succeeded")
+                                .data(data.to_string());
+                            if tx.send(Ok(event)).await.is_err() {
+                                return;
+                            }
+                        }
+                        Ok(CoreEvent::RebaseConflict { branch, worktree_path, error }) => {
+                            let data = serde_json::json!({
+                                "branch": branch,
+                                "worktree_path": worktree_path,
+                                "error": error,
+                            });
+                            let event = Event::default()
+                                .event("rebase_conflict")
+                                .data(data.to_string());
+                            if tx.send(Ok(event)).await.is_err() {
+                                return;
+                            }
+                        }
                         Ok(CoreEvent::ConfigChanged { .. })
                         | Ok(CoreEvent::InstructionsLoaded { .. })
                         | Ok(CoreEvent::ReviewReady { .. })


### PR DESCRIPTION
## Summary
- Add auto-rebase service that rebases tmai-managed worktree branches onto the default branch when a merge is detected
- Poller tracks `origin/<default_branch>` HEAD and triggers rebase when it advances (~30s interval)
- New config: `[workflow] auto_rebase_on_merge = false` (opt-in)
- Only rebases `.claude/worktrees/` branches with open PRs targeting the default branch
- Clean rebases are force-pushed (`--force-with-lease`); conflicts are aborted and reported via `RebaseConflict` event
- Rebase events forwarded to WebUI via SSE (`rebase_succeeded`, `rebase_conflict`)

## Changes
- `crates/tmai-core/src/config/settings.rs`: Add `WorkflowSettings` with `auto_rebase_on_merge`
- `crates/tmai-core/src/api/events.rs`: Add `RebaseSucceeded` / `RebaseConflict` CoreEvent variants
- `crates/tmai-core/src/git/mod.rs`: Add `resolve_remote_head()`, `rebase_worktree_branches()`, `rebase_single_branch()`
- `crates/tmai-core/src/monitor/poller.rs`: Add `check_and_rebase()` with merge detection via HEAD tracking
- `src/web/events.rs`: Forward rebase events as SSE

## Test plan
- [x] `cargo check` passes
- [x] `cargo fmt -- --check` passes
- [x] `cargo clippy --all-targets` passes
- [x] New unit tests pass (`test_resolve_remote_head_invalid_dir`, `test_rebase_worktree_branches_*`, `test_rebase_result_fields`)
- [ ] Manual: enable `auto_rebase_on_merge = true`, merge a PR, verify other worktree branches get rebased
- [ ] Manual: introduce a conflict, verify `RebaseConflict` event is emitted and rebase is aborted cleanly

Closes #224

🤖 Generated with [Claude Code](https://claude.com/claude-code)