### PR TITLE
feat: dispatch_review should create a worktree on latest main (#336)

### DIFF
--- a/crates/tmai-core/src/auto_cleanup/service.rs
+++ b/crates/tmai-core/src/auto_cleanup/service.rs
@@ -6,15 +6,16 @@ use tracing::{debug, info, warn};
 use crate::api::CoreEvent;
 use crate::state::SharedState;
 
-/// Background service that cleans up agents and worktrees when PRs close.
+/// Background service that cleans up agents and worktrees when PRs close
+/// or review agents stop.
 pub struct AutoCleanupService;
 
 impl AutoCleanupService {
     /// Spawn the auto-cleanup service as a background task.
     ///
-    /// Listens for `PrClosed` events and performs cleanup:
-    /// - Kill agents whose `git_branch` matches the closed PR's branch
-    /// - Delete worktrees associated with that branch
+    /// Listens for:
+    /// - `PrClosed` events: kill agents and delete worktrees for the closed PR's branch
+    /// - `AgentStopped` events: delete review worktrees when the review agent finishes
     pub fn spawn(
         state: SharedState,
         mut event_rx: broadcast::Receiver<CoreEvent>,
@@ -35,6 +36,9 @@ impl AutoCleanupService {
                         );
                         Self::cleanup_for_branch(&state, &event_tx, pr_number, &title, &branch)
                             .await;
+                    }
+                    Ok(CoreEvent::AgentStopped { target, cwd, .. }) => {
+                        Self::cleanup_review_worktree(&state, &event_tx, &target, &cwd).await;
                     }
                     Err(broadcast::error::RecvError::Lagged(n)) => {
                         debug!(skipped = n, "Auto-cleanup service lagged");
@@ -149,6 +153,73 @@ impl AutoCleanupService {
             ),
         });
     }
+
+    /// Clean up review worktree when a review agent stops.
+    ///
+    /// Review worktrees are identified by the `review-pr-` prefix in their name.
+    /// When a review agent finishes (posts its review and exits), the worktree
+    /// is no longer needed and can be deleted.
+    async fn cleanup_review_worktree(
+        state: &SharedState,
+        event_tx: &broadcast::Sender<CoreEvent>,
+        target: &str,
+        cwd: &str,
+    ) {
+        // Extract worktree name from cwd path (e.g., .../.claude/worktrees/review-pr-42)
+        let worktree_name = match crate::git::extract_claude_worktree_name(cwd) {
+            Some(name) if name.starts_with("review-pr-") => name,
+            _ => return, // Not a review worktree — nothing to clean up
+        };
+
+        // Resolve the repo path from the agent's git_common_dir
+        let repo_path = {
+            let s = state.read();
+            s.agents
+                .get(target)
+                .and_then(|a| a.git_common_dir.clone())
+                .map(|d| format!("{d}/.git"))
+        };
+
+        let repo_path = match repo_path {
+            Some(p) => p,
+            None => {
+                debug!(
+                    target = %target,
+                    worktree = %worktree_name,
+                    "Auto-cleanup: cannot resolve repo path for review worktree"
+                );
+                return;
+            }
+        };
+
+        let req = crate::worktree::WorktreeDeleteRequest {
+            repo_path,
+            worktree_name: worktree_name.to_string(),
+            force: true,
+        };
+        match crate::worktree::delete_worktree(&req).await {
+            Ok(()) => {
+                info!(
+                    worktree = %worktree_name,
+                    "Auto-cleanup: deleted review worktree after agent stopped"
+                );
+                let _ = event_tx.send(CoreEvent::ActionPerformed {
+                    origin: crate::api::ActionOrigin::system("auto_cleanup"),
+                    action: "auto_cleanup".to_string(),
+                    summary: format!(
+                        "Deleted review worktree \"{worktree_name}\" after review agent stopped"
+                    ),
+                });
+            }
+            Err(e) => {
+                warn!(
+                    worktree = %worktree_name,
+                    error = %e,
+                    "Auto-cleanup: failed to delete review worktree"
+                );
+            }
+        }
+    }
 }
 
 #[cfg(test)]
@@ -246,6 +317,61 @@ mod tests {
             .await;
 
         // Should not emit (no agents found)
+        let result = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+        assert!(result.is_err(), "Should not have emitted any event");
+    }
+
+    /// Helper: insert an agent with a cwd in a review worktree path
+    fn insert_review_agent(state: &SharedState, target: &str, cwd: &str) {
+        let mut s = state.write();
+        let mut agent = MonitoredAgent::new(
+            target.to_string(),
+            AgentType::ClaudeCode,
+            String::new(),
+            cwd.to_string(),
+            0,
+            target.to_string(),
+            String::new(),
+            0,
+            0,
+        );
+        agent.status = AgentStatus::Idle;
+        agent.pr_number = Some(42);
+        agent.git_common_dir = Some("/tmp/repo".to_string());
+        s.agents.insert(target.to_string(), agent);
+    }
+
+    #[tokio::test]
+    async fn test_review_cleanup_skips_non_review_worktree() {
+        let state = AppState::shared();
+        // Agent in a regular worktree (not review-)
+        insert_review_agent(&state, "worker:0.0", "/tmp/repo/.claude/worktrees/42-auth");
+
+        let (tx, mut rx) = broadcast::channel(16);
+
+        AutoCleanupService::cleanup_review_worktree(
+            &state,
+            &tx,
+            "worker:0.0",
+            "/tmp/repo/.claude/worktrees/42-auth",
+        )
+        .await;
+
+        // Should not emit (not a review worktree)
+        let result = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+        assert!(result.is_err(), "Should not have emitted any event");
+    }
+
+    #[tokio::test]
+    async fn test_review_cleanup_skips_non_worktree_cwd() {
+        let state = AppState::shared();
+        insert_review_agent(&state, "worker:0.0", "/tmp/repo");
+
+        let (tx, mut rx) = broadcast::channel(16);
+
+        AutoCleanupService::cleanup_review_worktree(&state, &tx, "worker:0.0", "/tmp/repo").await;
+
+        // Should not emit (cwd is not in a worktree)
         let result = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
         assert!(result.is_err(), "Should not have emitted any event");
     }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -2529,6 +2529,46 @@ pub async fn dispatch_review(
     let head_branch = pr_json["headRefName"].as_str().unwrap_or("");
     let base_branch = pr_json["baseRefName"].as_str().unwrap_or("main");
 
+    // Fetch latest remote main so worktree starts from up-to-date state
+    let fetch_output = tokio::process::Command::new("git")
+        .args(["-C", &req.cwd, "fetch", "origin", base_branch])
+        .output()
+        .await
+        .map_err(|e| {
+            json_error(
+                StatusCode::BAD_REQUEST,
+                &format!("Failed to fetch origin/{base_branch}: {e}"),
+            )
+        })?;
+
+    if !fetch_output.status.success() {
+        let stderr = String::from_utf8_lossy(&fetch_output.stderr);
+        return Err(json_error(
+            StatusCode::BAD_REQUEST,
+            &format!("Failed to fetch origin/{}: {}", base_branch, stderr.trim()),
+        ));
+    }
+
+    // Create a dedicated worktree for the review agent
+    let worktree_name = format!("review-pr-{}", req.pr_number);
+    let wt_req = tmai_core::worktree::WorktreeCreateRequest {
+        repo_path: req.cwd.clone(),
+        branch_name: worktree_name.clone(),
+        dir_name: None,
+        base_branch: Some(format!("origin/{base_branch}")),
+    };
+
+    let wt_result = tmai_core::worktree::create_worktree(&wt_req)
+        .await
+        .map_err(|e| json_error(StatusCode::BAD_REQUEST, &e.to_string()))?;
+
+    tracing::info!(
+        "dispatch_review: created worktree '{}' at {} for PR #{}",
+        worktree_name,
+        wt_result.path,
+        req.pr_number,
+    );
+
     // Compose review prompt
     let extra = req
         .additional_instructions
@@ -2537,7 +2577,10 @@ pub async fn dispatch_review(
         .unwrap_or_default();
 
     let prompt = format!(
-        "You are a code reviewer. Review PR #{pr_number} and post your review via `gh pr review`.\n\n\
+        "IMPORTANT: You are working in a git worktree at: {worktree_path}\n\
+         All file reads and edits MUST use paths starting with this directory.\n\
+         NEVER edit files outside your worktree directory.\n\n\
+         You are a code reviewer. Review PR #{pr_number} and post your review via `gh pr review`.\n\n\
          ## PR Context\n\
          - Title: {title}\n\
          - URL: {url}\n\
@@ -2549,6 +2592,7 @@ pub async fn dispatch_review(
          4. Post your review with `gh pr review {pr_number}` using --comment, --approve, or --request-changes\n\
          5. If you find issues, include specific file/line references in your review body\n\
          {extra}",
+        worktree_path = wt_result.path,
         pr_number = req.pr_number,
         title = pr_title,
         url = pr_url,
@@ -2557,11 +2601,12 @@ pub async fn dispatch_review(
         extra = extra,
     );
 
-    // Spawn agent in the main repo directory (no worktree)
+    // Spawn agent in the review worktree directory
+    let worktree_path = wt_result.path.clone();
     let spawn_req = SpawnRequest {
         command: "claude".to_string(),
         args: vec![prompt],
-        cwd: req.cwd,
+        cwd: wt_result.path,
         rows: req.rows,
         cols: req.cols,
         force_pty: false,
@@ -2578,7 +2623,7 @@ pub async fn dispatch_review(
         spawn_in_pty(&core, &spawn_req).await
     };
 
-    // Set pr_number metadata on the spawned agent
+    // Set pr_number metadata and register pending worktree
     if let Ok(ref resp) = result {
         #[allow(deprecated)]
         let state = core.raw_state();
@@ -2595,6 +2640,9 @@ pub async fn dispatch_review(
                 },
             );
         }
+        // Protect worktree from premature deletion during agent detection
+        s.pending_agent_worktrees
+            .insert(worktree_path, std::time::Instant::now());
     }
 
     if result.is_ok() {
@@ -2602,8 +2650,8 @@ pub async fn dispatch_review(
             origin,
             action: "dispatch_review".to_string(),
             summary: format!(
-                "Spawned review agent for PR #{} \"{}\" ({} → {})",
-                req.pr_number, pr_title, head_branch, base_branch
+                "Spawned review agent for PR #{} \"{}\" ({} → {}) in worktree {}",
+                req.pr_number, pr_title, head_branch, base_branch, worktree_name
             ),
         });
     }


### PR DESCRIPTION
## Summary

- `dispatch_review` now creates a dedicated worktree (`review-pr-{pr_number}`) checked out to `origin/main` instead of spawning the review agent in the main repo directory. This prevents branch conflicts between the orchestrator and review agents.
- Before creating the worktree, fetches `origin/{base_branch}` to ensure the review starts from the latest remote state.
- Registers the worktree in `pending_agent_worktrees` to protect against premature deletion during agent detection.
- Auto-cleanup service now listens for `AgentStopped` events and deletes review worktrees (identified by `review-pr-` prefix) when the review agent finishes.

## Test plan

- [x] Existing auto_cleanup tests pass
- [x] New tests: review cleanup skips non-review worktrees
- [x] New tests: review cleanup skips non-worktree cwds
- [x] `cargo check` and `cargo clippy` pass
- [ ] Manual: `dispatch_review` creates worktree and spawns agent inside it
- [ ] Manual: orchestrator branch is not affected during review
- [ ] Manual: review worktree is cleaned up after agent stops

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * エージェント停止時の自動クリーンアップ機能を改善しました。

* **新機能**
  * レビュー環境の設定プロセスを強化し、より堅牢なワークツリー管理を実装しました。
  * レビュー作成時にリモートブランチを自動的に同期するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->