### PR TITLE
fix: hook errors (PreToolUse/PostToolUse/Stop) in spawned worktree agents (#324)

### DIFF
--- a/src/init.rs
+++ b/src/init.rs
@@ -74,6 +74,112 @@ pub fn load_hook_token() -> Option<String> {
         .filter(|s| !s.is_empty())
 }
 
+/// Ensure hooks are configured and in sync with the running tmai instance.
+///
+/// Called on webui/tui startup to guarantee that `~/.claude/settings.json` has
+/// hook entries pointing to the correct port with a valid token. This prevents
+/// stale hooks (wrong port, missing/mismatched token) from causing hook errors
+/// in spawned agents — especially worktree agents that inherit the global config.
+///
+/// Returns the hook token (existing or newly generated).
+pub fn ensure_hooks_configured(port: u16) -> Result<String> {
+    // Step 1: Ensure hook token exists (reuse existing, generate if missing)
+    let token = ensure_hook_token(false)?;
+
+    // Step 2: Read current Claude Code settings
+    let settings_path = claude_settings_path()?;
+    let mut settings: Value = if settings_path.exists() {
+        let content = fs::read_to_string(&settings_path)
+            .with_context(|| format!("Failed to read {}", settings_path.display()))?;
+        serde_json::from_str(&content)
+            .with_context(|| format!("Failed to parse {}", settings_path.display()))?
+    } else {
+        json!({})
+    };
+
+    // Step 3: Check if hooks are already correctly configured
+    if hooks_are_current(&settings, &token, port) {
+        return Ok(token);
+    }
+
+    // Step 4: Merge tmai hooks with current token and port
+    // In webui mode, pane_id is resolved via session_id/cwd fallback (no tmux header)
+    let include_tmux_pane = std::env::var("TMUX").is_ok();
+    merge_hooks(&mut settings, &token, port, include_tmux_pane);
+
+    // Step 5: Write back settings
+    if let Some(parent) = settings_path.parent() {
+        fs::create_dir_all(parent)?;
+    }
+    let formatted = serde_json::to_string_pretty(&settings)?;
+    fs::write(&settings_path, &formatted)
+        .with_context(|| format!("Failed to write {}", settings_path.display()))?;
+
+    eprintln!(
+        "tmai: hooks synced in {} (port {}, token {}…)",
+        settings_path.display(),
+        port,
+        &token[..8.min(token.len())]
+    );
+
+    Ok(token)
+}
+
+/// Check if existing hooks in settings already have the correct token and port.
+///
+/// Returns true only when ALL target events have exactly one tmai hook entry
+/// whose URL matches the expected port and whose Authorization header matches
+/// the expected token. Any mismatch triggers a re-sync.
+fn hooks_are_current(settings: &Value, token: &str, port: u16) -> bool {
+    let expected_url_fragment = format!("localhost:{}/hooks/event", port);
+    let expected_auth = format!("Bearer {}", token);
+
+    let hooks = match settings.get("hooks").and_then(|h| h.as_object()) {
+        Some(h) => h,
+        None => return false,
+    };
+
+    for event in target_events() {
+        let event_hooks = match hooks.get(*event).and_then(|e| e.as_array()) {
+            Some(arr) => arr,
+            None => return false,
+        };
+
+        // Find exactly one tmai entry with correct token and port
+        let tmai_entries: Vec<_> = event_hooks.iter().filter(|e| is_tmai_entry(e)).collect();
+        if tmai_entries.len() != 1 {
+            return false;
+        }
+
+        let entry = tmai_entries[0];
+        // Check inside wrapper format: entry.hooks[0].url and entry.hooks[0].headers.Authorization
+        let inner = match entry
+            .get("hooks")
+            .and_then(|h| h.as_array())
+            .and_then(|a| a.first())
+        {
+            Some(h) => h,
+            None => return false,
+        };
+
+        let url_ok = inner
+            .get("url")
+            .and_then(|u| u.as_str())
+            .is_some_and(|u| u.contains(&expected_url_fragment));
+        let auth_ok = inner
+            .get("headers")
+            .and_then(|h| h.get("Authorization"))
+            .and_then(|a| a.as_str())
+            .is_some_and(|a| a == expected_auth);
+
+        if !url_ok || !auth_ok {
+            return false;
+        }
+    }
+
+    true
+}
+
 /// Generate the statusline.sh script that forwards JSON to tmai
 ///
 /// The script reads stdin (statusline JSON from Claude Code), forwards it to
@@ -1254,6 +1360,44 @@ mod tests {
             settings["mcpServers"]["tmai"]["args"],
             json!(["custom-arg"])
         );
+    }
+
+    #[test]
+    fn test_hooks_are_current_matching() {
+        let mut settings = json!({});
+        merge_hooks(&mut settings, "token-abc", 9876, false);
+        assert!(hooks_are_current(&settings, "token-abc", 9876));
+    }
+
+    #[test]
+    fn test_hooks_are_current_wrong_token() {
+        let mut settings = json!({});
+        merge_hooks(&mut settings, "token-abc", 9876, false);
+        // Different token → not current
+        assert!(!hooks_are_current(&settings, "token-xyz", 9876));
+    }
+
+    #[test]
+    fn test_hooks_are_current_wrong_port() {
+        let mut settings = json!({});
+        merge_hooks(&mut settings, "token-abc", 9876, false);
+        // Different port → not current
+        assert!(!hooks_are_current(&settings, "token-abc", 1234));
+    }
+
+    #[test]
+    fn test_hooks_are_current_empty_settings() {
+        let settings = json!({});
+        assert!(!hooks_are_current(&settings, "token-abc", 9876));
+    }
+
+    #[test]
+    fn test_hooks_are_current_missing_event() {
+        let mut settings = json!({});
+        merge_hooks(&mut settings, "token-abc", 9876, false);
+        // Remove one event → not current
+        settings["hooks"].as_object_mut().unwrap().remove("Stop");
+        assert!(!hooks_are_current(&settings, "token-abc", 9876));
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -134,10 +134,22 @@ async fn run_tmux_mode(settings: Settings, _cli: Config) -> Result<()> {
     // Build TmaiCore facade (shared between Web and TUI for event broadcasting)
     let app_state = app.shared_state();
 
-    // Create hook registry and load hook token
+    // Create hook registry and ensure hooks are configured
     let hook_registry = tmai_core::hooks::new_hook_registry();
     let session_pane_map = tmai_core::hooks::new_session_pane_map();
-    let hook_token = tmai::init::load_hook_token();
+    // Auto-sync hooks in ~/.claude/settings.json with current token and port.
+    // This prevents stale hooks from causing errors in spawned worktree agents.
+    let hook_token = if settings.web.enabled {
+        match tmai::init::ensure_hooks_configured(settings.web.port) {
+            Ok(token) => Some(token),
+            Err(e) => {
+                tracing::warn!("Failed to auto-sync hooks: {} — falling back to load", e);
+                tmai::init::load_hook_token()
+            }
+        }
+    } else {
+        tmai::init::load_hook_token()
+    };
 
     let core_cmd_sender = Arc::new(
         CommandSender::new(Some(ipc_server.clone()), runtime.clone(), app_state.clone())
@@ -326,7 +338,7 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
         s.spawn_tmux_window_name = settings.spawn.tmux_window_name.clone();
     }
 
-    // Create hook registry and load token
+    // Create hook registry and ensure hooks are configured
     let hook_registry = tmai_core::hooks::new_hook_registry();
 
     // Create command sender (PTY session → IPC → tmux → PTY inject)
@@ -336,7 +348,18 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
     );
     // Note: pty_registry is attached after core is built (see below)
     let session_pane_map = tmai_core::hooks::new_session_pane_map();
-    let hook_token = tmai::init::load_hook_token();
+    // Auto-sync hooks in ~/.claude/settings.json with current token and port.
+    // This prevents stale hooks from causing errors in spawned worktree agents.
+    let hook_token = match tmai::init::ensure_hooks_configured(settings.web.port) {
+        Ok(token) => Some(token),
+        Err(e) => {
+            eprintln!(
+                "tmai: failed to auto-sync hooks: {} — falling back to load",
+                e
+            );
+            tmai::init::load_hook_token()
+        }
+    };
 
     // Create shared transcript registry (shared between Poller and TmaiCore)
     let transcript_registry = tmai_core::transcript::watcher::new_transcript_registry();


### PR DESCRIPTION
## Summary
- Auto-sync hooks in `~/.claude/settings.json` on startup (both TUI and WebUI modes), ensuring token and port match the running tmai instance
- Add `ensure_hooks_configured(port)` that generates a token if missing, checks if hooks are already current via `hooks_are_current()`, and only writes when stale
- Prevents persistent PreToolUse/PostToolUse/Stop hook errors in spawned worktree agents caused by stale hooks after config reset/port change

## Root Cause
When tmai started, it loaded the hook token from `~/.config/tmai/hooks_token` but never verified that `~/.claude/settings.json` had hooks pointing to the correct token and port. After a config reset, token regeneration, or port change, spawned worktree agents (which inherit the global hook config) would send requests with mismatched credentials, causing 400/401 errors on every tool use.

## Test plan
- [x] 5 new unit tests: `hooks_are_current` matching, wrong token, wrong port, empty settings, missing event
- [x] All 27 `init::tests` pass
- [x] `cargo check` and `cargo clippy` clean
- [ ] Manual: dispatch_issue after config reset → verify no hook errors in spawned agent

Closes #324

🤖 Generated with [Claude Code](https://claude.com/claude-code)