### PR TITLE
refactor: type-safe permission_mode and notification_type in hook types (#294)

### DIFF
--- a/crates/tmai-core/src/audit/analyze.rs
+++ b/crates/tmai-core/src/audit/analyze.rs
@@ -360,6 +360,7 @@ fn event_reason(event: &AuditEvent) -> Option<&crate::detectors::DetectionReason
 mod tests {
     use super::*;
     use crate::detectors::{DetectionConfidence, DetectionReason};
+    use crate::hooks::types::PermissionMode;
 
     /// Helper to build a StateChanged event
     fn state_changed(ts: u64, rule: &str, confidence: DetectionConfidence) -> AuditEvent {
@@ -620,7 +621,7 @@ mod tests {
                 agent_type: "ClaudeCode".to_string(),
                 tool_name: Some("Bash".to_string()),
                 tool_input: Some(serde_json::json!({"command": "rm -rf /"})),
-                permission_mode: Some("default".to_string()),
+                permission_mode: Some(PermissionMode::Default),
             },
             state_changed(1000, "rule_a", DetectionConfidence::High),
         ];

--- a/crates/tmai-core/src/audit/events.rs
+++ b/crates/tmai-core/src/audit/events.rs
@@ -2,6 +2,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::auto_approve::types::JudgmentUsage;
 use crate::detectors::DetectionReason;
+use crate::hooks::types::PermissionMode;
 
 /// Audit event types for detection logging
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -103,7 +104,7 @@ pub enum AuditEvent {
         hook_tool_input: Option<serde_json::Value>,
         /// Permission mode from hook
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        hook_permission_mode: Option<String>,
+        hook_permission_mode: Option<PermissionMode>,
         /// Last N lines of screen content (included on disagreement, max 1000 chars)
         #[serde(default, skip_serializing_if = "Option::is_none")]
         screen_context: Option<String>,
@@ -119,9 +120,9 @@ pub enum AuditEvent {
         /// Tool input parameters at the time of denial
         #[serde(default, skip_serializing_if = "Option::is_none")]
         tool_input: Option<serde_json::Value>,
-        /// Permission mode (e.g., "default", "plan")
+        /// Permission mode (e.g., Default, Plan)
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        permission_mode: Option<String>,
+        permission_mode: Option<PermissionMode>,
     },
     /// User sent input while agent was detected as Processing
     /// (possible false negative — detection may have missed an approval prompt)
@@ -169,7 +170,7 @@ mod tests {
             ipc_agrees: Some(false),
             capture_agrees: false,
             hook_tool_input: Some(serde_json::json!({"command": "cargo test"})),
-            hook_permission_mode: Some("default".to_string()),
+            hook_permission_mode: Some(PermissionMode::Default),
             screen_context: Some("last few lines".to_string()),
         };
 
@@ -200,7 +201,7 @@ mod tests {
             assert_eq!(ipc_agrees, Some(false));
             assert!(!capture_agrees);
             assert!(hook_tool_input.is_some());
-            assert_eq!(hook_permission_mode.as_deref(), Some("default"));
+            assert_eq!(hook_permission_mode, Some(PermissionMode::Default));
             assert_eq!(screen_context.as_deref(), Some("last few lines"));
         } else {
             panic!("Expected DetectionValidation");
@@ -260,7 +261,7 @@ mod tests {
             agent_type: "ClaudeCode".to_string(),
             tool_name: Some("Bash".to_string()),
             tool_input: Some(serde_json::json!({"command": "rm -rf /"})),
-            permission_mode: Some("default".to_string()),
+            permission_mode: Some(PermissionMode::Default),
         };
 
         let json = serde_json::to_string(&event).unwrap();
@@ -281,7 +282,7 @@ mod tests {
             assert_eq!(agent_type, "ClaudeCode");
             assert_eq!(tool_name.as_deref(), Some("Bash"));
             assert!(tool_input.is_some());
-            assert_eq!(permission_mode.as_deref(), Some("default"));
+            assert_eq!(permission_mode, Some(PermissionMode::Default));
         } else {
             panic!("Expected PermissionDenied");
         }

--- a/crates/tmai-core/src/audit/helper.rs
+++ b/crates/tmai-core/src/audit/helper.rs
@@ -3,6 +3,7 @@
 use crate::agents::{AgentStatus, DetectionSource};
 use crate::audit::{AuditEvent, AuditEventSender};
 use crate::detectors::DetectionReason;
+use crate::hooks::types::PermissionMode;
 use crate::state::SharedState;
 
 /// Pre-extracted agent info for audit (avoids holding state lock during emit)
@@ -116,7 +117,7 @@ impl AuditHelper {
         agent_type: &str,
         tool_name: Option<String>,
         tool_input: Option<serde_json::Value>,
-        permission_mode: Option<String>,
+        permission_mode: Option<PermissionMode>,
     ) {
         let Some(ref tx) = self.tx else {
             return;

--- a/crates/tmai-core/src/hooks/handler.rs
+++ b/crates/tmai-core/src/hooks/handler.rs
@@ -8,8 +8,8 @@ use crate::state::SharedState;
 
 use super::registry::{HookRegistry, SessionPaneMap};
 use super::types::{
-    event_names, HookContext, HookEventPayload, HookState, HookStatus, ToolActivity,
-    MAX_ACTIVITY_LOG,
+    event_names, HookContext, HookEventPayload, HookState, HookStatus, NotificationType,
+    ToolActivity, MAX_ACTIVITY_LOG,
 };
 
 /// Process an incoming hook event and update the registry
@@ -139,11 +139,8 @@ pub fn handle_hook_event(
 
         event_names::NOTIFICATION => {
             // Check for permission_prompt notification type
-            let is_permission = payload
-                .notification_type
-                .as_deref()
-                .map(|t| t == "permission_prompt")
-                .unwrap_or(false);
+            let is_permission =
+                payload.notification_type == Some(NotificationType::PermissionPrompt);
             if is_permission {
                 update_status(
                     hook_registry,
@@ -806,6 +803,7 @@ pub fn handle_statusline(
 mod tests {
     use super::*;
     use crate::hooks::registry::{new_hook_registry, new_session_pane_map};
+    use crate::hooks::types::PermissionMode;
 
     fn make_payload(event: &str) -> HookEventPayload {
         serde_json::from_value(serde_json::json!({
@@ -1128,8 +1126,8 @@ mod tests {
         assert_eq!(state.last_tool.as_deref(), Some("Edit"));
         assert_eq!(state.last_context.event_name, "PermissionDenied");
         assert_eq!(
-            state.last_context.permission_mode.as_deref(),
-            Some("default")
+            state.last_context.permission_mode,
+            Some(PermissionMode::Default)
         );
     }
 
@@ -1288,8 +1286,8 @@ mod tests {
         assert_eq!(state.last_context.event_name, "PreToolUse");
         assert!(state.last_context.tool_input.is_some());
         assert_eq!(
-            state.last_context.permission_mode.as_deref(),
-            Some("default")
+            state.last_context.permission_mode,
+            Some(PermissionMode::Default)
         );
     }
 
@@ -1509,8 +1507,8 @@ mod tests {
         let state = reg.get("5").unwrap();
         assert_eq!(state.last_context.event_name, "PostToolUse");
         assert_eq!(
-            state.last_context.permission_mode.as_deref(),
-            Some("dontAsk")
+            state.last_context.permission_mode,
+            Some(PermissionMode::DontAsk)
         );
     }
 

--- a/crates/tmai-core/src/hooks/types.rs
+++ b/crates/tmai-core/src/hooks/types.rs
@@ -31,6 +31,30 @@ pub mod event_names {
     pub const PERMISSION_DENIED: &str = "PermissionDenied";
 }
 
+/// Permission mode reported by Claude Code in hook payloads.
+///
+/// Maps to the session's current permission level (e.g., "default", "plan", "dontAsk").
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum PermissionMode {
+    /// Normal interactive mode — prompts for each tool use
+    Default,
+    /// Plan mode — requires plan approval before execution
+    Plan,
+    /// Auto-approve all tool uses without prompting
+    DontAsk,
+}
+
+/// Notification type for the Notification hook event.
+///
+/// Currently only "permission_prompt" is defined by Claude Code.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum NotificationType {
+    /// Agent is waiting for a permission prompt response
+    PermissionPrompt,
+}
+
 /// Worktree information attached to hook events in `--worktree` sessions
 ///
 /// Contains name, path, branch, and the original repo directory.
@@ -73,9 +97,9 @@ pub struct HookEventPayload {
     #[serde(default)]
     pub transcript_path: Option<String>,
 
-    /// Current permission mode (e.g., "default", "plan", "dontAsk")
+    /// Current permission mode (e.g., Default, Plan, DontAsk)
     #[serde(default)]
-    pub permission_mode: Option<String>,
+    pub permission_mode: Option<PermissionMode>,
 
     /// Tool name (for PreToolUse / PostToolUse / PermissionRequest)
     #[serde(default)]
@@ -99,9 +123,9 @@ pub struct HookEventPayload {
     #[serde(default)]
     pub last_assistant_message: Option<String>,
 
-    /// Notification type (for Notification event, e.g., "permission_prompt")
+    /// Notification type (for Notification event)
     #[serde(default)]
-    pub notification_type: Option<String>,
+    pub notification_type: Option<NotificationType>,
 
     /// Notification message text (for Notification)
     #[serde(default)]
@@ -337,8 +361,8 @@ pub struct HookContext {
     pub event_name: String,
     /// Tool input parameters (from PreToolUse/PostToolUse/PermissionRequest)
     pub tool_input: Option<serde_json::Value>,
-    /// Current permission mode (e.g., "default", "plan", "dontAsk")
-    pub permission_mode: Option<String>,
+    /// Current permission mode
+    pub permission_mode: Option<PermissionMode>,
 }
 
 /// Maximum number of tool activities retained per agent
@@ -457,7 +481,7 @@ mod tests {
         assert_eq!(payload.session_id, "sess-123");
         assert_eq!(payload.tool_name.as_deref(), Some("Bash"));
         assert_eq!(payload.cwd.as_deref(), Some("/home/user/project"));
-        assert_eq!(payload.permission_mode.as_deref(), Some("default"));
+        assert_eq!(payload.permission_mode, Some(PermissionMode::Default));
     }
 
     #[test]
@@ -486,8 +510,8 @@ mod tests {
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
         assert_eq!(payload.hook_event_name, "Notification");
         assert_eq!(
-            payload.notification_type.as_deref(),
-            Some("permission_prompt")
+            payload.notification_type,
+            Some(NotificationType::PermissionPrompt)
         );
         assert_eq!(payload.message.as_deref(), Some("Claude needs permission"));
     }
@@ -545,7 +569,7 @@ mod tests {
             Some("/home/user/.claude/projects/proj/transcript.jsonl")
         );
         assert_eq!(payload.cwd.as_deref(), Some("/home/user/project"));
-        assert_eq!(payload.permission_mode.as_deref(), Some("default"));
+        assert_eq!(payload.permission_mode, Some(PermissionMode::Default));
         assert_eq!(payload.tool_name.as_deref(), Some("Bash"));
         assert!(payload.tool_input.is_some());
     }
@@ -662,7 +686,7 @@ mod tests {
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
         assert_eq!(payload.hook_event_name, "SessionStart");
         assert_eq!(payload.session_id, "new-session");
-        assert_eq!(payload.permission_mode.as_deref(), Some("plan"));
+        assert_eq!(payload.permission_mode, Some(PermissionMode::Plan));
         // All optional event-specific fields should be None
         assert!(payload.tool_name.is_none());
         assert!(payload.stop_hook_active.is_none());
@@ -750,7 +774,7 @@ mod tests {
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
         assert_eq!(payload.hook_event_name, "PermissionDenied");
         assert_eq!(payload.tool_name.as_deref(), Some("Bash"));
-        assert_eq!(payload.permission_mode.as_deref(), Some("default"));
+        assert_eq!(payload.permission_mode, Some(PermissionMode::Default));
         let tool_input = payload.tool_input.unwrap();
         assert_eq!(tool_input["command"], "rm -rf /tmp/build");
     }


### PR DESCRIPTION
## Summary
- Add `PermissionMode` enum (`Default`, `Plan`, `DontAsk`) and `NotificationType` enum (`PermissionPrompt`) to `hooks/types.rs`
- Replace `Option<String>` with `Option<PermissionMode>` and `Option<NotificationType>` in `HookEventPayload`, `HookContext`, and audit event types
- Update match logic in `handler.rs` to use enum comparison instead of string comparison

## Test plan
- [x] All 812 existing tests pass
- [x] Serde roundtrip tests verify correct serialization/deserialization of new enum types
- [x] `cargo clippy` and `cargo fmt` clean

Closes #294

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 権限管理システムの内部型安全性を強化しました。通知タイプと権限モードの処理をより堅牢にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->