### PR TITLE
feat: add kill_agent MCP tool for agent lifecycle management (#265)

### DIFF
--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -134,6 +134,17 @@ impl TmaiHttpClient {
             .ok_or_else(|| anyhow::anyhow!("No registered projects. Specify repo explicitly."))
     }
 
+    /// Make a DELETE request that returns a simple status (no body parsing)
+    pub fn delete_ok(&self, path: &str) -> Result<()> {
+        let info = Self::read_connection_info()?;
+        let url = format!("http://localhost:{}/api{}", info.port, path);
+        ureq::delete(&url)
+            .header("Authorization", &format!("Bearer {}", info.token))
+            .call()
+            .with_context(|| format!("DELETE {path} failed"))?;
+        Ok(())
+    }
+
     /// Make a GET request that returns raw text.
     pub fn get_text(&self, path: &str) -> Result<String> {
         let info = Self::read_connection_info()?;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -310,6 +310,15 @@ impl TmaiMcpServer {
         }
     }
 
+    /// Kill (terminate) an agent. Works for both PTY-spawned and tmux-managed agents.
+    #[tool(description = "Kill (terminate) an agent by ID")]
+    fn kill_agent(&self, Parameters(p): Parameters<AgentIdParams>) -> String {
+        match self.client.delete_ok(&format!("/agents/{}", p.id)) {
+            Ok(()) => format!("Killed agent {}", p.id),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
     // ----- Team Queries -----
 
     /// List all Claude Code Agent Teams with their member count and task progress.


### PR DESCRIPTION
## Summary

- Add `kill_agent` MCP tool that wraps `DELETE /api/agents/{id}` endpoint
- Add `delete_ok` method to `TmaiHttpClient` for DELETE HTTP requests
- Works for both PTY-spawned and tmux-managed agents

Closes #265

## Test plan

- [ ] Verify `kill_agent` appears in `tmai mcp` tool list
- [ ] Test killing a PTY-spawned agent via MCP
- [ ] Test killing a tmux-managed agent via MCP
- [ ] Test error handling for non-existent agent ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エージェント削除機能を追加しました。システムに登録されたエージェントを削除できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->