### PR TITLE
feat: add review_pr MCP tool for orchestrator-driven code review

### DIFF
--- a/crates/tmai-core/src/github/mod.rs
+++ b/crates/tmai-core/src/github/mod.rs
@@ -427,6 +427,34 @@ pub struct MergeResult {
     pub worktree_cleanup: Option<String>,
 }
 
+/// Review action for `gh pr review`
+#[derive(Debug, Clone, Copy, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ReviewAction {
+    Approve,
+    RequestChanges,
+    Comment,
+}
+
+impl ReviewAction {
+    /// Convert to the `gh pr review` CLI flag
+    fn as_flag(self) -> &'static str {
+        match self {
+            ReviewAction::Approve => "--approve",
+            ReviewAction::RequestChanges => "--request-changes",
+            ReviewAction::Comment => "--comment",
+        }
+    }
+}
+
+/// Result of a PR review operation
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ReviewResult {
+    pub pr_number: u64,
+    pub action: String,
+    pub message: String,
+}
+
 /// CI failure log output (truncated to 50KB)
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct CiFailureLog {
@@ -1166,6 +1194,57 @@ pub async fn merge_pr(
     })
 }
 
+/// Submit a review on a pull request via `gh pr review`
+pub async fn review_pr(
+    repo_dir: &str,
+    pr_number: u64,
+    action: ReviewAction,
+    body: Option<&str>,
+) -> Result<ReviewResult, String> {
+    let mut args = vec![
+        "pr".to_string(),
+        "review".to_string(),
+        pr_number.to_string(),
+        action.as_flag().to_string(),
+    ];
+    if let Some(body_text) = body {
+        args.push("--body".to_string());
+        args.push(body_text.to_string());
+    }
+
+    let output = tokio::time::timeout(
+        GH_TIMEOUT,
+        Command::new("gh")
+            .args(&args)
+            .current_dir(repo_dir)
+            .output(),
+    )
+    .await
+    .map_err(|_| "gh pr review timed out".to_string())?
+    .map_err(|e| format!("Failed to run gh: {}", e))?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+
+    if !output.status.success() {
+        return Err(format!("gh pr review failed: {}", stderr));
+    }
+
+    let message = if stdout.is_empty() { stderr } else { stdout };
+
+    let action_str = match action {
+        ReviewAction::Approve => "approve",
+        ReviewAction::RequestChanges => "request_changes",
+        ReviewAction::Comment => "comment",
+    };
+
+    Ok(ReviewResult {
+        pr_number,
+        action: action_str.to_string(),
+        message,
+    })
+}
+
 /// Extract issue numbers from a branch name
 ///
 /// Matches patterns like: `fix/123-desc`, `feat/42`, `issue-7`, `gh-99`
@@ -1230,6 +1309,34 @@ mod tests {
         };
         let json = serde_json::to_value(&result).unwrap();
         assert_eq!(json["worktree_cleanup"], "Deleted worktree: feat-branch");
+    }
+
+    #[test]
+    fn review_action_serde_roundtrip() {
+        let approve: ReviewAction = serde_json::from_str("\"approve\"").unwrap();
+        assert_eq!(approve, ReviewAction::Approve);
+        assert_eq!(approve.as_flag(), "--approve");
+
+        let request_changes: ReviewAction = serde_json::from_str("\"request_changes\"").unwrap();
+        assert_eq!(request_changes, ReviewAction::RequestChanges);
+        assert_eq!(request_changes.as_flag(), "--request-changes");
+
+        let comment: ReviewAction = serde_json::from_str("\"comment\"").unwrap();
+        assert_eq!(comment, ReviewAction::Comment);
+        assert_eq!(comment.as_flag(), "--comment");
+    }
+
+    #[test]
+    fn review_result_serializes_correctly() {
+        let result = ReviewResult {
+            pr_number: 42,
+            action: "approve".to_string(),
+            message: "Approved".to_string(),
+        };
+        let json = serde_json::to_value(&result).unwrap();
+        assert_eq!(json["pr_number"], 42);
+        assert_eq!(json["action"], "approve");
+        assert_eq!(json["message"], "Approved");
     }
 
     #[test]

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -189,6 +189,20 @@ pub struct MergePrParams {
     pub repo: Option<String>,
 }
 
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ReviewPrParams {
+    /// Pull request number to review
+    pub pr_number: u32,
+    /// Review action: "approve", "request_changes", or "comment"
+    pub action: String,
+    /// Review body text / summary (optional)
+    #[serde(default)]
+    pub body: Option<String>,
+    /// Repository path (optional, defaults to first registered project)
+    #[serde(default)]
+    pub repo: Option<String>,
+}
+
 fn default_merge_method() -> String {
     "squash".to_string()
 }
@@ -620,6 +634,34 @@ impl TmaiMcpServer {
             &serde_json::json!({"branch": p.branch, "repo": repo}),
         ) {
             Ok(()) => format!("Rerunning failed checks for branch: {}", p.branch),
+            Err(e) => format!("Error: {e}"),
+        }
+    }
+
+    /// Submit a review on a pull request (approve, request changes, or comment).
+    #[tool(description = "Review a pull request — approve, request changes, or post a comment")]
+    fn review_pr(&self, Parameters(p): Parameters<ReviewPrParams>) -> String {
+        if !["approve", "request_changes", "comment"].contains(&p.action.as_str()) {
+            return format!(
+                "Error: invalid action '{}' — must be approve, request_changes, or comment",
+                p.action
+            );
+        }
+        let repo = match self.client.resolve_repo(&p.repo) {
+            Ok(r) => r,
+            Err(e) => return format!("Error: {e}"),
+        };
+        let body = serde_json::json!({
+            "repo": repo,
+            "pr_number": p.pr_number,
+            "action": p.action,
+            "body": p.body,
+        });
+        match self
+            .client
+            .post::<serde_json::Value>("/github/pr/review", &body)
+        {
+            Ok(data) => format_json(&data),
             Err(e) => format!("Error: {e}"),
         }
     }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -2994,6 +2994,28 @@ pub async fn rerun_failed_checks(
         .map(|()| Json(serde_json::json!({"status": "ok"})))
 }
 
+/// Request body for PR review
+#[derive(Debug, Deserialize)]
+pub struct PrReviewRequest {
+    pub repo: String,
+    pub pr_number: u64,
+    pub action: tmai_core::github::ReviewAction,
+    #[serde(default)]
+    pub body: Option<String>,
+}
+
+/// POST /api/github/pr/review — submit a review on a pull request
+pub async fn review_pr(
+    Json(body): Json<PrReviewRequest>,
+) -> Result<Json<tmai_core::github::ReviewResult>, (StatusCode, Json<serde_json::Value>)> {
+    let repo_dir = validate_repo(&body.repo)?;
+
+    tmai_core::github::review_pr(&repo_dir, body.pr_number, body.action, body.body.as_deref())
+        .await
+        .map(Json)
+        .map_err(|e| json_error(StatusCode::BAD_REQUEST, &e))
+}
+
 /// POST /api/github/pr/merge — merge a pull request
 pub async fn merge_pr(
     Json(body): Json<PrMergeRequest>,

--- a/src/web/server.rs
+++ b/src/web/server.rs
@@ -108,6 +108,7 @@ impl WebServer {
             .route("/github/pr/merge-status", get(api::get_pr_merge_status))
             .route("/github/ci/failure-log", get(api::get_ci_failure_log))
             .route("/github/ci/rerun", post(api::rerun_failed_checks))
+            .route("/github/pr/review", post(api::review_pr))
             .route("/github/pr/merge", post(api::merge_pr))
             .route("/git/merge", post(api::git_merge))
             .route("/projects", get(api::get_projects).post(api::add_project))


### PR DESCRIPTION
## Summary

Closes #262

- Add `review_pr` MCP tool so the orchestrator can approve, request changes, or comment on PRs without falling back to bash
- Add `POST /api/github/pr/review` HTTP API endpoint
- Add `ReviewAction` enum and `ReviewResult` struct in the GitHub module
- Call `gh pr review` with `--approve` / `--request-changes` / `--comment` and optional `--body`

## API

### MCP Tool
```
review_pr(pr_number, action, body?, repo?)
```
- `action`: `"approve"` | `"request_changes"` | `"comment"`

### HTTP Endpoint
```
POST /api/github/pr/review
{ "repo": "...", "pr_number": 42, "action": "approve", "body": "LGTM" }
```

## Test plan

- [x] `cargo check` passes
- [x] `cargo fmt --check` passes
- [x] `cargo clippy` passes
- [x] Unit tests for `ReviewAction` serde roundtrip
- [x] Unit tests for `ReviewResult` serialization
- [ ] Manual: `tmai mcp` exposes `review_pr` tool
- [ ] Manual: orchestrator can approve a PR via MCP

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * PullRequestレビュー機能を追加。承認、変更のリクエスト、コメントアクションに対応。新しいAPIエンドポイントでレビューの実行と結果の取得が可能に。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->