### PR TITLE
feat: add project-scoped filtering to MCP agent tools (#285)

### DIFF
--- a/crates/tmai-core/src/api/queries.rs
+++ b/crates/tmai-core/src/api/queries.rs
@@ -66,6 +66,52 @@ impl TmaiCore {
             .collect()
     }
 
+    /// List agents filtered by project (git_common_dir).
+    ///
+    /// Agents are matched when their `git_common_dir` equals the given project path,
+    /// or when `git_common_dir` is None, by checking if the agent's `cwd` starts with
+    /// the project path. This ensures worktree agents are included since they share
+    /// the same git_common_dir as the main repo.
+    pub fn list_agents_by_project(&self, project: &str) -> Vec<AgentSnapshot> {
+        let state = self.state().read();
+        let defs = &state.agent_definitions;
+        let project_git_dir = normalize_git_dir(project);
+        state
+            .agent_order
+            .iter()
+            .filter_map(|id| state.agents.get(id))
+            .filter(|a| agent_matches_project(a, &project_git_dir, project))
+            .map(|a| {
+                let mut snap = AgentSnapshot::from_agent(a);
+                snap.agent_definition = Self::match_agent_definition(a, defs);
+                snap
+            })
+            .collect()
+    }
+
+    /// Validate that an agent belongs to the given project scope.
+    ///
+    /// Returns Ok(()) if the agent's git_common_dir matches the project,
+    /// or Err with a clear message if it belongs to a different project.
+    pub fn validate_agent_project(&self, id: &str, project: &str) -> Result<(), ApiError> {
+        let state = self.state().read();
+        let key = Self::resolve_agent_key_in_state(&state, id)?;
+        let agent = state.agents.get(&key).unwrap();
+        let project_git_dir = normalize_git_dir(project);
+        if agent_matches_project(agent, &project_git_dir, project) {
+            Ok(())
+        } else {
+            Err(ApiError::ProjectScopeMismatch {
+                agent_id: id.to_string(),
+                agent_project: agent
+                    .git_common_dir
+                    .clone()
+                    .unwrap_or_else(|| agent.cwd.clone()),
+                expected_project: project.to_string(),
+            })
+        }
+    }
+
     /// Get a single agent snapshot by any accepted ID form (stable_id, target, pty_session_id).
     pub fn get_agent(&self, id: &str) -> Result<AgentSnapshot, ApiError> {
         let state = self.state().read();
@@ -348,6 +394,32 @@ impl TmaiCore {
     }
 }
 
+/// Normalize a project path to its `.git` directory for comparison with git_common_dir.
+///
+/// If the path already ends with `.git`, return as-is. Otherwise append `/.git`.
+fn normalize_git_dir(project: &str) -> String {
+    if project.ends_with(".git") {
+        project.to_string()
+    } else {
+        let trimmed = project.trim_end_matches('/');
+        format!("{trimmed}/.git")
+    }
+}
+
+/// Check whether an agent belongs to a project by comparing git_common_dir or cwd.
+fn agent_matches_project(
+    agent: &crate::agents::MonitoredAgent,
+    project_git_dir: &str,
+    project_path: &str,
+) -> bool {
+    if let Some(ref gcd) = agent.git_common_dir {
+        gcd == project_git_dir
+    } else {
+        // Fallback: check if agent cwd is within the project directory
+        agent.cwd.starts_with(project_path)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -601,5 +673,204 @@ mod tests {
         let snapshot = AgentSnapshot::from_agent(&agent);
         assert_eq!(snapshot.id, stable_id);
         assert_eq!(snapshot.pane_id, "main:0.0");
+    }
+
+    // =========================================================
+    // Project-scoped filtering tests
+    // =========================================================
+
+    /// Create an agent with a specific cwd and git_common_dir
+    fn test_agent_with_project(
+        id: &str,
+        cwd: &str,
+        git_common_dir: Option<&str>,
+    ) -> MonitoredAgent {
+        let mut agent = MonitoredAgent::new(
+            id.to_string(),
+            AgentType::ClaudeCode,
+            "Title".to_string(),
+            cwd.to_string(),
+            100,
+            "main".to_string(),
+            "win".to_string(),
+            0,
+            0,
+        );
+        agent.git_common_dir = git_common_dir.map(|s| s.to_string());
+        agent
+    }
+
+    #[test]
+    fn test_list_agents_by_project_filters_by_git_common_dir() {
+        let agents = vec![
+            test_agent_with_project(
+                "main:0.0",
+                "/home/user/project-a",
+                Some("/home/user/project-a/.git"),
+            ),
+            test_agent_with_project(
+                "main:0.1",
+                "/home/user/project-a/.claude/worktrees/feat-x",
+                Some("/home/user/project-a/.git"),
+            ),
+            test_agent_with_project(
+                "main:0.2",
+                "/home/user/project-b",
+                Some("/home/user/project-b/.git"),
+            ),
+        ];
+        let core = make_core_with_agents(agents);
+
+        // Filter by project-a
+        let result = core.list_agents_by_project("/home/user/project-a");
+        assert_eq!(result.len(), 2);
+        assert!(result
+            .iter()
+            .all(|a| a.pane_id == "main:0.0" || a.pane_id == "main:0.1"));
+
+        // Filter by project-b
+        let result = core.list_agents_by_project("/home/user/project-b");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].pane_id, "main:0.2");
+    }
+
+    #[test]
+    fn test_list_agents_by_project_cwd_fallback() {
+        // Agents without git_common_dir fall back to cwd prefix matching
+        let agents = vec![
+            test_agent_with_project("main:0.0", "/home/user/project-a/src", None),
+            test_agent_with_project("main:0.1", "/home/user/project-b/src", None),
+        ];
+        let core = make_core_with_agents(agents);
+
+        let result = core.list_agents_by_project("/home/user/project-a");
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].pane_id, "main:0.0");
+    }
+
+    #[test]
+    fn test_list_agents_by_project_git_dir_suffix() {
+        // Passing path with .git suffix should also work
+        let agents = vec![test_agent_with_project(
+            "main:0.0",
+            "/home/user/project-a",
+            Some("/home/user/project-a/.git"),
+        )];
+        let core = make_core_with_agents(agents);
+
+        let result = core.list_agents_by_project("/home/user/project-a/.git");
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_list_agents_by_project_empty_result() {
+        let agents = vec![test_agent_with_project(
+            "main:0.0",
+            "/home/user/project-a",
+            Some("/home/user/project-a/.git"),
+        )];
+        let core = make_core_with_agents(agents);
+
+        let result = core.list_agents_by_project("/home/user/project-c");
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_validate_agent_project_same_project() {
+        let agents = vec![test_agent_with_project(
+            "main:0.0",
+            "/home/user/project-a",
+            Some("/home/user/project-a/.git"),
+        )];
+        let core = make_core_with_agents(agents);
+
+        assert!(core
+            .validate_agent_project("main:0.0", "/home/user/project-a")
+            .is_ok());
+    }
+
+    #[test]
+    fn test_validate_agent_project_different_project() {
+        let agents = vec![test_agent_with_project(
+            "main:0.0",
+            "/home/user/project-b",
+            Some("/home/user/project-b/.git"),
+        )];
+        let core = make_core_with_agents(agents);
+
+        let result = core.validate_agent_project("main:0.0", "/home/user/project-a");
+        assert!(matches!(result, Err(ApiError::ProjectScopeMismatch { .. })));
+    }
+
+    #[test]
+    fn test_validate_agent_project_not_found() {
+        let core = TmaiCoreBuilder::new(Settings::default()).build();
+        let result = core.validate_agent_project("nonexistent", "/home/user/project-a");
+        assert!(matches!(result, Err(ApiError::AgentNotFound { .. })));
+    }
+
+    #[test]
+    fn test_validate_agent_project_worktree_agent() {
+        // Worktree agent shares git_common_dir with main repo
+        let agents = vec![test_agent_with_project(
+            "main:0.0",
+            "/home/user/project-a/.claude/worktrees/feat-x",
+            Some("/home/user/project-a/.git"),
+        )];
+        let core = make_core_with_agents(agents);
+
+        assert!(core
+            .validate_agent_project("main:0.0", "/home/user/project-a")
+            .is_ok());
+    }
+
+    #[test]
+    fn test_normalize_git_dir() {
+        assert_eq!(
+            normalize_git_dir("/home/user/project"),
+            "/home/user/project/.git"
+        );
+        assert_eq!(
+            normalize_git_dir("/home/user/project/"),
+            "/home/user/project/.git"
+        );
+        assert_eq!(
+            normalize_git_dir("/home/user/project/.git"),
+            "/home/user/project/.git"
+        );
+    }
+
+    #[test]
+    fn test_agent_matches_project_with_git_common_dir() {
+        let agent = test_agent_with_project(
+            "main:0.0",
+            "/home/user/project-a",
+            Some("/home/user/project-a/.git"),
+        );
+        assert!(agent_matches_project(
+            &agent,
+            "/home/user/project-a/.git",
+            "/home/user/project-a"
+        ));
+        assert!(!agent_matches_project(
+            &agent,
+            "/home/user/project-b/.git",
+            "/home/user/project-b"
+        ));
+    }
+
+    #[test]
+    fn test_agent_matches_project_cwd_fallback() {
+        let agent = test_agent_with_project("main:0.0", "/home/user/project-a/subdir", None);
+        assert!(agent_matches_project(
+            &agent,
+            "/home/user/project-a/.git",
+            "/home/user/project-a"
+        ));
+        assert!(!agent_matches_project(
+            &agent,
+            "/home/user/project-b/.git",
+            "/home/user/project-b"
+        ));
     }
 }

--- a/crates/tmai-core/src/api/types.rs
+++ b/crates/tmai-core/src/api/types.rs
@@ -47,6 +47,14 @@ pub enum ApiError {
     /// A tmux or IPC operation failed
     #[error("command failed: {0}")]
     CommandError(#[from] anyhow::Error),
+
+    /// Agent belongs to a different project (cross-project operation denied)
+    #[error("agent {agent_id} belongs to project {agent_project}, not {expected_project}")]
+    ProjectScopeMismatch {
+        agent_id: String,
+        agent_project: String,
+        expected_project: String,
+    },
 }
 
 /// Owned snapshot of a `MonitoredAgent`, returned by query methods.

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -134,6 +134,38 @@ impl TmaiHttpClient {
             .ok_or_else(|| anyhow::anyhow!("No registered projects. Specify repo explicitly."))
     }
 
+    /// Resolve the git common directory for the MCP client's project context.
+    ///
+    /// Runs `git rev-parse --git-common-dir` in the resolved repo directory to get the
+    /// canonical git directory path. This is used for project-scoped filtering of agents.
+    pub fn resolve_git_common_dir(&self) -> Result<String> {
+        let repo = self.resolve_repo(&None)?;
+        let output = std::process::Command::new("git")
+            .args(["rev-parse", "--git-common-dir"])
+            .current_dir(&repo)
+            .output()
+            .context("Failed to run git rev-parse --git-common-dir")?;
+        if !output.status.success() {
+            anyhow::bail!(
+                "git rev-parse --git-common-dir failed: {}",
+                String::from_utf8_lossy(&output.stderr).trim()
+            );
+        }
+        let git_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        // If the result is relative, resolve it against the repo path
+        let path = std::path::Path::new(&git_dir);
+        if path.is_relative() {
+            let abs = std::path::Path::new(&repo).join(path);
+            Ok(abs
+                .canonicalize()
+                .unwrap_or(abs)
+                .to_string_lossy()
+                .to_string())
+        } else {
+            Ok(git_dir)
+        }
+    }
+
     /// Make a DELETE request that returns a simple status (no body parsing)
     pub fn delete_ok(&self, path: &str) -> Result<()> {
         let info = Self::read_connection_info()?;

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -24,6 +24,62 @@ impl TmaiMcpServer {
             client,
         }
     }
+
+    /// Validate that the target agent belongs to the MCP client's project.
+    ///
+    /// Fetches the agent, then checks its git_common_dir against the client's resolved
+    /// git common directory. Returns an error message if the agent belongs to a different
+    /// project. Returns None if validation passes or cannot be determined (fail-open).
+    fn validate_project_scope(&self, agent_id: &str) -> Option<String> {
+        let project_git_dir = match self.client.resolve_git_common_dir() {
+            Ok(dir) => dir,
+            Err(_) => return None, // Cannot determine project context — allow
+        };
+        // Fetch agent info and check its git_common_dir
+        match self.client.get::<serde_json::Value>("/agents") {
+            Ok(data) => {
+                if let Some(agents) = data.as_array() {
+                    if let Some(agent) = agents.iter().find(|a| {
+                        a.get("id").and_then(|v| v.as_str()) == Some(agent_id)
+                            || a.get("pane_id").and_then(|v| v.as_str()) == Some(agent_id)
+                            || a.get("target").and_then(|v| v.as_str()) == Some(agent_id)
+                            || a.get("pty_session_id").and_then(|v| v.as_str()) == Some(agent_id)
+                    }) {
+                        if let Some(agent_gcd) =
+                            agent.get("git_common_dir").and_then(|v| v.as_str())
+                        {
+                            if agent_gcd != project_git_dir {
+                                let agent_display = agent
+                                    .get("cwd")
+                                    .and_then(|v| v.as_str())
+                                    .unwrap_or("unknown");
+                                return Some(format!(
+                                    "Error: agent {} belongs to a different project ({}). \
+                                     Cross-project operations are not allowed.",
+                                    agent_id, agent_display
+                                ));
+                            }
+                        }
+                        // No git_common_dir on agent — check cwd prefix
+                        else if let Some(agent_cwd) = agent.get("cwd").and_then(|v| v.as_str()) {
+                            // Resolve the repo path for prefix check
+                            if let Ok(repo) = self.client.resolve_repo(&None) {
+                                if !agent_cwd.starts_with(&repo) {
+                                    return Some(format!(
+                                        "Error: agent {} belongs to a different project ({}). \
+                                         Cross-project operations are not allowed.",
+                                        agent_id, agent_cwd
+                                    ));
+                                }
+                            }
+                        }
+                    }
+                }
+                None // Agent not found or passes validation — let the action endpoint handle errors
+            }
+            Err(_) => None, // Cannot fetch agents — fail-open
+        }
+    }
 }
 
 // =========================================================
@@ -32,6 +88,14 @@ impl TmaiMcpServer {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct EmptyParams {}
+
+#[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
+pub struct ListAgentsParams {
+    /// Filter by project path (git_common_dir). Defaults to the MCP client's own project context.
+    /// Set to "*" to list agents from all projects.
+    #[serde(default)]
+    pub project: Option<String>,
+}
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct AgentIdParams {
@@ -205,18 +269,32 @@ fn default_true() -> bool {
 impl TmaiMcpServer {
     // ----- Agent Queries -----
 
-    /// List all monitored AI agents with their current status, type, working directory, and detection source.
-    #[tool(description = "List all monitored AI agents with their status")]
-    fn list_agents(&self, Parameters(_): Parameters<EmptyParams>) -> String {
-        match self.client.get::<serde_json::Value>("/agents") {
+    /// List monitored AI agents scoped to the current project. By default, only agents belonging
+    /// to the same git repository as the MCP client are shown. Pass project="*" to list all agents.
+    #[tool(description = "List monitored AI agents (scoped to current project by default)")]
+    fn list_agents(&self, Parameters(p): Parameters<ListAgentsParams>) -> String {
+        let project = match &p.project {
+            Some(proj) if proj == "*" => None,
+            Some(proj) => Some(proj.clone()),
+            None => self.client.resolve_git_common_dir().ok(),
+        };
+        let path = match &project {
+            Some(proj) => format!("/agents?project={}", encode(proj)),
+            None => "/agents".to_string(),
+        };
+        match self.client.get::<serde_json::Value>(&path) {
             Ok(agents) => format_json(&agents),
             Err(e) => format!("Error: {e}"),
         }
     }
 
     /// Get detailed information about a specific agent including its status, working directory, git branch, and connection channels.
+    /// Only agents within the same project scope are accessible.
     #[tool(description = "Get detailed info about a specific agent")]
     fn get_agent(&self, Parameters(p): Parameters<AgentIdParams>) -> String {
+        if let Some(err) = self.validate_project_scope(&p.id) {
+            return err;
+        }
         match self.client.get::<serde_json::Value>("/agents") {
             Ok(data) => {
                 if let Some(agents) = data.as_array() {
@@ -236,9 +314,12 @@ impl TmaiMcpServer {
         }
     }
 
-    /// Get the plain-text terminal output of an agent. Useful for seeing what the agent is currently displaying.
+    /// Get the plain-text terminal output of an agent. Only agents within the same project scope are accessible.
     #[tool(description = "Get the terminal output of an agent")]
     fn get_agent_output(&self, Parameters(p): Parameters<AgentIdParams>) -> String {
+        if let Some(err) = self.validate_project_scope(&p.id) {
+            return err;
+        }
         match self.client.get_text(&format!("/agents/{}/output", p.id)) {
             Ok(text) => text,
             Err(e) => format!("Error: {e}"),
@@ -246,8 +327,12 @@ impl TmaiMcpServer {
     }
 
     /// Get the conversation transcript of an agent (parsed from JSONL session log).
+    /// Only agents within the same project scope are accessible.
     #[tool(description = "Get the conversation transcript of an agent")]
     fn get_transcript(&self, Parameters(p): Parameters<AgentIdParams>) -> String {
+        if let Some(err) = self.validate_project_scope(&p.id) {
+            return err;
+        }
         match self
             .client
             .get::<serde_json::Value>(&format!("/agents/{}/transcript", p.id))
@@ -260,8 +345,12 @@ impl TmaiMcpServer {
     // ----- Agent Actions -----
 
     /// Approve a pending permission request for an agent (equivalent to pressing 'y').
+    /// Only agents within the same project scope can be approved.
     #[tool(description = "Approve a pending permission request for an agent")]
     fn approve(&self, Parameters(p): Parameters<AgentIdParams>) -> String {
+        if let Some(err) = self.validate_project_scope(&p.id) {
+            return err;
+        }
         match self
             .client
             .post_ok(&format!("/agents/{}/approve", p.id), &serde_json::json!({}))
@@ -272,8 +361,12 @@ impl TmaiMcpServer {
     }
 
     /// Send text input to an agent (like typing in the terminal). Use this to send prompts or commands.
+    /// Only agents within the same project scope can receive text.
     #[tool(description = "Send text input to an agent")]
     fn send_text(&self, Parameters(p): Parameters<SendTextParams>) -> String {
+        if let Some(err) = self.validate_project_scope(&p.id) {
+            return err;
+        }
         match self.client.post_ok(
             &format!("/agents/{}/input", p.id),
             &serde_json::json!({"text": p.text}),
@@ -286,9 +379,12 @@ impl TmaiMcpServer {
     /// Send a prompt to an agent with status-aware delivery. If the agent is idle, the prompt is
     /// sent immediately. If the agent is processing, the prompt is queued (max 5) and delivered
     /// automatically when the agent becomes idle. If the agent is stopped/offline, the prompt is
-    /// sent to restart it.
+    /// sent to restart it. Only agents within the same project scope can receive prompts.
     #[tool(description = "Send a prompt to an agent (queues if busy, delivers when idle)")]
     fn send_prompt(&self, Parameters(p): Parameters<SendPromptParams>) -> String {
+        if let Some(err) = self.validate_project_scope(&p.id) {
+            return err;
+        }
         match self.client.post::<serde_json::Value>(
             &format!("/agents/{}/prompt", p.id),
             &serde_json::json!({"prompt": p.prompt}),
@@ -316,8 +412,12 @@ impl TmaiMcpServer {
     }
 
     /// Send a special key to an agent (Enter, Escape, Space, Up, Down, Left, Right, Tab).
+    /// Only agents within the same project scope can receive keys.
     #[tool(description = "Send a special key to an agent")]
     fn send_key(&self, Parameters(p): Parameters<SendKeyParams>) -> String {
+        if let Some(err) = self.validate_project_scope(&p.id) {
+            return err;
+        }
         match self.client.post_ok(
             &format!("/agents/{}/key", p.id),
             &serde_json::json!({"key": p.key}),
@@ -328,8 +428,12 @@ impl TmaiMcpServer {
     }
 
     /// Select a numbered choice for an agent's AskUserQuestion prompt (1-based index).
+    /// Only agents within the same project scope can be interacted with.
     #[tool(description = "Select a choice for an agent's question")]
     fn select_choice(&self, Parameters(p): Parameters<SelectChoiceParams>) -> String {
+        if let Some(err) = self.validate_project_scope(&p.id) {
+            return err;
+        }
         match self.client.post_ok(
             &format!("/agents/{}/select", p.id),
             &serde_json::json!({"index": p.index}),
@@ -340,8 +444,12 @@ impl TmaiMcpServer {
     }
 
     /// Kill (terminate) an agent. Works for both PTY-spawned and tmux-managed agents.
+    /// Only agents within the same project scope can be killed.
     #[tool(description = "Kill (terminate) an agent by ID")]
     fn kill_agent(&self, Parameters(p): Parameters<AgentIdParams>) -> String {
+        if let Some(err) = self.validate_project_scope(&p.id) {
+            return err;
+        }
         match self.client.delete_ok(&format!("/agents/{}", p.id)) {
             Ok(()) => format!("Killed agent {}", p.id),
             Err(e) => format!("Error: {e}"),
@@ -711,6 +819,27 @@ fn format_json(value: &serde_json::Value) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn list_agents_params_empty() {
+        let json = serde_json::json!({});
+        let p: ListAgentsParams = serde_json::from_value(json).unwrap();
+        assert!(p.project.is_none());
+    }
+
+    #[test]
+    fn list_agents_params_with_project() {
+        let json = serde_json::json!({"project": "/home/user/project-a/.git"});
+        let p: ListAgentsParams = serde_json::from_value(json).unwrap();
+        assert_eq!(p.project.as_deref(), Some("/home/user/project-a/.git"));
+    }
+
+    #[test]
+    fn list_agents_params_wildcard() {
+        let json = serde_json::json!({"project": "*"});
+        let p: ListAgentsParams = serde_json::from_value(json).unwrap();
+        assert_eq!(p.project.as_deref(), Some("*"));
+    }
 
     #[test]
     fn spawn_orchestrator_params_empty() {

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -85,6 +85,7 @@ fn api_error_to_http(err: ApiError) -> (StatusCode, Json<serde_json::Value>) {
         ApiError::VirtualAgent { .. } | ApiError::InvalidInput { .. } | ApiError::NoSelection => {
             StatusCode::BAD_REQUEST
         }
+        ApiError::ProjectScopeMismatch { .. } => StatusCode::FORBIDDEN,
         ApiError::WorktreeError(e) => match e {
             tmai_core::worktree::WorktreeOpsError::NotFound(_) => StatusCode::NOT_FOUND,
             tmai_core::worktree::WorktreeOpsError::AlreadyExists(_)
@@ -291,9 +292,25 @@ pub struct SubmitRequest {
     pub selected_choices: Vec<usize>,
 }
 
-/// Get all agents
-pub async fn get_agents(State(core): State<Arc<TmaiCore>>) -> Json<Vec<AgentSnapshot>> {
-    Json(core.list_agents())
+/// Query parameters for agent listing
+#[derive(Debug, Deserialize)]
+pub struct AgentListQuery {
+    /// Filter agents by project path (git_common_dir). When provided, only agents
+    /// belonging to this project (matching git_common_dir or cwd prefix) are returned.
+    #[serde(default)]
+    pub project: Option<String>,
+}
+
+/// Get all agents, optionally filtered by project
+pub async fn get_agents(
+    State(core): State<Arc<TmaiCore>>,
+    axum::extract::Query(query): axum::extract::Query<AgentListQuery>,
+) -> Json<Vec<AgentSnapshot>> {
+    let agents = match query.project {
+        Some(ref project) => core.list_agents_by_project(project),
+        None => core.list_agents(),
+    };
+    Json(agents)
 }
 
 /// Approve an agent action (send approval keys)


### PR DESCRIPTION
## Summary

- **`list_agents`** now filters by `git_common_dir` (defaults to MCP client's project context). Pass `project="*"` to list all agents across projects.
- **Action tools** (`approve`, `send_prompt`, `send_text`, `send_key`, `select_choice`, `get_agent`, `get_agent_output`, `get_transcript`, `kill_agent`) validate that the target agent belongs to the same project before executing. Cross-project operations return a clear error.
- **REST API** `GET /api/agents` accepts optional `?project=` query parameter for server-side filtering.
- New `ProjectScopeMismatch` error variant with HTTP 403 status.

## Files changed

- `crates/tmai-core/src/api/queries.rs` — `list_agents_by_project()`, `validate_agent_project()`, helper functions
- `crates/tmai-core/src/api/types.rs` — `ProjectScopeMismatch` error variant
- `src/mcp/client.rs` — `resolve_git_common_dir()` via `git rev-parse --git-common-dir`
- `src/mcp/tools.rs` — Project-scoped `list_agents` + `validate_project_scope()` guard on action tools
- `src/web/api.rs` — Optional `project` query param on agents endpoint

## Test plan

- [x] Unit tests for `list_agents_by_project` filtering (git_common_dir match, cwd fallback, worktree agents)
- [x] Unit tests for `validate_agent_project` (same project, different project, not found, worktree)
- [x] Unit tests for `normalize_git_dir` and `agent_matches_project` helpers
- [x] Unit tests for `ListAgentsParams` deserialization (empty, with project, wildcard)
- [x] All 123 existing tests pass

Closes #285

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * プロジェクト単位でエージェントをフィルタリング表示できるようになりました
  * エージェント一覧取得APIに`project`パラメータを追加し、特定プロジェクトのエージェントのみを取得可能にしました
  * エージェントのプロジェクト範囲を検証し、プロジェクト外からのアクセスを制限できるようになりました

* **Bug Fixes**
  * クロスプロジェクトアクセス試行時に適切な403エラーを返すようになりました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->