### PR TITLE
feat: allow re-registering a running agent as orchestrator (#268)

### DIFF
--- a/crates/tmai-core/src/api/actions.rs
+++ b/crates/tmai-core/src/api/actions.rs
@@ -940,6 +940,39 @@ impl TmaiCore {
     // Orchestrator
     // =========================================================
 
+    /// Mark an existing agent as the orchestrator for its project.
+    ///
+    /// Any previous orchestrator for the same project is automatically demoted.
+    /// Emits `AgentsUpdated` so all subscribers (WebUI, notifier) reflect the change.
+    pub fn set_orchestrator(&self, id: &str) -> Result<(), ApiError> {
+        let target = self.resolve_agent_key(id)?;
+
+        let mut state = self.state().write();
+
+        // Determine the project (cwd) of the target agent
+        let project = state
+            .agents
+            .get(&target)
+            .map(|a| a.cwd.clone())
+            .unwrap_or_default();
+
+        // Demote any existing orchestrator for the same project
+        for agent in state.agents.values_mut() {
+            if agent.is_orchestrator && agent.cwd == project {
+                agent.is_orchestrator = false;
+            }
+        }
+
+        // Promote the target agent
+        if let Some(agent) = state.agents.get_mut(&target) {
+            agent.is_orchestrator = true;
+        }
+
+        drop(state);
+        self.notify_agents_updated();
+        Ok(())
+    }
+
     /// Compose a system prompt from orchestrator settings.
     ///
     /// The prompt includes the role description, any non-empty workflow rules,
@@ -1563,5 +1596,63 @@ mod tests {
         assert!(prompt.contains("- Review: Run CI first"));
         // Merge rule is empty, should not appear
         assert!(!prompt.contains("- Merge:"));
+    }
+
+    #[test]
+    fn test_set_orchestrator_not_found() {
+        let core = TmaiCoreBuilder::new(Settings::default()).build();
+        let result = core.set_orchestrator("nonexistent");
+        assert!(matches!(result, Err(ApiError::AgentNotFound { .. })));
+    }
+
+    #[test]
+    fn test_set_orchestrator_promotes_agent() {
+        let agent = test_agent("main:0.0", AgentStatus::Idle);
+        let core = make_core_with_agents(vec![agent]);
+        assert!(core.set_orchestrator("main:0.0").is_ok());
+        let state = core.state().read();
+        assert!(state.agents.get("main:0.0").unwrap().is_orchestrator);
+    }
+
+    #[test]
+    fn test_set_orchestrator_demotes_previous() {
+        let mut agent1 = test_agent("main:0.0", AgentStatus::Idle);
+        agent1.is_orchestrator = true;
+        let agent2 = test_agent("main:0.1", AgentStatus::Idle);
+        let core = make_core_with_agents(vec![agent1, agent2]);
+
+        // Promote agent2 — agent1 should be demoted (same cwd)
+        assert!(core.set_orchestrator("main:0.1").is_ok());
+        let state = core.state().read();
+        assert!(!state.agents.get("main:0.0").unwrap().is_orchestrator);
+        assert!(state.agents.get("main:0.1").unwrap().is_orchestrator);
+    }
+
+    #[test]
+    fn test_set_orchestrator_different_project_not_demoted() {
+        let mut agent1 = test_agent("main:0.0", AgentStatus::Idle);
+        agent1.is_orchestrator = true;
+        agent1.cwd = "/project-a".to_string();
+        let mut agent2 = test_agent("main:0.1", AgentStatus::Idle);
+        agent2.cwd = "/project-b".to_string();
+        let core = make_core_with_agents(vec![agent1, agent2]);
+
+        // Promote agent2 in project-b — agent1 in project-a stays orchestrator
+        assert!(core.set_orchestrator("main:0.1").is_ok());
+        let state = core.state().read();
+        assert!(state.agents.get("main:0.0").unwrap().is_orchestrator);
+        assert!(state.agents.get("main:0.1").unwrap().is_orchestrator);
+    }
+
+    #[test]
+    fn test_set_orchestrator_idempotent() {
+        let mut agent = test_agent("main:0.0", AgentStatus::Idle);
+        agent.is_orchestrator = true;
+        let core = make_core_with_agents(vec![agent]);
+
+        // Re-setting the same agent should succeed
+        assert!(core.set_orchestrator("main:0.0").is_ok());
+        let state = core.state().read();
+        assert!(state.agents.get("main:0.0").unwrap().is_orchestrator);
     }
 }

--- a/crates/tmai-core/src/orchestrator_notify/service.rs
+++ b/crates/tmai-core/src/orchestrator_notify/service.rs
@@ -443,6 +443,7 @@ mod tests {
             on_idle: false,
             on_ci: true,
             on_pr_comment: true,
+            on_pr_created: true,
         };
 
         let event = CoreEvent::AgentStopped {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -153,6 +153,12 @@ pub struct DispatchIssueParams {
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct SetOrchestratorParams {
+    /// Agent ID — accepts stable ID, pane target, or PTY session UUID
+    pub id: String,
+}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SpawnOrchestratorParams {
     /// Working directory (optional, defaults to first registered project or cwd)
     #[serde(default)]
@@ -389,6 +395,20 @@ impl TmaiMcpServer {
             .post::<serde_json::Value>("/orchestrator/spawn", &body)
         {
             Ok(data) => format_json(&data),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Mark an existing running agent as the orchestrator for its project.
+    /// Any previous orchestrator for the same project is automatically demoted.
+    /// Use this to re-register yourself as orchestrator after /resume.
+    #[tool(description = "Mark an existing agent as orchestrator (e.g. after /resume recovery)")]
+    fn set_orchestrator(&self, Parameters(p): Parameters<SetOrchestratorParams>) -> String {
+        match self.client.post_ok(
+            &format!("/agents/{}/set-orchestrator", p.id),
+            &serde_json::json!({}),
+        ) {
+            Ok(()) => format!("Agent {} is now the orchestrator", p.id),
             Err(e) => format!("Error: {e}"),
         }
     }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1802,6 +1802,15 @@ async fn spawn_in_pty(
     }
 }
 
+/// POST /api/agents/{id}/set-orchestrator — mark an existing agent as orchestrator
+pub async fn set_orchestrator(
+    State(core): State<Arc<TmaiCore>>,
+    Path(id): Path<String>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    core.set_orchestrator(&id).map_err(api_error_to_http)?;
+    Ok(Json(serde_json::json!({"ok": true})))
+}
+
 /// Request body for spawning an orchestrator agent
 #[derive(Debug, Deserialize)]
 pub struct SpawnOrchestratorRequest {

--- a/src/web/server.rs
+++ b/src/web/server.rs
@@ -78,6 +78,7 @@ impl WebServer {
             .route("/agents/{id}/key", post(api::send_key))
             .route("/agents/{id}/auto-approve", put(api::set_auto_approve))
             .route("/agents/{id}/kill", post(api::kill_agent))
+            .route("/agents/{id}/set-orchestrator", post(api::set_orchestrator))
             .route("/agents/{id}/passthrough", post(api::passthrough_input))
             .route("/agents/{id}/preview", get(api::get_preview))
             .route("/agents/{id}/transcript", get(api::get_transcript))


### PR DESCRIPTION
## Summary

- Add `set_orchestrator` API to mark an existing running agent as the orchestrator for its project
- Enables recovery when the orchestrator is accidentally killed and resumed via `/resume`
- Previous orchestrator for the same project is automatically demoted (only one per project)
- Available as both HTTP endpoint (`POST /api/agents/{id}/set-orchestrator`) and MCP tool (`set_orchestrator`)

Closes #268

## Test plan

- [x] Unit tests for `set_orchestrator` action (5 tests: not found, promotes, demotes previous, different project isolation, idempotent)
- [x] `cargo check` passes
- [x] `cargo fmt` / `cargo clippy` pass
- [ ] Manual: resume an orchestrator via `/resume`, call `set_orchestrator` MCP tool, verify WebUI badge updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * エージェントをプロジェクトのオーケストレータとして設定できるようになりました。既存のオーケストレータは自動的に降格されます。

* **Tests**
  * オーケストレータ設定機能の検証テストを追加しました。エージェントIDの存在確認、昇格・降格動作、複数プロジェクト間の独立性、べき等性を検証しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->