### PR TITLE
fix: use stable pane ID instead of index for kill operations (#267)

### DIFF
--- a/crates/tmai-core/src/api/actions.rs
+++ b/crates/tmai-core/src/api/actions.rs
@@ -808,10 +808,12 @@ impl TmaiCore {
         }
     }
 
-    /// Kill a specific agent (PTY session or tmux pane)
+    /// Kill a specific agent (PTY session or tmux pane).
+    /// Uses stable pane ID (%N) when available to avoid index-shift issues
+    /// during sequential kills.
     pub fn kill_pane(&self, id: &str) -> Result<(), ApiError> {
         let target = self.resolve_agent_key(id)?;
-        let has_pty = {
+        let (has_pty, pane_id) = {
             let state = self.state().read();
             let a = state.agents.get(&target).unwrap();
             if a.is_virtual {
@@ -819,7 +821,8 @@ impl TmaiCore {
                     target: target.clone(),
                 });
             }
-            a.pty_session_id.is_some()
+            let pane_id = state.target_to_pane_id.get(&target).cloned();
+            (a.pty_session_id.is_some(), pane_id)
         };
 
         if has_pty {
@@ -835,7 +838,13 @@ impl TmaiCore {
             Ok(())
         } else {
             let cmd = self.require_command_sender()?;
-            cmd.runtime().kill_pane(&target)?;
+            // Prefer stable pane ID to avoid index-shift when killing multiple panes
+            if let Some(pid) = pane_id {
+                let pane_id_target = format!("%{}", pid);
+                cmd.runtime().kill_pane_by_id(&pane_id_target)?;
+            } else {
+                cmd.runtime().kill_pane(&target)?;
+            }
             Ok(())
         }
     }

--- a/crates/tmai-core/src/runtime/mod.rs
+++ b/crates/tmai-core/src/runtime/mod.rs
@@ -84,6 +84,12 @@ pub trait RuntimeAdapter: Send + Sync {
     /// Terminate a pane / agent process.
     fn kill_pane(&self, target: &str) -> Result<()>;
 
+    /// Terminate a pane by stable pane ID (%N format).
+    /// Pane IDs survive sibling pane kills, unlike pane indices.
+    fn kill_pane_by_id(&self, _pane_id: &str) -> Result<()> {
+        anyhow::bail!("kill_pane_by_id not supported by {} runtime", self.name())
+    }
+
     // =========================================================
     // Session Management (optional capabilities)
     // =========================================================

--- a/crates/tmai-core/src/runtime/tmux_adapter.rs
+++ b/crates/tmai-core/src/runtime/tmux_adapter.rs
@@ -87,6 +87,10 @@ impl RuntimeAdapter for TmuxAdapter {
         self.client.kill_pane(target)
     }
 
+    fn kill_pane_by_id(&self, pane_id: &str) -> Result<()> {
+        self.client.kill_pane_by_id(pane_id)
+    }
+
     // --- Session Management ---
 
     fn create_session(&self, name: &str, cwd: &str, window_name: Option<&str>) -> Result<()> {

--- a/crates/tmai-core/src/tmux/client.rs
+++ b/crates/tmai-core/src/tmux/client.rs
@@ -9,11 +9,24 @@ use super::pane::PaneInfo;
 static TARGET_PATTERN: Lazy<Regex> =
     Lazy::new(|| Regex::new(r"^[A-Za-z0-9_.-]+:\d+\.\d+$").expect("Invalid TARGET_PATTERN regex"));
 
+/// Regex pattern for validating tmux pane ID format (%N)
+static PANE_ID_PATTERN: Lazy<Regex> =
+    Lazy::new(|| Regex::new(r"^%\d+$").expect("Invalid PANE_ID_PATTERN regex"));
+
 /// Validate tmux target format to prevent command injection
 /// Only allows `session:window.pane` format (e.g., "main:0.1")
 fn validate_target(target: &str) -> Result<()> {
     if !TARGET_PATTERN.is_match(target) {
         anyhow::bail!("Invalid tmux target format: {}", target);
+    }
+    Ok(())
+}
+
+/// Validate tmux pane ID format to prevent command injection
+/// Only allows `%N` format (e.g., "%42")
+fn validate_pane_id(pane_id: &str) -> Result<()> {
+    if !PANE_ID_PATTERN.is_match(pane_id) {
+        anyhow::bail!("Invalid tmux pane ID format: {}", pane_id);
     }
     Ok(())
 }
@@ -572,7 +585,7 @@ impl TmuxClient {
         Ok(())
     }
 
-    /// Kill a specific pane
+    /// Kill a specific pane by target (session:window.pane format)
     pub fn kill_pane(&self, target: &str) -> Result<()> {
         validate_target(target)?;
         let output = Command::new("tmux")
@@ -583,6 +596,23 @@ impl TmuxClient {
         if !output.status.success() {
             let stderr = String::from_utf8_lossy(&output.stderr);
             anyhow::bail!("tmux kill-pane failed for {}: {}", target, stderr);
+        }
+
+        Ok(())
+    }
+
+    /// Kill a specific pane by stable pane ID (%N format).
+    /// Pane IDs are stable across sibling pane kills, unlike pane indices.
+    pub fn kill_pane_by_id(&self, pane_id: &str) -> Result<()> {
+        validate_pane_id(pane_id)?;
+        let output = Command::new("tmux")
+            .args(["kill-pane", "-t", pane_id])
+            .output()
+            .context("Failed to execute tmux kill-pane")?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            anyhow::bail!("tmux kill-pane failed for {}: {}", pane_id, stderr);
         }
 
         Ok(())
@@ -653,5 +683,24 @@ mod tests {
         assert!(validate_target("`whoami`:0.0").is_err());
         assert!(validate_target("main:0.0\necho evil").is_err());
         assert!(validate_target("../etc/passwd").is_err());
+    }
+
+    #[test]
+    fn test_validate_pane_id_valid() {
+        assert!(validate_pane_id("%0").is_ok());
+        assert!(validate_pane_id("%5").is_ok());
+        assert!(validate_pane_id("%42").is_ok());
+        assert!(validate_pane_id("%999").is_ok());
+    }
+
+    #[test]
+    fn test_validate_pane_id_invalid() {
+        assert!(validate_pane_id("").is_err());
+        assert!(validate_pane_id("5").is_err());
+        assert!(validate_pane_id("%").is_err());
+        assert!(validate_pane_id("%abc").is_err());
+        assert!(validate_pane_id("%; rm -rf /").is_err());
+        assert!(validate_pane_id("%5; echo pwned").is_err());
+        assert!(validate_pane_id("main:0.1").is_err());
     }
 }


### PR DESCRIPTION
## Summary
- Use tmux pane ID (`%N` format) instead of pane index for `kill_pane` operations to prevent index-shift issues during sequential kills
- Add `validate_pane_id()` and `kill_pane_by_id()` to `TmuxClient` with proper input validation
- Thread `kill_pane_by_id()` through `RuntimeAdapter` trait
- `TmaiCore::kill_pane()` now prefers stable pane ID from `target_to_pane_id` map, falling back to target-based kill when pane ID is unavailable

Closes #267

## Test plan
- [x] `validate_pane_id` unit tests (valid: `%0`, `%42`, `%999`; invalid: injection attempts)
- [x] Existing `test_kill_pane_not_found` and `test_kill_pane_virtual_agent` pass
- [x] `cargo clippy` and `cargo fmt` clean
- [ ] Manual: kill multiple panes in same window sequentially — verify correct panes are killed

🤖 Generated with [Claude Code](https://claude.com/claude-code)