### PR TITLE
fix: MCP validate_project_scope bypasses backend normalization, blocks worktree agents (#301)

### DIFF
--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -4,6 +4,15 @@ use anyhow::{Context, Result};
 use serde::de::DeserializeOwned;
 use std::path::PathBuf;
 
+/// Error type for operations that need to distinguish HTTP status codes.
+#[derive(Debug)]
+pub enum ValidateError {
+    /// HTTP 4xx/5xx response with status code
+    HttpError { status: u16 },
+    /// Transport or parsing error
+    Transport(anyhow::Error),
+}
+
 /// Connection info for the tmai HTTP API
 #[derive(Debug, Clone, serde::Deserialize, serde::Serialize)]
 pub struct ApiConnectionInfo {
@@ -163,6 +172,33 @@ impl TmaiHttpClient {
                 .to_string())
         } else {
             Ok(git_dir)
+        }
+    }
+
+    /// Make a POST request and return the parsed JSON error body on failure.
+    ///
+    /// Unlike `post()`, HTTP 4xx/5xx responses are read and returned as a
+    /// structured error value instead of a generic ureq error.
+    pub fn post_with_error_body(
+        &self,
+        path: &str,
+        body: &serde_json::Value,
+    ) -> Result<serde_json::Value, ValidateError> {
+        let info = Self::read_connection_info().map_err(ValidateError::Transport)?;
+        let url = format!("http://localhost:{}/api{}", info.port, path);
+        match ureq::post(&url)
+            .header("Authorization", &format!("Bearer {}", info.token))
+            .send_json(body)
+        {
+            Ok(mut resp) => {
+                let val: serde_json::Value = resp
+                    .body_mut()
+                    .read_json()
+                    .map_err(|e| ValidateError::Transport(e.into()))?;
+                Ok(val)
+            }
+            Err(ureq::Error::StatusCode(status)) => Err(ValidateError::HttpError { status }),
+            Err(e) => Err(ValidateError::Transport(e.into())),
         }
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -27,57 +27,30 @@ impl TmaiMcpServer {
 
     /// Validate that the target agent belongs to the MCP client's project.
     ///
-    /// Fetches the agent, then checks its git_common_dir against the client's resolved
-    /// git common directory. Returns an error message if the agent belongs to a different
-    /// project. Returns None if validation passes or cannot be determined (fail-open).
+    /// Delegates to the backend's `validate-project` endpoint which uses
+    /// `normalize_git_dir()` for consistent comparison. Returns an error message
+    /// if the agent belongs to a different project. Returns None if validation
+    /// passes or cannot be determined (fail-open).
     fn validate_project_scope(&self, agent_id: &str) -> Option<String> {
+        use super::client::ValidateError;
+
         let project_git_dir = match self.client.resolve_git_common_dir() {
             Ok(dir) => dir,
             Err(_) => return None, // Cannot determine project context — allow
         };
-        // Fetch agent info and check its git_common_dir
-        match self.client.get::<serde_json::Value>("/agents") {
-            Ok(data) => {
-                if let Some(agents) = data.as_array() {
-                    if let Some(agent) = agents.iter().find(|a| {
-                        a.get("id").and_then(|v| v.as_str()) == Some(agent_id)
-                            || a.get("pane_id").and_then(|v| v.as_str()) == Some(agent_id)
-                            || a.get("target").and_then(|v| v.as_str()) == Some(agent_id)
-                            || a.get("pty_session_id").and_then(|v| v.as_str()) == Some(agent_id)
-                    }) {
-                        if let Some(agent_gcd) =
-                            agent.get("git_common_dir").and_then(|v| v.as_str())
-                        {
-                            if agent_gcd != project_git_dir {
-                                let agent_display = agent
-                                    .get("cwd")
-                                    .and_then(|v| v.as_str())
-                                    .unwrap_or("unknown");
-                                return Some(format!(
-                                    "Error: agent {} belongs to a different project ({}). \
-                                     Cross-project operations are not allowed.",
-                                    agent_id, agent_display
-                                ));
-                            }
-                        }
-                        // No git_common_dir on agent — check cwd prefix
-                        else if let Some(agent_cwd) = agent.get("cwd").and_then(|v| v.as_str()) {
-                            // Resolve the repo path for prefix check
-                            if let Ok(repo) = self.client.resolve_repo(&None) {
-                                if !agent_cwd.starts_with(&repo) {
-                                    return Some(format!(
-                                        "Error: agent {} belongs to a different project ({}). \
-                                         Cross-project operations are not allowed.",
-                                        agent_id, agent_cwd
-                                    ));
-                                }
-                            }
-                        }
-                    }
-                }
-                None // Agent not found or passes validation — let the action endpoint handle errors
+        let path = format!("/agents/{}/validate-project", agent_id);
+        let body = serde_json::json!({ "project": project_git_dir });
+        match self.client.post_with_error_body(&path, &body) {
+            Ok(_) => None, // 200 OK — validation passed
+            Err(ValidateError::HttpError { status: 403 }) => Some(format!(
+                "Error: agent {} belongs to a different project. \
+                 Cross-project operations are not allowed.",
+                agent_id
+            )),
+            Err(ValidateError::HttpError { status: 404 }) => {
+                None // Agent not found — let the action endpoint handle it
             }
-            Err(_) => None, // Cannot fetch agents — fail-open
+            Err(_) => None, // Other errors — fail-open
         }
     }
 }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -301,6 +301,26 @@ pub struct AgentListQuery {
     pub project: Option<String>,
 }
 
+/// Request body for project scope validation
+#[derive(Debug, Deserialize)]
+pub struct ValidateProjectRequest {
+    /// The project path (git_common_dir) to validate against
+    pub project: String,
+}
+
+/// Validate that an agent belongs to the given project scope.
+///
+/// Returns 200 if the agent matches, 403 if it belongs to a different project.
+pub async fn validate_agent_project(
+    State(core): State<Arc<TmaiCore>>,
+    Path(id): Path<String>,
+    Json(req): Json<ValidateProjectRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
+    core.validate_agent_project(&id, &req.project)
+        .map(|()| Json(serde_json::json!({"status": "ok"})))
+        .map_err(api_error_to_http)
+}
+
 /// Get all agents, optionally filtered by project
 pub async fn get_agents(
     State(core): State<Arc<TmaiCore>>,
@@ -3514,6 +3534,10 @@ mod tests {
         Router::new()
             .route("/agents", get(get_agents))
             .route("/agents/{id}/approve", post(approve_agent))
+            .route(
+                "/agents/{id}/validate-project",
+                post(validate_agent_project),
+            )
             .route("/agents/{id}/select", post(select_choice))
             .route("/agents/{id}/submit", post(submit_selection))
             .route("/agents/{id}/input", post(send_text))
@@ -3534,12 +3558,22 @@ mod tests {
 
     /// Add an idle agent to the shared state
     fn add_idle_agent(state: &SharedState, id: &str) {
+        add_agent_with_project(state, id, "/tmp", None);
+    }
+
+    /// Add an agent with a specific cwd and git_common_dir
+    fn add_agent_with_project(
+        state: &SharedState,
+        id: &str,
+        cwd: &str,
+        git_common_dir: Option<&str>,
+    ) {
         let mut s = state.write();
         let mut agent = tmai_core::agents::MonitoredAgent::new(
             id.to_string(),
             tmai_core::agents::AgentType::ClaudeCode,
             "Test".to_string(),
-            "/tmp".to_string(),
+            cwd.to_string(),
             1234,
             "main".to_string(),
             "window".to_string(),
@@ -3547,6 +3581,7 @@ mod tests {
             0,
         );
         agent.status = AgentStatus::Idle;
+        agent.git_common_dir = git_common_dir.map(|s| s.to_string());
         s.agents.insert(id.to_string(), agent);
         s.agent_order.push(id.to_string());
     }
@@ -3922,5 +3957,129 @@ mod tests {
             .as_str()
             .unwrap()
             .contains("Invalid branch name"));
+    }
+
+    // =========================================================
+    // validate-project endpoint tests
+    // =========================================================
+
+    #[tokio::test]
+    async fn test_validate_project_same_project() {
+        let state = test_app_state();
+        add_agent_with_project(
+            &state,
+            "main:0.0",
+            "/home/user/project-a",
+            Some("/home/user/project-a/.git"),
+        );
+        let app = test_router_with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/agents/main:0.0/validate-project")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"project":"/home/user/project-a"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_validate_project_worktree_agent_same_project() {
+        let state = test_app_state();
+        // Worktree agent: cwd differs but git_common_dir matches
+        add_agent_with_project(
+            &state,
+            "main:0.0",
+            "/home/user/project-a/.claude/worktrees/feat-x",
+            Some("/home/user/project-a/.git"),
+        );
+        let app = test_router_with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/agents/main:0.0/validate-project")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"project":"/home/user/project-a"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn test_validate_project_different_project() {
+        let state = test_app_state();
+        add_agent_with_project(
+            &state,
+            "main:0.0",
+            "/home/user/project-b",
+            Some("/home/user/project-b/.git"),
+        );
+        let app = test_router_with_state(state);
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/agents/main:0.0/validate-project")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"project":"/home/user/project-a"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_validate_project_agent_not_found() {
+        let app = test_router();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/agents/nonexistent/validate-project")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"project":"/home/user/project-a"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_validate_project_git_suffix_normalization() {
+        let state = test_app_state();
+        add_agent_with_project(
+            &state,
+            "main:0.0",
+            "/home/user/project-a",
+            Some("/home/user/project-a/.git"),
+        );
+        let app = test_router_with_state(state);
+
+        // Pass project path WITH .git suffix — should still match
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/agents/main:0.0/validate-project")
+                    .header("content-type", "application/json")
+                    .body(Body::from(r#"{"project":"/home/user/project-a/.git"}"#))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
     }
 }

--- a/src/web/server.rs
+++ b/src/web/server.rs
@@ -71,6 +71,10 @@ impl WebServer {
         let api_routes = Router::new()
             .route("/agents", get(api::get_agents))
             .route("/agents/{id}/approve", post(api::approve_agent))
+            .route(
+                "/agents/{id}/validate-project",
+                post(api::validate_agent_project),
+            )
             .route("/agents/{id}/select", post(api::select_choice))
             .route("/agents/{id}/submit", post(api::submit_selection))
             .route("/agents/{id}/input", post(api::send_text))


### PR DESCRIPTION
## Summary

- Replaced MCP-layer `validate_project_scope()` JSON comparison with a backend API call (`POST /agents/{id}/validate-project`)
- The backend's `validate_agent_project()` uses `normalize_git_dir()` which handles `.git` suffix normalization, fixing false positives for worktree agents
- Added `ValidateError` type and `post_with_error_body()` to `TmaiHttpClient` for proper HTTP error status handling

## Root cause

The MCP layer performed its own string comparison of `git_common_dir` values without `.git` suffix normalization. When a worktree agent's stored `git_common_dir` (e.g., `/home/user/project/.git`) was compared with `resolve_git_common_dir()` output (e.g., `/home/user/project`), the comparison failed despite both referring to the same project.

## Test plan

- [x] `test_validate_project_same_project` — agent in same project passes
- [x] `test_validate_project_worktree_agent_same_project` — worktree agent with different cwd but same git_common_dir passes
- [x] `test_validate_project_different_project` — agent in different project returns 403
- [x] `test_validate_project_agent_not_found` — missing agent returns 404
- [x] `test_validate_project_git_suffix_normalization` — `.git` suffix in project path is normalized

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)