### PR TITLE
feat: Orchestrator Agent — dedicated launcher with workflow settings (#226)

### DIFF
--- a/crates/tmai-app/web/src/lib/api-http.ts
+++ b/crates/tmai-app/web/src/lib/api-http.ts
@@ -116,6 +116,7 @@ export interface AgentSnapshot {
   connection_channels?: ConnectionChannels;
   model_id?: string | null;
   model_display_name?: string | null;
+  is_orchestrator?: boolean;
 }
 
 // ── Project grouping ──
@@ -535,6 +536,19 @@ export interface SpawnSettings {
   tmux_window_name: string;
 }
 
+export interface OrchestratorRules {
+  branch: string;
+  merge: string;
+  review: string;
+  custom: string;
+}
+
+export interface OrchestratorSettings {
+  enabled: boolean;
+  role: string;
+  rules: OrchestratorRules;
+}
+
 export interface SpawnRequest {
   command: string;
   args?: string[];
@@ -879,6 +893,23 @@ export const api = {
     apiFetch("/settings/spawn", {
       method: "PUT",
       body: JSON.stringify(params),
+    }),
+
+  // Orchestrator settings
+  getOrchestratorSettings: () => apiFetch<OrchestratorSettings>("/settings/orchestrator"),
+  updateOrchestratorSettings: (params: {
+    enabled?: boolean;
+    role?: string;
+    rules?: Partial<OrchestratorRules>;
+  }) =>
+    apiFetch("/settings/orchestrator", {
+      method: "PUT",
+      body: JSON.stringify(params),
+    }),
+  spawnOrchestrator: (params?: { cwd?: string; additional_instructions?: string }) =>
+    apiFetch<SpawnResponse>("/orchestrator/spawn", {
+      method: "POST",
+      body: JSON.stringify(params ?? {}),
     }),
 
   // Preview settings

--- a/crates/tmai-app/web/src/lib/api-tauri.ts
+++ b/crates/tmai-app/web/src/lib/api-tauri.ts
@@ -5,7 +5,13 @@
 export * from "./api-http";
 export * from "./teams";
 
-import type { AgentSnapshot, AutoApproveRules, SpawnRequest, UsageSettings } from "./api-http";
+import type {
+  AgentSnapshot,
+  AutoApproveRules,
+  OrchestratorRules,
+  SpawnRequest,
+  UsageSettings,
+} from "./api-http";
 import { api as httpApi } from "./api-http";
 // Import for implementation
 import { tauri } from "./tauri";
@@ -179,6 +185,16 @@ export const api = {
   getSpawnSettings: () => httpApi.getSpawnSettings(),
   updateSpawnSettings: (params: { use_tmux_window: boolean; tmux_window_name?: string }) =>
     httpApi.updateSpawnSettings(params),
+
+  // Orchestrator settings
+  getOrchestratorSettings: () => httpApi.getOrchestratorSettings(),
+  updateOrchestratorSettings: (params: {
+    enabled?: boolean;
+    role?: string;
+    rules?: Partial<OrchestratorRules>;
+  }) => httpApi.updateOrchestratorSettings(params),
+  spawnOrchestrator: (params?: { cwd?: string; additional_instructions?: string }) =>
+    httpApi.spawnOrchestrator(params),
 
   // Preview settings
   getPreviewSettings: () => httpApi.getPreviewSettings(),

--- a/crates/tmai-core/src/agents/types.rs
+++ b/crates/tmai-core/src/agents/types.rs
@@ -618,6 +618,8 @@ pub struct MonitoredAgent {
     pub claude_version: Option<String>,
     /// Human-readable session name set via /rename (from statusline hook)
     pub session_name: Option<String>,
+    /// Whether this agent was spawned as an orchestrator
+    pub is_orchestrator: bool,
 }
 
 impl MonitoredAgent {
@@ -685,6 +687,7 @@ impl MonitoredAgent {
             context_window_size: None,
             claude_version: None,
             session_name: None,
+            is_orchestrator: false,
         }
     }
 

--- a/crates/tmai-core/src/api/actions.rs
+++ b/crates/tmai-core/src/api/actions.rs
@@ -935,6 +935,49 @@ impl TmaiCore {
 
         changed
     }
+
+    // =========================================================
+    // Orchestrator
+    // =========================================================
+
+    /// Compose a system prompt from orchestrator settings.
+    ///
+    /// The prompt includes the role description, any non-empty workflow rules,
+    /// and an instruction to use tmai MCP tools.
+    pub fn compose_orchestrator_prompt(&self) -> String {
+        let orch = &self.settings().orchestrator;
+        let mut parts: Vec<String> = Vec::new();
+
+        // Role
+        parts.push(orch.role.clone());
+
+        // Rules (only include non-empty ones)
+        let mut rule_lines: Vec<String> = Vec::new();
+        if !orch.rules.branch.is_empty() {
+            rule_lines.push(format!("- Branch: {}", orch.rules.branch));
+        }
+        if !orch.rules.merge.is_empty() {
+            rule_lines.push(format!("- Merge: {}", orch.rules.merge));
+        }
+        if !orch.rules.review.is_empty() {
+            rule_lines.push(format!("- Review: {}", orch.rules.review));
+        }
+        if !orch.rules.custom.is_empty() {
+            rule_lines.push(format!("- {}", orch.rules.custom));
+        }
+        if !rule_lines.is_empty() {
+            parts.push(format!("\nWorkflow rules:\n{}", rule_lines.join("\n")));
+        }
+
+        // MCP instruction
+        parts.push(
+            "\nUse tmai MCP tools to manage agents: list_agents, spawn_worktree, \
+             dispatch_issue, get_agent_output, send_prompt, approve, etc."
+                .to_string(),
+        );
+
+        parts.join("\n")
+    }
 }
 
 #[cfg(test)]
@@ -1489,5 +1532,34 @@ mod tests {
             s.prompt_queue.get("agent1").unwrap().len()
         };
         assert_eq!(remaining, 1);
+    }
+
+    #[test]
+    fn test_compose_orchestrator_prompt_default() {
+        let core = TmaiCoreBuilder::new(Settings::default()).build();
+        let prompt = core.compose_orchestrator_prompt();
+        // Should contain default role
+        assert!(prompt.contains("orchestrator agent"));
+        // Should contain MCP tools instruction
+        assert!(prompt.contains("tmai MCP tools"));
+        // No rules section with empty rules
+        assert!(!prompt.contains("Workflow rules:"));
+    }
+
+    #[test]
+    fn test_compose_orchestrator_prompt_with_rules() {
+        let mut settings = Settings::default();
+        settings.orchestrator.role = "You are the boss.".to_string();
+        settings.orchestrator.rules.branch = "feat/{issue}-{slug}".to_string();
+        settings.orchestrator.rules.review = "Run CI first".to_string();
+
+        let core = TmaiCoreBuilder::new(settings).build();
+        let prompt = core.compose_orchestrator_prompt();
+        assert!(prompt.contains("You are the boss."));
+        assert!(prompt.contains("Workflow rules:"));
+        assert!(prompt.contains("- Branch: feat/{issue}-{slug}"));
+        assert!(prompt.contains("- Review: Run CI first"));
+        // Merge rule is empty, should not appear
+        assert!(!prompt.contains("- Merge:"));
     }
 }

--- a/crates/tmai-core/src/api/types.rs
+++ b/crates/tmai-core/src/api/types.rs
@@ -193,6 +193,9 @@ pub struct AgentSnapshot {
     /// Human-readable session name set via /rename (from statusline hook)
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_name: Option<String>,
+    /// Whether this agent was spawned as an orchestrator
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub is_orchestrator: bool,
 }
 
 /// Helper for skip_serializing_if on u32
@@ -285,6 +288,7 @@ impl AgentSnapshot {
             context_window_size: agent.context_window_size,
             claude_version: agent.claude_version.clone(),
             session_name: agent.session_name.clone(),
+            is_orchestrator: agent.is_orchestrator,
         }
     }
 

--- a/crates/tmai-core/src/config/settings.rs
+++ b/crates/tmai-core/src/config/settings.rs
@@ -286,6 +286,10 @@ pub struct Settings {
     #[serde(default)]
     pub spawn: SpawnSettings,
 
+    /// Orchestrator agent settings
+    #[serde(default)]
+    pub orchestrator: OrchestratorSettings,
+
     /// Registered project directories (absolute paths)
     #[serde(default)]
     pub projects: Vec<String>,
@@ -832,6 +836,60 @@ impl Default for SpawnSettings {
     }
 }
 
+/// Orchestrator agent settings
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OrchestratorSettings {
+    /// Enable orchestrator functionality
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Role description for the orchestrator agent (system prompt preamble)
+    #[serde(default = "default_orchestrator_role")]
+    pub role: String,
+
+    /// Workflow rules that guide the orchestrator's behavior
+    #[serde(default)]
+    pub rules: OrchestratorRules,
+}
+
+/// Workflow rules for the orchestrator agent
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct OrchestratorRules {
+    /// Branch naming convention (e.g., "Use {issue_number}-{slug} format")
+    #[serde(default)]
+    pub branch: String,
+
+    /// Merge strategy (e.g., "squash merge to main, delete branch after merge")
+    #[serde(default)]
+    pub merge: String,
+
+    /// Review process (e.g., "check CI status and run tests before merge")
+    #[serde(default)]
+    pub review: String,
+
+    /// Custom rules (free-form instructions appended to the prompt)
+    #[serde(default)]
+    pub custom: String,
+}
+
+/// Default orchestrator role
+fn default_orchestrator_role() -> String {
+    "You are an orchestrator agent managing a team of AI coding agents. \
+     Coordinate work by dispatching issues to worktree agents, monitoring their progress, \
+     and ensuring quality through reviews."
+        .to_string()
+}
+
+impl Default for OrchestratorSettings {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            role: default_orchestrator_role(),
+            rules: OrchestratorRules::default(),
+        }
+    }
+}
+
 /// Codex CLI app-server WebSocket connection settings
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CodexWsSettings {
@@ -873,6 +931,7 @@ impl Default for Settings {
             worktree: WorktreeSettings::default(),
             workflow: WorkflowSettings::default(),
             spawn: SpawnSettings::default(),
+            orchestrator: OrchestratorSettings::default(),
             projects: Vec::new(),
             webui: true,
         }
@@ -1144,6 +1203,59 @@ mod tests {
         assert_eq!(settings.poll_interval_ms, 1000);
         assert_eq!(settings.capture_lines, 200);
         assert!(!settings.ui.show_preview);
+    }
+
+    #[test]
+    fn test_orchestrator_settings_default() {
+        let settings = OrchestratorSettings::default();
+        assert!(!settings.enabled);
+        assert!(!settings.role.is_empty());
+        assert!(settings.rules.branch.is_empty());
+        assert!(settings.rules.merge.is_empty());
+        assert!(settings.rules.review.is_empty());
+        assert!(settings.rules.custom.is_empty());
+    }
+
+    #[test]
+    fn test_orchestrator_settings_deserialization() {
+        let toml = r#"
+            [orchestrator]
+            enabled = true
+            role = "Custom orchestrator role"
+
+            [orchestrator.rules]
+            branch = "Use {issue_number}-{slug} format"
+            merge = "squash merge to main"
+            review = "check CI before merge"
+            custom = "always create PR with description"
+        "#;
+        let settings: Settings = toml::from_str(toml).expect("Should parse TOML");
+        assert!(settings.orchestrator.enabled);
+        assert_eq!(settings.orchestrator.role, "Custom orchestrator role");
+        assert_eq!(
+            settings.orchestrator.rules.branch,
+            "Use {issue_number}-{slug} format"
+        );
+        assert_eq!(settings.orchestrator.rules.merge, "squash merge to main");
+        assert_eq!(settings.orchestrator.rules.review, "check CI before merge");
+        assert_eq!(
+            settings.orchestrator.rules.custom,
+            "always create PR with description"
+        );
+    }
+
+    #[test]
+    fn test_orchestrator_partial_deserialization() {
+        let toml = r#"
+            [orchestrator]
+            enabled = true
+        "#;
+        let settings: Settings = toml::from_str(toml).expect("Should parse TOML");
+        assert!(settings.orchestrator.enabled);
+        // role should get the default value
+        assert!(!settings.orchestrator.role.is_empty());
+        // rules should be empty defaults
+        assert!(settings.orchestrator.rules.branch.is_empty());
     }
 
     #[test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -152,6 +152,16 @@ pub struct DispatchIssueParams {
     pub additional_instructions: Option<String>,
 }
 
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SpawnOrchestratorParams {
+    /// Working directory (optional, defaults to first registered project or cwd)
+    #[serde(default)]
+    pub cwd: Option<String>,
+    /// Additional instructions appended to the composed orchestrator prompt
+    #[serde(default)]
+    pub additional_instructions: Option<String>,
+}
+
 // =========================================================
 // Tool implementations
 // =========================================================
@@ -357,6 +367,26 @@ impl TmaiMcpServer {
         match self
             .client
             .post::<serde_json::Value>("/spawn/worktree", &body)
+        {
+            Ok(data) => format_json(&data),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Spawn an orchestrator agent with a composed prompt from the [orchestrator] config settings.
+    /// The orchestrator coordinates work across sub-agents using tmai MCP tools.
+    #[tool(description = "Spawn an orchestrator agent with workflow settings from config")]
+    fn spawn_orchestrator(&self, Parameters(p): Parameters<SpawnOrchestratorParams>) -> String {
+        let mut body = serde_json::json!({});
+        if let Some(ref cwd) = p.cwd {
+            body["cwd"] = serde_json::json!(cwd);
+        }
+        if let Some(ref extra) = p.additional_instructions {
+            body["additional_instructions"] = serde_json::json!(extra);
+        }
+        match self
+            .client
+            .post::<serde_json::Value>("/orchestrator/spawn", &body)
         {
             Ok(data) => format_json(&data),
             Err(e) => format!("Error: {e}"),
@@ -590,6 +620,28 @@ fn format_json(value: &serde_json::Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn spawn_orchestrator_params_empty() {
+        let json = serde_json::json!({});
+        let p: SpawnOrchestratorParams = serde_json::from_value(json).unwrap();
+        assert!(p.cwd.is_none());
+        assert!(p.additional_instructions.is_none());
+    }
+
+    #[test]
+    fn spawn_orchestrator_params_all_fields() {
+        let json = serde_json::json!({
+            "cwd": "/tmp/project",
+            "additional_instructions": "Focus on issue #42"
+        });
+        let p: SpawnOrchestratorParams = serde_json::from_value(json).unwrap();
+        assert_eq!(p.cwd.as_deref(), Some("/tmp/project"));
+        assert_eq!(
+            p.additional_instructions.as_deref(),
+            Some("Focus on issue #42")
+        );
+    }
 
     #[test]
     fn dispatch_issue_params_required_only() {

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1163,6 +1163,127 @@ pub async fn update_spawn_settings(
 }
 
 // =========================================================
+// Orchestrator settings endpoints
+// =========================================================
+
+/// Response body for orchestrator settings
+#[derive(Debug, Serialize)]
+pub struct OrchestratorSettingsResponse {
+    pub enabled: bool,
+    pub role: String,
+    pub rules: OrchestratorRulesResponse,
+}
+
+/// Rules sub-object in orchestrator settings response
+#[derive(Debug, Serialize)]
+pub struct OrchestratorRulesResponse {
+    pub branch: String,
+    pub merge: String,
+    pub review: String,
+    pub custom: String,
+}
+
+/// Request body for updating orchestrator settings
+#[derive(Debug, Deserialize)]
+pub struct UpdateOrchestratorSettingsRequest {
+    #[serde(default)]
+    pub enabled: Option<bool>,
+    #[serde(default)]
+    pub role: Option<String>,
+    #[serde(default)]
+    pub rules: Option<UpdateOrchestratorRulesRequest>,
+}
+
+/// Rules sub-object in orchestrator settings update request
+#[derive(Debug, Deserialize)]
+pub struct UpdateOrchestratorRulesRequest {
+    #[serde(default)]
+    pub branch: Option<String>,
+    #[serde(default)]
+    pub merge: Option<String>,
+    #[serde(default)]
+    pub review: Option<String>,
+    #[serde(default)]
+    pub custom: Option<String>,
+}
+
+/// GET /api/settings/orchestrator — get orchestrator settings
+pub async fn get_orchestrator_settings(
+    State(core): State<Arc<TmaiCore>>,
+) -> Json<OrchestratorSettingsResponse> {
+    let orch = &core.settings().orchestrator;
+    Json(OrchestratorSettingsResponse {
+        enabled: orch.enabled,
+        role: orch.role.clone(),
+        rules: OrchestratorRulesResponse {
+            branch: orch.rules.branch.clone(),
+            merge: orch.rules.merge.clone(),
+            review: orch.rules.review.clone(),
+            custom: orch.rules.custom.clone(),
+        },
+    })
+}
+
+/// PUT /api/settings/orchestrator — update orchestrator settings (persisted to config.toml)
+pub async fn update_orchestrator_settings(
+    State(core): State<Arc<TmaiCore>>,
+    Json(req): Json<UpdateOrchestratorSettingsRequest>,
+) -> Json<serde_json::Value> {
+    if let Some(enabled) = req.enabled {
+        tmai_core::config::Settings::save_toml_value(
+            "orchestrator",
+            "enabled",
+            toml_edit::Value::from(enabled),
+        );
+    }
+    if let Some(ref role) = req.role {
+        tmai_core::config::Settings::save_toml_value(
+            "orchestrator",
+            "role",
+            toml_edit::Value::from(role.as_str()),
+        );
+    }
+    if let Some(ref rules) = req.rules {
+        if let Some(ref v) = rules.branch {
+            tmai_core::config::Settings::save_toml_nested_value(
+                "orchestrator",
+                "rules",
+                "branch",
+                toml_edit::Value::from(v.as_str()),
+            );
+        }
+        if let Some(ref v) = rules.merge {
+            tmai_core::config::Settings::save_toml_nested_value(
+                "orchestrator",
+                "rules",
+                "merge",
+                toml_edit::Value::from(v.as_str()),
+            );
+        }
+        if let Some(ref v) = rules.review {
+            tmai_core::config::Settings::save_toml_nested_value(
+                "orchestrator",
+                "rules",
+                "review",
+                toml_edit::Value::from(v.as_str()),
+            );
+        }
+        if let Some(ref v) = rules.custom {
+            tmai_core::config::Settings::save_toml_nested_value(
+                "orchestrator",
+                "rules",
+                "custom",
+                toml_edit::Value::from(v.as_str()),
+            );
+        }
+    }
+
+    core.reload_settings();
+    tracing::info!("Orchestrator settings updated");
+    Json(serde_json::json!({"ok": true}))
+}
+
+// =========================================================
 // Auto-approve settings endpoint
 // =========================================================
 
@@ -1668,6 +1789,74 @@ async fn spawn_in_pty(
             ))
         }
     }
+}
+
+/// Request body for spawning an orchestrator agent
+#[derive(Debug, Deserialize)]
+pub struct SpawnOrchestratorRequest {
+    /// Working directory (defaults to first registered project or cwd)
+    #[serde(default)]
+    pub cwd: Option<String>,
+    /// Additional instructions appended to the composed prompt
+    #[serde(default)]
+    pub additional_instructions: Option<String>,
+}
+
+/// POST /api/orchestrator/spawn — spawn an orchestrator agent with composed prompt
+pub async fn spawn_orchestrator(
+    State(core): State<Arc<TmaiCore>>,
+    Json(req): Json<SpawnOrchestratorRequest>,
+) -> Result<Json<SpawnResponse>, (StatusCode, Json<serde_json::Value>)> {
+    // Resolve cwd: explicit > first registered project > default_cwd()
+    let cwd = req
+        .cwd
+        .clone()
+        .or_else(|| core.settings().projects.first().cloned())
+        .unwrap_or_else(default_cwd);
+
+    if !std::path::Path::new(&cwd).is_dir() {
+        return Err(json_error(
+            StatusCode::BAD_REQUEST,
+            &format!("Directory does not exist: {}", cwd),
+        ));
+    }
+
+    // Compose orchestrator prompt from settings
+    let mut prompt = core.compose_orchestrator_prompt();
+    if let Some(ref extra) = req.additional_instructions {
+        if !extra.is_empty() {
+            prompt.push_str("\n\n");
+            prompt.push_str(extra);
+        }
+    }
+
+    // Spawn as a regular claude agent with the composed prompt as the initial argument
+    let spawn_req = SpawnRequest {
+        command: "claude".to_string(),
+        args: vec![prompt],
+        cwd: cwd.clone(),
+        rows: default_rows(),
+        cols: default_cols(),
+        force_pty: true, // orchestrator always uses PTY for reliable monitoring
+    };
+
+    // Use spawn_in_pty directly (orchestrator always uses PTY)
+    let result = spawn_in_pty(&core, &spawn_req).await?;
+
+    // Mark the newly spawned agent as an orchestrator
+    let session_id = &result.session_id;
+    {
+        #[allow(deprecated)]
+        let state = core.raw_state();
+        let mut s = state.write();
+        if let Some(agent) = s.agents.get_mut(session_id) {
+            agent.is_orchestrator = true;
+        }
+    }
+    core.notify_agents_updated();
+
+    tracing::info!("API: spawned orchestrator agent session_id={}", session_id);
+    Ok(result)
 }
 
 /// Start a Codex app-server and return its WebSocket URL.

--- a/src/web/server.rs
+++ b/src/web/server.rs
@@ -119,11 +119,16 @@ impl WebServer {
                 get(api::get_spawn_settings).put(api::update_spawn_settings),
             )
             .route(
+                "/settings/orchestrator",
+                get(api::get_orchestrator_settings).put(api::update_orchestrator_settings),
+            )
+            .route(
                 "/settings/auto-approve",
                 get(api::get_auto_approve_settings).put(api::update_auto_approve_settings),
             )
             .route("/spawn", post(api::spawn_agent))
             .route("/spawn/worktree", post(api::spawn_worktree))
+            .route("/orchestrator/spawn", post(api::spawn_orchestrator))
             .route("/git/branches", get(api::list_branches))
             .route("/agents/{id}/output", get(api::get_agent_output))
             .route("/agents/{from}/send-to/{to}", post(api::send_to_agent))


### PR DESCRIPTION
## Summary
- Add `[orchestrator]` config section with `role`, `rules.{branch,merge,review,custom}`, and `enabled` flag
- Add `GET/PUT /api/settings/orchestrator` endpoints to read/update orchestrator settings (persisted to config.toml)
- Add `POST /api/orchestrator/spawn` endpoint that composes a system prompt from settings and spawns a dedicated orchestrator agent with `is_orchestrator` flag
- Add `spawn_orchestrator` MCP tool for agent-driven orchestrator launch
- Add `getOrchestratorSettings`, `updateOrchestratorSettings`, `spawnOrchestrator` to frontend API layer (api-http.ts / api-tauri.ts)
- Track `is_orchestrator` flag on `MonitoredAgent` and `AgentSnapshot`

## Test plan
- [x] Config deserialization tests (full, partial, defaults) — 3 tests
- [x] `compose_orchestrator_prompt` tests (default, with rules) — 2 tests
- [x] MCP `SpawnOrchestratorParams` serde tests — 2 tests
- [x] `cargo check`, `cargo clippy`, `cargo fmt` clean
- [x] Full test suite passes (720+ core tests, 113 bin tests)

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)