### PR TITLE
refactor: replace stringly-typed hook event names with enum (#293)

### DIFF
--- a/crates/tmai-core/src/hooks/handler.rs
+++ b/crates/tmai-core/src/hooks/handler.rs
@@ -1,14 +1,14 @@
 //! Hook event handler — processes incoming Claude Code hook events
 //! and updates the HookRegistry accordingly.
 
-use tracing::{debug, warn};
+use tracing::debug;
 
 use crate::api::CoreEvent;
 use crate::state::SharedState;
 
 use super::registry::{HookRegistry, SessionPaneMap};
 use super::types::{
-    event_names, HookContext, HookEventPayload, HookState, HookStatus, NotificationType,
+    HookContext, HookEventName, HookEventPayload, HookState, HookStatus, NotificationType,
     ToolActivity, MAX_ACTIVITY_LOG,
 };
 
@@ -27,9 +27,9 @@ pub fn handle_hook_event(
         map.insert(payload.session_id.clone(), pane_id.to_string());
     }
 
-    let event = payload.hook_event_name.as_str();
+    let event = &payload.hook_event_name;
     debug!(
-        event,
+        event = %event,
         pane_id,
         session_id = %payload.session_id,
         tool_name = ?payload.tool_name,
@@ -37,7 +37,7 @@ pub fn handle_hook_event(
     );
 
     match event {
-        event_names::SESSION_START => {
+        HookEventName::SessionStart => {
             let mut state = HookState::new(payload.session_id.clone(), payload.cwd.clone());
             state.last_context = build_context(payload);
             state.worktree = payload.worktree.clone();
@@ -52,7 +52,7 @@ pub fn handle_hook_event(
             None
         }
 
-        event_names::USER_PROMPT_SUBMIT => {
+        HookEventName::UserPromptSubmit => {
             // Clear last_tool and activity_log on new prompt (fresh processing cycle)
             let ctx = build_context(payload);
             let mut reg = hook_registry.write();
@@ -82,7 +82,7 @@ pub fn handle_hook_event(
             None
         }
 
-        event_names::PRE_TOOL_USE => {
+        HookEventName::PreToolUse => {
             // Filter empty tool names to prevent "Tool: " display
             let tool_name = payload.tool_name.clone().filter(|t| !t.is_empty());
             update_status(
@@ -95,7 +95,7 @@ pub fn handle_hook_event(
             None
         }
 
-        event_names::POST_TOOL_USE => {
+        HookEventName::PostToolUse => {
             // Tool completed, still processing (more tools may follow)
             // Keep last_tool so the display shows which tool was last used.
             // It will be overwritten by the next PreToolUse or cleared by
@@ -137,7 +137,7 @@ pub fn handle_hook_event(
             None
         }
 
-        event_names::NOTIFICATION => {
+        HookEventName::Notification => {
             // Check for permission_prompt notification type
             let is_permission =
                 payload.notification_type == Some(NotificationType::PermissionPrompt);
@@ -154,7 +154,7 @@ pub fn handle_hook_event(
             None
         }
 
-        event_names::PERMISSION_REQUEST => {
+        HookEventName::PermissionRequest => {
             update_status(
                 hook_registry,
                 pane_id,
@@ -165,7 +165,7 @@ pub fn handle_hook_event(
             None
         }
 
-        event_names::PERMISSION_DENIED => {
+        HookEventName::PermissionDenied => {
             // Permission was denied by the user; agent returns to processing
             update_status(
                 hook_registry,
@@ -177,7 +177,7 @@ pub fn handle_hook_event(
             None
         }
 
-        event_names::STOP => {
+        HookEventName::Stop => {
             // Clear last_tool on stop (session returns to idle)
             let ctx = build_context(payload);
             let cwd = {
@@ -221,7 +221,7 @@ pub fn handle_hook_event(
             })
         }
 
-        event_names::SESSION_END => {
+        HookEventName::SessionEnd => {
             // Drop each lock before acquiring the next to avoid holding
             // multiple write locks simultaneously
             {
@@ -236,7 +236,7 @@ pub fn handle_hook_event(
             None
         }
 
-        event_names::SUBAGENT_START => {
+        HookEventName::SubagentStart => {
             // Increment active subagent count, agent is processing
             update_status(
                 hook_registry,
@@ -252,7 +252,7 @@ pub fn handle_hook_event(
             None
         }
 
-        event_names::SUBAGENT_STOP => {
+        HookEventName::SubagentStop => {
             // Decrement active subagent count, agent is still processing
             update_status(
                 hook_registry,
@@ -268,7 +268,7 @@ pub fn handle_hook_event(
             None
         }
 
-        event_names::TEAMMATE_IDLE => {
+        HookEventName::TeammateIdle => {
             let team_name = payload.team_name.clone().unwrap_or_default();
             let member_name = payload.teammate_name.clone().unwrap_or_default();
             if !team_name.is_empty() && !member_name.is_empty() {
@@ -282,7 +282,7 @@ pub fn handle_hook_event(
             }
         }
 
-        event_names::TASK_CREATED => {
+        HookEventName::TaskCreated => {
             let team_name = payload.team_name.clone().unwrap_or_default();
             let task_id = payload.task_id.clone().unwrap_or_default();
             let task_subject = payload.task_subject.clone().unwrap_or_default();
@@ -297,7 +297,7 @@ pub fn handle_hook_event(
             }
         }
 
-        event_names::TASK_COMPLETED => {
+        HookEventName::TaskCompleted => {
             let team_name = payload.team_name.clone().unwrap_or_default();
             let task_id = payload.task_id.clone().unwrap_or_default();
             let task_subject = payload.task_subject.clone().unwrap_or_default();
@@ -312,7 +312,7 @@ pub fn handle_hook_event(
             }
         }
 
-        event_names::CONFIG_CHANGE => {
+        HookEventName::ConfigChange => {
             // Config file changed — emit event for security/audit, touch timestamp only
             let ctx = build_context(payload);
             let source = payload.source.clone().unwrap_or_default();
@@ -329,7 +329,7 @@ pub fn handle_hook_event(
             })
         }
 
-        event_names::WORKTREE_CREATE => {
+        HookEventName::WorktreeCreate => {
             // Worktree created — set Processing, store worktree info, emit event
             let worktree_info = payload.worktree.clone();
             update_status(
@@ -352,7 +352,7 @@ pub fn handle_hook_event(
             })
         }
 
-        event_names::WORKTREE_REMOVE => {
+        HookEventName::WorktreeRemove => {
             // Worktree removed — touch timestamp, emit event with worktree info
             let worktree_info = payload.worktree.clone();
             let ctx = build_context(payload);
@@ -369,7 +369,7 @@ pub fn handle_hook_event(
             })
         }
 
-        event_names::PRE_COMPACT => {
+        HookEventName::PreCompact => {
             // Context compaction starting — set Compacting status, increment counter
             let ctx = build_context(payload);
             let count = {
@@ -390,7 +390,7 @@ pub fn handle_hook_event(
             })
         }
 
-        event_names::INSTRUCTIONS_LOADED => {
+        HookEventName::InstructionsLoaded => {
             // CLAUDE.md or rules files loaded — touch timestamp, emit event
             let ctx = build_context(payload);
             let mut reg = hook_registry.write();
@@ -403,7 +403,7 @@ pub fn handle_hook_event(
             })
         }
 
-        event_names::POST_TOOL_USE_FAILURE => {
+        HookEventName::PostToolUseFailure => {
             // Tool failed — same as PostToolUse (Processing continues, keep last_tool)
             let ctx = build_context(payload);
             let mut reg = hook_registry.write();
@@ -412,11 +412,6 @@ pub fn handle_hook_event(
                 state.last_context = ctx;
                 state.touch();
             }
-            None
-        }
-
-        _ => {
-            warn!(event, "Unknown hook event type, ignoring");
             None
         }
     }
@@ -501,7 +496,7 @@ pub fn resolve_pane_id(
 /// Build a HookContext from a hook event payload
 fn build_context(payload: &HookEventPayload) -> HookContext {
     HookContext {
-        event_name: payload.hook_event_name.clone(),
+        event_name: payload.hook_event_name.to_string(),
         tool_input: payload.tool_input.clone(),
         permission_mode: payload.permission_mode.clone(),
     }

--- a/crates/tmai-core/src/hooks/mod.rs
+++ b/crates/tmai-core/src/hooks/mod.rs
@@ -14,5 +14,6 @@ pub mod types;
 
 pub use registry::{new_hook_registry, new_session_pane_map, HookRegistry, SessionPaneMap};
 pub use types::{
-    HookEventPayload, HookState, HookStatus, StatuslineData, ToolActivity, WorktreeInfo,
+    HookEventName, HookEventPayload, HookState, HookStatus, StatuslineData, ToolActivity,
+    WorktreeInfo,
 };

--- a/crates/tmai-core/src/hooks/types.rs
+++ b/crates/tmai-core/src/hooks/types.rs
@@ -4,31 +4,63 @@
 //! and the internal state tracked per agent.
 
 use std::collections::HashMap;
+use std::fmt;
 
 use serde::{Deserialize, Serialize};
 
-/// Hook event name constants
-pub mod event_names {
-    pub const SESSION_START: &str = "SessionStart";
-    pub const USER_PROMPT_SUBMIT: &str = "UserPromptSubmit";
-    pub const PRE_TOOL_USE: &str = "PreToolUse";
-    pub const POST_TOOL_USE: &str = "PostToolUse";
-    pub const NOTIFICATION: &str = "Notification";
-    pub const PERMISSION_REQUEST: &str = "PermissionRequest";
-    pub const STOP: &str = "Stop";
-    pub const SUBAGENT_START: &str = "SubagentStart";
-    pub const SUBAGENT_STOP: &str = "SubagentStop";
-    pub const TEAMMATE_IDLE: &str = "TeammateIdle";
-    pub const TASK_CREATED: &str = "TaskCreated";
-    pub const TASK_COMPLETED: &str = "TaskCompleted";
-    pub const SESSION_END: &str = "SessionEnd";
-    pub const CONFIG_CHANGE: &str = "ConfigChange";
-    pub const WORKTREE_CREATE: &str = "WorktreeCreate";
-    pub const WORKTREE_REMOVE: &str = "WorktreeRemove";
-    pub const PRE_COMPACT: &str = "PreCompact";
-    pub const POST_TOOL_USE_FAILURE: &str = "PostToolUseFailure";
-    pub const INSTRUCTIONS_LOADED: &str = "InstructionsLoaded";
-    pub const PERMISSION_DENIED: &str = "PermissionDenied";
+/// Hook event name — typed enum replacing stringly-typed constants.
+///
+/// Variant names match the PascalCase wire format sent by Claude Code,
+/// so serde default (de)serialization works without `rename_all`.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum HookEventName {
+    SessionStart,
+    UserPromptSubmit,
+    PreToolUse,
+    PostToolUse,
+    PostToolUseFailure,
+    Notification,
+    PermissionRequest,
+    PermissionDenied,
+    Stop,
+    SubagentStart,
+    SubagentStop,
+    TeammateIdle,
+    TaskCreated,
+    TaskCompleted,
+    SessionEnd,
+    ConfigChange,
+    WorktreeCreate,
+    WorktreeRemove,
+    PreCompact,
+    InstructionsLoaded,
+}
+
+impl fmt::Display for HookEventName {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::SessionStart => write!(f, "SessionStart"),
+            Self::UserPromptSubmit => write!(f, "UserPromptSubmit"),
+            Self::PreToolUse => write!(f, "PreToolUse"),
+            Self::PostToolUse => write!(f, "PostToolUse"),
+            Self::PostToolUseFailure => write!(f, "PostToolUseFailure"),
+            Self::Notification => write!(f, "Notification"),
+            Self::PermissionRequest => write!(f, "PermissionRequest"),
+            Self::PermissionDenied => write!(f, "PermissionDenied"),
+            Self::Stop => write!(f, "Stop"),
+            Self::SubagentStart => write!(f, "SubagentStart"),
+            Self::SubagentStop => write!(f, "SubagentStop"),
+            Self::TeammateIdle => write!(f, "TeammateIdle"),
+            Self::TaskCreated => write!(f, "TaskCreated"),
+            Self::TaskCompleted => write!(f, "TaskCompleted"),
+            Self::SessionEnd => write!(f, "SessionEnd"),
+            Self::ConfigChange => write!(f, "ConfigChange"),
+            Self::WorktreeCreate => write!(f, "WorktreeCreate"),
+            Self::WorktreeRemove => write!(f, "WorktreeRemove"),
+            Self::PreCompact => write!(f, "PreCompact"),
+            Self::InstructionsLoaded => write!(f, "InstructionsLoaded"),
+        }
+    }
 }
 
 /// Permission mode reported by Claude Code in hook payloads.
@@ -82,8 +114,8 @@ pub struct WorktreeInfo {
 /// to support all event types.
 #[derive(Debug, Clone, Deserialize)]
 pub struct HookEventPayload {
-    /// Event name (e.g., "PreToolUse", "Stop", "Notification")
-    pub hook_event_name: String,
+    /// Event name (e.g., PreToolUse, Stop, Notification)
+    pub hook_event_name: HookEventName,
 
     /// Claude Code session ID (unique per session)
     #[serde(default)]
@@ -477,7 +509,7 @@ mod tests {
             "tool_input": {"command": "npm test"}
         }"#;
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.hook_event_name, "PreToolUse");
+        assert_eq!(payload.hook_event_name, HookEventName::PreToolUse);
         assert_eq!(payload.session_id, "sess-123");
         assert_eq!(payload.tool_name.as_deref(), Some("Bash"));
         assert_eq!(payload.cwd.as_deref(), Some("/home/user/project"));
@@ -493,7 +525,7 @@ mod tests {
             "last_assistant_message": "Done."
         }"#;
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.hook_event_name, "Stop");
+        assert_eq!(payload.hook_event_name, HookEventName::Stop);
         assert_eq!(payload.stop_hook_active, Some(true));
         assert_eq!(payload.last_assistant_message.as_deref(), Some("Done."));
     }
@@ -508,7 +540,7 @@ mod tests {
             "title": "Permission needed"
         }"#;
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.hook_event_name, "Notification");
+        assert_eq!(payload.hook_event_name, HookEventName::Notification);
         assert_eq!(
             payload.notification_type,
             Some(NotificationType::PermissionPrompt)
@@ -525,7 +557,7 @@ mod tests {
             "another_field": 42
         }"#;
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.hook_event_name, "PreToolUse");
+        assert_eq!(payload.hook_event_name, HookEventName::PreToolUse);
         assert!(payload.extra.contains_key("unknown_field"));
     }
 
@@ -562,7 +594,7 @@ mod tests {
             "tool_input": {"command": "cargo test"}
         }"#;
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.hook_event_name, "PreToolUse");
+        assert_eq!(payload.hook_event_name, HookEventName::PreToolUse);
         assert_eq!(payload.session_id, "abc123");
         assert_eq!(
             payload.transcript_path.as_deref(),
@@ -601,7 +633,7 @@ mod tests {
             "agent_type": "Explore"
         }"#;
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.hook_event_name, "SubagentStart");
+        assert_eq!(payload.hook_event_name, HookEventName::SubagentStart);
         assert_eq!(payload.agent_id.as_deref(), Some("agent-abc123"));
         assert_eq!(payload.agent_type.as_deref(), Some("Explore"));
     }
@@ -618,7 +650,7 @@ mod tests {
             "team_name": "my-project"
         }"#;
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.hook_event_name, "TeammateIdle");
+        assert_eq!(payload.hook_event_name, HookEventName::TeammateIdle);
         assert_eq!(payload.teammate_name.as_deref(), Some("researcher"));
         assert_eq!(payload.team_name.as_deref(), Some("my-project"));
     }
@@ -638,7 +670,7 @@ mod tests {
             "team_name": "my-project"
         }"#;
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.hook_event_name, "TaskCompleted");
+        assert_eq!(payload.hook_event_name, HookEventName::TaskCompleted);
         assert_eq!(payload.task_id.as_deref(), Some("task-001"));
         assert_eq!(payload.task_subject.as_deref(), Some("Implement auth"));
         assert_eq!(
@@ -663,7 +695,7 @@ mod tests {
             "team_name": "my-project"
         }"#;
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.hook_event_name, "TaskCreated");
+        assert_eq!(payload.hook_event_name, HookEventName::TaskCreated);
         assert_eq!(payload.task_id.as_deref(), Some("task-001"));
         assert_eq!(payload.task_subject.as_deref(), Some("Implement feature"));
         assert_eq!(
@@ -684,7 +716,7 @@ mod tests {
             "permission_mode": "plan"
         }"#;
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.hook_event_name, "SessionStart");
+        assert_eq!(payload.hook_event_name, HookEventName::SessionStart);
         assert_eq!(payload.session_id, "new-session");
         assert_eq!(payload.permission_mode, Some(PermissionMode::Plan));
         // All optional event-specific fields should be None
@@ -702,7 +734,7 @@ mod tests {
             "cwd": "/home/user/project"
         }"#;
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.hook_event_name, "InstructionsLoaded");
+        assert_eq!(payload.hook_event_name, HookEventName::InstructionsLoaded);
         assert_eq!(payload.cwd.as_deref(), Some("/home/user/project"));
     }
 
@@ -722,7 +754,7 @@ mod tests {
             }
         }"#;
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.hook_event_name, "PreToolUse");
+        assert_eq!(payload.hook_event_name, HookEventName::PreToolUse);
         let wt = payload.worktree.as_ref().unwrap();
         assert_eq!(wt.name.as_deref(), Some("feat-auth"));
         assert_eq!(wt.path.as_deref(), Some("/home/user/worktrees/feat-auth"));
@@ -754,7 +786,7 @@ mod tests {
             "tool_input": {"command": "rm -rf /tmp/build"}
         }"#;
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.hook_event_name, "PermissionRequest");
+        assert_eq!(payload.hook_event_name, HookEventName::PermissionRequest);
         assert_eq!(payload.tool_name.as_deref(), Some("Bash"));
         let tool_input = payload.tool_input.unwrap();
         assert_eq!(tool_input["command"], "rm -rf /tmp/build");
@@ -772,7 +804,7 @@ mod tests {
             "tool_input": {"command": "rm -rf /tmp/build"}
         }"#;
         let payload: HookEventPayload = serde_json::from_str(json).unwrap();
-        assert_eq!(payload.hook_event_name, "PermissionDenied");
+        assert_eq!(payload.hook_event_name, HookEventName::PermissionDenied);
         assert_eq!(payload.tool_name.as_deref(), Some("Bash"));
         assert_eq!(payload.permission_mode, Some(PermissionMode::Default));
         let tool_input = payload.tool_input.unwrap();

--- a/src/web/hooks.rs
+++ b/src/web/hooks.rs
@@ -20,7 +20,7 @@ use tracing::{debug, info, warn};
 use tmai_core::api::{CoreEvent, TmaiCore};
 use tmai_core::auto_approve::types::PermissionDecision;
 use tmai_core::hooks::handler::{handle_hook_event, handle_statusline, resolve_pane_id};
-use tmai_core::hooks::{HookEventPayload, StatuslineData};
+use tmai_core::hooks::{HookEventName, HookEventPayload, StatuslineData};
 
 /// Response body for hook events that support stop control
 ///
@@ -106,7 +106,7 @@ pub async fn hook_event(
     // For PreToolUse: check worktree path guard FIRST, then auto-approve.
     // Worktree guard Deny takes absolute precedence — prevents worktree agents
     // from contaminating the main working tree via absolute path resolution.
-    let pre_tool_use_response = if payload.hook_event_name == "PreToolUse" {
+    let pre_tool_use_response = if payload.hook_event_name == HookEventName::PreToolUse {
         if let Some(deny) = core.validate_worktree_path(&pane_id, &payload) {
             Some(deny)
         } else {
@@ -130,7 +130,7 @@ pub async fn hook_event(
     }
 
     // Emit PermissionDenied audit event when a permission is denied
-    if event_name == "PermissionDenied" {
+    if event_name == HookEventName::PermissionDenied {
         core.audit_helper().emit_permission_denied(
             &pane_id,
             "ClaudeCode",
@@ -144,9 +144,9 @@ pub async fn hook_event(
     core.notify_agents_updated();
 
     // Build event-specific response body
-    match event_name.as_str() {
+    match event_name {
         // PreToolUse: return permissionDecision for instant auto-approval
-        "PreToolUse" => {
+        HookEventName::PreToolUse => {
             if let Some(decision) = pre_tool_use_response {
                 match decision.decision {
                     // Defer: hold HTTP connection while awaiting AI/human resolution
@@ -257,7 +257,7 @@ pub async fn hook_event(
         }
 
         // TeammateIdle/TaskCreated/TaskCompleted: return stop control response
-        "TeammateIdle" | "TaskCreated" | "TaskCompleted" => {
+        HookEventName::TeammateIdle | HookEventName::TaskCreated | HookEventName::TaskCompleted => {
             let response = HookEventResponse {
                 should_continue: true,
                 stop_reason: None,


### PR DESCRIPTION
## Summary

- Replace `String` field + 20 string constants (`event_names` module) with a `HookEventName` enum for `HookEventPayload.hook_event_name`
- Enable exhaustive pattern matching in `handle_hook_event()` — compiler now catches missing cases when new events are added
- Implement `Display` for `HookEventName` to preserve string representation where needed (e.g., `HookContext.event_name`)

## Test plan

- [x] All 75 existing hook tests pass
- [x] `cargo check` with zero warnings
- [x] `cargo clippy` clean
- [x] Serde deserialization from JSON wire format ("PreToolUse" etc.) verified by existing tests

Closes #293

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  - フックイベント処理システムの内部実装を改善しました。これにより、イベント管理メカニズムの信頼性と保守性が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->