### PR TITLE
feat: agent metadata — issue/PR association and semantic addressing

### DIFF
--- a/crates/tmai-core/src/agents/types.rs
+++ b/crates/tmai-core/src/agents/types.rs
@@ -806,6 +806,10 @@ pub struct MonitoredAgent {
     pub session_name: Option<String>,
     /// Whether this agent was spawned as an orchestrator
     pub is_orchestrator: bool,
+    /// Associated issue number (set at dispatch_issue time)
+    pub issue_number: Option<u64>,
+    /// Associated PR number (auto-detected from branch or set manually)
+    pub pr_number: Option<u64>,
 }
 
 impl MonitoredAgent {
@@ -874,6 +878,8 @@ impl MonitoredAgent {
             claude_version: None,
             session_name: None,
             is_orchestrator: false,
+            issue_number: None,
+            pr_number: None,
         }
     }
 

--- a/crates/tmai-core/src/api/queries.rs
+++ b/crates/tmai-core/src/api/queries.rs
@@ -21,10 +21,49 @@ impl TmaiCore {
     }
 
     /// Resolve agent ID within an already-locked state (avoids double-lock).
+    ///
+    /// Accepts any of:
+    /// - Direct HashMap key (target / session_id)
+    /// - stable_id (UUID short hash)
+    /// - pty_session_id
+    /// - `issue:N` — resolve to the agent working on issue #N
+    /// - `pr:N` — resolve to the agent associated with PR #N
     pub fn resolve_agent_key_in_state(
         state: &crate::state::AppState,
         id: &str,
     ) -> Result<String, ApiError> {
+        // Semantic addressing: issue:N or pr:N
+        if let Some(num_str) = id.strip_prefix("issue:") {
+            let issue_num: u64 = num_str.parse().map_err(|_| ApiError::AgentNotFound {
+                target: id.to_string(),
+            })?;
+            if let Some((key, _)) = state
+                .agents
+                .iter()
+                .find(|(_, a)| a.issue_number == Some(issue_num))
+            {
+                return Ok(key.clone());
+            }
+            return Err(ApiError::AgentNotFound {
+                target: id.to_string(),
+            });
+        }
+        if let Some(num_str) = id.strip_prefix("pr:") {
+            let pr_num: u64 = num_str.parse().map_err(|_| ApiError::AgentNotFound {
+                target: id.to_string(),
+            })?;
+            if let Some((key, _)) = state
+                .agents
+                .iter()
+                .find(|(_, a)| a.pr_number == Some(pr_num))
+            {
+                return Ok(key.clone());
+            }
+            return Err(ApiError::AgentNotFound {
+                target: id.to_string(),
+            });
+        }
+
         // 1) Direct HashMap key match (existing behavior)
         if state.agents.contains_key(id) {
             return Ok(id.to_string());
@@ -878,5 +917,84 @@ mod tests {
             "/home/user/project-b",
             "/home/user/project-b"
         ));
+    }
+
+    // =========================================================
+    // Semantic addressing tests
+    // =========================================================
+
+    #[test]
+    fn test_resolve_by_issue_number() {
+        let mut agent = test_agent("main:0.0", AgentStatus::Idle);
+        agent.issue_number = Some(322);
+        let core = make_core_with_agents(vec![agent]);
+
+        let result = core.get_agent("issue:322");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().pane_id, "main:0.0");
+    }
+
+    #[test]
+    fn test_resolve_by_pr_number() {
+        let mut agent = test_agent("main:0.1", AgentStatus::Idle);
+        agent.pr_number = Some(330);
+        let core = make_core_with_agents(vec![agent]);
+
+        let result = core.get_agent("pr:330");
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().pane_id, "main:0.1");
+    }
+
+    #[test]
+    fn test_resolve_issue_not_found() {
+        let core = make_core_with_agents(vec![test_agent("main:0.0", AgentStatus::Idle)]);
+        let result = core.get_agent("issue:999");
+        assert!(matches!(result, Err(ApiError::AgentNotFound { .. })));
+    }
+
+    #[test]
+    fn test_resolve_pr_not_found() {
+        let core = make_core_with_agents(vec![test_agent("main:0.0", AgentStatus::Idle)]);
+        let result = core.get_agent("pr:999");
+        assert!(matches!(result, Err(ApiError::AgentNotFound { .. })));
+    }
+
+    #[test]
+    fn test_resolve_issue_invalid_number() {
+        let core = make_core_with_agents(vec![test_agent("main:0.0", AgentStatus::Idle)]);
+        let result = core.get_agent("issue:abc");
+        assert!(matches!(result, Err(ApiError::AgentNotFound { .. })));
+    }
+
+    #[test]
+    fn test_resolve_pr_invalid_number() {
+        let core = make_core_with_agents(vec![test_agent("main:0.0", AgentStatus::Idle)]);
+        let result = core.get_agent("pr:abc");
+        assert!(matches!(result, Err(ApiError::AgentNotFound { .. })));
+    }
+
+    #[test]
+    fn test_issue_and_pr_on_same_agent() {
+        let mut agent = test_agent("main:0.0", AgentStatus::Idle);
+        agent.issue_number = Some(100);
+        agent.pr_number = Some(200);
+        let core = make_core_with_agents(vec![agent]);
+
+        // Both should resolve to the same agent
+        let by_issue = core.get_agent("issue:100").unwrap();
+        let by_pr = core.get_agent("pr:200").unwrap();
+        assert_eq!(by_issue.pane_id, by_pr.pane_id);
+    }
+
+    #[test]
+    fn test_snapshot_includes_issue_pr_numbers() {
+        let mut agent = test_agent("main:0.0", AgentStatus::Idle);
+        agent.issue_number = Some(42);
+        agent.pr_number = Some(99);
+        let core = make_core_with_agents(vec![agent]);
+
+        let snap = core.get_agent("main:0.0").unwrap();
+        assert_eq!(snap.issue_number, Some(42));
+        assert_eq!(snap.pr_number, Some(99));
     }
 }

--- a/crates/tmai-core/src/api/queries.rs
+++ b/crates/tmai-core/src/api/queries.rs
@@ -45,31 +45,45 @@ impl TmaiCore {
             let issue_num: u64 = num_str.parse().map_err(|_| ApiError::AgentNotFound {
                 target: id.to_string(),
             })?;
-            if let Some((key, _)) = state
+            let matches: Vec<String> = state
                 .agents
                 .iter()
-                .find(|(_, a)| a.issue_number == Some(issue_num))
-            {
-                return Ok(key.clone());
-            }
-            return Err(ApiError::AgentNotFound {
-                target: id.to_string(),
-            });
+                .filter(|(_, a)| a.issue_number == Some(issue_num))
+                .map(|(key, _)| key.clone())
+                .collect();
+            return match matches.len() {
+                0 => Err(ApiError::AgentNotFound {
+                    target: id.to_string(),
+                }),
+                1 => Ok(matches.into_iter().next().unwrap()),
+                n => Err(ApiError::AmbiguousAgent {
+                    identifier: id.to_string(),
+                    count: n,
+                    matches: matches.join(", "),
+                }),
+            };
         }
         if let Some(num_str) = id.strip_prefix("pr:") {
             let pr_num: u64 = num_str.parse().map_err(|_| ApiError::AgentNotFound {
                 target: id.to_string(),
             })?;
-            if let Some((key, _)) = state
+            let matches: Vec<String> = state
                 .agents
                 .iter()
-                .find(|(_, a)| a.pr_number == Some(pr_num))
-            {
-                return Ok(key.clone());
-            }
-            return Err(ApiError::AgentNotFound {
-                target: id.to_string(),
-            });
+                .filter(|(_, a)| a.pr_number == Some(pr_num))
+                .map(|(key, _)| key.clone())
+                .collect();
+            return match matches.len() {
+                0 => Err(ApiError::AgentNotFound {
+                    target: id.to_string(),
+                }),
+                1 => Ok(matches.into_iter().next().unwrap()),
+                n => Err(ApiError::AmbiguousAgent {
+                    identifier: id.to_string(),
+                    count: n,
+                    matches: matches.join(", "),
+                }),
+            };
         }
 
         // 1) Direct HashMap key match (existing behavior)

--- a/crates/tmai-core/src/api/types.rs
+++ b/crates/tmai-core/src/api/types.rs
@@ -290,6 +290,12 @@ pub struct AgentSnapshot {
     /// Whether this agent was spawned as an orchestrator
     #[serde(skip_serializing_if = "std::ops::Not::not")]
     pub is_orchestrator: bool,
+    /// Associated issue number (set at dispatch_issue time)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub issue_number: Option<u64>,
+    /// Associated PR number (auto-detected from branch or set manually)
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub pr_number: Option<u64>,
 }
 
 /// Helper for skip_serializing_if on u32
@@ -385,6 +391,8 @@ impl AgentSnapshot {
             claude_version: agent.claude_version.clone(),
             session_name: agent.session_name.clone(),
             is_orchestrator: agent.is_orchestrator,
+            issue_number: agent.issue_number,
+            pr_number: agent.pr_number,
         }
     }
 

--- a/crates/tmai-core/src/api/types.rs
+++ b/crates/tmai-core/src/api/types.rs
@@ -130,6 +130,14 @@ pub enum ApiError {
     #[error("command failed: {0}")]
     CommandError(#[from] anyhow::Error),
 
+    /// Multiple agents match the same semantic identifier (issue:N or pr:N)
+    #[error("ambiguous identifier {identifier}: matches {count} agents ({matches})")]
+    AmbiguousAgent {
+        identifier: String,
+        count: usize,
+        matches: String,
+    },
+
     /// Agent belongs to a different project (cross-project operation denied)
     #[error("agent {agent_id} belongs to project {agent_project}, not {expected_project}")]
     ProjectScopeMismatch {

--- a/crates/tmai-core/src/github/pr_monitor.rs
+++ b/crates/tmai-core/src/github/pr_monitor.rs
@@ -11,6 +11,7 @@ use tokio::sync::broadcast;
 use crate::api::events::CoreEvent;
 use crate::config::OrchestratorSettings;
 use crate::github::{self, CheckStatus, PrInfo, ReviewDecision};
+use crate::state::SharedState;
 
 /// Snapshot of a PR's state for change detection
 #[derive(Debug, Clone, PartialEq)]
@@ -398,14 +399,61 @@ pub enum PrNotification {
     },
 }
 
+/// Associate PR numbers with agents by matching PR head branch to agent git_branch.
+///
+/// Called after each poll cycle to keep agent metadata up to date.
+fn associate_pr_numbers(state: &SharedState, notifications: &[PrNotification]) {
+    // Collect branch→pr_number mappings from Created notifications
+    let branch_prs: Vec<(String, u64)> = notifications
+        .iter()
+        .filter_map(|n| {
+            if let PrNotification::Created {
+                pr_number, branch, ..
+            } = n
+            {
+                Some((branch.clone(), *pr_number))
+            } else {
+                None
+            }
+        })
+        .collect();
+
+    if branch_prs.is_empty() {
+        return;
+    }
+
+    let mut s = state.write();
+    for agent in s.agents.values_mut() {
+        if agent.pr_number.is_some() {
+            continue; // already has a PR association
+        }
+        if let Some(ref git_branch) = agent.git_branch {
+            for (branch, pr_number) in &branch_prs {
+                if git_branch == branch {
+                    tracing::info!(
+                        "Auto-associated PR #{} with agent {} (branch: {})",
+                        pr_number,
+                        agent.stable_id,
+                        branch
+                    );
+                    agent.pr_number = Some(*pr_number);
+                    break;
+                }
+            }
+        }
+    }
+}
+
 /// Spawn the PR monitor as a background task.
 ///
 /// Polls GitHub at the configured interval and emits CoreEvents.
 /// The OrchestratorNotifier service handles delivering these to orchestrator agents.
+/// When new PRs are detected, automatically associates pr_number with matching agents.
 pub fn spawn_pr_monitor(
     repo_dir: String,
     event_tx: broadcast::Sender<CoreEvent>,
     settings: OrchestratorSettings,
+    state: Option<SharedState>,
 ) -> tokio::task::JoinHandle<()> {
     let interval_secs = settings.pr_monitor_interval_secs.max(10); // minimum 10s
     let mut monitor = PrMonitor::new(repo_dir, event_tx, settings);
@@ -420,6 +468,11 @@ pub fn spawn_pr_monitor(
             let notifications = monitor.poll().await;
             for notif in &notifications {
                 tracing::info!("PR monitor detected: {}", PrMonitor::format_prompt(notif));
+            }
+
+            // Auto-associate PR numbers with agents by branch matching
+            if let Some(ref state) = state {
+                associate_pr_numbers(state, &notifications);
             }
         }
     })
@@ -544,18 +597,24 @@ mod tests {
     fn test_state_transition_detection() {
         // Verify that PrState comparison works for transition detection
         let pending = PrState {
+            title: "test".to_string(),
+            branch: "feat/test".to_string(),
             check_status: Some(CheckStatus::Pending),
             review_decision: None,
             comments: 0,
             reviews: 0,
         };
         let success = PrState {
+            title: "test".to_string(),
+            branch: "feat/test".to_string(),
             check_status: Some(CheckStatus::Success),
             review_decision: None,
             comments: 0,
             reviews: 0,
         };
         let failure = PrState {
+            title: "test".to_string(),
+            branch: "feat/test".to_string(),
             check_status: Some(CheckStatus::Failure),
             review_decision: None,
             comments: 0,
@@ -638,5 +697,114 @@ mod tests {
         assert_eq!(interval, 10);
         let interval = 60u64.max(10);
         assert_eq!(interval, 60);
+    }
+
+    #[test]
+    fn test_associate_pr_numbers_matches_branch() {
+        use crate::agents::{AgentType, MonitoredAgent};
+        use crate::state::AppState;
+
+        let state = AppState::shared();
+        {
+            let mut s = state.write();
+            let mut agent = MonitoredAgent::new(
+                "main:0.0".to_string(),
+                AgentType::ClaudeCode,
+                "Test".to_string(),
+                "/tmp".to_string(),
+                100,
+                "main".to_string(),
+                "win".to_string(),
+                0,
+                0,
+            );
+            agent.git_branch = Some("feat/test-42".to_string());
+            s.update_agents(vec![agent]);
+        }
+
+        let notifications = vec![PrNotification::Created {
+            pr_number: 42,
+            title: "Test PR".to_string(),
+            branch: "feat/test-42".to_string(),
+        }];
+
+        associate_pr_numbers(&state, &notifications);
+
+        let s = state.read();
+        let agent = s.agents.values().next().unwrap();
+        assert_eq!(agent.pr_number, Some(42));
+    }
+
+    #[test]
+    fn test_associate_pr_numbers_skips_already_set() {
+        use crate::agents::{AgentType, MonitoredAgent};
+        use crate::state::AppState;
+
+        let state = AppState::shared();
+        {
+            let mut s = state.write();
+            let mut agent = MonitoredAgent::new(
+                "main:0.0".to_string(),
+                AgentType::ClaudeCode,
+                "Test".to_string(),
+                "/tmp".to_string(),
+                100,
+                "main".to_string(),
+                "win".to_string(),
+                0,
+                0,
+            );
+            agent.git_branch = Some("feat/test-42".to_string());
+            agent.pr_number = Some(99); // already set
+            s.update_agents(vec![agent]);
+        }
+
+        let notifications = vec![PrNotification::Created {
+            pr_number: 42,
+            title: "Test PR".to_string(),
+            branch: "feat/test-42".to_string(),
+        }];
+
+        associate_pr_numbers(&state, &notifications);
+
+        let s = state.read();
+        let agent = s.agents.values().next().unwrap();
+        assert_eq!(agent.pr_number, Some(99)); // unchanged
+    }
+
+    #[test]
+    fn test_associate_pr_numbers_no_match() {
+        use crate::agents::{AgentType, MonitoredAgent};
+        use crate::state::AppState;
+
+        let state = AppState::shared();
+        {
+            let mut s = state.write();
+            let mut agent = MonitoredAgent::new(
+                "main:0.0".to_string(),
+                AgentType::ClaudeCode,
+                "Test".to_string(),
+                "/tmp".to_string(),
+                100,
+                "main".to_string(),
+                "win".to_string(),
+                0,
+                0,
+            );
+            agent.git_branch = Some("feat/other".to_string());
+            s.update_agents(vec![agent]);
+        }
+
+        let notifications = vec![PrNotification::Created {
+            pr_number: 42,
+            title: "Test PR".to_string(),
+            branch: "feat/test-42".to_string(),
+        }];
+
+        associate_pr_numbers(&state, &notifications);
+
+        let s = state.read();
+        let agent = s.agents.values().next().unwrap();
+        assert_eq!(agent.pr_number, None); // no match
     }
 }

--- a/crates/tmai-core/src/github/pr_monitor.rs
+++ b/crates/tmai-core/src/github/pr_monitor.rs
@@ -307,6 +307,16 @@ impl PrMonitor {
         }
     }
 
+    /// Get all tracked PR branch→number mappings for agent association.
+    ///
+    /// Returns all open PRs currently tracked, regardless of notification settings.
+    pub fn branch_pr_mappings(&self) -> Vec<(String, u64)> {
+        self.previous_states
+            .iter()
+            .map(|(num, state)| (state.branch.clone(), *num))
+            .collect()
+    }
+
     /// Format a notification as a prompt message for the orchestrator
     pub fn format_prompt(notif: &PrNotification) -> String {
         match notif {
@@ -401,23 +411,9 @@ pub enum PrNotification {
 
 /// Associate PR numbers with agents by matching PR head branch to agent git_branch.
 ///
-/// Called after each poll cycle to keep agent metadata up to date.
-fn associate_pr_numbers(state: &SharedState, notifications: &[PrNotification]) {
-    // Collect branch→pr_number mappings from Created notifications
-    let branch_prs: Vec<(String, u64)> = notifications
-        .iter()
-        .filter_map(|n| {
-            if let PrNotification::Created {
-                pr_number, branch, ..
-            } = n
-            {
-                Some((branch.clone(), *pr_number))
-            } else {
-                None
-            }
-        })
-        .collect();
-
+/// Uses the full list of open PRs (not just notifications) so that association
+/// works regardless of the `on_pr_created` notification setting.
+fn associate_pr_numbers(state: &SharedState, branch_prs: &[(String, u64)]) {
     if branch_prs.is_empty() {
         return;
     }
@@ -428,7 +424,7 @@ fn associate_pr_numbers(state: &SharedState, notifications: &[PrNotification]) {
             continue; // already has a PR association
         }
         if let Some(ref git_branch) = agent.git_branch {
-            for (branch, pr_number) in &branch_prs {
+            for (branch, pr_number) in branch_prs {
                 if git_branch == branch {
                     tracing::info!(
                         "Auto-associated PR #{} with agent {} (branch: {})",
@@ -470,9 +466,12 @@ pub fn spawn_pr_monitor(
                 tracing::info!("PR monitor detected: {}", PrMonitor::format_prompt(notif));
             }
 
-            // Auto-associate PR numbers with agents by branch matching
+            // Auto-associate PR numbers with agents by branch matching.
+            // Uses all tracked PRs (not just Created notifications) so association
+            // works even when on_pr_created is disabled.
             if let Some(ref state) = state {
-                associate_pr_numbers(state, &notifications);
+                let branch_prs = monitor.branch_pr_mappings();
+                associate_pr_numbers(state, &branch_prs);
             }
         }
     })
@@ -722,13 +721,9 @@ mod tests {
             s.update_agents(vec![agent]);
         }
 
-        let notifications = vec![PrNotification::Created {
-            pr_number: 42,
-            title: "Test PR".to_string(),
-            branch: "feat/test-42".to_string(),
-        }];
+        let branch_prs = vec![("feat/test-42".to_string(), 42u64)];
 
-        associate_pr_numbers(&state, &notifications);
+        associate_pr_numbers(&state, &branch_prs);
 
         let s = state.read();
         let agent = s.agents.values().next().unwrap();
@@ -759,13 +754,9 @@ mod tests {
             s.update_agents(vec![agent]);
         }
 
-        let notifications = vec![PrNotification::Created {
-            pr_number: 42,
-            title: "Test PR".to_string(),
-            branch: "feat/test-42".to_string(),
-        }];
+        let branch_prs = vec![("feat/test-42".to_string(), 42u64)];
 
-        associate_pr_numbers(&state, &notifications);
+        associate_pr_numbers(&state, &branch_prs);
 
         let s = state.read();
         let agent = s.agents.values().next().unwrap();
@@ -795,13 +786,9 @@ mod tests {
             s.update_agents(vec![agent]);
         }
 
-        let notifications = vec![PrNotification::Created {
-            pr_number: 42,
-            title: "Test PR".to_string(),
-            branch: "feat/test-42".to_string(),
-        }];
+        let branch_prs = vec![("feat/test-42".to_string(), 42u64)];
 
-        associate_pr_numbers(&state, &notifications);
+        associate_pr_numbers(&state, &branch_prs);
 
         let s = state.read();
         let agent = s.agents.values().next().unwrap();

--- a/crates/tmai-core/src/orchestrator_notify/service.rs
+++ b/crates/tmai-core/src/orchestrator_notify/service.rs
@@ -109,7 +109,7 @@ impl OrchestratorNotifier {
                     return None;
                 }
                 // Don't notify about orchestrator agents stopping
-                if Self::is_orchestrator(target, state) {
+                if Self::is_orchestrator_or_untracked(target, state) {
                     return None;
                 }
 
@@ -134,7 +134,7 @@ impl OrchestratorNotifier {
                 if !settings.on_idle {
                     return None;
                 }
-                if Self::is_orchestrator(target, state) {
+                if Self::is_orchestrator_or_untracked(target, state) {
                     return None;
                 }
 
@@ -265,13 +265,18 @@ impl OrchestratorNotifier {
         }
     }
 
-    /// Check if a target agent is an orchestrator
-    fn is_orchestrator(target: &str, state: &SharedState) -> bool {
+    /// Check if a target agent is an orchestrator or untracked (not in state).
+    ///
+    /// Returns true for orchestrator agents AND for targets not found in state.
+    /// Untracked agents (e.g., the user's own Claude Code session sending hooks)
+    /// should not generate notifications — they would be noise that triggers
+    /// unnecessary LLM responses.
+    fn is_orchestrator_or_untracked(target: &str, state: &SharedState) -> bool {
         let s = state.read();
-        s.agents
-            .get(target)
-            .map(|a| a.is_orchestrator)
-            .unwrap_or(false)
+        match s.agents.get(target) {
+            Some(a) => a.is_orchestrator,
+            None => true, // untracked session — suppress notification
+        }
     }
 
     /// Gather contextual info about an agent for notification formatting
@@ -629,5 +634,45 @@ mod tests {
         let (msg, _) = result.unwrap();
         assert!(msg.contains("Agent (mcp)"));
         assert!(msg.contains("merge_pr"));
+    }
+
+    #[test]
+    fn test_untracked_agent_stopped_not_notified() {
+        // An agent not in state (e.g., user's own Claude Code session)
+        // should not generate notifications
+        let state = AppState::shared();
+        // Don't insert any agent — "0" is untracked
+
+        let settings = OrchestratorNotifySettings::default();
+        let event = CoreEvent::AgentStopped {
+            target: "0".to_string(),
+            cwd: "/tmp".to_string(),
+            last_assistant_message: Some("done".to_string()),
+        };
+
+        let result = OrchestratorNotifier::build_notification(&event, &settings, &state);
+        assert!(
+            result.is_none(),
+            "Untracked agent stop should not generate notification"
+        );
+    }
+
+    #[test]
+    fn test_untracked_agent_status_change_not_notified() {
+        let state = AppState::shared();
+        // Don't insert agent — untracked
+
+        let settings = OrchestratorNotifySettings::default();
+        let event = CoreEvent::AgentStatusChanged {
+            target: "unknown:0.0".to_string(),
+            old_status: "idle".to_string(),
+            new_status: "error".to_string(),
+        };
+
+        let result = OrchestratorNotifier::build_notification(&event, &settings, &state);
+        assert!(
+            result.is_none(),
+            "Untracked agent status change should not generate notification"
+        );
     }
 }

--- a/crates/tmai-core/src/state/mod.rs
+++ b/crates/tmai-core/src/state/mod.rs
@@ -2,6 +2,7 @@ mod store;
 
 pub use store::{
     AppState, ConfirmAction, ConfirmationState, CreateProcessState, CreateProcessStep, DirItem,
-    InputMode, InputState, MonitorScope, PlacementType, RepoWorktreeInfo, SelectionState,
-    SharedState, SortBy, TeamSnapshot, TreeEntry, ViewState, WebState, WorktreeDetail,
+    InputMode, InputState, MonitorScope, PendingAgentMetadata, PlacementType, RepoWorktreeInfo,
+    SelectionState, SharedState, SortBy, TeamSnapshot, TreeEntry, ViewState, WebState,
+    WorktreeDetail,
 };

--- a/crates/tmai-core/src/state/store.rs
+++ b/crates/tmai-core/src/state/store.rs
@@ -11,6 +11,18 @@ use crate::usage::UsageSnapshot;
 /// Shared state type alias
 pub type SharedState = Arc<RwLock<AppState>>;
 
+/// Metadata to apply to an agent on first detection.
+/// Used when spawning via tmux where the agent doesn't exist in state yet.
+#[derive(Debug, Clone, Default)]
+pub struct PendingAgentMetadata {
+    /// Issue number from dispatch_issue
+    pub issue_number: Option<u64>,
+    /// PR number from dispatch_review
+    pub pr_number: Option<u64>,
+    /// Worktree base branch
+    pub worktree_base_branch: Option<String>,
+}
+
 /// Input mode for the application
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub enum InputMode {
@@ -508,6 +520,11 @@ pub struct AppState {
     /// Populated by `spawn_orchestrator` before the agent appears in the agents map.
     /// Consumed by `update_agents` when the agent is first inserted.
     pub pending_orchestrator_ids: HashSet<String>,
+
+    /// Pending metadata for agents not yet detected by the poller.
+    /// Key: session_id from spawn response. Applied and removed on first agent detection.
+    /// Used by dispatch_issue (issue_number) and dispatch_review (pr_number).
+    pub pending_agent_metadata: HashMap<String, PendingAgentMetadata>,
 }
 
 impl AppState {
@@ -550,6 +567,7 @@ impl AppState {
             pending_agent_worktrees: HashMap::new(),
             prompt_queue: HashMap::new(),
             pending_orchestrator_ids: HashSet::new(),
+            pending_agent_metadata: HashMap::new(),
         }
     }
 
@@ -730,14 +748,24 @@ impl AppState {
                     existing.auto_approve_phase = None;
                 }
             } else {
-                // Apply pending orchestrator flag for newly detected agents
+                // Apply pending flags for newly detected agents
+                let mut agent = agent;
                 if self.pending_orchestrator_ids.remove(&id) {
-                    let mut agent = agent;
                     agent.is_orchestrator = true;
-                    self.agents.insert(id.clone(), agent);
-                } else {
-                    self.agents.insert(id.clone(), agent);
                 }
+                // Apply pending metadata (issue_number, pr_number, base_branch)
+                if let Some(meta) = self.pending_agent_metadata.remove(&id) {
+                    if meta.issue_number.is_some() {
+                        agent.issue_number = meta.issue_number;
+                    }
+                    if meta.pr_number.is_some() {
+                        agent.pr_number = meta.pr_number;
+                    }
+                    if meta.worktree_base_branch.is_some() {
+                        agent.worktree_base_branch = meta.worktree_base_branch;
+                    }
+                }
+                self.agents.insert(id.clone(), agent);
             }
         }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -482,10 +482,13 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
                     let project_orch = settings.resolve_orchestrator(Some(path));
                     if project_orch.pr_monitor_enabled {
                         tracing::info!("Starting PR monitor for project: {}", path);
+                        #[allow(deprecated)]
+                        let shared_state = core.raw_state().clone();
                         tmai_core::github::pr_monitor::spawn_pr_monitor(
                             path.clone(),
                             core.event_sender().clone(),
                             project_orch.clone(),
+                            Some(shared_state),
                         );
                     }
                 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -75,13 +75,13 @@ pub struct ListAgentsParams {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct AgentIdParams {
-    /// Agent ID — accepts stable ID (e.g., "a1b2c3d4"), pane target (e.g., "main:0.0"), or PTY session UUID
+    /// Agent ID — accepts stable ID (e.g., "a1b2c3d4"), pane target (e.g., "main:0.0"), PTY session UUID, "issue:N", or "pr:N"
     pub id: String,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SendTextParams {
-    /// Agent ID — accepts stable ID, pane target, or PTY session UUID
+    /// Agent ID — accepts stable ID, pane target, PTY session UUID, "issue:N", or "pr:N"
     pub id: String,
     /// Text to send to the agent
     pub text: String,
@@ -89,7 +89,7 @@ pub struct SendTextParams {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SendPromptParams {
-    /// Agent ID — accepts stable ID, pane target, or PTY session UUID
+    /// Agent ID — accepts stable ID, pane target, PTY session UUID, "issue:N", or "pr:N"
     pub id: String,
     /// Prompt text to send to the agent
     pub prompt: String,
@@ -97,7 +97,7 @@ pub struct SendPromptParams {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SendKeyParams {
-    /// Agent ID — accepts stable ID, pane target, or PTY session UUID
+    /// Agent ID — accepts stable ID, pane target, PTY session UUID, "issue:N", or "pr:N"
     pub id: String,
     /// Key name (Enter, Escape, Space, Up, Down, Left, Right, Tab, BTab, BSpace)
     pub key: String,
@@ -105,7 +105,7 @@ pub struct SendKeyParams {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SelectChoiceParams {
-    /// Agent ID — accepts stable ID, pane target, or PTY session UUID
+    /// Agent ID — accepts stable ID, pane target, PTY session UUID, "issue:N", or "pr:N"
     pub id: String,
     /// Choice index (1-based)
     pub index: u32,
@@ -206,7 +206,7 @@ pub struct DispatchReviewParams {
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
 pub struct SetOrchestratorParams {
-    /// Agent ID — accepts stable ID, pane target, or PTY session UUID
+    /// Agent ID — accepts stable ID, pane target, PTY session UUID, "issue:N", or "pr:N"
     pub id: String,
 }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -323,12 +323,25 @@ impl TmaiMcpServer {
         match self.client.get::<serde_json::Value>("/agents") {
             Ok(data) => {
                 if let Some(agents) = data.as_array() {
-                    // Search by stable id (primary), pane_id, target, or pty_session_id
-                    if let Some(agent) = agents.iter().find(|a| {
-                        a.get("id").and_then(|v| v.as_str()) == Some(&p.id)
-                            || a.get("pane_id").and_then(|v| v.as_str()) == Some(&p.id)
-                            || a.get("target").and_then(|v| v.as_str()) == Some(&p.id)
-                            || a.get("pty_session_id").and_then(|v| v.as_str()) == Some(&p.id)
+                    // Parse semantic addressing: "issue:N" or "pr:N"
+                    let semantic =
+                        p.id.split_once(':')
+                            .and_then(|(kind, n)| n.parse::<u64>().ok().map(|num| (kind, num)));
+
+                    // Search by semantic ID, stable id, pane_id, target, or pty_session_id
+                    if let Some(agent) = agents.iter().find(|a| match semantic {
+                        Some(("issue", num)) => {
+                            a.get("issue_number").and_then(|v| v.as_u64()) == Some(num)
+                        }
+                        Some(("pr", num)) => {
+                            a.get("pr_number").and_then(|v| v.as_u64()) == Some(num)
+                        }
+                        _ => {
+                            a.get("id").and_then(|v| v.as_str()) == Some(&p.id)
+                                || a.get("pane_id").and_then(|v| v.as_str()) == Some(&p.id)
+                                || a.get("target").and_then(|v| v.as_str()) == Some(&p.id)
+                                || a.get("pty_session_id").and_then(|v| v.as_str()) == Some(&p.id)
+                        }
                     }) {
                         return format_json(agent);
                     }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -98,6 +98,7 @@ fn api_error_to_http(err: ApiError) -> (StatusCode, Json<serde_json::Value>) {
         ApiError::VirtualAgent { .. } | ApiError::InvalidInput { .. } | ApiError::NoSelection => {
             StatusCode::BAD_REQUEST
         }
+        ApiError::AmbiguousAgent { .. } => StatusCode::CONFLICT,
         ApiError::ProjectScopeMismatch { .. } => StatusCode::FORBIDDEN,
         ApiError::WorktreeError(e) => match e {
             tmai_core::worktree::WorktreeOpsError::NotFound(_) => StatusCode::NOT_FOUND,
@@ -2584,6 +2585,15 @@ pub async fn dispatch_review(
         let mut s = state.write();
         if let Some(agent) = s.agents.get_mut(&resp.session_id) {
             agent.pr_number = Some(req.pr_number);
+        } else {
+            // Agent not yet in state (tmux spawn) — store for deferred application
+            s.pending_agent_metadata.insert(
+                resp.session_id.clone(),
+                tmai_core::state::PendingAgentMetadata {
+                    pr_number: Some(req.pr_number),
+                    ..Default::default()
+                },
+            );
         }
     }
 
@@ -2730,10 +2740,20 @@ pub async fn spawn_worktree(
         #[allow(deprecated)]
         let state = core.raw_state();
         let mut s = state.write();
-        // Set worktree metadata on the spawned agent
+        // Set worktree metadata on the spawned agent (or defer for tmux)
         if let Some(agent) = s.agents.get_mut(&resp.session_id) {
             agent.worktree_base_branch = effective_base;
             agent.issue_number = req.issue_number;
+        } else {
+            // Agent not yet in state (tmux spawn) — store for deferred application
+            s.pending_agent_metadata.insert(
+                resp.session_id.clone(),
+                tmai_core::state::PendingAgentMetadata {
+                    issue_number: req.issue_number,
+                    worktree_base_branch: effective_base,
+                    ..Default::default()
+                },
+            );
         }
         s.pending_agent_worktrees
             .insert(worktree_path, std::time::Instant::now());

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -2577,6 +2577,16 @@ pub async fn dispatch_review(
         spawn_in_pty(&core, &spawn_req).await
     };
 
+    // Set pr_number metadata on the spawned agent
+    if let Ok(ref resp) = result {
+        #[allow(deprecated)]
+        let state = core.raw_state();
+        let mut s = state.write();
+        if let Some(agent) = s.agents.get_mut(&resp.session_id) {
+            agent.pr_number = Some(req.pr_number);
+        }
+    }
+
     if result.is_ok() {
         let _ = core.event_sender().send(CoreEvent::ActionPerformed {
             origin,
@@ -2720,9 +2730,10 @@ pub async fn spawn_worktree(
         #[allow(deprecated)]
         let state = core.raw_state();
         let mut s = state.write();
-        // Set worktree_base_branch on the spawned agent
+        // Set worktree metadata on the spawned agent
         if let Some(agent) = s.agents.get_mut(&resp.session_id) {
             agent.worktree_base_branch = effective_base;
+            agent.issue_number = req.issue_number;
         }
         s.pending_agent_worktrees
             .insert(worktree_path, std::time::Instant::now());


### PR DESCRIPTION
## Summary
- Add `issue_number` and `pr_number` fields to `MonitoredAgent` / `AgentSnapshot` for tracking which issue/PR each agent is working on
- Record metadata at dispatch time: `dispatch_issue` sets `issue_number`, `dispatch_review` sets `pr_number`
- Auto-associate `pr_number` when `PrMonitor` detects new PRs by matching head branch to agent `git_branch`
- Enable semantic addressing: all agent-targeting APIs (`approve`, `send_prompt`, `kill_agent`, `get_agent`, etc.) now accept `issue:N` or `pr:N` in addition to stable ID, pane target, and PTY session UUID

## Test plan
- [x] Unit tests for semantic addressing resolution (8 tests: by issue, by PR, not found, invalid number, both on same agent, snapshot fields)
- [x] Unit tests for PR branch→agent auto-association (3 tests: match, skip already set, no match)
- [x] `cargo clippy -- -D warnings` passes
- [x] `cargo fmt --check` passes

Closes #331

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新機能**
  - エージェントを Issue/PR 表記（issue:N、pr:N）で指定可能に。  
  - APIのエージェント情報に Issue番号 / PR番号 が含まれるように。

- **改善**
  - PR監視で該当するエージェントへPR番号を自動関連付け。起動時のレビュー/作業ツリー作成で Issue/PR 情報を確実に記録。
  - 同一識別子の曖昧性は明示的なエラーで通知。
  - 未追跡対象への不要な通知を抑制。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->