### PR TITLE
feat: use stable agent IDs independent of tmux pane numbering (#232)

### DIFF
--- a/crates/tmai-core/src/agents/types.rs
+++ b/crates/tmai-core/src/agents/types.rs
@@ -522,6 +522,8 @@ pub struct TeamTaskSummaryItem {
 pub struct MonitoredAgent {
     /// Unique identifier (session:window.pane)
     pub id: String,
+    /// Stable identifier that persists across tmux pane recycling (UUID short hash)
+    pub stable_id: String,
     /// tmux target identifier
     pub target: String,
     /// Type of agent
@@ -632,8 +634,10 @@ impl MonitoredAgent {
         window_index: u32,
         pane_index: u32,
     ) -> Self {
+        let stable_id = uuid::Uuid::new_v4().to_string()[..8].to_string();
         Self {
             id: target.clone(),
+            stable_id,
             target,
             agent_type,
             status: AgentStatus::Unknown,

--- a/crates/tmai-core/src/api/actions.rs
+++ b/crates/tmai-core/src/api/actions.rs
@@ -51,65 +51,49 @@ impl TmaiCore {
     /// Approve an agent action (send approval keys based on agent type).
     ///
     /// Returns `Ok(())` if approval was sent or the agent was already not awaiting.
-    pub fn approve(&self, target: &str) -> Result<(), ApiError> {
+    pub fn approve(&self, id: &str) -> Result<(), ApiError> {
+        let target = self.resolve_agent_key(id)?;
         let (is_awaiting, agent_type, is_virtual) = {
             let state = self.state().read();
-            match state.agents.get(target) {
-                Some(a) => (
-                    matches!(&a.status, AgentStatus::AwaitingApproval { .. }),
-                    a.agent_type.clone(),
-                    a.is_virtual,
-                ),
-                None => {
-                    return Err(ApiError::AgentNotFound {
-                        target: target.to_string(),
-                    })
-                }
-            }
+            let a = state.agents.get(&target).unwrap();
+            (
+                matches!(&a.status, AgentStatus::AwaitingApproval { .. }),
+                a.agent_type.clone(),
+                a.is_virtual,
+            )
         };
 
         if is_virtual {
-            return Err(ApiError::VirtualAgent {
-                target: target.to_string(),
-            });
+            return Err(ApiError::VirtualAgent { target });
         }
 
         if !is_awaiting {
-            // Already handled — idempotent success
             return Ok(());
         }
 
         let cmd = self.require_command_sender()?;
         let detector = get_detector(&agent_type);
-        cmd.send_keys(target, detector.approval_keys())?;
+        cmd.send_keys(&target, detector.approval_keys())?;
         Ok(())
     }
 
     /// Select a choice for a UserQuestion prompt.
     ///
     /// `choice` is 1-indexed (1 = first option, N+1 = "Other").
-    pub fn select_choice(&self, target: &str, choice: usize) -> Result<(), ApiError> {
+    pub fn select_choice(&self, id: &str, choice: usize) -> Result<(), ApiError> {
+        let target = self.resolve_agent_key(id)?;
         // Virtual agents cannot receive key input
         {
             let state = self.state().read();
-            match state.agents.get(target) {
-                Some(a) if a.is_virtual => {
-                    return Err(ApiError::VirtualAgent {
-                        target: target.to_string(),
-                    });
-                }
-                Some(_) => {}
-                None => {
-                    return Err(ApiError::AgentNotFound {
-                        target: target.to_string(),
-                    });
-                }
+            let a = state.agents.get(&target).unwrap();
+            if a.is_virtual {
+                return Err(ApiError::VirtualAgent { target });
             }
         }
 
         let question_info = {
             let state = self.state().read();
-            state.agents.get(target).and_then(|agent| {
+            state.agents.get(&target).and_then(|agent| {
                 if let AgentStatus::AwaitingApproval {
                     approval_type:
                         ApprovalType::UserQuestion {
@@ -136,12 +120,12 @@ impl TmaiCore {
                 let steps = choice as i32 - cursor as i32;
                 let key = if steps > 0 { "Down" } else { "Up" };
                 for _ in 0..steps.unsigned_abs() {
-                    cmd.send_keys(target, key)?;
+                    cmd.send_keys(&target, key)?;
                 }
 
                 // Confirm: single-select always, multi-select only for checkbox toggle
                 if !multi_select || has_checkbox_format(&choices) {
-                    cmd.send_keys(target, "Enter")?;
+                    cmd.send_keys(&target, "Enter")?;
                 }
 
                 Ok(())
@@ -157,32 +141,20 @@ impl TmaiCore {
     /// Submit multi-select choices (checkbox or legacy format).
     ///
     /// `selected_choices` is a list of 1-indexed choice numbers.
-    pub fn submit_selection(
-        &self,
-        target: &str,
-        selected_choices: &[usize],
-    ) -> Result<(), ApiError> {
+    pub fn submit_selection(&self, id: &str, selected_choices: &[usize]) -> Result<(), ApiError> {
+        let target = self.resolve_agent_key(id)?;
         // Virtual agents cannot receive key input
         {
             let state = self.state().read();
-            match state.agents.get(target) {
-                Some(a) if a.is_virtual => {
-                    return Err(ApiError::VirtualAgent {
-                        target: target.to_string(),
-                    });
-                }
-                Some(_) => {}
-                None => {
-                    return Err(ApiError::AgentNotFound {
-                        target: target.to_string(),
-                    });
-                }
+            let a = state.agents.get(&target).unwrap();
+            if a.is_virtual {
+                return Err(ApiError::VirtualAgent { target });
             }
         }
 
         let multi_info = {
             let state = self.state().read();
-            state.agents.get(target).and_then(|agent| {
+            state.agents.get(&target).and_then(|agent| {
                 if let AgentStatus::AwaitingApproval {
                     approval_type:
                         ApprovalType::UserQuestion {
@@ -224,22 +196,22 @@ impl TmaiCore {
                         let steps = choice as i32 - current_pos as i32;
                         let key = if steps > 0 { "Down" } else { "Up" };
                         for _ in 0..steps.unsigned_abs() {
-                            cmd.send_keys(target, key)?;
+                            cmd.send_keys(&target, key)?;
                         }
                         // Enter to toggle checkbox
-                        cmd.send_keys(target, "Enter")?;
+                        cmd.send_keys(&target, "Enter")?;
                         current_pos = choice;
                     }
                     // Right + Enter to submit
-                    cmd.send_keys(target, "Right")?;
-                    cmd.send_keys(target, "Enter")?;
+                    cmd.send_keys(&target, "Right")?;
+                    cmd.send_keys(&target, "Enter")?;
                 } else {
                     // Legacy format: navigate past all choices then Enter
                     let downs_needed = choices.len().saturating_sub(cursor_pos.saturating_sub(1));
                     for _ in 0..downs_needed {
-                        cmd.send_keys(target, "Down")?;
+                        cmd.send_keys(&target, "Down")?;
                     }
-                    cmd.send_keys(target, "Enter")?;
+                    cmd.send_keys(&target, "Enter")?;
                 }
                 Ok(())
             }
@@ -251,7 +223,7 @@ impl TmaiCore {
     /// Send text input to an agent followed by Enter.
     ///
     /// Includes a 50ms delay between text and Enter to prevent paste-burst issues.
-    pub async fn send_text(&self, target: &str, text: &str) -> Result<(), ApiError> {
+    pub async fn send_text(&self, id: &str, text: &str) -> Result<(), ApiError> {
         if text.chars().count() > MAX_TEXT_LENGTH {
             return Err(ApiError::InvalidInput {
                 message: format!(
@@ -261,31 +233,23 @@ impl TmaiCore {
             });
         }
 
+        let target = self.resolve_agent_key(id)?;
         let is_virtual = {
             let state = self.state().read();
-            match state.agents.get(target) {
-                Some(a) => a.is_virtual,
-                None => {
-                    return Err(ApiError::AgentNotFound {
-                        target: target.to_string(),
-                    })
-                }
-            }
+            state.agents.get(&target).unwrap().is_virtual
         };
 
         if is_virtual {
-            return Err(ApiError::VirtualAgent {
-                target: target.to_string(),
-            });
+            return Err(ApiError::VirtualAgent { target });
         }
 
         let cmd = self.require_command_sender()?;
-        cmd.send_keys_literal(target, text)?;
+        cmd.send_keys_literal(&target, text)?;
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
-        cmd.send_keys(target, "Enter")?;
+        cmd.send_keys(&target, "Enter")?;
 
         self.audit_helper()
-            .maybe_emit_input(target, "input_text", "api_input", None);
+            .maybe_emit_input(&target, "input_text", "api_input", None);
 
         Ok(())
     }
@@ -298,11 +262,7 @@ impl TmaiCore {
     /// - **Other** (AwaitingApproval, Error, Unknown): queues like Processing.
     ///
     /// Returns a JSON-serializable status indicating the action taken.
-    pub async fn send_prompt(
-        &self,
-        target: &str,
-        prompt: &str,
-    ) -> Result<SendPromptResult, ApiError> {
+    pub async fn send_prompt(&self, id: &str, prompt: &str) -> Result<SendPromptResult, ApiError> {
         if prompt.chars().count() > MAX_TEXT_LENGTH {
             return Err(ApiError::InvalidInput {
                 message: format!(
@@ -312,28 +272,20 @@ impl TmaiCore {
             });
         }
 
+        let target = self.resolve_agent_key(id)?;
         let (status, is_virtual) = {
             let state = self.state().read();
-            match state.agents.get(target) {
-                Some(a) => (a.status.clone(), a.is_virtual),
-                None => {
-                    return Err(ApiError::AgentNotFound {
-                        target: target.to_string(),
-                    })
-                }
-            }
+            let a = state.agents.get(&target).unwrap();
+            (a.status.clone(), a.is_virtual)
         };
 
         if is_virtual {
-            return Err(ApiError::VirtualAgent {
-                target: target.to_string(),
-            });
+            return Err(ApiError::VirtualAgent { target });
         }
 
         match status {
             AgentStatus::Idle | AgentStatus::Offline => {
-                // Send immediately — Idle agents accept input; Offline panes may restart
-                self.send_text(target, prompt).await?;
+                self.send_text(&target, prompt).await?;
                 let action = if status.is_idle() {
                     "sent"
                 } else {
@@ -345,7 +297,6 @@ impl TmaiCore {
                 })
             }
             _ => {
-                // Processing, AwaitingApproval, Error, Unknown — queue the prompt
                 let queue_size = {
                     let mut state = self.state().write();
                     let queue = state.prompt_queue.entry(target.to_string()).or_default();
@@ -369,49 +320,40 @@ impl TmaiCore {
     }
 
     /// Send a special key to an agent (whitelist-validated).
-    pub fn send_key(&self, target: &str, key: &str) -> Result<(), ApiError> {
+    pub fn send_key(&self, id: &str, key: &str) -> Result<(), ApiError> {
         if !ALLOWED_KEYS.contains(&key) {
             return Err(ApiError::InvalidInput {
                 message: "Invalid key name".to_string(),
             });
         }
 
+        let target = self.resolve_agent_key(id)?;
         let (is_virtual, has_pty) = {
             let state = self.state().read();
-            match state.agents.get(target) {
-                Some(a) => (a.is_virtual, a.pty_session_id.is_some()),
-                None => {
-                    return Err(ApiError::AgentNotFound {
-                        target: target.to_string(),
-                    })
-                }
-            }
+            let a = state.agents.get(&target).unwrap();
+            (a.is_virtual, a.pty_session_id.is_some())
         };
 
         if is_virtual {
-            return Err(ApiError::VirtualAgent {
-                target: target.to_string(),
-            });
+            return Err(ApiError::VirtualAgent { target });
         }
 
-        // PTY-spawned agents: write directly to PTY session
         if has_pty {
-            if let Some(session) = self.pty_registry().get(target) {
+            if let Some(session) = self.pty_registry().get(&target) {
                 let data = crate::utils::keys::tmux_key_to_bytes(key);
                 session.write_input(&data).map_err(ApiError::CommandError)?;
             } else {
-                // PTY session gone — agent may have exited
                 return Err(ApiError::CommandError(anyhow::anyhow!(
                     "PTY session not found for agent"
                 )));
             }
         } else {
             let cmd = self.require_command_sender()?;
-            cmd.send_keys(target, key)?;
+            cmd.send_keys(&target, key)?;
         }
 
         self.audit_helper()
-            .maybe_emit_input(target, "special_key", "api_input", None);
+            .maybe_emit_input(&target, "special_key", "api_input", None);
 
         Ok(())
     }
@@ -423,43 +365,28 @@ impl TmaiCore {
     /// - `Some(false)` → force disabled for this agent
     pub fn set_auto_approve_override(
         &self,
-        target: &str,
+        id: &str,
         enabled: Option<bool>,
     ) -> Result<(), ApiError> {
+        let target = self.resolve_agent_key(id)?;
         let mut state = self.state().write();
-        match state.agents.get_mut(target) {
-            Some(agent) => {
-                agent.auto_approve_override = enabled;
-                Ok(())
-            }
-            None => Err(ApiError::AgentNotFound {
-                target: target.to_string(),
-            }),
-        }
+        state.agents.get_mut(&target).unwrap().auto_approve_override = enabled;
+        Ok(())
     }
 
     /// Focus on a specific pane in tmux
-    pub fn focus_pane(&self, target: &str) -> Result<(), ApiError> {
-        // Validate agent exists and is not virtual
+    pub fn focus_pane(&self, id: &str) -> Result<(), ApiError> {
+        let target = self.resolve_agent_key(id)?;
         {
             let state = self.state().read();
-            match state.agents.get(target) {
-                Some(a) if a.is_virtual => {
-                    return Err(ApiError::VirtualAgent {
-                        target: target.to_string(),
-                    });
-                }
-                Some(_) => {}
-                None => {
-                    return Err(ApiError::AgentNotFound {
-                        target: target.to_string(),
-                    });
-                }
+            let a = state.agents.get(&target).unwrap();
+            if a.is_virtual {
+                return Err(ApiError::VirtualAgent { target });
             }
         }
 
         let cmd = self.require_command_sender()?;
-        cmd.runtime().focus_pane(target)?;
+        cmd.runtime().focus_pane(&target)?;
         Ok(())
     }
 
@@ -467,17 +394,12 @@ impl TmaiCore {
     ///
     /// Directly launches a review session in a new tmux window (blocking I/O
     /// is offloaded to `spawn_blocking`). Works regardless of `review.enabled`.
-    pub fn request_review(&self, target: &str) -> Result<(), ApiError> {
+    pub fn request_review(&self, id: &str) -> Result<(), ApiError> {
+        let target = self.resolve_agent_key(id)?;
         let (cwd, branch) = {
             let state = self.state().read();
-            match state.agents.get(target) {
-                Some(a) => (a.cwd.clone(), a.git_branch.clone()),
-                None => {
-                    return Err(ApiError::AgentNotFound {
-                        target: target.to_string(),
-                    })
-                }
-            }
+            let a = state.agents.get(&target).unwrap();
+            (a.cwd.clone(), a.git_branch.clone())
         };
 
         let request = crate::review::ReviewRequest {
@@ -887,41 +809,33 @@ impl TmaiCore {
     }
 
     /// Kill a specific agent (PTY session or tmux pane)
-    pub fn kill_pane(&self, target: &str) -> Result<(), ApiError> {
-        // Validate agent exists and is not virtual
+    pub fn kill_pane(&self, id: &str) -> Result<(), ApiError> {
+        let target = self.resolve_agent_key(id)?;
         let has_pty = {
             let state = self.state().read();
-            match state.agents.get(target) {
-                Some(a) if a.is_virtual => {
-                    return Err(ApiError::VirtualAgent {
-                        target: target.to_string(),
-                    });
-                }
-                Some(a) => a.pty_session_id.is_some(),
-                None => {
-                    return Err(ApiError::AgentNotFound {
-                        target: target.to_string(),
-                    });
-                }
+            let a = state.agents.get(&target).unwrap();
+            if a.is_virtual {
+                return Err(ApiError::VirtualAgent {
+                    target: target.clone(),
+                });
             }
+            a.pty_session_id.is_some()
         };
 
         if has_pty {
-            // PTY-spawned agent: kill the child process
-            if let Some(session) = self.pty_registry().get(target) {
+            if let Some(session) = self.pty_registry().get(&target) {
                 session.kill();
             }
-            // Remove from agent list
             {
                 let mut state = self.state().write();
-                state.agents.remove(target);
-                state.agent_order.retain(|id| id != target);
+                state.agents.remove(&target);
+                state.agent_order.retain(|k| k != &target);
             }
             self.notify_agents_updated();
             Ok(())
         } else {
             let cmd = self.require_command_sender()?;
-            cmd.runtime().kill_pane(target)?;
+            cmd.runtime().kill_pane(&target)?;
             Ok(())
         }
     }

--- a/crates/tmai-core/src/api/queries.rs
+++ b/crates/tmai-core/src/api/queries.rs
@@ -8,6 +8,45 @@ use super::types::{AgentDefinitionInfo, AgentSnapshot, ApiError, TeamSummary, Te
 
 impl TmaiCore {
     // =========================================================
+    // Agent ID resolution
+    // =========================================================
+
+    /// Resolve a user-supplied ID to the internal HashMap key.
+    ///
+    /// Accepts any of: stable_id (UUID short hash), internal key (target/session_id),
+    /// or pty_session_id. Returns the HashMap key used in `state.agents`.
+    pub fn resolve_agent_key(&self, id: &str) -> Result<String, ApiError> {
+        let state = self.state().read();
+        Self::resolve_agent_key_in_state(&state, id)
+    }
+
+    /// Resolve agent ID within an already-locked state (avoids double-lock).
+    pub fn resolve_agent_key_in_state(
+        state: &crate::state::AppState,
+        id: &str,
+    ) -> Result<String, ApiError> {
+        // 1) Direct HashMap key match (existing behavior)
+        if state.agents.contains_key(id) {
+            return Ok(id.to_string());
+        }
+        // 2) Match by stable_id
+        if let Some((key, _)) = state.agents.iter().find(|(_, a)| a.stable_id == id) {
+            return Ok(key.clone());
+        }
+        // 3) Match by pty_session_id
+        if let Some((key, _)) = state
+            .agents
+            .iter()
+            .find(|(_, a)| a.pty_session_id.as_deref() == Some(id))
+        {
+            return Ok(key.clone());
+        }
+        Err(ApiError::AgentNotFound {
+            target: id.to_string(),
+        })
+    }
+
+    // =========================================================
     // Agent queries
     // =========================================================
 
@@ -27,21 +66,15 @@ impl TmaiCore {
             .collect()
     }
 
-    /// Get a single agent snapshot by target ID.
-    pub fn get_agent(&self, target: &str) -> Result<AgentSnapshot, ApiError> {
+    /// Get a single agent snapshot by any accepted ID form (stable_id, target, pty_session_id).
+    pub fn get_agent(&self, id: &str) -> Result<AgentSnapshot, ApiError> {
         let state = self.state().read();
+        let key = Self::resolve_agent_key_in_state(&state, id)?;
         let defs = &state.agent_definitions;
-        state
-            .agents
-            .get(target)
-            .map(|a| {
-                let mut snap = AgentSnapshot::from_agent(a);
-                snap.agent_definition = Self::match_agent_definition(a, defs);
-                snap
-            })
-            .ok_or_else(|| ApiError::AgentNotFound {
-                target: target.to_string(),
-            })
+        let a = state.agents.get(&key).unwrap();
+        let mut snap = AgentSnapshot::from_agent(a);
+        snap.agent_definition = Self::match_agent_definition(a, defs);
+        Ok(snap)
     }
 
     /// Get the currently selected agent snapshot.
@@ -87,27 +120,17 @@ impl TmaiCore {
     // =========================================================
 
     /// Get the ANSI preview content for an agent.
-    pub fn get_preview(&self, target: &str) -> Result<String, ApiError> {
+    pub fn get_preview(&self, id: &str) -> Result<String, ApiError> {
         let state = self.state().read();
-        state
-            .agents
-            .get(target)
-            .map(|a| a.last_content_ansi.clone())
-            .ok_or_else(|| ApiError::AgentNotFound {
-                target: target.to_string(),
-            })
+        let key = Self::resolve_agent_key_in_state(&state, id)?;
+        Ok(state.agents.get(&key).unwrap().last_content_ansi.clone())
     }
 
     /// Get the plain-text content for an agent.
-    pub fn get_content(&self, target: &str) -> Result<String, ApiError> {
+    pub fn get_content(&self, id: &str) -> Result<String, ApiError> {
         let state = self.state().read();
-        state
-            .agents
-            .get(target)
-            .map(|a| a.last_content.clone())
-            .ok_or_else(|| ApiError::AgentNotFound {
-                target: target.to_string(),
-            })
+        let key = Self::resolve_agent_key_in_state(&state, id)?;
+        Ok(state.agents.get(&key).unwrap().last_content.clone())
     }
 
     // =========================================================
@@ -120,18 +143,14 @@ impl TmaiCore {
     /// The records are looked up by pane_id from the transcript registry.
     pub fn get_transcript(
         &self,
-        target: &str,
+        id: &str,
     ) -> Result<Vec<crate::transcript::TranscriptRecord>, ApiError> {
         // Verify agent exists and get pane_id
         let pane_id = {
             let state = self.state().read();
-            let agent = state
-                .agents
-                .get(target)
-                .ok_or_else(|| ApiError::AgentNotFound {
-                    target: target.to_string(),
-                })?;
-            // Use target_to_pane_id mapping, or fall back to using the target itself
+            let key = Self::resolve_agent_key_in_state(&state, id)?;
+            let agent = state.agents.get(&key).unwrap();
+            // Use target_to_pane_id mapping, or fall back to using the internal key
             state
                 .target_to_pane_id
                 .get(&agent.id)
@@ -392,7 +411,7 @@ mod tests {
 
         let result = core.get_agent("main:0.0");
         assert!(result.is_ok());
-        assert_eq!(result.unwrap().id, "main:0.0");
+        assert_eq!(result.unwrap().pane_id, "main:0.0");
     }
 
     #[test]
@@ -440,7 +459,7 @@ mod tests {
 
         let attention = core.agents_needing_attention();
         assert_eq!(attention.len(), 1);
-        assert_eq!(attention[0].id, "main:0.1");
+        assert_eq!(attention[0].pane_id, "main:0.1");
     }
 
     #[test]
@@ -527,5 +546,60 @@ mod tests {
 
         let records = core.get_transcript("main:0.0").unwrap();
         assert_eq!(records.len(), 2);
+    }
+
+    #[test]
+    fn test_resolve_agent_key_by_internal_key() {
+        let core = make_core_with_agents(vec![test_agent("main:0.0", AgentStatus::Idle)]);
+        // Direct HashMap key lookup
+        assert_eq!(core.resolve_agent_key("main:0.0").unwrap(), "main:0.0");
+    }
+
+    #[test]
+    fn test_resolve_agent_key_by_stable_id() {
+        let agent = test_agent("main:0.0", AgentStatus::Idle);
+        let stable_id = agent.stable_id.clone();
+        let core = make_core_with_agents(vec![agent]);
+        // Lookup by stable_id
+        assert_eq!(core.resolve_agent_key(&stable_id).unwrap(), "main:0.0");
+    }
+
+    #[test]
+    fn test_resolve_agent_key_by_pty_session_id() {
+        let mut agent = test_agent("pty-session-123", AgentStatus::Idle);
+        agent.pty_session_id = Some("pty-session-123".to_string());
+        let core = make_core_with_agents(vec![agent]);
+        // Lookup by pty_session_id
+        assert_eq!(
+            core.resolve_agent_key("pty-session-123").unwrap(),
+            "pty-session-123"
+        );
+    }
+
+    #[test]
+    fn test_resolve_agent_key_not_found() {
+        let core = TmaiCoreBuilder::new(Settings::default()).build();
+        assert!(matches!(
+            core.resolve_agent_key("nonexistent"),
+            Err(ApiError::AgentNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn test_stable_id_is_unique_per_agent() {
+        let a1 = test_agent("main:0.0", AgentStatus::Idle);
+        let a2 = test_agent("main:0.1", AgentStatus::Idle);
+        assert_ne!(a1.stable_id, a2.stable_id);
+        assert_eq!(a1.stable_id.len(), 8);
+        assert_eq!(a2.stable_id.len(), 8);
+    }
+
+    #[test]
+    fn test_agent_snapshot_returns_stable_id_as_primary() {
+        let agent = test_agent("main:0.0", AgentStatus::Idle);
+        let stable_id = agent.stable_id.clone();
+        let snapshot = AgentSnapshot::from_agent(&agent);
+        assert_eq!(snapshot.id, stable_id);
+        assert_eq!(snapshot.pane_id, "main:0.0");
     }
 }

--- a/crates/tmai-core/src/api/types.rs
+++ b/crates/tmai-core/src/api/types.rs
@@ -64,8 +64,10 @@ pub struct SendPromptResult {
 /// never need to hold a read lock beyond the query call.
 #[derive(Debug, Clone, Serialize)]
 pub struct AgentSnapshot {
-    /// Unique identifier (session:window.pane)
+    /// Stable identifier that persists across tmux pane recycling
     pub id: String,
+    /// tmux pane target (e.g., "main:0.1") — may be recycled by tmux
+    pub pane_id: String,
     /// tmux target identifier
     pub target: String,
     /// Type of agent
@@ -230,7 +232,8 @@ impl AgentSnapshot {
     /// Convert a `MonitoredAgent` reference into an owned snapshot
     pub fn from_agent(agent: &crate::agents::MonitoredAgent) -> Self {
         Self {
-            id: agent.id.clone(),
+            id: agent.stable_id.clone(),
+            pane_id: agent.id.clone(),
             target: agent.target.clone(),
             agent_type: agent.agent_type.clone(),
             status: agent.status.clone(),
@@ -476,7 +479,8 @@ mod tests {
 
         let snapshot = AgentSnapshot::from_agent(&agent);
 
-        assert_eq!(snapshot.id, "main:0.0");
+        assert_eq!(snapshot.id.len(), 8); // stable UUID short hash
+        assert_eq!(snapshot.pane_id, "main:0.0");
         assert_eq!(snapshot.target, "main:0.0");
         assert!(matches!(snapshot.agent_type, AgentType::ClaudeCode));
         assert!(matches!(snapshot.status, AgentStatus::Idle));

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -35,13 +35,13 @@ pub struct EmptyParams {}
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct AgentIdParams {
-    /// Agent ID (e.g., "main:0.0" or a PTY session ID)
+    /// Agent ID — accepts stable ID (e.g., "a1b2c3d4"), pane target (e.g., "main:0.0"), or PTY session UUID
     pub id: String,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SendTextParams {
-    /// Agent ID
+    /// Agent ID — accepts stable ID, pane target, or PTY session UUID
     pub id: String,
     /// Text to send to the agent
     pub text: String,
@@ -49,7 +49,7 @@ pub struct SendTextParams {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SendPromptParams {
-    /// Agent ID
+    /// Agent ID — accepts stable ID, pane target, or PTY session UUID
     pub id: String,
     /// Prompt text to send to the agent
     pub prompt: String,
@@ -57,7 +57,7 @@ pub struct SendPromptParams {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SendKeyParams {
-    /// Agent ID
+    /// Agent ID — accepts stable ID, pane target, or PTY session UUID
     pub id: String,
     /// Key name (Enter, Escape, Space, Up, Down, Left, Right, Tab, BTab, BSpace)
     pub key: String,
@@ -65,7 +65,7 @@ pub struct SendKeyParams {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SelectChoiceParams {
-    /// Agent ID
+    /// Agent ID — accepts stable ID, pane target, or PTY session UUID
     pub id: String,
     /// Choice index (1-based)
     pub index: u32,
@@ -160,8 +160,11 @@ impl TmaiMcpServer {
         match self.client.get::<serde_json::Value>("/agents") {
             Ok(data) => {
                 if let Some(agents) = data.as_array() {
+                    // Search by stable id (primary), pane_id, target, or pty_session_id
                     if let Some(agent) = agents.iter().find(|a| {
                         a.get("id").and_then(|v| v.as_str()) == Some(&p.id)
+                            || a.get("pane_id").and_then(|v| v.as_str()) == Some(&p.id)
+                            || a.get("target").and_then(|v| v.as_str()) == Some(&p.id)
                             || a.get("pty_session_id").and_then(|v| v.as_str()) == Some(&p.id)
                     }) {
                         return format_json(agent);

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -413,15 +413,13 @@ pub async fn passthrough_input(
     Path(id): Path<String>,
     Json(req): Json<PassthroughRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    // Resolve the tmux target — agent id may be "hook:0.x" (not a valid tmux target)
-    // so we need to find the actual tmux pane target from the agent's target field
+    // Resolve the user-supplied ID to internal key, then find tmux target
     let tmux_target = {
         #[allow(deprecated)]
         let state = core.raw_state().read();
-        state
-            .agents
-            .get(&id)
-            .map(|a| a.target.clone())
+        tmai_core::api::TmaiCore::resolve_agent_key_in_state(&state, &id)
+            .ok()
+            .and_then(|key| state.agents.get(&key).map(|a| a.target.clone()))
             .filter(|t| !t.starts_with("hook:") && !t.starts_with("discovered:"))
     };
 
@@ -468,10 +466,16 @@ pub async fn get_preview(
 ) -> Result<Json<PreviewResponse>, StatusCode> {
     let show_cursor = core.settings().web.show_cursor;
 
+    // Resolve the user-supplied ID to internal key
+    let resolved_key = {
+        let state = core.raw_state().read();
+        tmai_core::api::TmaiCore::resolve_agent_key_in_state(&state, &id).ok()
+    };
+
     // Look up agent target for capture-pane (id may differ from tmux target)
     let (agent_target, agent_content, agent_cursor) = {
         let state = core.raw_state().read();
-        match state.agents.get(&id) {
+        match resolved_key.as_deref().and_then(|k| state.agents.get(k)) {
             Some(a) => (
                 Some(a.target.clone()),
                 Some(a.last_content.clone()),
@@ -1630,6 +1634,7 @@ async fn spawn_in_pty(
                 agent.status = tmai_core::agents::AgentStatus::Processing {
                     activity: "Starting...".to_string(),
                 };
+                agent.stable_id = session_id.clone();
                 agent.pty_session_id = Some(session_id.clone());
                 if let Some(ref info) = git_info {
                     agent.git_branch = Some(info.branch.clone());
@@ -2387,9 +2392,11 @@ pub async fn get_agent_output(
     State(core): State<Arc<TmaiCore>>,
     Path(id): Path<String>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    // Resolve stable_id/pane_id to internal key, then try PTY lookup by key
+    let resolved = core.resolve_agent_key(&id).unwrap_or_else(|_| id.clone());
     let session = core
         .pty_registry()
-        .get(&id)
+        .get(&resolved)
         .ok_or_else(|| json_error(StatusCode::NOT_FOUND, "PTY session not found"))?;
 
     let snapshot = session.scrollback_snapshot();
@@ -2415,11 +2422,13 @@ pub async fn send_to_agent(
     Path((from, to)): Path<(String, String)>,
     Json(req): Json<SendToRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
-    // Validate source exists (either PTY or regular agent)
-    let source_exists = core.pty_registry().get(&from).is_some() || core.get_agent(&from).is_ok();
-    if !source_exists {
-        return Err(json_error(StatusCode::NOT_FOUND, "Source agent not found"));
-    }
+    // Resolve both agent IDs
+    let from_key = core
+        .resolve_agent_key(&from)
+        .map_err(|_| json_error(StatusCode::NOT_FOUND, "Source agent not found"))?;
+    let to_key = core
+        .resolve_agent_key(&to)
+        .map_err(|_| json_error(StatusCode::NOT_FOUND, "Target agent not found"))?;
 
     // Validate text length
     if req.text.len() > 10240 {
@@ -2428,9 +2437,10 @@ pub async fn send_to_agent(
             "Text too long (max 10KB)",
         ));
     }
+    let _ = &from_key; // ensure source is valid
 
     // Try PTY write first (for PTY-spawned targets)
-    if let Some(target_session) = core.pty_registry().get(&to) {
+    if let Some(target_session) = core.pty_registry().get(&to_key) {
         target_session
             .write_input(req.text.as_bytes())
             .map_err(|e| {
@@ -3423,7 +3433,8 @@ mod tests {
         let body = response.into_body().collect().await.unwrap().to_bytes();
         let agents: Vec<serde_json::Value> = serde_json::from_slice(&body).unwrap();
         assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0]["id"], "main:0.0");
+        assert_eq!(agents[0]["id"].as_str().unwrap().len(), 8); // stable UUID short hash
+        assert_eq!(agents[0]["pane_id"], "main:0.0");
         // AgentStatus uses serde externally tagged: unit variants serialize as strings
         assert_eq!(agents[0]["status"], "Idle");
     }


### PR DESCRIPTION
## Summary
- Add UUID-based `stable_id` to `MonitoredAgent`, generated as 8-char short hash on first detection
- PTY-spawned agents reuse their session UUID as `stable_id`
- API `/api/agents` returns `stable_id` as primary `id` field, tmux target as `pane_id` secondary field
- All API endpoints and MCP tools accept `stable_id`, pane target, or `pty_session_id` with fallback resolution via `resolve_agent_key()`
- Internal routing maintains `stable_id` → HashMap key mapping for command delivery

## Changes
- `MonitoredAgent` (types.rs): added `stable_id: String` field, UUID v4 short hash generated in `new()`
- `AgentSnapshot` (api/types.rs): `id` is now `stable_id`, added `pane_id` for tmux target
- `TmaiCore` (queries.rs): added `resolve_agent_key()` / `resolve_agent_key_in_state()` — resolves by direct key, `stable_id`, or `pty_session_id`
- `TmaiCore` actions (actions.rs): all action methods (`approve`, `send_text`, `send_key`, `send_prompt`, `select_choice`, `kill_pane`, etc.) wired through resolver
- Web API (web/api.rs): `get_preview`, `passthrough_input`, `get_agent_output`, `send_to_agent` use resolver
- MCP tools (mcp/tools.rs): `get_agent` searches by `id`, `pane_id`, `target`, and `pty_session_id`; param docs updated

## Test plan
- [x] 822 existing tests pass (108 tmai + 711 tmai-core + 3 integration)
- [x] New tests for `resolve_agent_key` (by internal key, stable_id, pty_session_id, not found)
- [x] New test for stable_id uniqueness and 8-char length
- [x] New test for `AgentSnapshot` returning stable_id as primary `id`
- [x] `cargo clippy` clean, `cargo fmt` clean

Closes #232

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * エージェント識別が改善され、複数の方法（安定ID、ペーンターゲット、PTYセッション識別子）でエージェントを識別できるようになりました。
  * エージェント再起動時に安定なIDが維持されるようになり、ペーン再利用によるIDの変動に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->