### PR TITLE
fix: auto-approve icon should gray out when auto-approve is disabled (#322)

### DIFF
--- a/crates/tmai-app/web/src/components/agent/AgentCard.tsx
+++ b/crates/tmai-app/web/src/components/agent/AgentCard.tsx
@@ -84,14 +84,9 @@ function buildConnectionTooltip(
   return `Detect: ${detectMethods.join(" + ")} (active: ${activeLabel})\nSend: ${sendLabel}`;
 }
 
-/// Resolve effective auto-approve state: override > global
+/// Resolve effective auto-approve state from backend-computed field
 function autoApproveEffective(agent: AgentSnapshot): boolean {
-  if (agent.auto_approve_override !== null && agent.auto_approve_override !== undefined) {
-    return agent.auto_approve_override;
-  }
-  // No override — assume global default (we don't have global state here,
-  // but the badge only shows when override is explicitly set)
-  return true;
+  return agent.auto_approve_effective;
 }
 
 // Channel badge: rounded pill with color when active, gray when inactive
@@ -215,7 +210,12 @@ export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
             onClick={handleAutoApproveToggle}
             className={cn(
               "shrink-0 cursor-pointer rounded px-1 py-0.5 text-[10px] transition-subtle",
-              !hasOverride && "text-zinc-600 hover:text-zinc-400 hover:bg-white/5",
+              !hasOverride &&
+                isAutoApproveOn &&
+                "text-amber-400/60 hover:text-amber-300 hover:bg-white/5",
+              !hasOverride &&
+                !isAutoApproveOn &&
+                "text-zinc-700 hover:text-zinc-500 hover:bg-white/5",
               hasOverride &&
                 isAutoApproveOn &&
                 "text-emerald-400 bg-emerald-500/10 hover:bg-emerald-500/15",
@@ -223,7 +223,7 @@ export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
             )}
             title={
               !hasOverride
-                ? "Auto-approve: global default (click to override)"
+                ? `Auto-approve: global default (${isAutoApproveOn ? "ON" : "OFF"}) — click to override`
                 : isAutoApproveOn
                   ? "Auto-approve: ON (click to cycle)"
                   : "Auto-approve: OFF (click to cycle)"

--- a/crates/tmai-app/web/src/lib/api-http.ts
+++ b/crates/tmai-app/web/src/lib/api-http.ts
@@ -139,6 +139,7 @@ export interface AgentSnapshot {
     | { ManualRequired: string }
     | null;
   auto_approve_override: boolean | null;
+  auto_approve_effective: boolean;
   connection_channels?: ConnectionChannels;
   model_id?: string | null;
   model_display_name?: string | null;

--- a/crates/tmai-app/web/src/lib/tauri.ts
+++ b/crates/tmai-app/web/src/lib/tauri.ts
@@ -95,6 +95,7 @@ function convertTauriAgent(info: TauriAgentInfo): AgentSnapshot {
     team_info: info.team_name ? { team_name: info.team_name, member_name: "" } : null,
     auto_approve_phase: null,
     auto_approve_override: null,
+    auto_approve_effective: false,
   };
 }
 

--- a/crates/tmai-core/src/api/queries.rs
+++ b/crates/tmai-core/src/api/queries.rs
@@ -6,6 +6,14 @@
 use super::core::TmaiCore;
 use super::types::{AgentDefinitionInfo, AgentSnapshot, ApiError, TeamSummary, TeamTaskInfo};
 
+/// Compute effective auto-approve state from global mode and per-agent override
+fn compute_auto_approve_effective(global_enabled: bool, override_val: Option<bool>) -> bool {
+    match override_val {
+        Some(v) => v,
+        None => global_enabled,
+    }
+}
+
 impl TmaiCore {
     // =========================================================
     // Agent ID resolution
@@ -54,6 +62,8 @@ impl TmaiCore {
     pub fn list_agents(&self) -> Vec<AgentSnapshot> {
         let state = self.state().read();
         let defs = &state.agent_definitions;
+        let global_aa = self.settings().auto_approve.effective_mode()
+            != crate::auto_approve::types::AutoApproveMode::Off;
         state
             .agent_order
             .iter()
@@ -61,6 +71,8 @@ impl TmaiCore {
             .map(|a| {
                 let mut snap = AgentSnapshot::from_agent(a);
                 snap.agent_definition = Self::match_agent_definition(a, defs);
+                snap.auto_approve_effective =
+                    compute_auto_approve_effective(global_aa, a.auto_approve_override);
                 snap
             })
             .collect()
@@ -76,6 +88,8 @@ impl TmaiCore {
         let state = self.state().read();
         let defs = &state.agent_definitions;
         let project_git_dir = normalize_git_dir(project);
+        let global_aa = self.settings().auto_approve.effective_mode()
+            != crate::auto_approve::types::AutoApproveMode::Off;
         state
             .agent_order
             .iter()
@@ -84,6 +98,8 @@ impl TmaiCore {
             .map(|a| {
                 let mut snap = AgentSnapshot::from_agent(a);
                 snap.agent_definition = Self::match_agent_definition(a, defs);
+                snap.auto_approve_effective =
+                    compute_auto_approve_effective(global_aa, a.auto_approve_override);
                 snap
             })
             .collect()
@@ -117,9 +133,13 @@ impl TmaiCore {
         let state = self.state().read();
         let key = Self::resolve_agent_key_in_state(&state, id)?;
         let defs = &state.agent_definitions;
+        let global_aa = self.settings().auto_approve.effective_mode()
+            != crate::auto_approve::types::AutoApproveMode::Off;
         let a = state.agents.get(&key).unwrap();
         let mut snap = AgentSnapshot::from_agent(a);
         snap.agent_definition = Self::match_agent_definition(a, defs);
+        snap.auto_approve_effective =
+            compute_auto_approve_effective(global_aa, a.auto_approve_override);
         Ok(snap)
     }
 
@@ -127,11 +147,15 @@ impl TmaiCore {
     pub fn selected_agent(&self) -> Result<AgentSnapshot, ApiError> {
         let state = self.state().read();
         let defs = &state.agent_definitions;
+        let global_aa = self.settings().auto_approve.effective_mode()
+            != crate::auto_approve::types::AutoApproveMode::Off;
         state
             .selected_agent()
             .map(|agent| {
                 let mut snapshot = AgentSnapshot::from_agent(agent);
                 snapshot.agent_definition = Self::match_agent_definition(agent, defs);
+                snapshot.auto_approve_effective =
+                    compute_auto_approve_effective(global_aa, agent.auto_approve_override);
                 snapshot
             })
             .ok_or(ApiError::NoSelection)
@@ -152,12 +176,19 @@ impl TmaiCore {
     /// List agents that need attention (awaiting approval or error).
     pub fn agents_needing_attention(&self) -> Vec<AgentSnapshot> {
         let state = self.state().read();
+        let global_aa = self.settings().auto_approve.effective_mode()
+            != crate::auto_approve::types::AutoApproveMode::Off;
         state
             .agent_order
             .iter()
             .filter_map(|id| state.agents.get(id))
             .filter(|a| a.status.needs_attention())
-            .map(AgentSnapshot::from_agent)
+            .map(|a| {
+                let mut snap = AgentSnapshot::from_agent(a);
+                snap.auto_approve_effective =
+                    compute_auto_approve_effective(global_aa, a.auto_approve_override);
+                snap
+            })
             .collect()
     }
 
@@ -878,5 +909,29 @@ mod tests {
             "/home/user/project-b",
             "/home/user/project-b"
         ));
+    }
+
+    // =========================================================
+    // Auto-approve effective state tests
+    // =========================================================
+
+    #[test]
+    fn test_compute_auto_approve_effective_global_off_no_override() {
+        assert!(!compute_auto_approve_effective(false, None));
+    }
+
+    #[test]
+    fn test_compute_auto_approve_effective_global_on_no_override() {
+        assert!(compute_auto_approve_effective(true, None));
+    }
+
+    #[test]
+    fn test_compute_auto_approve_effective_override_true_overrides_global_off() {
+        assert!(compute_auto_approve_effective(false, Some(true)));
+    }
+
+    #[test]
+    fn test_compute_auto_approve_effective_override_false_overrides_global_on() {
+        assert!(!compute_auto_approve_effective(true, Some(false)));
     }
 }

--- a/crates/tmai-core/src/api/types.rs
+++ b/crates/tmai-core/src/api/types.rs
@@ -249,6 +249,8 @@ pub struct AgentSnapshot {
     /// Per-agent auto-approve override: None = follow global, Some(bool) = override
     #[serde(skip_serializing_if = "Option::is_none")]
     pub auto_approve_override: Option<bool>,
+    /// Effective auto-approve state (resolved from global setting + per-agent override)
+    pub auto_approve_effective: bool,
     /// Which communication channels are currently available
     pub connection_channels: crate::agents::ConnectionChannels,
     /// Model ID (e.g., "claude-opus-4-6")
@@ -368,6 +370,7 @@ impl AgentSnapshot {
             pty_session_id: agent.pty_session_id.clone(),
             send_capability: agent.send_capability,
             auto_approve_override: agent.auto_approve_override,
+            auto_approve_effective: agent.auto_approve_override.unwrap_or(false),
             connection_channels: agent.connection_channels,
             model_display_name: agent
                 .model_id


### PR DESCRIPTION
## Summary

- Added `auto_approve_effective: bool` field to `AgentSnapshot` that resolves the effective auto-approve state from global settings + per-agent override
- Updated `AgentCard` icon styling: dimmed gray (`text-zinc-700`) when effectively OFF, amber when following global ON, green/red for explicit overrides
- Tooltip now shows actual effective state ("ON"/"OFF") when using global default

Closes #322

## Test plan

- [ ] Verify icon is **dimmed gray** when global auto-approve is OFF and no per-agent override
- [ ] Verify icon is **amber** when global auto-approve is ON and no per-agent override  
- [ ] Verify icon is **green** with "⚡on" when per-agent override is ON (regardless of global)
- [ ] Verify icon is **red** with "⚡off" when per-agent override is OFF (regardless of global)
- [ ] Verify tooltip shows "(ON)" or "(OFF)" reflecting effective state
- [ ] Unit tests pass: `cargo test -p tmai-core --lib -- api::queries::tests::test_compute_auto_approve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改善**
  * 自動承認トグルの表示が改善され、有効（琥珀色）/無効（グレー）状態が視覚的により明確になりました。
  * トグルのツールチップがオーバーライド未設定時に実際の有効/無効状態を示すようになりました。
  * グローバル設定と個別設定を組み合わせてエージェントの「実際の自動承認状態」を正しく算出して表示するようになりました。
* **新機能**
  * API出力に「実際の自動承認状態」を示すブール値が追加されました。
* **テスト**
  * 実際の状態算出ロジックを網羅する単体テストが追加されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->