### PR TITLE
fix: delegate MCP project scope validation to backend API (#301)

### DIFF
--- a/crates/tmai-core/src/api/queries.rs
+++ b/crates/tmai-core/src/api/queries.rs
@@ -394,16 +394,14 @@ impl TmaiCore {
     }
 }
 
-/// Normalize a project path to its `.git` directory for comparison with git_common_dir.
+/// Normalize a project path for comparison with agent git_common_dir.
 ///
-/// If the path already ends with `.git`, return as-is. Otherwise append `/.git`.
+/// Agents store git_common_dir **without** the `/.git` suffix (e.g., `/home/user/project`).
+/// The MCP client's `resolve_git_common_dir` may return the path **with** `/.git`.
+/// This function strips `/.git` if present to ensure consistent comparison.
 fn normalize_git_dir(project: &str) -> String {
-    if project.ends_with(".git") {
-        project.to_string()
-    } else {
-        let trimmed = project.trim_end_matches('/');
-        format!("{trimmed}/.git")
-    }
+    let trimmed = project.trim_end_matches('/');
+    trimmed.strip_suffix("/.git").unwrap_or(trimmed).to_string()
 }
 
 /// Check whether an agent belongs to a project by comparing git_common_dir or cwd.
@@ -706,17 +704,17 @@ mod tests {
             test_agent_with_project(
                 "main:0.0",
                 "/home/user/project-a",
-                Some("/home/user/project-a/.git"),
+                Some("/home/user/project-a"),
             ),
             test_agent_with_project(
                 "main:0.1",
                 "/home/user/project-a/.claude/worktrees/feat-x",
-                Some("/home/user/project-a/.git"),
+                Some("/home/user/project-a"),
             ),
             test_agent_with_project(
                 "main:0.2",
                 "/home/user/project-b",
-                Some("/home/user/project-b/.git"),
+                Some("/home/user/project-b"),
             ),
         ];
         let core = make_core_with_agents(agents);
@@ -754,7 +752,7 @@ mod tests {
         let agents = vec![test_agent_with_project(
             "main:0.0",
             "/home/user/project-a",
-            Some("/home/user/project-a/.git"),
+            Some("/home/user/project-a"),
         )];
         let core = make_core_with_agents(agents);
 
@@ -767,7 +765,7 @@ mod tests {
         let agents = vec![test_agent_with_project(
             "main:0.0",
             "/home/user/project-a",
-            Some("/home/user/project-a/.git"),
+            Some("/home/user/project-a"),
         )];
         let core = make_core_with_agents(agents);
 
@@ -780,7 +778,7 @@ mod tests {
         let agents = vec![test_agent_with_project(
             "main:0.0",
             "/home/user/project-a",
-            Some("/home/user/project-a/.git"),
+            Some("/home/user/project-a"),
         )];
         let core = make_core_with_agents(agents);
 
@@ -794,7 +792,7 @@ mod tests {
         let agents = vec![test_agent_with_project(
             "main:0.0",
             "/home/user/project-b",
-            Some("/home/user/project-b/.git"),
+            Some("/home/user/project-b"),
         )];
         let core = make_core_with_agents(agents);
 
@@ -815,7 +813,7 @@ mod tests {
         let agents = vec![test_agent_with_project(
             "main:0.0",
             "/home/user/project-a/.claude/worktrees/feat-x",
-            Some("/home/user/project-a/.git"),
+            Some("/home/user/project-a"),
         )];
         let core = make_core_with_agents(agents);
 
@@ -826,35 +824,39 @@ mod tests {
 
     #[test]
     fn test_normalize_git_dir() {
+        // Already without .git — returned as-is
         assert_eq!(
             normalize_git_dir("/home/user/project"),
-            "/home/user/project/.git"
+            "/home/user/project"
         );
+        // Trailing slash stripped
         assert_eq!(
             normalize_git_dir("/home/user/project/"),
-            "/home/user/project/.git"
+            "/home/user/project"
         );
+        // .git suffix stripped to match agent git_common_dir format
         assert_eq!(
             normalize_git_dir("/home/user/project/.git"),
-            "/home/user/project/.git"
+            "/home/user/project"
         );
     }
 
     #[test]
     fn test_agent_matches_project_with_git_common_dir() {
+        // Agent git_common_dir is stored without .git suffix (as set by poller)
         let agent = test_agent_with_project(
             "main:0.0",
             "/home/user/project-a",
-            Some("/home/user/project-a/.git"),
+            Some("/home/user/project-a"),
         );
         assert!(agent_matches_project(
             &agent,
-            "/home/user/project-a/.git",
+            "/home/user/project-a",
             "/home/user/project-a"
         ));
         assert!(!agent_matches_project(
             &agent,
-            "/home/user/project-b/.git",
+            "/home/user/project-b",
             "/home/user/project-b"
         ));
     }
@@ -864,12 +866,12 @@ mod tests {
         let agent = test_agent_with_project("main:0.0", "/home/user/project-a/subdir", None);
         assert!(agent_matches_project(
             &agent,
-            "/home/user/project-a/.git",
+            "/home/user/project-a",
             "/home/user/project-a"
         ));
         assert!(!agent_matches_project(
             &agent,
-            "/home/user/project-b/.git",
+            "/home/user/project-b",
             "/home/user/project-b"
         ));
     }

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -163,16 +163,20 @@ impl TmaiHttpClient {
         let git_dir = String::from_utf8_lossy(&output.stdout).trim().to_string();
         // If the result is relative, resolve it against the repo path
         let path = std::path::Path::new(&git_dir);
-        if path.is_relative() {
+        let resolved = if path.is_relative() {
             let abs = std::path::Path::new(&repo).join(path);
-            Ok(abs
-                .canonicalize()
+            abs.canonicalize()
                 .unwrap_or(abs)
                 .to_string_lossy()
-                .to_string())
+                .to_string()
         } else {
-            Ok(git_dir)
-        }
+            git_dir
+        };
+        // Strip /.git suffix to match agent git_common_dir format (poller strips it)
+        Ok(resolved
+            .strip_suffix("/.git")
+            .unwrap_or(&resolved)
+            .to_string())
     }
 
     /// Make a POST request and return the parsed JSON error body on failure.

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -3970,7 +3970,7 @@ mod tests {
             &state,
             "main:0.0",
             "/home/user/project-a",
-            Some("/home/user/project-a/.git"),
+            Some("/home/user/project-a"),
         );
         let app = test_router_with_state(state);
 
@@ -3996,7 +3996,7 @@ mod tests {
             &state,
             "main:0.0",
             "/home/user/project-a/.claude/worktrees/feat-x",
-            Some("/home/user/project-a/.git"),
+            Some("/home/user/project-a"),
         );
         let app = test_router_with_state(state);
 
@@ -4021,7 +4021,7 @@ mod tests {
             &state,
             "main:0.0",
             "/home/user/project-b",
-            Some("/home/user/project-b/.git"),
+            Some("/home/user/project-b"),
         );
         let app = test_router_with_state(state);
 
@@ -4064,7 +4064,7 @@ mod tests {
             &state,
             "main:0.0",
             "/home/user/project-a",
-            Some("/home/user/project-a/.git"),
+            Some("/home/user/project-a"),
         );
         let app = test_router_with_state(state);
 


### PR DESCRIPTION
## Summary

- Fix `list_agents` returning empty by default and `validate_project_scope` blocking worktree agents
- Root cause: poller stores `git_common_dir` **without** `.git` suffix but MCP client returned it **with** `.git`, and `normalize_git_dir` was adding `.git` instead of stripping it
- Now both sides consistently use `.git`-stripped format
- Update all test fixtures to match actual poller behavior

## Changes

- `crates/tmai-core/src/api/queries.rs`: `normalize_git_dir` now strips `/.git` instead of appending it
- `src/mcp/client.rs`: `resolve_git_common_dir` strips `/.git` suffix after resolution
- Test fixtures updated to use `.git`-free `git_common_dir` values

## Test plan

- [x] All 128 lib tests pass
- [x] All tmai-core tests pass
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Closes #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * Gitディレクトリパスの正規化処理を改善し、プロジェクトパス全体における一貫性を強化しました。

* **Tests**
  * テストケースを更新し、新しいパス正規化動作に対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->