### PR TITLE
feat: add orchestrator guardrails config (max_ci_retries, max_review_loops, escalate_to_human) (#343)

### DIFF
--- a/crates/tmai-app/web/src/components/settings/SettingsPanel.tsx
+++ b/crates/tmai-app/web/src/components/settings/SettingsPanel.tsx
@@ -1143,7 +1143,7 @@ function GuardrailsSection({
               value={orchestrator.guardrails[field.key]}
               onChange={(e) => {
                 const val = parseInt(e.target.value, 10);
-                if (!isNaN(val)) {
+                if (!Number.isNaN(val)) {
                   setOrchestrator({
                     ...orchestrator,
                     guardrails: { ...orchestrator.guardrails, [field.key]: val },
@@ -1152,7 +1152,7 @@ function GuardrailsSection({
               }}
               onBlur={(e) => {
                 const val = parseInt(e.target.value, 10);
-                if (!isNaN(val) && val >= 1) {
+                if (!Number.isNaN(val) && val >= 1) {
                   updateField(field.key, val);
                 }
               }}

--- a/crates/tmai-app/web/src/components/settings/SettingsPanel.tsx
+++ b/crates/tmai-app/web/src/components/settings/SettingsPanel.tsx
@@ -617,6 +617,13 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                     setOrchestrator={setOrchestrator}
                     orchProject={orchProject}
                   />
+
+                  {/* Guardrails */}
+                  <GuardrailsSection
+                    orchestrator={orchestrator}
+                    setOrchestrator={setOrchestrator}
+                    orchProject={orchProject}
+                  />
                 </div>
               )}
             </div>
@@ -944,6 +951,12 @@ const NOTIFY_EVENTS: NotifyEventDef[] = [
     label: "PR closed",
     description: "Pull request closed or merged",
   },
+  {
+    key: "on_guardrail_exceeded",
+    templateKey: "guardrail_exceeded",
+    label: "Guardrail exceeded",
+    description: "CI retries, review loops, or failure limit exceeded",
+  },
 ];
 
 /** Orchestrator notification settings with per-event toggles and template editing */
@@ -1063,6 +1076,90 @@ function NotifySettingsSection({
             </div>
           );
         })}
+      </div>
+    </>
+  );
+}
+
+/** Guardrails settings — limits to prevent infinite loops */
+function GuardrailsSection({
+  orchestrator,
+  setOrchestrator,
+  orchProject,
+}: {
+  orchestrator: OrchestratorSettings;
+  setOrchestrator: (v: OrchestratorSettings) => void;
+  orchProject: string | undefined;
+}) {
+  const guardrailFields: {
+    key: keyof OrchestratorSettings["guardrails"];
+    label: string;
+    description: string;
+  }[] = [
+    {
+      key: "max_ci_retries",
+      label: "Max CI retries",
+      description: "CI fix attempts per PR before escalation",
+    },
+    {
+      key: "max_review_loops",
+      label: "Max review loops",
+      description: "Review→fix cycles per PR before escalation",
+    },
+    {
+      key: "escalate_to_human_after",
+      label: "Escalate after failures",
+      description: "Consecutive failures before notifying human",
+    },
+  ];
+
+  const updateField = async (key: keyof OrchestratorSettings["guardrails"], value: number) => {
+    if (value < 1) return;
+    const updated = {
+      ...orchestrator,
+      guardrails: { ...orchestrator.guardrails, [key]: value },
+    };
+    setOrchestrator(updated);
+    try {
+      await api.updateOrchestratorSettings({ guardrails: { [key]: value } }, orchProject);
+    } catch (_e) {}
+  };
+
+  return (
+    <>
+      <h4 className="text-xs font-semibold text-zinc-400 uppercase tracking-wider mt-4 mb-2">
+        Guardrails
+      </h4>
+      <div className="space-y-2">
+        {guardrailFields.map((field) => (
+          <div key={field.key} className="flex items-center justify-between gap-3">
+            <div className="flex-1 min-w-0">
+              <span className="text-xs text-zinc-300">{field.label}</span>
+              <p className="text-[10px] text-zinc-600 leading-tight">{field.description}</p>
+            </div>
+            <input
+              type="number"
+              min={1}
+              value={orchestrator.guardrails[field.key]}
+              onChange={(e) => {
+                const val = parseInt(e.target.value, 10);
+                if (!isNaN(val)) {
+                  setOrchestrator({
+                    ...orchestrator,
+                    guardrails: { ...orchestrator.guardrails, [field.key]: val },
+                  });
+                }
+              }}
+              onBlur={(e) => {
+                const val = parseInt(e.target.value, 10);
+                if (!isNaN(val) && val >= 1) {
+                  updateField(field.key, val);
+                }
+              }}
+              className="w-16 rounded-md border border-white/10 bg-white/5 px-2 py-1 text-xs text-zinc-200 text-center outline-none focus:border-cyan-500/30"
+            />
+          </div>
+        ))}
       </div>
     </>
   );

--- a/crates/tmai-app/web/src/lib/api-http.ts
+++ b/crates/tmai-app/web/src/lib/api-http.ts
@@ -599,6 +599,7 @@ export interface NotifyTemplates {
   pr_comment: string;
   rebase_conflict: string;
   pr_closed: string;
+  guardrail_exceeded: string;
 }
 
 export interface NotifySettings {
@@ -610,7 +611,14 @@ export interface NotifySettings {
   on_pr_created: boolean;
   on_pr_comment: boolean;
   on_pr_closed: boolean;
+  on_guardrail_exceeded: boolean;
   templates: NotifyTemplates;
+}
+
+export interface GuardrailsSettings {
+  max_ci_retries: number;
+  max_review_loops: number;
+  escalate_to_human_after: number;
 }
 
 export interface OrchestratorSettings {
@@ -618,6 +626,7 @@ export interface OrchestratorSettings {
   role: string;
   rules: OrchestratorRules;
   notify: NotifySettings;
+  guardrails: GuardrailsSettings;
   /** Whether this is a per-project override (true) or global fallback (false) */
   is_project_override: boolean;
 }
@@ -981,6 +990,7 @@ export const api = {
       notify?: Partial<Omit<NotifySettings, "templates">> & {
         templates?: Partial<NotifyTemplates>;
       };
+      guardrails?: Partial<GuardrailsSettings>;
     },
     project?: string,
   ) =>

--- a/crates/tmai-app/web/src/lib/api-tauri.ts
+++ b/crates/tmai-app/web/src/lib/api-tauri.ts
@@ -8,6 +8,7 @@ export * from "./teams";
 import type {
   AgentSnapshot,
   AutoApproveRules,
+  GuardrailsSettings,
   NotifySettings,
   NotifyTemplates,
   OrchestratorRules,
@@ -198,6 +199,7 @@ export const api = {
       notify?: Partial<Omit<NotifySettings, "templates">> & {
         templates?: Partial<NotifyTemplates>;
       };
+      guardrails?: Partial<GuardrailsSettings>;
     },
     project?: string,
   ) => httpApi.updateOrchestratorSettings(params, project),

--- a/crates/tmai-core/src/api/events.rs
+++ b/crates/tmai-core/src/api/events.rs
@@ -6,12 +6,36 @@
 //! - **External mode**: The consumer (TUI) runs its own Poller and calls
 //!   `notify_agents_updated()` / `notify_teams_updated()` to emit events.
 
+use std::fmt;
+
 use tokio::sync::broadcast;
 
 use crate::hooks::WorktreeInfo;
 use crate::review::ReviewRequest;
 
 use super::core::TmaiCore;
+
+/// The type of guardrail that was exceeded
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GuardrailKind {
+    /// CI fix attempts exceeded max_ci_retries
+    CiRetries,
+    /// Review→fix cycles exceeded max_review_loops
+    ReviewLoops,
+    /// Consecutive failures exceeded escalate_to_human_after
+    ConsecutiveFailures,
+}
+
+impl fmt::Display for GuardrailKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            GuardrailKind::CiRetries => write!(f, "CI retries"),
+            GuardrailKind::ReviewLoops => write!(f, "review loops"),
+            GuardrailKind::ConsecutiveFailures => write!(f, "consecutive failures"),
+        }
+    }
+}
 
 /// Events emitted by the core when state changes occur.
 ///
@@ -269,6 +293,20 @@ pub enum CoreEvent {
         title: String,
         /// Head branch name
         branch: String,
+    },
+
+    /// A guardrail limit was exceeded (CI retries, review loops, or consecutive failures)
+    GuardrailExceeded {
+        /// The type of guardrail that was exceeded
+        guardrail: GuardrailKind,
+        /// Associated branch
+        branch: String,
+        /// Associated PR number (if any)
+        pr_number: Option<u64>,
+        /// Current count that exceeded the limit
+        count: u64,
+        /// The configured limit
+        limit: u64,
     },
 
     /// A side-effect API action was performed (for orchestrator notification)

--- a/crates/tmai-core/src/api/mod.rs
+++ b/crates/tmai-core/src/api/mod.rs
@@ -31,7 +31,7 @@ mod worktree_guard;
 
 pub use builder::TmaiCoreBuilder;
 pub use core::TmaiCore;
-pub use events::CoreEvent;
+pub use events::{CoreEvent, GuardrailKind};
 pub use types::{
     ActionOrigin, AgentSnapshot, ApiError, SendPromptResult, TeamSummary, TeamTaskInfo,
     WorktreeSnapshot,

--- a/crates/tmai-core/src/config/mod.rs
+++ b/crates/tmai-core/src/config/mod.rs
@@ -6,7 +6,7 @@ pub use claude_settings::{
 };
 pub use settings::{
     AuditCommand, AutoApproveSettings, CodexWsConnection, CodexWsSettings, Command, Config,
-    CreateProcessSettings, ExfilDetectionSettings, NotifyTemplates, OrchestratorNotifySettings,
-    OrchestratorRules, OrchestratorSettings, ProjectConfig, ReviewSettings, RuleSettings, Settings,
-    TeamSettings,
+    CreateProcessSettings, ExfilDetectionSettings, GuardrailsSettings, NotifyTemplates,
+    OrchestratorNotifySettings, OrchestratorRules, OrchestratorSettings, ProjectConfig,
+    ReviewSettings, RuleSettings, Settings, TeamSettings,
 };

--- a/crates/tmai-core/src/config/settings.rs
+++ b/crates/tmai-core/src/config/settings.rs
@@ -874,6 +874,10 @@ pub struct OrchestratorSettings {
     #[serde(default)]
     pub notify: OrchestratorNotifySettings,
 
+    /// Guardrail limits to prevent infinite loops
+    #[serde(default)]
+    pub guardrails: GuardrailsSettings,
+
     /// Enable automatic PR/CI status monitoring with notifications
     #[serde(default)]
     pub pr_monitor_enabled: bool,
@@ -925,6 +929,11 @@ pub struct OrchestratorNotifySettings {
     #[serde(default = "default_true")]
     pub on_pr_closed: bool,
 
+    // ── Guardrail events ────────────────────────────────────
+    /// Notify when a guardrail limit is exceeded (CI retries, review loops, etc.)
+    #[serde(default = "default_true")]
+    pub on_guardrail_exceeded: bool,
+
     // ── Template overrides ──────────────────────────────────
     /// Per-event prompt template overrides (empty = use built-in default)
     #[serde(default)]
@@ -942,6 +951,7 @@ impl Default for OrchestratorNotifySettings {
             on_pr_created: true,
             on_pr_comment: true,
             on_pr_closed: true,
+            on_guardrail_exceeded: true,
             templates: NotifyTemplates::default(),
         }
     }
@@ -977,6 +987,49 @@ pub struct NotifyTemplates {
     pub rebase_conflict: String,
     #[serde(default)]
     pub pr_closed: String,
+    #[serde(default)]
+    pub guardrail_exceeded: String,
+}
+
+/// Guardrail limits to prevent infinite loops and enable human escalation.
+///
+/// When a limit is hit, a `GuardrailExceeded` CoreEvent is emitted so the
+/// notification system can alert the orchestrator (or a human).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct GuardrailsSettings {
+    /// Max CI fix attempts per PR before escalation
+    #[serde(default = "default_max_ci_retries")]
+    pub max_ci_retries: u64,
+
+    /// Max review→fix cycles per PR before escalation
+    #[serde(default = "default_max_review_loops")]
+    pub max_review_loops: u64,
+
+    /// Consecutive failures before notifying human
+    #[serde(default = "default_escalate_to_human_after")]
+    pub escalate_to_human_after: u64,
+}
+
+impl Default for GuardrailsSettings {
+    fn default() -> Self {
+        Self {
+            max_ci_retries: default_max_ci_retries(),
+            max_review_loops: default_max_review_loops(),
+            escalate_to_human_after: default_escalate_to_human_after(),
+        }
+    }
+}
+
+fn default_max_ci_retries() -> u64 {
+    3
+}
+
+fn default_max_review_loops() -> u64 {
+    5
+}
+
+fn default_escalate_to_human_after() -> u64 {
+    3
 }
 
 /// Workflow rules for the orchestrator agent
@@ -1014,6 +1067,7 @@ impl Default for OrchestratorSettings {
             role: default_orchestrator_role(),
             rules: OrchestratorRules::default(),
             notify: OrchestratorNotifySettings::default(),
+            guardrails: GuardrailsSettings::default(),
             pr_monitor_enabled: false,
             pr_monitor_interval_secs: default_pr_monitor_interval(),
         }
@@ -1730,5 +1784,57 @@ mod tests {
         assert!(rules.allow_format_lint);
         assert_eq!(rules.allow_patterns.len(), 2);
         assert_eq!(rules.allow_patterns[0], "cargo build.*");
+    }
+
+    #[test]
+    fn test_guardrails_defaults() {
+        let g = GuardrailsSettings::default();
+        assert_eq!(g.max_ci_retries, 3);
+        assert_eq!(g.max_review_loops, 5);
+        assert_eq!(g.escalate_to_human_after, 3);
+    }
+
+    #[test]
+    fn test_guardrails_serde_defaults() {
+        // Empty TOML should produce defaults
+        let toml = "";
+        let g: GuardrailsSettings = toml::from_str(toml).unwrap();
+        assert_eq!(g.max_ci_retries, 3);
+        assert_eq!(g.max_review_loops, 5);
+        assert_eq!(g.escalate_to_human_after, 3);
+    }
+
+    #[test]
+    fn test_guardrails_serde_partial() {
+        let toml = "max_ci_retries = 10";
+        let g: GuardrailsSettings = toml::from_str(toml).unwrap();
+        assert_eq!(g.max_ci_retries, 10);
+        assert_eq!(g.max_review_loops, 5); // default
+        assert_eq!(g.escalate_to_human_after, 3); // default
+    }
+
+    #[test]
+    fn test_orchestrator_settings_includes_guardrails() {
+        let toml = r#"
+            enabled = true
+            [guardrails]
+            max_ci_retries = 7
+            max_review_loops = 10
+            escalate_to_human_after = 5
+        "#;
+        let orch: OrchestratorSettings = toml::from_str(toml).unwrap();
+        assert!(orch.enabled);
+        assert_eq!(orch.guardrails.max_ci_retries, 7);
+        assert_eq!(orch.guardrails.max_review_loops, 10);
+        assert_eq!(orch.guardrails.escalate_to_human_after, 5);
+    }
+
+    #[test]
+    fn test_notify_settings_guardrail_exceeded_default() {
+        let n = OrchestratorNotifySettings::default();
+        assert!(
+            n.on_guardrail_exceeded,
+            "on_guardrail_exceeded should be ON by default"
+        );
     }
 }

--- a/crates/tmai-core/src/orchestrator_notify/service.rs
+++ b/crates/tmai-core/src/orchestrator_notify/service.rs
@@ -336,6 +336,32 @@ impl OrchestratorNotifier {
                 Some((msg, format!("pr-{pr_number}")))
             }
 
+            CoreEvent::GuardrailExceeded {
+                guardrail,
+                branch,
+                pr_number,
+                count,
+                limit,
+            } => {
+                if !settings.on_guardrail_exceeded {
+                    return None;
+                }
+                let pr_label = pr_number.map(|n| format!(" (PR #{n})")).unwrap_or_default();
+                let msg = render_template(
+                    &settings.templates.guardrail_exceeded,
+                    &format!(
+                        "[tmai] ⚠ Guardrail exceeded: {guardrail} on branch \"{branch}\"{pr_label}.\n  Count: {count} / limit: {limit}\n  Action required: please review and intervene."
+                    ),
+                    &[
+                        ("guardrail", &guardrail.to_string()),
+                        ("branch", branch.as_str()),
+                        ("count", &count.to_string()),
+                        ("limit", &limit.to_string()),
+                    ],
+                );
+                Some((msg, branch.clone()))
+            }
+
             CoreEvent::ActionPerformed {
                 origin,
                 action,
@@ -1051,5 +1077,72 @@ mod tests {
             !found_prompt,
             "Orchestrator should NOT receive its own stop notification via pane_id"
         );
+    }
+
+    #[test]
+    fn test_guardrail_exceeded_notification() {
+        let state = AppState::shared();
+        let settings = OrchestratorNotifySettings::default();
+
+        let event = CoreEvent::GuardrailExceeded {
+            guardrail: crate::api::GuardrailKind::CiRetries,
+            branch: "feat/42-auth".to_string(),
+            pr_number: Some(10),
+            count: 3,
+            limit: 3,
+        };
+
+        let result = OrchestratorNotifier::build_notification(&event, &settings, &state);
+        assert!(
+            result.is_some(),
+            "Guardrail exceeded should notify by default"
+        );
+        let (msg, source) = result.unwrap();
+        assert_eq!(source, "feat/42-auth");
+        assert!(msg.contains("Guardrail exceeded"));
+        assert!(msg.contains("CI retries"));
+        assert!(msg.contains("PR #10"));
+        assert!(msg.contains("3 / limit: 3"));
+    }
+
+    #[test]
+    fn test_guardrail_exceeded_disabled() {
+        let state = AppState::shared();
+        let mut settings = OrchestratorNotifySettings::default();
+        settings.on_guardrail_exceeded = false;
+
+        let event = CoreEvent::GuardrailExceeded {
+            guardrail: crate::api::GuardrailKind::ReviewLoops,
+            branch: "feat/50-api".to_string(),
+            pr_number: Some(20),
+            count: 5,
+            limit: 5,
+        };
+
+        let result = OrchestratorNotifier::build_notification(&event, &settings, &state);
+        assert!(
+            result.is_none(),
+            "Guardrail exceeded should not notify when disabled"
+        );
+    }
+
+    #[test]
+    fn test_guardrail_exceeded_consecutive_failures() {
+        let state = AppState::shared();
+        let settings = OrchestratorNotifySettings::default();
+
+        let event = CoreEvent::GuardrailExceeded {
+            guardrail: crate::api::GuardrailKind::ConsecutiveFailures,
+            branch: "feat/99-bug".to_string(),
+            pr_number: None,
+            count: 3,
+            limit: 3,
+        };
+
+        let result = OrchestratorNotifier::build_notification(&event, &settings, &state);
+        assert!(result.is_some());
+        let (msg, _) = result.unwrap();
+        assert!(msg.contains("consecutive failures"));
+        assert!(!msg.contains("PR #")); // No PR number
     }
 }

--- a/crates/tmai-core/src/state/store.rs
+++ b/crates/tmai-core/src/state/store.rs
@@ -529,6 +529,10 @@ pub struct AppState {
     /// Shared handle to orchestrator notification settings (hot-reloadable from WebUI).
     /// None if orchestrator is disabled.
     pub notify_settings: Option<crate::orchestrator_notify::SharedNotifySettings>,
+
+    /// Shared handle to guardrails settings (hot-reloadable from WebUI).
+    /// None until TaskMetaService is started.
+    pub guardrails_settings: Option<crate::task_meta::SharedGuardrailsSettings>,
 }
 
 impl AppState {
@@ -573,6 +577,7 @@ impl AppState {
             pending_orchestrator_ids: HashSet::new(),
             pending_agent_metadata: HashMap::new(),
             notify_settings: None,
+            guardrails_settings: None,
         }
     }
 

--- a/crates/tmai-core/src/task_meta/mod.rs
+++ b/crates/tmai-core/src/task_meta/mod.rs
@@ -7,5 +7,8 @@
 mod service;
 pub mod store;
 
-pub use service::{restore_from_disk, TaskMetaService};
+pub use service::{
+    count_ci_failures, count_consecutive_failures, count_review_loops, restore_from_disk,
+    SharedGuardrailsSettings, TaskMetaService,
+};
 pub use store::{Milestone, TaskMeta};

--- a/crates/tmai-core/src/task_meta/service.rs
+++ b/crates/tmai-core/src/task_meta/service.rs
@@ -1,13 +1,24 @@
 //! Background service that records milestones on CoreEvent changes.
+//!
+//! Also enforces guardrail limits: when CI failure count, review loop count,
+//! or consecutive failure count exceeds the configured threshold, a
+//! `GuardrailExceeded` CoreEvent is emitted.
 
 use std::path::PathBuf;
+use std::sync::Arc;
+
+use parking_lot::RwLock;
 use tokio::sync::broadcast;
 use tracing::{debug, info, warn};
 
-use crate::api::CoreEvent;
+use crate::api::{CoreEvent, GuardrailKind};
+use crate::config::GuardrailsSettings;
 use crate::state::SharedState;
 
 use super::store;
+
+/// Shared, hot-reloadable reference to guardrails settings
+pub type SharedGuardrailsSettings = Arc<RwLock<GuardrailsSettings>>;
 
 /// Background service that listens to CoreEvents and appends milestones
 /// to the corresponding `.task-meta/{branch}.json` files.
@@ -18,14 +29,17 @@ impl TaskMetaService {
     ///
     /// Listens for relevant events and appends milestones to task meta files.
     /// Also handles cleanup (deleting meta files) on PrClosed.
+    /// When guardrail limits are exceeded, emits `GuardrailExceeded` events.
     pub fn spawn(
         state: SharedState,
         mut event_rx: broadcast::Receiver<CoreEvent>,
+        guardrails: SharedGuardrailsSettings,
+        event_tx: broadcast::Sender<CoreEvent>,
     ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
             loop {
                 match event_rx.recv().await {
-                    Ok(event) => Self::handle_event(&state, &event),
+                    Ok(event) => Self::handle_event(&state, &event, &guardrails, &event_tx),
                     Err(broadcast::error::RecvError::Lagged(n)) => {
                         debug!(skipped = n, "TaskMetaService lagged");
                     }
@@ -39,7 +53,13 @@ impl TaskMetaService {
     }
 
     /// Handle a single event, appending milestones or cleaning up as needed.
-    fn handle_event(state: &SharedState, event: &CoreEvent) {
+    /// Checks guardrail limits after recording CI failure and review feedback milestones.
+    fn handle_event(
+        state: &SharedState,
+        event: &CoreEvent,
+        guardrails: &SharedGuardrailsSettings,
+        event_tx: &broadcast::Sender<CoreEvent>,
+    ) {
         let project_roots = Self::project_roots(state);
         if project_roots.is_empty() {
             return;
@@ -83,6 +103,45 @@ impl TaskMetaService {
                     for root in &project_roots {
                         store::append_milestone(root, &branch, &milestone);
                     }
+
+                    // Check CI retry guardrail
+                    let g = guardrails.read().clone();
+                    if let Some(meta) = store::read_meta(&project_roots[0], &branch) {
+                        let ci_fail_count = count_ci_failures(&meta);
+                        if ci_fail_count >= g.max_ci_retries {
+                            info!(
+                                branch = %branch,
+                                count = ci_fail_count,
+                                limit = g.max_ci_retries,
+                                "CI retries guardrail exceeded"
+                            );
+                            let _ = event_tx.send(CoreEvent::GuardrailExceeded {
+                                guardrail: GuardrailKind::CiRetries,
+                                branch: branch.clone(),
+                                pr_number: Some(*pr_number),
+                                count: ci_fail_count,
+                                limit: g.max_ci_retries,
+                            });
+                        }
+
+                        // Check consecutive failures guardrail
+                        let consec = count_consecutive_failures(&meta);
+                        if consec >= g.escalate_to_human_after {
+                            info!(
+                                branch = %branch,
+                                count = consec,
+                                limit = g.escalate_to_human_after,
+                                "Consecutive failures guardrail exceeded"
+                            );
+                            let _ = event_tx.send(CoreEvent::GuardrailExceeded {
+                                guardrail: GuardrailKind::ConsecutiveFailures,
+                                branch: branch.clone(),
+                                pr_number: Some(*pr_number),
+                                count: consec,
+                                limit: g.escalate_to_human_after,
+                            });
+                        }
+                    }
                 }
             }
 
@@ -96,6 +155,27 @@ impl TaskMetaService {
                         format!("Review feedback (PR #{pr_number}): {comments_summary}");
                     for root in &project_roots {
                         store::append_milestone(root, &branch, &milestone);
+                    }
+
+                    // Check review loops guardrail
+                    let g = guardrails.read().clone();
+                    if let Some(meta) = store::read_meta(&project_roots[0], &branch) {
+                        let review_count = count_review_loops(&meta);
+                        if review_count >= g.max_review_loops {
+                            info!(
+                                branch = %branch,
+                                count = review_count,
+                                limit = g.max_review_loops,
+                                "Review loops guardrail exceeded"
+                            );
+                            let _ = event_tx.send(CoreEvent::GuardrailExceeded {
+                                guardrail: GuardrailKind::ReviewLoops,
+                                branch: branch.clone(),
+                                pr_number: Some(*pr_number),
+                                count: review_count,
+                                limit: g.max_review_loops,
+                            });
+                        }
                     }
                 }
             }
@@ -146,6 +226,32 @@ impl TaskMetaService {
         let s = state.read();
         s.agents.get(target).and_then(|a| a.git_branch.clone())
     }
+}
+
+/// Count CI failure milestones in a task meta.
+pub fn count_ci_failures(meta: &store::TaskMeta) -> u64 {
+    meta.milestones
+        .iter()
+        .filter(|m| m.event.starts_with("CI failed"))
+        .count() as u64
+}
+
+/// Count review feedback milestones in a task meta.
+pub fn count_review_loops(meta: &store::TaskMeta) -> u64 {
+    meta.milestones
+        .iter()
+        .filter(|m| m.event.starts_with("Review feedback"))
+        .count() as u64
+}
+
+/// Count consecutive failures (CI failure or review feedback) from the end
+/// of the milestone history, stopping at the first non-failure event.
+pub fn count_consecutive_failures(meta: &store::TaskMeta) -> u64 {
+    meta.milestones
+        .iter()
+        .rev()
+        .take_while(|m| m.event.starts_with("CI failed") || m.event.starts_with("Review feedback"))
+        .count() as u64
 }
 
 /// Restore in-memory issue/PR associations from persisted `.task-meta/` files.
@@ -203,6 +309,13 @@ mod tests {
     use crate::agents::{AgentStatus, AgentType, MonitoredAgent};
     use crate::state::AppState;
 
+    /// Create default guardrails and event channel for tests
+    fn test_guardrails_and_tx() -> (SharedGuardrailsSettings, broadcast::Sender<CoreEvent>) {
+        let g = Arc::new(RwLock::new(crate::config::GuardrailsSettings::default()));
+        let (tx, _) = broadcast::channel(16);
+        (g, tx)
+    }
+
     fn insert_agent(state: &SharedState, target: &str, branch: &str, pr: Option<u64>) {
         let mut s = state.write();
         let mut agent = MonitoredAgent::new(
@@ -240,7 +353,8 @@ mod tests {
             title: "Add auth".to_string(),
             branch: "feat/42-auth".to_string(),
         };
-        TaskMetaService::handle_event(&state, &event);
+        let (g, tx) = test_guardrails_and_tx();
+        TaskMetaService::handle_event(&state, &event, &g, &tx);
 
         let loaded = store::read_meta(dir.path(), "feat/42-auth").unwrap();
         assert_eq!(loaded.pr, Some(10));
@@ -265,7 +379,8 @@ mod tests {
             title: "Add auth".to_string(),
             branch: "feat/42-auth".to_string(),
         };
-        TaskMetaService::handle_event(&state, &event);
+        let (g, tx) = test_guardrails_and_tx();
+        TaskMetaService::handle_event(&state, &event, &g, &tx);
 
         assert!(store::read_meta(dir.path(), "feat/42-auth").is_none());
     }
@@ -288,7 +403,8 @@ mod tests {
             title: "Add auth".to_string(),
             checks_summary: "3/3 checks passed".to_string(),
         };
-        TaskMetaService::handle_event(&state, &event);
+        let (g, tx) = test_guardrails_and_tx();
+        TaskMetaService::handle_event(&state, &event, &g, &tx);
 
         let loaded = store::read_meta(dir.path(), "feat/42-auth").unwrap();
         assert!(loaded
@@ -315,7 +431,8 @@ mod tests {
             cwd: "/tmp".to_string(),
             last_assistant_message: None,
         };
-        TaskMetaService::handle_event(&state, &event);
+        let (g, tx) = test_guardrails_and_tx();
+        TaskMetaService::handle_event(&state, &event, &g, &tx);
 
         let loaded = store::read_meta(dir.path(), "feat/99-test").unwrap();
         assert!(loaded
@@ -370,5 +487,175 @@ mod tests {
         // Should keep existing values
         assert_eq!(agent.issue_number, Some(100));
         assert_eq!(agent.pr_number, Some(99));
+    }
+
+    // ── Guardrail counting tests ────────────────────────────
+
+    #[test]
+    fn test_count_ci_failures() {
+        let mut meta = store::TaskMeta::for_issue(1, None);
+        assert_eq!(count_ci_failures(&meta), 0);
+
+        meta.add_milestone("CI failed (PR #10): lint");
+        meta.add_milestone("CI passed (PR #10): ok");
+        meta.add_milestone("CI failed (PR #10): test");
+        assert_eq!(count_ci_failures(&meta), 2);
+    }
+
+    #[test]
+    fn test_count_review_loops() {
+        let mut meta = store::TaskMeta::for_issue(1, None);
+        meta.add_milestone("Review feedback (PR #10): fix types");
+        meta.add_milestone("CI passed (PR #10): ok");
+        meta.add_milestone("Review feedback (PR #10): fix naming");
+        assert_eq!(count_review_loops(&meta), 2);
+    }
+
+    #[test]
+    fn test_count_consecutive_failures() {
+        let mut meta = store::TaskMeta::for_issue(1, None);
+        meta.add_milestone("CI passed (PR #10): ok");
+        meta.add_milestone("CI failed (PR #10): lint");
+        meta.add_milestone("Review feedback (PR #10): nit");
+        meta.add_milestone("CI failed (PR #10): test");
+        // Last 3 milestones are failures
+        assert_eq!(count_consecutive_failures(&meta), 3);
+    }
+
+    #[test]
+    fn test_consecutive_failures_broken_by_pass() {
+        let mut meta = store::TaskMeta::for_issue(1, None);
+        meta.add_milestone("CI failed (PR #10): a");
+        meta.add_milestone("CI passed (PR #10): ok"); // breaks the streak
+        meta.add_milestone("CI failed (PR #10): b");
+        assert_eq!(count_consecutive_failures(&meta), 1);
+    }
+
+    #[test]
+    fn test_guardrail_ci_retries_exceeded_emits_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::shared();
+        {
+            let mut s = state.write();
+            s.registered_projects = vec![dir.path().to_string_lossy().to_string()];
+        }
+        insert_agent(&state, "worker:0.0", "feat/42-auth", Some(10));
+
+        // Set up meta with 2 CI failures already
+        let mut meta = store::TaskMeta::for_issue(42, None);
+        meta.add_milestone("CI failed (PR #10): lint");
+        meta.add_milestone("CI failed (PR #10): test");
+        store::write_meta(dir.path(), "feat/42-auth", &meta).unwrap();
+
+        // Set max_ci_retries = 3
+        let g = Arc::new(RwLock::new(crate::config::GuardrailsSettings {
+            max_ci_retries: 3,
+            ..Default::default()
+        }));
+        let (tx, mut rx) = broadcast::channel(16);
+
+        // Third CI failure should trigger guardrail
+        let event = CoreEvent::PrCiFailed {
+            pr_number: 10,
+            title: "Add auth".to_string(),
+            failed_details: "cargo test failed".to_string(),
+        };
+        TaskMetaService::handle_event(&state, &event, &g, &tx);
+
+        // Should have emitted a GuardrailExceeded event
+        let emitted = rx.try_recv().unwrap();
+        match emitted {
+            CoreEvent::GuardrailExceeded {
+                guardrail,
+                branch,
+                pr_number,
+                count,
+                limit,
+            } => {
+                assert_eq!(guardrail, crate::api::GuardrailKind::CiRetries);
+                assert_eq!(branch, "feat/42-auth");
+                assert_eq!(pr_number, Some(10));
+                assert_eq!(count, 3);
+                assert_eq!(limit, 3);
+            }
+            other => panic!("Expected GuardrailExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_guardrail_review_loops_exceeded_emits_event() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::shared();
+        {
+            let mut s = state.write();
+            s.registered_projects = vec![dir.path().to_string_lossy().to_string()];
+        }
+        insert_agent(&state, "worker:0.0", "feat/50-api", Some(20));
+
+        // Set up meta with 4 review feedbacks already
+        let mut meta = store::TaskMeta::for_issue(50, None);
+        for i in 0..4 {
+            meta.add_milestone(&format!("Review feedback (PR #20): round {i}"));
+        }
+        store::write_meta(dir.path(), "feat/50-api", &meta).unwrap();
+
+        let g = Arc::new(RwLock::new(crate::config::GuardrailsSettings {
+            max_review_loops: 5,
+            ..Default::default()
+        }));
+        let (tx, mut rx) = broadcast::channel(16);
+
+        // 5th review feedback should trigger guardrail
+        let event = CoreEvent::PrReviewFeedback {
+            pr_number: 20,
+            title: "API endpoints".to_string(),
+            comments_summary: "needs more tests".to_string(),
+        };
+        TaskMetaService::handle_event(&state, &event, &g, &tx);
+
+        let emitted = rx.try_recv().unwrap();
+        match emitted {
+            CoreEvent::GuardrailExceeded {
+                guardrail,
+                count,
+                limit,
+                ..
+            } => {
+                assert_eq!(guardrail, crate::api::GuardrailKind::ReviewLoops);
+                assert_eq!(count, 5);
+                assert_eq!(limit, 5);
+            }
+            other => panic!("Expected GuardrailExceeded, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn test_guardrail_not_triggered_below_limit() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::shared();
+        {
+            let mut s = state.write();
+            s.registered_projects = vec![dir.path().to_string_lossy().to_string()];
+        }
+        insert_agent(&state, "worker:0.0", "feat/42-auth", Some(10));
+
+        let meta = store::TaskMeta::for_issue(42, None);
+        store::write_meta(dir.path(), "feat/42-auth", &meta).unwrap();
+
+        let g = Arc::new(RwLock::new(crate::config::GuardrailsSettings::default()));
+        let (tx, mut rx) = broadcast::channel(16);
+
+        // First CI failure — should NOT trigger guardrail (limit=3)
+        let event = CoreEvent::PrCiFailed {
+            pr_number: 10,
+            title: "Add auth".to_string(),
+            failed_details: "lint failed".to_string(),
+        };
+        TaskMetaService::handle_event(&state, &event, &g, &tx);
+
+        assert!(
+            rx.try_recv().is_err(),
+            "Should not emit GuardrailExceeded below limit"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -258,7 +258,15 @@ async fn run_tmux_mode(settings: Settings, _cli: Config) -> Result<()> {
     );
 
     // Start task metadata milestone service (records events to .task-meta/ files)
-    tmai_core::task_meta::TaskMetaService::spawn(app.shared_state(), core.subscribe());
+    let guardrails_settings = std::sync::Arc::new(parking_lot::RwLock::new(
+        settings.orchestrator.guardrails.clone(),
+    ));
+    tmai_core::task_meta::TaskMetaService::spawn(
+        app.shared_state(),
+        core.subscribe(),
+        guardrails_settings,
+        core.event_sender(),
+    );
 
     // Restore in-memory issue/PR associations from persisted .task-meta/ files
     tmai_core::task_meta::restore_from_disk(&app.shared_state(), &settings.project_paths());
@@ -453,7 +461,17 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
     }
 
     // Start task metadata milestone service (records events to .task-meta/ files)
-    tmai_core::task_meta::TaskMetaService::spawn(state.clone(), core.subscribe());
+    let guardrails_settings = std::sync::Arc::new(parking_lot::RwLock::new(
+        settings.orchestrator.guardrails.clone(),
+    ));
+    // Store in state for hot-reload from WebUI settings API
+    state.write().guardrails_settings = Some(guardrails_settings.clone());
+    tmai_core::task_meta::TaskMetaService::spawn(
+        state.clone(),
+        core.subscribe(),
+        guardrails_settings,
+        core.event_sender(),
+    );
 
     // Restore in-memory issue/PR associations from persisted .task-meta/ files
     tmai_core::task_meta::restore_from_disk(&state, &settings.project_paths());

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1261,8 +1261,17 @@ pub struct OrchestratorSettingsResponse {
     pub role: String,
     pub rules: OrchestratorRulesResponse,
     pub notify: NotifySettingsResponse,
+    pub guardrails: GuardrailsSettingsResponse,
     /// Whether this is a per-project override (true) or global fallback (false)
     pub is_project_override: bool,
+}
+
+/// Guardrails settings response
+#[derive(Debug, Serialize)]
+pub struct GuardrailsSettingsResponse {
+    pub max_ci_retries: u64,
+    pub max_review_loops: u64,
+    pub escalate_to_human_after: u64,
 }
 
 /// Rules sub-object in orchestrator settings response
@@ -1285,6 +1294,7 @@ pub struct NotifySettingsResponse {
     pub on_pr_created: bool,
     pub on_pr_comment: bool,
     pub on_pr_closed: bool,
+    pub on_guardrail_exceeded: bool,
     pub templates: NotifyTemplatesResponse,
 }
 
@@ -1299,6 +1309,7 @@ pub struct NotifyTemplatesResponse {
     pub pr_comment: String,
     pub rebase_conflict: String,
     pub pr_closed: String,
+    pub guardrail_exceeded: String,
 }
 
 /// Request body for updating orchestrator settings
@@ -1312,6 +1323,19 @@ pub struct UpdateOrchestratorSettingsRequest {
     pub rules: Option<UpdateOrchestratorRulesRequest>,
     #[serde(default)]
     pub notify: Option<UpdateNotifySettingsRequest>,
+    #[serde(default)]
+    pub guardrails: Option<UpdateGuardrailsRequest>,
+}
+
+/// Guardrails settings update request (all fields optional for partial updates)
+#[derive(Debug, Deserialize)]
+pub struct UpdateGuardrailsRequest {
+    #[serde(default)]
+    pub max_ci_retries: Option<u64>,
+    #[serde(default)]
+    pub max_review_loops: Option<u64>,
+    #[serde(default)]
+    pub escalate_to_human_after: Option<u64>,
 }
 
 /// Rules sub-object in orchestrator settings update request
@@ -1347,6 +1371,8 @@ pub struct UpdateNotifySettingsRequest {
     #[serde(default)]
     pub on_pr_closed: Option<bool>,
     #[serde(default)]
+    pub on_guardrail_exceeded: Option<bool>,
+    #[serde(default)]
     pub templates: Option<UpdateNotifyTemplatesRequest>,
 }
 
@@ -1369,6 +1395,8 @@ pub struct UpdateNotifyTemplatesRequest {
     pub rebase_conflict: Option<String>,
     #[serde(default)]
     pub pr_closed: Option<String>,
+    #[serde(default)]
+    pub guardrail_exceeded: Option<String>,
 }
 
 /// GET /api/settings/orchestrator — get orchestrator settings
@@ -1402,6 +1430,7 @@ pub async fn get_orchestrator_settings(
             on_pr_created: orch.notify.on_pr_created,
             on_pr_comment: orch.notify.on_pr_comment,
             on_pr_closed: orch.notify.on_pr_closed,
+            on_guardrail_exceeded: orch.notify.on_guardrail_exceeded,
             templates: NotifyTemplatesResponse {
                 agent_stopped: orch.notify.templates.agent_stopped.clone(),
                 agent_error: orch.notify.templates.agent_error.clone(),
@@ -1411,7 +1440,13 @@ pub async fn get_orchestrator_settings(
                 pr_comment: orch.notify.templates.pr_comment.clone(),
                 rebase_conflict: orch.notify.templates.rebase_conflict.clone(),
                 pr_closed: orch.notify.templates.pr_closed.clone(),
+                guardrail_exceeded: orch.notify.templates.guardrail_exceeded.clone(),
             },
+        },
+        guardrails: GuardrailsSettingsResponse {
+            max_ci_retries: orch.guardrails.max_ci_retries,
+            max_review_loops: orch.guardrails.max_review_loops,
+            escalate_to_human_after: orch.guardrails.escalate_to_human_after,
         },
         is_project_override: is_override,
     })
@@ -1490,6 +1525,10 @@ pub async fn update_orchestrator_settings(
                     .as_ref()
                     .and_then(|r| r.on_pr_closed)
                     .unwrap_or(n.on_pr_closed),
+                on_guardrail_exceeded: nr
+                    .as_ref()
+                    .and_then(|r| r.on_guardrail_exceeded)
+                    .unwrap_or(n.on_guardrail_exceeded),
                 templates: tmai_core::config::NotifyTemplates {
                     agent_stopped: t
                         .and_then(|t| t.agent_stopped.clone())
@@ -1515,7 +1554,28 @@ pub async fn update_orchestrator_settings(
                     pr_closed: t
                         .and_then(|t| t.pr_closed.clone())
                         .unwrap_or_else(|| n.templates.pr_closed.clone()),
+                    guardrail_exceeded: t
+                        .and_then(|t| t.guardrail_exceeded.clone())
+                        .unwrap_or_else(|| n.templates.guardrail_exceeded.clone()),
                 },
+            }
+        },
+        guardrails: {
+            let g = &current.guardrails;
+            let gr = &req.guardrails;
+            tmai_core::config::GuardrailsSettings {
+                max_ci_retries: gr
+                    .as_ref()
+                    .and_then(|r| r.max_ci_retries)
+                    .unwrap_or(g.max_ci_retries),
+                max_review_loops: gr
+                    .as_ref()
+                    .and_then(|r| r.max_review_loops)
+                    .unwrap_or(g.max_review_loops),
+                escalate_to_human_after: gr
+                    .as_ref()
+                    .and_then(|r| r.escalate_to_human_after)
+                    .unwrap_or(g.escalate_to_human_after),
             }
         },
         pr_monitor_enabled: current.pr_monitor_enabled,
@@ -1526,18 +1586,21 @@ pub async fn update_orchestrator_settings(
     tmai_core::config::Settings::save_project_orchestrator(q.project.as_deref(), &updated);
     core.reload_settings();
 
-    // Hot-reload the live notifier service if running
+    // Hot-reload the live notifier and guardrails services if running
     #[allow(deprecated)]
     let state = core.raw_state();
     let s = state.read();
     if let Some(ref ns) = s.notify_settings {
         *ns.write() = updated.notify;
     }
+    if let Some(ref gs) = s.guardrails_settings {
+        *gs.write() = updated.guardrails;
+    }
     drop(s);
 
     tracing::info!(
         project = ?q.project,
-        "Orchestrator settings updated (including notify)"
+        "Orchestrator settings updated (including notify and guardrails)"
     );
     Json(serde_json::json!({"ok": true}))
 }

--- a/src/web/events.rs
+++ b/src/web/events.rs
@@ -330,6 +330,21 @@ pub async fn events(State(core): State<Arc<TmaiCore>>) -> impl IntoResponse {
                                 return;
                             }
                         }
+                        Ok(CoreEvent::GuardrailExceeded { ref guardrail, ref branch, pr_number, count, limit }) => {
+                            let data = serde_json::json!({
+                                "guardrail": guardrail,
+                                "branch": branch,
+                                "pr_number": pr_number,
+                                "count": count,
+                                "limit": limit,
+                            });
+                            let event = Event::default()
+                                .event("guardrail_exceeded")
+                                .data(data.to_string());
+                            if tx.send(Ok(event)).await.is_err() {
+                                return;
+                            }
+                        }
                         Ok(CoreEvent::ActionPerformed { ref origin, ref action, ref summary }) => {
                             let data = serde_json::json!({
                                 "origin": origin,


### PR DESCRIPTION
## Summary

- Add `GuardrailsSettings` struct (`max_ci_retries: 3`, `max_review_loops: 5`, `escalate_to_human_after: 3`) under `[orchestrator.guardrails]` in config
- Track CI failure count, review loop count, and consecutive failures in `TaskMetaService` by parsing milestones
- Emit `GuardrailExceeded` CoreEvent (with `GuardrailKind` enum) when any limit is hit
- Add `on_guardrail_exceeded` toggle to `OrchestratorNotifySettings` (default: ON) with template override support
- WebUI: guardrails section in SettingsPanel with editable number inputs, hot-reloadable via API
- SSE: `guardrail_exceeded` event forwarded to browser clients

## Test plan

- [x] `GuardrailsSettings` defaults (3, 5, 3) and serde partial deserialization
- [x] Milestone counting: `count_ci_failures`, `count_review_loops`, `count_consecutive_failures`
- [x] `GuardrailExceeded` event emitted when CI retries hit limit
- [x] `GuardrailExceeded` event emitted when review loops hit limit
- [x] No event emitted below guardrail limits
- [x] Notification routing: `on_guardrail_exceeded` toggle ON/OFF
- [x] Notification message includes guardrail kind, branch, PR number, count/limit
- [x] All 134 existing tests pass, no clippy warnings

Closes #343

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * オーケストレーター設定に新しい「Guardrails」セクションを追加しました。CI再試行の最大回数、レビューループの最大回数、人間へのエスカレーション基準を設定できるようになります。
  * Guardrails制限を超えた場合に新しい通知イベント「guardrail_exceeded」が発生するようになりました。
  * WebUI設定から、Guardrails値をリアルタイムで更新できます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->