### PR TITLE
chore: gitignore .task-meta/ directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ knowledge/
 .cursor/
 .aider*
 
+# tmai dispatch state (per-local-environment)
+.task-meta/
+
 # IDE / Editor
 .idea/
 .vscode/


### PR DESCRIPTION
## Summary

Add `.task-meta/` to `.gitignore`.

This directory stores tmai's per-agent dispatch state (issue/PR associations, agent IDs) written by `dispatch_issue` and `dispatch_review`. The state is environment-specific and should not be tracked in the repository.

## Test plan

- [x] `.gitignore` updated
- [x] Local `.task-meta/` no longer shows as untracked in `git status`
- [x] Pre-commit hooks pass (fmt + clippy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ローカル環境のディレクトリを Git の追跡対象から除外するよう `.gitignore` を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->