### PR TITLE
fix: increase send_text character limit from 1024 to 32768

### DIFF
--- a/crates/tmai-core/src/api/actions.rs
+++ b/crates/tmai-core/src/api/actions.rs
@@ -9,8 +9,8 @@ use crate::detectors::get_detector;
 use super::core::TmaiCore;
 use super::types::{ApiError, SendPromptResult};
 
-/// Maximum text length for send_text
-const MAX_TEXT_LENGTH: usize = 1024;
+/// Maximum text length for send_text / send_prompt (32KB)
+const MAX_TEXT_LENGTH: usize = 32_768;
 
 /// Maximum number of queued prompts per agent
 const MAX_PROMPT_QUEUE_SIZE: usize = 5;
@@ -1158,7 +1158,7 @@ mod tests {
     async fn test_send_text_too_long() {
         let agent = test_agent("main:0.0", AgentStatus::Idle);
         let core = make_core_with_agents(vec![agent]);
-        let long_text = "x".repeat(1025);
+        let long_text = "x".repeat(32_769);
         let result = core.send_text("main:0.0", &long_text).await;
         assert!(matches!(result, Err(ApiError::InvalidInput { .. })));
     }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -2604,11 +2604,11 @@ pub async fn send_to_agent(
         .resolve_agent_key(&to)
         .map_err(|_| json_error(StatusCode::NOT_FOUND, "Target agent not found"))?;
 
-    // Validate text length
-    if req.text.len() > 10240 {
+    // Validate text length (32KB, matching MAX_TEXT_LENGTH in tmai-core)
+    if req.text.len() > 32_768 {
         return Err(json_error(
             StatusCode::BAD_REQUEST,
-            "Text too long (max 10KB)",
+            "Text too long (max 32KB)",
         ));
     }
     let _ = &from_key; // ensure source is valid


### PR DESCRIPTION
## Summary
- Increase `MAX_TEXT_LENGTH` from 1024 to 32768 (32KB) in `tmai-core` for `send_text` and `send_prompt` APIs
- Align `send_to_agent` endpoint limit from 10KB to 32KB to match
- Update tests accordingly

Closes #248

## Test plan
- [x] `cargo check` passes
- [x] `cargo test --lib -p tmai-core -- send_text send_prompt` — all 12 tests pass
- [x] `cargo fmt` / `cargo clippy` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * テキスト送信の最大文字数制限を拡張しました。これまでより長いメッセージを送信できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->