### PR TITLE
refactor: structure ToolActivity and Processing activity field (#297)

### DIFF
--- a/crates/tmai-core/src/agents/mod.rs
+++ b/crates/tmai-core/src/agents/mod.rs
@@ -3,6 +3,7 @@ mod types;
 
 pub use subagent::{Subagent, SubagentStatus, SubagentType};
 pub use types::{
-    AgentMode, AgentStatus, AgentTeamInfo, AgentType, ApprovalType, ConnectionChannels, Detail,
-    DetectionSource, EffortLevel, MonitoredAgent, Phase, SendCapability, TeamTaskSummaryItem,
+    Activity, AgentMode, AgentStatus, AgentTeamInfo, AgentType, ApprovalType, ConnectionChannels,
+    Detail, DetectionSource, EffortLevel, MonitoredAgent, Phase, SendCapability,
+    TeamTaskSummaryItem, ToolOutcome,
 };

--- a/crates/tmai-core/src/agents/types.rs
+++ b/crates/tmai-core/src/agents/types.rs
@@ -503,13 +503,57 @@ impl fmt::Display for Detail {
     }
 }
 
+/// Structured activity describing what an agent is currently doing
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum Activity {
+    /// Executing a specific tool (Read, Edit, Bash, etc.)
+    ToolExecution { tool_name: String },
+    /// Compacting context window
+    Compacting,
+    /// Thinking / processing without a specific tool
+    #[default]
+    Thinking,
+    /// Other activity with descriptive text
+    Other(String),
+}
+
+impl Activity {
+    /// Check if this activity represents an empty/default state
+    pub fn is_thinking(&self) -> bool {
+        matches!(self, Activity::Thinking)
+    }
+}
+
+impl fmt::Display for Activity {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Activity::ToolExecution { tool_name } => write!(f, "Tool: {}", tool_name),
+            Activity::Compacting => write!(f, "Compacting context…"),
+            Activity::Thinking => write!(f, "Thinking"),
+            Activity::Other(text) => write!(f, "{}", text),
+        }
+    }
+}
+
+/// Outcome of a tool execution
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ToolOutcome {
+    /// Tool completed successfully
+    #[default]
+    Success,
+    /// Tool encountered an error
+    Error,
+    /// Tool timed out
+    Timeout,
+}
+
 /// Current status of an agent
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AgentStatus {
     /// Agent is idle, waiting for input
     Idle,
     /// Agent is actively processing
-    Processing { activity: String },
+    Processing { activity: Activity },
     /// Agent is waiting for user approval
     AwaitingApproval {
         approval_type: ApprovalType,
@@ -538,22 +582,16 @@ impl AgentStatus {
     /// Derive the fine-grained detail from this status
     pub fn detail(&self) -> Detail {
         match self {
-            AgentStatus::Processing { activity } => {
-                if activity.starts_with("Tool: ") {
-                    Detail::ToolExecution {
-                        tool_name: activity.trim_start_matches("Tool: ").to_string(),
-                    }
-                } else if activity.contains("Compacting") || activity.contains("compacting") {
-                    Detail::Compacting
-                } else if activity.is_empty() {
-                    Detail::Thinking
-                } else {
-                    // General activity text — treat as tool execution with activity as name
-                    Detail::ToolExecution {
-                        tool_name: activity.clone(),
-                    }
-                }
-            }
+            AgentStatus::Processing { activity } => match activity {
+                Activity::ToolExecution { tool_name } => Detail::ToolExecution {
+                    tool_name: tool_name.clone(),
+                },
+                Activity::Compacting => Detail::Compacting,
+                Activity::Thinking => Detail::Thinking,
+                Activity::Other(text) => Detail::ToolExecution {
+                    tool_name: text.clone(),
+                },
+            },
             AgentStatus::AwaitingApproval {
                 approval_type,
                 details,
@@ -606,7 +644,7 @@ impl fmt::Display for AgentStatus {
         match self {
             AgentStatus::Idle => write!(f, "Idle"),
             AgentStatus::Processing { activity } => {
-                if activity.is_empty() {
+                if activity.is_thinking() {
                     write!(f, "Processing")
                 } else {
                     write!(f, "Processing: {}", activity)
@@ -1034,21 +1072,23 @@ mod tests {
     fn test_phase_from_agent_status() {
         assert_eq!(
             AgentStatus::Processing {
-                activity: "Tool: Bash".to_string()
+                activity: Activity::ToolExecution {
+                    tool_name: "Bash".to_string()
+                }
             }
             .phase(),
             Phase::Working
         );
         assert_eq!(
             AgentStatus::Processing {
-                activity: String::new()
+                activity: Activity::Thinking
             }
             .phase(),
             Phase::Working
         );
         assert_eq!(
             AgentStatus::Processing {
-                activity: "Compacting context…".to_string()
+                activity: Activity::Compacting
             }
             .phase(),
             Phase::Working
@@ -1077,7 +1117,9 @@ mod tests {
     fn test_detail_from_agent_status() {
         // Tool execution
         let detail = AgentStatus::Processing {
-            activity: "Tool: Bash".to_string(),
+            activity: Activity::ToolExecution {
+                tool_name: "Bash".to_string(),
+            },
         }
         .detail();
         assert_eq!(
@@ -1089,14 +1131,14 @@ mod tests {
 
         // Compacting
         let detail = AgentStatus::Processing {
-            activity: "Compacting context…".to_string(),
+            activity: Activity::Compacting,
         }
         .detail();
         assert_eq!(detail, Detail::Compacting);
 
-        // Thinking (empty activity)
+        // Thinking
         let detail = AgentStatus::Processing {
-            activity: String::new(),
+            activity: Activity::Thinking,
         }
         .detail();
         assert_eq!(detail, Detail::Thinking);
@@ -1184,7 +1226,7 @@ mod tests {
 
         assert!(!AgentStatus::Idle.needs_attention());
         assert!(!AgentStatus::Processing {
-            activity: String::new()
+            activity: Activity::Thinking
         }
         .needs_attention());
     }

--- a/crates/tmai-core/src/api/actions.rs
+++ b/crates/tmai-core/src/api/actions.rs
@@ -1349,7 +1349,7 @@ mod tests {
                 is_main: false,
                 agent_target,
                 agent_status: Some(AgentStatus::Processing {
-                    activity: String::new(),
+                    activity: crate::agents::Activity::Thinking,
                 }),
                 is_dirty: Some(false),
                 diff_summary: None,
@@ -1420,7 +1420,7 @@ mod tests {
         let agent = test_agent(
             "test:0.0",
             AgentStatus::Processing {
-                activity: "thinking".to_string(),
+                activity: crate::agents::Activity::Thinking,
             },
         );
         let core = make_core_with_agents(vec![agent]);
@@ -1444,7 +1444,7 @@ mod tests {
         let agent = test_agent(
             "test:0.0",
             AgentStatus::Processing {
-                activity: "thinking".to_string(),
+                activity: crate::agents::Activity::Thinking,
             },
         );
         let core = make_core_with_agents(vec![agent]);

--- a/crates/tmai-core/src/api/queries.rs
+++ b/crates/tmai-core/src/api/queries.rs
@@ -466,7 +466,9 @@ mod tests {
             test_agent(
                 "main:0.1",
                 AgentStatus::Processing {
-                    activity: "Bash".to_string(),
+                    activity: crate::agents::Activity::ToolExecution {
+                        tool_name: "Bash".to_string(),
+                    },
                 },
             ),
         ]);

--- a/crates/tmai-core/src/api/types.rs
+++ b/crates/tmai-core/src/api/types.rs
@@ -504,11 +504,13 @@ mod tests {
 
     #[test]
     fn test_agent_snapshot_phase_and_detail() {
-        use crate::agents::{Detail, Phase};
+        use crate::agents::{Activity, Detail, Phase};
 
         let mut agent = test_agent("main:0.0");
         agent.status = AgentStatus::Processing {
-            activity: "Tool: Bash".to_string(),
+            activity: Activity::ToolExecution {
+                tool_name: "Bash".to_string(),
+            },
         };
         let snapshot = AgentSnapshot::from_agent(&agent);
         assert_eq!(snapshot.phase, Phase::Working);

--- a/crates/tmai-core/src/codex_ws/translator.rs
+++ b/crates/tmai-core/src/codex_ws/translator.rs
@@ -147,9 +147,12 @@ pub fn translate_event(
                     push_activity(
                         state,
                         ToolActivity {
-                            tool_name: tool_name.to_string(),
+                            tool: crate::agents::Activity::ToolExecution {
+                                tool_name: tool_name.to_string(),
+                            },
                             input_summary,
                             response_summary,
+                            outcome: crate::agents::ToolOutcome::Success,
                             timestamp: crate::hooks::types::current_time_millis(),
                         },
                     );

--- a/crates/tmai-core/src/detectors/claude_code/mod.rs
+++ b/crates/tmai-core/src/detectors/claude_code/mod.rs
@@ -7,7 +7,7 @@ mod tests;
 use regex::Regex;
 use tracing::trace;
 
-use crate::agents::{AgentStatus, AgentType};
+use crate::agents::{Activity, AgentStatus, AgentType};
 
 use super::{DetectionConfidence, DetectionContext, DetectionResult, StatusDetector};
 use crate::detectors::common::safe_tail;
@@ -115,10 +115,13 @@ impl StatusDetector for ClaudeCodeDetector {
                 .skip_while(|c| matches!(*c, '\u{2800}'..='\u{28FF}') || c.is_whitespace())
                 .collect::<String>();
             if title.chars().any(|c| matches!(c, '\u{2800}'..='\u{28FF}')) {
+                let activity = if title_activity.is_empty() {
+                    Activity::Thinking
+                } else {
+                    Activity::Other(title_activity)
+                };
                 return DetectionResult::new(
-                    AgentStatus::Processing {
-                        activity: title_activity,
-                    },
+                    AgentStatus::Processing { activity },
                     "title_braille_spinner_fast_path",
                     DetectionConfidence::High,
                 )
@@ -142,7 +145,7 @@ impl StatusDetector for ClaudeCodeDetector {
         if Self::has_in_progress_tasks(content) {
             return DetectionResult::new(
                 AgentStatus::Processing {
-                    activity: "Tasks running".to_string(),
+                    activity: Activity::Other("Tasks running".to_string()),
                 },
                 "tasks_in_progress",
                 DetectionConfidence::High,
@@ -153,7 +156,7 @@ impl StatusDetector for ClaudeCodeDetector {
         if title.contains('✽') && title.to_lowercase().contains("compacting") {
             return DetectionResult::new(
                 AgentStatus::Processing {
-                    activity: "Compacting...".to_string(),
+                    activity: Activity::Compacting,
                 },
                 "title_compacting",
                 DetectionConfidence::High,
@@ -192,20 +195,23 @@ impl StatusDetector for ClaudeCodeDetector {
         // 6. Content-based spinner detection (overrides title idle)
         //    Catches cases where title still shows ✳ but content has active spinner
         //    e.g. during /compact, or title update lag
-        if let Some((activity, is_builtin)) = Self::detect_content_spinner(content, context) {
+        if let Some((activity_text, is_builtin)) = Self::detect_content_spinner(content, context) {
             let confidence = if is_builtin {
                 DetectionConfidence::High
             } else {
                 DetectionConfidence::Medium
             };
+            let activity = if activity_text.is_empty() {
+                Activity::Thinking
+            } else {
+                Activity::Other(activity_text.clone())
+            };
             return DetectionResult::new(
-                AgentStatus::Processing {
-                    activity: activity.clone(),
-                },
+                AgentStatus::Processing { activity },
                 "content_spinner_verb",
                 confidence,
             )
-            .with_matched_text(&activity);
+            .with_matched_text(&activity_text);
         }
 
         // 7. Check for turn duration completion (e.g., "✻ Cooked for 1m 6s")
@@ -235,7 +241,12 @@ impl StatusDetector for ClaudeCodeDetector {
         }
 
         // 9. Check for custom spinner verbs from settings
-        if let Some(activity) = Self::detect_custom_spinner_verb(title, context) {
+        if let Some(activity_text) = Self::detect_custom_spinner_verb(title, context) {
+            let activity = if activity_text.is_empty() {
+                Activity::Thinking
+            } else {
+                Activity::Other(activity_text)
+            };
             return DetectionResult::new(
                 AgentStatus::Processing { activity },
                 "custom_spinner_verb",
@@ -248,10 +259,15 @@ impl StatusDetector for ClaudeCodeDetector {
         if !Self::should_skip_default_spinners(context)
             && title.chars().any(|c| PROCESSING_SPINNERS.contains(&c))
         {
-            let activity = title
+            let activity_text: String = title
                 .chars()
                 .skip_while(|c| PROCESSING_SPINNERS.contains(c) || c.is_whitespace())
-                .collect::<String>();
+                .collect();
+            let activity = if activity_text.is_empty() {
+                Activity::Thinking
+            } else {
+                Activity::Other(activity_text)
+            };
             return DetectionResult::new(
                 AgentStatus::Processing { activity },
                 "braille_spinner",
@@ -286,7 +302,7 @@ impl StatusDetector for ClaudeCodeDetector {
         // No indicator - default to Processing
         DetectionResult::new(
             AgentStatus::Processing {
-                activity: String::new(),
+                activity: Activity::Thinking,
             },
             "fallback_no_indicator",
             DetectionConfidence::Low,

--- a/crates/tmai-core/src/detectors/codex.rs
+++ b/crates/tmai-core/src/detectors/codex.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
 
-use crate::agents::{AgentStatus, AgentType, ApprovalType};
+use crate::agents::{Activity, AgentStatus, AgentType, ApprovalType};
 
 use super::{DetectionConfidence, DetectionContext, DetectionResult, StatusDetector};
 
@@ -270,7 +270,7 @@ impl StatusDetector for CodexDetector {
             if self.working_elapsed_pattern.is_match(trimmed) {
                 return DetectionResult::new(
                     AgentStatus::Processing {
-                        activity: trimmed.to_string(),
+                        activity: Activity::Other(trimmed.to_string()),
                     },
                     "working_elapsed_time",
                     DetectionConfidence::High,
@@ -296,7 +296,7 @@ impl StatusDetector for CodexDetector {
             {
                 return DetectionResult::new(
                     AgentStatus::Processing {
-                        activity: trimmed.to_string(),
+                        activity: Activity::Other(trimmed.to_string()),
                     },
                     "codex_spinner",
                     DetectionConfidence::Medium,
@@ -311,7 +311,7 @@ impl StatusDetector for CodexDetector {
             if trimmed.contains("esc to interrupt") {
                 return DetectionResult::new(
                     AgentStatus::Processing {
-                        activity: String::new(),
+                        activity: Activity::Thinking,
                     },
                     "codex_esc_to_interrupt",
                     DetectionConfidence::Medium,
@@ -326,7 +326,7 @@ impl StatusDetector for CodexDetector {
             if trimmed.contains("Thinking") || trimmed.contains("Generating") {
                 return DetectionResult::new(
                     AgentStatus::Processing {
-                        activity: trimmed.to_string(),
+                        activity: Activity::Other(trimmed.to_string()),
                     },
                     "codex_thinking",
                     DetectionConfidence::Medium,
@@ -349,7 +349,7 @@ impl StatusDetector for CodexDetector {
         if title_lower.contains("working") || title_lower.contains("processing") {
             return DetectionResult::new(
                 AgentStatus::Processing {
-                    activity: title.to_string(),
+                    activity: Activity::Other(title.to_string()),
                 },
                 "codex_title_processing",
                 DetectionConfidence::Medium,
@@ -431,7 +431,7 @@ impl StatusDetector for CodexDetector {
             // 11. Fallback - Processing (Low confidence)
             DetectionResult::new(
                 AgentStatus::Processing {
-                    activity: String::new(),
+                    activity: Activity::Thinking,
                 },
                 "codex_fallback_processing",
                 DetectionConfidence::Low,

--- a/crates/tmai-core/src/detectors/default.rs
+++ b/crates/tmai-core/src/detectors/default.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
 
-use crate::agents::{AgentStatus, AgentType, ApprovalType};
+use crate::agents::{Activity, AgentStatus, AgentType, ApprovalType};
 
 use super::{DetectionConfidence, DetectionContext, DetectionResult, StatusDetector};
 
@@ -97,7 +97,7 @@ impl StatusDetector for DefaultDetector {
         {
             return DetectionResult::new(
                 AgentStatus::Processing {
-                    activity: title.to_string(),
+                    activity: Activity::Other(title.to_string()),
                 },
                 "default_title_processing",
                 DetectionConfidence::Medium,

--- a/crates/tmai-core/src/detectors/gemini.rs
+++ b/crates/tmai-core/src/detectors/gemini.rs
@@ -1,6 +1,6 @@
 use regex::Regex;
 
-use crate::agents::{AgentMode, AgentStatus, AgentType, ApprovalType};
+use crate::agents::{Activity, AgentMode, AgentStatus, AgentType, ApprovalType};
 
 use super::{DetectionConfidence, DetectionContext, DetectionResult, StatusDetector};
 
@@ -440,7 +440,7 @@ impl StatusDetector for GeminiDetector {
         if title.contains(TITLE_WORKING_ICON) {
             return DetectionResult::new(
                 AgentStatus::Processing {
-                    activity: String::new(),
+                    activity: Activity::Thinking,
                 },
                 "title_working_icon",
                 DetectionConfidence::High,
@@ -451,7 +451,7 @@ impl StatusDetector for GeminiDetector {
         if title.contains(TITLE_SILENT_WORKING_ICON) {
             return DetectionResult::new(
                 AgentStatus::Processing {
-                    activity: String::new(),
+                    activity: Activity::Thinking,
                 },
                 "title_silent_working_icon",
                 DetectionConfidence::High,
@@ -473,7 +473,7 @@ impl StatusDetector for GeminiDetector {
         if self.detect_content_spinner(content) {
             return DetectionResult::new(
                 AgentStatus::Processing {
-                    activity: String::new(),
+                    activity: Activity::Thinking,
                 },
                 "braille_spinner",
                 DetectionConfidence::Medium,
@@ -492,7 +492,7 @@ impl StatusDetector for GeminiDetector {
         // 8. Fallback → Processing
         DetectionResult::new(
             AgentStatus::Processing {
-                activity: String::new(),
+                activity: Activity::Thinking,
             },
             "fallback_processing",
             DetectionConfidence::Low,

--- a/crates/tmai-core/src/hooks/handler.rs
+++ b/crates/tmai-core/src/hooks/handler.rs
@@ -118,9 +118,10 @@ pub fn handle_hook_event(
                 })
                 .unwrap_or_default();
             let activity = ToolActivity {
-                tool_name,
+                tool: crate::agents::Activity::ToolExecution { tool_name },
                 input_summary,
                 response_summary,
+                outcome: crate::agents::ToolOutcome::Success,
                 timestamp: std::time::SystemTime::now()
                     .duration_since(std::time::UNIX_EPOCH)
                     .unwrap_or_default()
@@ -193,9 +194,10 @@ pub fn handle_hook_event(
                             push_activity(
                                 state,
                                 ToolActivity {
-                                    tool_name: "Assistant".to_string(),
+                                    tool: crate::agents::Activity::Other("Assistant".to_string()),
                                     input_summary: String::new(),
                                     response_summary: truncate_string(msg, 300),
+                                    outcome: crate::agents::ToolOutcome::Success,
                                     timestamp: std::time::SystemTime::now()
                                         .duration_since(std::time::UNIX_EPOCH)
                                         .unwrap_or_default()
@@ -509,7 +511,7 @@ fn build_context(payload: &HookEventPayload) -> HookContext {
 /// logic (for PTY-spawned agents that receive hook events).
 pub fn hook_status_to_agent_status(hs: &super::types::HookState) -> crate::agents::AgentStatus {
     use super::types::HookStatus;
-    use crate::agents::{AgentStatus, ApprovalType};
+    use crate::agents::{Activity, AgentStatus, ApprovalType};
 
     match hs.status {
         HookStatus::Processing => {
@@ -517,8 +519,10 @@ pub fn hook_status_to_agent_status(hs: &super::types::HookState) -> crate::agent
                 .last_tool
                 .as_ref()
                 .filter(|t| !t.is_empty())
-                .map(|t| format!("Tool: {}", t))
-                .unwrap_or_default();
+                .map(|t| Activity::ToolExecution {
+                    tool_name: t.clone(),
+                })
+                .unwrap_or(Activity::Thinking);
             AgentStatus::Processing { activity }
         }
         HookStatus::Idle => AgentStatus::Idle,
@@ -551,7 +555,7 @@ pub fn hook_status_to_agent_status(hs: &super::types::HookState) -> crate::agent
             }
         }
         HookStatus::Compacting => AgentStatus::Processing {
-            activity: "Compacting context…".to_string(),
+            activity: Activity::Compacting,
         },
     }
 }
@@ -661,11 +665,17 @@ pub fn format_activity_log(activities: &[ToolActivity]) -> String {
 
     let mut lines = Vec::new();
     for activity in activities {
-        // Tool header
+        // Tool header — display tool name from Activity enum
+        let tool_label = match &activity.tool {
+            crate::agents::Activity::ToolExecution { tool_name } => tool_name.as_str(),
+            crate::agents::Activity::Compacting => "Compacting",
+            crate::agents::Activity::Thinking => "Thinking",
+            crate::agents::Activity::Other(text) => text.as_str(),
+        };
         let tool_line = if activity.input_summary.is_empty() {
-            format!("⚙ {}", activity.tool_name)
+            format!("⚙ {}", tool_label)
         } else {
-            format!("⚙ {}: {}", activity.tool_name, activity.input_summary)
+            format!("⚙ {}: {}", tool_label, activity.input_summary)
         };
         lines.push(tool_line);
 
@@ -1695,7 +1705,10 @@ mod tests {
         let reg = registry.read();
         let state = reg.get("5").unwrap();
         assert_eq!(state.activity_log.len(), 1);
-        assert_eq!(state.activity_log[0].tool_name, "Bash");
+        assert!(matches!(
+            state.activity_log[0].tool,
+            crate::agents::Activity::ToolExecution { ref tool_name } if tool_name == "Bash"
+        ));
         assert_eq!(state.activity_log[0].input_summary, "cargo test");
         assert_eq!(state.activity_log[0].response_summary, "All tests passed");
     }
@@ -1751,7 +1764,10 @@ mod tests {
         let reg = registry.read();
         let state = reg.get("5").unwrap();
         assert_eq!(state.activity_log.len(), 1);
-        assert_eq!(state.activity_log[0].tool_name, "Assistant");
+        assert!(matches!(
+            state.activity_log[0].tool,
+            crate::agents::Activity::Other(ref name) if name == "Assistant"
+        ));
         assert!(state.activity_log[0]
             .response_summary
             .contains("Done! All changes applied."));
@@ -1784,7 +1800,10 @@ mod tests {
             "Activity log should be capped at MAX_ACTIVITY_LOG"
         );
         // First entry should be Tool5 (oldest 5 were evicted)
-        assert_eq!(state.activity_log[0].tool_name, "Tool5");
+        assert!(matches!(
+            state.activity_log[0].tool,
+            crate::agents::Activity::ToolExecution { ref tool_name } if tool_name == "Tool5"
+        ));
     }
 
     #[test]
@@ -1813,15 +1832,21 @@ mod tests {
     fn test_format_activity_log() {
         let activities = vec![
             super::ToolActivity {
-                tool_name: "Bash".to_string(),
+                tool: crate::agents::Activity::ToolExecution {
+                    tool_name: "Bash".to_string(),
+                },
                 input_summary: "cargo test".to_string(),
                 response_summary: "All tests passed".to_string(),
+                outcome: crate::agents::ToolOutcome::Success,
                 timestamp: 0,
             },
             super::ToolActivity {
-                tool_name: "Edit".to_string(),
+                tool: crate::agents::Activity::ToolExecution {
+                    tool_name: "Edit".to_string(),
+                },
                 input_summary: "src/main.rs".to_string(),
                 response_summary: String::new(),
+                outcome: crate::agents::ToolOutcome::Success,
                 timestamp: 0,
             },
         ];

--- a/crates/tmai-core/src/hooks/types.rs
+++ b/crates/tmai-core/src/hooks/types.rs
@@ -406,12 +406,14 @@ pub const MAX_ACTIVITY_LOG: usize = 20;
 /// A single tool execution record for activity log display
 #[derive(Debug, Clone)]
 pub struct ToolActivity {
-    /// Tool name (e.g., "Bash", "Edit", "Read")
-    pub tool_name: String,
+    /// Structured activity type
+    pub tool: crate::agents::Activity,
     /// Summarized input (e.g., "cargo test", "src/main.rs")
     pub input_summary: String,
     /// Summarized response/output
     pub response_summary: String,
+    /// Outcome of the tool execution
+    pub outcome: crate::agents::ToolOutcome,
     /// Timestamp (Unix millis)
     pub timestamp: u64,
 }

--- a/crates/tmai-core/src/monitor/poller.rs
+++ b/crates/tmai-core/src/monitor/poller.rs
@@ -5,7 +5,7 @@ use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 use tokio::sync::mpsc;
 
 use crate::agents::{
-    AgentStatus, AgentTeamInfo, AgentType, ApprovalType, DetectionSource, MonitoredAgent,
+    Activity, AgentStatus, AgentTeamInfo, AgentType, ApprovalType, DetectionSource, MonitoredAgent,
     TeamTaskSummaryItem,
 };
 use crate::api::CoreEvent;
@@ -838,7 +838,7 @@ impl Poller {
                             let status = enrich_ipc_activity(status, &result.status, &title);
                             let matched_text =
                                 if let AgentStatus::Processing { ref activity } = status {
-                                    if !activity.is_empty() {
+                                    if !activity.is_thinking() {
                                         Some(format!("enriched: {}", activity))
                                     } else {
                                         None
@@ -1621,7 +1621,7 @@ impl Poller {
                         agent.status = match committed.status.as_str() {
                             "idle" => AgentStatus::Idle,
                             "processing" => AgentStatus::Processing {
-                                activity: String::new(),
+                                activity: Activity::Thinking,
                             },
                             "error" => AgentStatus::Error {
                                 message: String::new(),
@@ -1645,7 +1645,7 @@ impl Poller {
                     agent.status = match committed.status.as_str() {
                         "idle" => AgentStatus::Idle,
                         "processing" => AgentStatus::Processing {
-                            activity: String::new(),
+                            activity: Activity::Thinking,
                         },
                         "error" => AgentStatus::Error {
                             message: String::new(),
@@ -1745,7 +1745,7 @@ impl Poller {
                         if last_processing.elapsed().as_secs() < GRACE_PERIOD_SECS {
                             // Within grace period — maintain Processing
                             return AgentStatus::Processing {
-                                activity: String::new(),
+                                activity: Activity::Thinking,
                             };
                         } else {
                             // Grace period expired — allow transition
@@ -2405,7 +2405,7 @@ fn extract_activity_from_title(title: &str) -> String {
 
 /// Enrich IPC Processing status with screen-detected activity
 ///
-/// When IPC reports Processing with empty activity, first try the screen-detected
+/// When IPC reports Processing with Thinking activity, first try the screen-detected
 /// activity, then fall back to extracting activity directly from the pane title.
 fn enrich_ipc_activity(
     ipc_status: AgentStatus,
@@ -2413,13 +2413,13 @@ fn enrich_ipc_activity(
     title: &str,
 ) -> AgentStatus {
     if let AgentStatus::Processing { ref activity } = ipc_status {
-        if activity.is_empty() {
+        if activity.is_thinking() {
             // 1. Try screen-detected activity
             if let AgentStatus::Processing {
                 activity: ref screen_activity,
             } = screen_status
             {
-                if !screen_activity.is_empty() {
+                if !screen_activity.is_thinking() {
                     return AgentStatus::Processing {
                         activity: screen_activity.clone(),
                     };
@@ -2429,7 +2429,7 @@ fn enrich_ipc_activity(
             let title_activity = extract_activity_from_title(title);
             if !title_activity.is_empty() {
                 return AgentStatus::Processing {
-                    activity: title_activity,
+                    activity: Activity::Other(title_activity),
                 };
             }
         }
@@ -2446,7 +2446,7 @@ fn hook_state_to_agent_status(hs: &crate::hooks::types::HookState) -> AgentStatu
 fn wrap_state_to_agent_status(ws: &WrapState) -> AgentStatus {
     match ws.status {
         WrapStatus::Processing => AgentStatus::Processing {
-            activity: String::new(),
+            activity: Activity::Thinking,
         },
         WrapStatus::Idle => AgentStatus::Idle,
         WrapStatus::AwaitingApproval => {
@@ -2508,45 +2508,45 @@ mod tests {
     #[test]
     fn test_enrich_ipc_activity_screen_priority() {
         let ipc = AgentStatus::Processing {
-            activity: String::new(),
+            activity: Activity::Thinking,
         };
         let screen = AgentStatus::Processing {
-            activity: "✶ Compacting…".to_string(),
+            activity: Activity::Other("✶ Compacting…".to_string()),
         };
         let result = enrich_ipc_activity(ipc, &screen, "⠐ Compacting");
         assert!(
-            matches!(result, AgentStatus::Processing { ref activity } if activity == "✶ Compacting…")
+            matches!(result, AgentStatus::Processing { ref activity } if matches!(activity, Activity::Other(t) if t == "✶ Compacting…"))
         );
     }
 
     #[test]
     fn test_enrich_ipc_activity_title_fallback() {
         let ipc = AgentStatus::Processing {
-            activity: String::new(),
+            activity: Activity::Thinking,
         };
         // Screen returns Idle (e.g., ✳ in title caused screen detector to return Idle)
         let screen = AgentStatus::Idle;
         let result = enrich_ipc_activity(ipc, &screen, "⠐ Compacting");
         assert!(
-            matches!(result, AgentStatus::Processing { ref activity } if activity == "Compacting")
+            matches!(result, AgentStatus::Processing { ref activity } if matches!(activity, Activity::Other(t) if t == "Compacting"))
         );
     }
 
     #[test]
     fn test_enrich_ipc_activity_no_enrichment_when_filled() {
         let ipc = AgentStatus::Processing {
-            activity: "Already set".to_string(),
+            activity: Activity::Other("Already set".to_string()),
         };
         let screen = AgentStatus::Processing {
-            activity: "Other".to_string(),
+            activity: Activity::Other("Other".to_string()),
         };
         let result = enrich_ipc_activity(ipc, &screen, "⠐ Compacting");
         assert!(
-            matches!(result, AgentStatus::Processing { ref activity } if activity == "Already set")
+            matches!(result, AgentStatus::Processing { ref activity } if matches!(activity, Activity::Other(t) if t == "Already set"))
         );
     }
 
-    /// hook_state_to_agent_status with a tool name shows "Tool: <name>"
+    /// hook_state_to_agent_status with a tool name produces ToolExecution
     #[test]
     fn test_hook_state_to_agent_status_with_tool() {
         use crate::hooks::types::{HookState, HookStatus};
@@ -2556,11 +2556,11 @@ mod tests {
 
         let status = hook_state_to_agent_status(&hs);
         assert!(
-            matches!(status, AgentStatus::Processing { ref activity } if activity == "Tool: Bash")
+            matches!(status, AgentStatus::Processing { activity: Activity::ToolExecution { ref tool_name } } if tool_name == "Bash")
         );
     }
 
-    /// hook_state_to_agent_status with None last_tool shows empty activity
+    /// hook_state_to_agent_status with None last_tool produces Thinking
     #[test]
     fn test_hook_state_to_agent_status_no_tool() {
         use crate::hooks::types::{HookState, HookStatus};
@@ -2569,7 +2569,12 @@ mod tests {
         hs.last_tool = None;
 
         let status = hook_state_to_agent_status(&hs);
-        assert!(matches!(status, AgentStatus::Processing { ref activity } if activity.is_empty()));
+        assert!(matches!(
+            status,
+            AgentStatus::Processing {
+                activity: Activity::Thinking
+            }
+        ));
     }
 
     /// hook_state_to_agent_status filters empty string tool name
@@ -2581,10 +2586,15 @@ mod tests {
         hs.last_tool = Some(String::new()); // empty string
 
         let status = hook_state_to_agent_status(&hs);
-        // Should NOT produce "Tool: ", should be empty activity
+        // Should NOT produce ToolExecution with empty name, should be Thinking
         assert!(
-            matches!(status, AgentStatus::Processing { ref activity } if activity.is_empty()),
-            "Empty tool name should be filtered, not displayed as 'Tool: '"
+            matches!(
+                status,
+                AgentStatus::Processing {
+                    activity: Activity::Thinking
+                }
+            ),
+            "Empty tool name should be filtered, not displayed as ToolExecution"
         );
     }
 
@@ -2638,7 +2648,7 @@ mod tests {
         ));
     }
 
-    /// hook_state_to_agent_status maps Compacting to Processing with activity
+    /// hook_state_to_agent_status maps Compacting to Processing with Activity::Compacting
     #[test]
     fn test_hook_state_to_agent_status_compacting() {
         use crate::hooks::types::{HookState, HookStatus};
@@ -2646,16 +2656,16 @@ mod tests {
         hs.status = HookStatus::Compacting;
 
         let status = hook_state_to_agent_status(&hs);
-        match status {
-            AgentStatus::Processing { ref activity } => {
-                assert!(
-                    activity.contains("Compacting"),
-                    "Compacting status should produce 'Compacting' activity, got: {}",
-                    activity
-                );
-            }
-            _ => panic!("Expected Processing status, got {:?}", status),
-        }
+        assert!(
+            matches!(
+                status,
+                AgentStatus::Processing {
+                    activity: Activity::Compacting
+                }
+            ),
+            "Compacting status should produce Activity::Compacting, got: {:?}",
+            status
+        );
     }
 
     /// Verify that audit_this_poll fires only every AUDIT_VALIDATION_INTERVAL polls

--- a/crates/tmai-core/src/orchestrator_notify/service.rs
+++ b/crates/tmai-core/src/orchestrator_notify/service.rs
@@ -511,7 +511,7 @@ mod tests {
             "sub:0.0",
             false,
             AgentStatus::Processing {
-                activity: String::new(),
+                activity: crate::agents::Activity::Thinking,
             },
         );
 

--- a/src/demo/poller.rs
+++ b/src/demo/poller.rs
@@ -1,7 +1,9 @@
 use std::time::{Duration, Instant};
 use tokio::sync::mpsc;
 
-use tmai_core::agents::{AgentMode, AgentStatus, AgentType, DetectionSource, MonitoredAgent};
+use tmai_core::agents::{
+    Activity, AgentMode, AgentStatus, AgentType, DetectionSource, MonitoredAgent,
+};
 use tmai_core::monitor::PollMessage;
 use tmai_core::state::SharedState;
 
@@ -225,7 +227,7 @@ impl DemoPoller {
 
         // Set to Processing after approval
         runtime.status = AgentStatus::Processing {
-            activity: String::new(),
+            activity: Activity::Thinking,
         };
         runtime.content_key = match action {
             DemoAction::Approve { .. } => "processing_read",

--- a/src/demo/scenario.rs
+++ b/src/demo/scenario.rs
@@ -1,6 +1,6 @@
 use std::time::Duration;
 
-use tmai_core::agents::{AgentStatus, AgentType, ApprovalType};
+use tmai_core::agents::{Activity, AgentStatus, AgentType, ApprovalType};
 
 /// A demo agent definition
 pub struct DemoAgent {
@@ -78,7 +78,7 @@ pub fn default_scenario() -> DemoScenario {
             at: Duration::from_secs(0),
             agent_idx: 0,
             status: AgentStatus::Processing {
-                activity: String::new(),
+                activity: Activity::Thinking,
             },
             wait_for_action: false,
             content_key: "processing_read",
@@ -94,7 +94,7 @@ pub fn default_scenario() -> DemoScenario {
             at: Duration::from_secs(0),
             agent_idx: 2,
             status: AgentStatus::Processing {
-                activity: String::new(),
+                activity: Activity::Thinking,
             },
             wait_for_action: false,
             content_key: "processing_gemini",
@@ -115,7 +115,7 @@ pub fn default_scenario() -> DemoScenario {
             at: Duration::from_secs(3),
             agent_idx: 1,
             status: AgentStatus::Processing {
-                activity: String::new(),
+                activity: Activity::Thinking,
             },
             wait_for_action: false,
             content_key: "processing_test",
@@ -168,7 +168,7 @@ pub fn default_scenario() -> DemoScenario {
             at: Duration::from_secs(10),
             agent_idx: 2,
             status: AgentStatus::Processing {
-                activity: String::new(),
+                activity: Activity::Thinking,
             },
             wait_for_action: false,
             content_key: "processing_gemini_2",

--- a/src/ui/components/session_list.rs
+++ b/src/ui/components/session_list.rs
@@ -684,30 +684,32 @@ impl SessionList {
 
     /// Map Processing activity to a specific status label
     ///
-    /// Extracts the leading verb from the activity string (e.g., "Compacting" from
-    /// "✶ Compacting…").  For hook-sourced "Tool: X" activities, returns the full
-    /// string.  Returns "Processing" when the activity is empty, does not start
-    /// with an uppercase letter, or when show_activity_name is false.
-    fn processing_label(activity: &str, show_activity_name: bool) -> String {
-        if !show_activity_name || activity.is_empty() {
+    /// Uses the structured Activity enum to produce a display label.
+    /// Returns "Processing" when show_activity_name is false or for Thinking.
+    fn processing_label(
+        activity: &tmai_core::agents::Activity,
+        show_activity_name: bool,
+    ) -> String {
+        use tmai_core::agents::Activity;
+        if !show_activity_name {
             return "Processing".to_string();
         }
-        // Hook-sourced activity: "Tool: Bash" → keep as-is
-        if let Some(tool) = activity.strip_prefix("Tool: ") {
-            if !tool.is_empty() {
-                return activity.to_string();
+        match activity {
+            Activity::ToolExecution { tool_name } => format!("Tool: {}", tool_name),
+            Activity::Compacting => "Compacting".to_string(),
+            Activity::Thinking => "Processing".to_string(),
+            Activity::Other(text) => {
+                // Strip spinner chars and whitespace prefix
+                let stripped =
+                    text.trim_start_matches(|c: char| "·✢✳✶✻✽*".contains(c) || c.is_whitespace());
+                // Take the first word (split on whitespace, '…', or '.')
+                let verb = stripped.split(['\u{2026}', '.', ' ']).next().unwrap_or("");
+                if verb.is_empty() || !verb.starts_with(|c: char| c.is_uppercase()) {
+                    "Processing".to_string()
+                } else {
+                    verb.to_string()
+                }
             }
-            return "Processing".to_string();
-        }
-        // Strip spinner chars and whitespace prefix
-        let stripped =
-            activity.trim_start_matches(|c: char| "·✢✳✶✻✽*".contains(c) || c.is_whitespace());
-        // Take the first word (split on whitespace, '…', or '.')
-        let verb = stripped.split(['\u{2026}', '.', ' ']).next().unwrap_or("");
-        if verb.is_empty() || !verb.starts_with(|c: char| c.is_uppercase()) {
-            "Processing".to_string()
-        } else {
-            verb.to_string()
         }
     }
 
@@ -1281,88 +1283,114 @@ mod tests {
 
     #[test]
     fn test_processing_label_compacting() {
+        use tmai_core::agents::Activity;
         assert_eq!(
-            SessionList::processing_label("✻ Compacting conversation…", true),
-            "Compacting"
-        );
-        assert_eq!(
-            SessionList::processing_label("Compacting...", true),
-            "Compacting"
-        );
-        assert_eq!(
-            SessionList::processing_label("Compacting", true),
+            SessionList::processing_label(&Activity::Compacting, true),
             "Compacting"
         );
     }
 
     #[test]
     fn test_processing_label_default() {
-        assert_eq!(SessionList::processing_label("", true), "Processing");
-        // Lowercase start → Processing
+        use tmai_core::agents::Activity;
+        // Thinking → Processing
         assert_eq!(
-            SessionList::processing_label("tasks running", true),
+            SessionList::processing_label(&Activity::Thinking, true),
+            "Processing"
+        );
+        // Lowercase start in Other → Processing
+        assert_eq!(
+            SessionList::processing_label(&Activity::Other("tasks running".to_string()), true),
             "Processing"
         );
     }
 
     #[test]
     fn test_processing_label_various_verbs() {
+        use tmai_core::agents::Activity;
         assert_eq!(
-            SessionList::processing_label("Cerebrating…", true),
+            SessionList::processing_label(&Activity::Other("Cerebrating…".to_string()), true),
             "Cerebrating"
         );
         assert_eq!(
-            SessionList::processing_label("✻ Levitating… (2m · ↓ 13 tokens)", true),
+            SessionList::processing_label(
+                &Activity::Other("✻ Levitating… (2m · ↓ 13 tokens)".to_string()),
+                true
+            ),
             "Levitating"
         );
         assert_eq!(
-            SessionList::processing_label("· Gallivanting…", true),
+            SessionList::processing_label(&Activity::Other("· Gallivanting…".to_string()), true),
             "Gallivanting"
         );
         assert_eq!(
-            SessionList::processing_label("✶ Crunching…", true),
+            SessionList::processing_label(&Activity::Other("✶ Crunching…".to_string()), true),
             "Crunching"
         );
         // First word is capitalized → extract it
         assert_eq!(
-            SessionList::processing_label("Tasks running", true),
+            SessionList::processing_label(&Activity::Other("Tasks running".to_string()), true),
             "Tasks"
         );
         // show_activity_name = false → always "Processing"
         assert_eq!(
-            SessionList::processing_label("✻ Compacting conversation…", false),
+            SessionList::processing_label(&Activity::Compacting, false),
             "Processing"
         );
         assert_eq!(
-            SessionList::processing_label("Cerebrating…", false),
+            SessionList::processing_label(&Activity::Other("Cerebrating…".to_string()), false),
             "Processing"
         );
     }
 
     #[test]
     fn test_processing_label_hook_tool_name() {
-        // Hook-sourced "Tool: X" activity should be preserved as-is
+        use tmai_core::agents::Activity;
+        // ToolExecution activity should show "Tool: X"
         assert_eq!(
-            SessionList::processing_label("Tool: Bash", true),
+            SessionList::processing_label(
+                &Activity::ToolExecution {
+                    tool_name: "Bash".to_string()
+                },
+                true
+            ),
             "Tool: Bash"
         );
         assert_eq!(
-            SessionList::processing_label("Tool: Read", true),
+            SessionList::processing_label(
+                &Activity::ToolExecution {
+                    tool_name: "Read".to_string()
+                },
+                true
+            ),
             "Tool: Read"
         );
         assert_eq!(
-            SessionList::processing_label("Tool: Edit", true),
+            SessionList::processing_label(
+                &Activity::ToolExecution {
+                    tool_name: "Edit".to_string()
+                },
+                true
+            ),
             "Tool: Edit"
         );
         assert_eq!(
-            SessionList::processing_label("Tool: Agent", true),
+            SessionList::processing_label(
+                &Activity::ToolExecution {
+                    tool_name: "Agent".to_string()
+                },
+                true
+            ),
             "Tool: Agent"
         );
-        // Empty tool name after prefix → fallback to Processing
-        assert_eq!(SessionList::processing_label("Tool: ", true), "Processing");
         // show_activity_name = false → always "Processing"
         assert_eq!(
-            SessionList::processing_label("Tool: Bash", false),
+            SessionList::processing_label(
+                &Activity::ToolExecution {
+                    tool_name: "Bash".to_string()
+                },
+                false
+            ),
             "Processing"
         );
     }

--- a/src/ui/components/worktree_overview.rs
+++ b/src/ui/components/worktree_overview.rs
@@ -435,7 +435,7 @@ mod tests {
         assert_eq!(color, Color::Green);
 
         let (icon, color) = status_icon_and_color(&AgentStatus::Processing {
-            activity: String::new(),
+            activity: tmai_core::agents::Activity::Thinking,
         });
         assert_eq!(icon, "\u{25cf}");
         assert_eq!(color, Color::Yellow);
@@ -446,7 +446,7 @@ mod tests {
         assert_eq!(status_label(&AgentStatus::Idle), "Idle");
         assert_eq!(
             status_label(&AgentStatus::Processing {
-                activity: String::new()
+                activity: tmai_core::agents::Activity::Thinking
             }),
             "Processing"
         );

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1801,7 +1801,7 @@ async fn spawn_in_pty(
                     0,
                 );
                 agent.status = tmai_core::agents::AgentStatus::Processing {
-                    activity: "Starting...".to_string(),
+                    activity: tmai_core::agents::Activity::Other("Starting...".to_string()),
                 };
                 agent.stable_id = session_id.clone();
                 agent.pty_session_id = Some(session_id.clone());


### PR DESCRIPTION
## Summary

- Replace freeform `activity: String` in `AgentStatus::Processing` with structured `Activity` enum (`ToolExecution`, `Compacting`, `Thinking`, `Other`)
- Add `ToolOutcome` enum (`Success`, `Error`, `Timeout`) and update `ToolActivity` struct to use `tool: Activity` + `outcome: ToolOutcome`
- Eliminate string parsing in `detail()` method — now uses direct pattern matching on `Activity` variants

## Test plan

- [x] All existing tests updated to use new `Activity` enum constructors
- [x] `cargo test` passes (128 tests)
- [x] `cargo clippy` clean
- [x] `cargo fmt` clean

Closes #297

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * エージェントのアクティビティ表現を型安全な列挙型に統一し、内部の状態管理を改善しました。
  * ツール実行結果の追跡機能を強化しました。

* **Tests**
  * 新しいアクティビティ型に対応するようにテストを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->