### PR TITLE
fix: orchestrator spawn should respect tmux mode (use tmux window instead of PTY) (#252)

### DIFF
--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1839,11 +1839,20 @@ pub async fn spawn_orchestrator(
         cwd: cwd.clone(),
         rows: default_rows(),
         cols: default_cols(),
-        force_pty: true, // orchestrator always uses PTY for reliable monitoring
+        force_pty: false,
     };
 
-    // Use spawn_in_pty directly (orchestrator always uses PTY)
-    let result = spawn_in_pty(&core, &spawn_req).await?;
+    // Respect tmux mode: use tmux window when available, fall back to PTY
+    let use_tmux = {
+        #[allow(deprecated)]
+        let state = core.raw_state().read();
+        state.spawn_in_tmux
+    };
+    let result = if use_tmux && is_tmux_available() {
+        spawn_in_tmux(&core, &spawn_req).await?
+    } else {
+        spawn_in_pty(&core, &spawn_req).await?
+    };
 
     // Mark the newly spawned agent as an orchestrator
     let session_id = &result.session_id;


### PR DESCRIPTION
## Summary

- When tmai runs in tmux mode (`spawn_in_tmux` config + `TMUX` env), orchestrator now spawns in a tmux window instead of always using PTY
- This inherits tmux environment variables (`TMUX`, `XDG_RUNTIME_DIR`), allowing tmai MCP server to connect properly
- Falls back to PTY spawn when tmux is not available (WebUI-only mode)

Closes #252

## Test plan

- [ ] Spawn orchestrator in tmux mode → verify it opens in a tmux window (not PTY)
- [ ] Spawn orchestrator without tmux → verify it falls back to PTY
- [ ] Verify MCP tools work in tmux-spawned orchestrator

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * プロセス起動の動作を最適化しました。Tmuxモードが有効で利用可能な場合、Tmuxを使用してプロセスを起動するようになりました。これにより、環境に応じたより適切なプロセス管理が可能になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->