### PR TITLE
feat: AutoActionExecutor service for CiFailed + PrReviewFeedback (#364 part 2/3)

### DIFF
--- a/crates/tmai-core/src/auto_action/mod.rs
+++ b/crates/tmai-core/src/auto_action/mod.rs
@@ -1,0 +1,19 @@
+//! AutoActionExecutor: event-driven worker guidance.
+//!
+//! Listens to `CoreEvent`s and, when `OrchestratorNotifySettings` configures
+//! an event as `EventHandling::AutoAction`, directly instructs the target
+//! worker (bypassing the orchestrator) by emitting a `PromptReady` event.
+//!
+//! Mutual exclusion with `OrchestratorNotifier` is enforced via
+//! `EventHandling` — the notifier skips `AutoAction` events, and this
+//! executor skips events not configured as `AutoAction`.
+
+pub mod resolver;
+pub mod service;
+pub mod templates;
+pub mod tracker;
+
+pub use resolver::{is_agent_online, resolve_target_agent, AgentRole};
+pub use service::{AutoActionExecutor, GithubApi, RealGithubApi};
+pub use templates::{render, AutoActionTemplates};
+pub use tracker::AutoActionTracker;

--- a/crates/tmai-core/src/auto_action/resolver.rs
+++ b/crates/tmai-core/src/auto_action/resolver.rs
@@ -1,0 +1,178 @@
+//! Target-agent resolution for AutoActionExecutor.
+//!
+//! Uses `.task-meta/{branch}.json` to map a branch to the `agent_id`
+//! (implementer) or `review_agent_id` (reviewer), then looks up the
+//! currently-running agent by several possible identifiers (target,
+//! stable_id, pty_session_id, id).
+
+use std::path::Path;
+
+use crate::agents::{MonitoredAgent, Phase};
+use crate::task_meta::store;
+
+/// Role of the agent an AutoAction targets.
+///
+/// `Reviewer` is reserved for future Phase-C handlers (e.g., `PrUpdated`)
+/// and currently unused by any event handler in this PR.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AgentRole {
+    Implementer,
+    Reviewer,
+}
+
+/// Resolve the currently-running agent for `branch` in the given `role`.
+///
+/// Returns the agent's tmux target string (e.g., `"main:0.2"`) or `None` if:
+/// - No task-meta file exists for the branch
+/// - The requested role id is unset in the meta
+/// - No running agent matches the stored id
+pub fn resolve_target_agent(
+    project_root: &Path,
+    branch: &str,
+    role: AgentRole,
+    agents: &[MonitoredAgent],
+) -> Option<String> {
+    let meta = store::read_meta(project_root, branch)?;
+    let id = match role {
+        AgentRole::Implementer => meta.agent_id?,
+        AgentRole::Reviewer => meta.review_agent_id?,
+    };
+    find_agent_by_id(agents, &id).map(|a| a.target.clone())
+}
+
+/// Locate an agent whose id, target, stable_id, or pty_session_id matches `id`.
+pub fn find_agent_by_id<'a>(agents: &'a [MonitoredAgent], id: &str) -> Option<&'a MonitoredAgent> {
+    agents.iter().find(|a| {
+        a.id == id || a.target == id || a.stable_id == id || a.pty_session_id.as_deref() == Some(id)
+    })
+}
+
+/// Whether `agent` is currently reachable (not offline/unknown).
+pub fn is_agent_online(agent: &MonitoredAgent) -> bool {
+    !matches!(agent.status.phase(), Phase::Offline)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::{AgentStatus, AgentType, MonitoredAgent};
+    use crate::task_meta::store::TaskMeta;
+
+    fn make_agent(target: &str) -> MonitoredAgent {
+        MonitoredAgent::new(
+            target.to_string(),
+            AgentType::ClaudeCode,
+            String::new(),
+            "/tmp".to_string(),
+            0,
+            target.to_string(),
+            String::new(),
+            0,
+            0,
+        )
+    }
+
+    #[test]
+    fn test_resolve_implementer_by_target() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch = "feat/a";
+        let agent = make_agent("main:0.2");
+        let meta = TaskMeta::for_issue(10, Some("main:0.2".into()));
+        store::write_meta(dir.path(), branch, &meta).unwrap();
+
+        let resolved = resolve_target_agent(
+            dir.path(),
+            branch,
+            AgentRole::Implementer,
+            std::slice::from_ref(&agent),
+        );
+        assert_eq!(resolved.as_deref(), Some("main:0.2"));
+    }
+
+    #[test]
+    fn test_resolve_implementer_by_stable_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch = "feat/a";
+        let agent = make_agent("main:0.2");
+        let stable = agent.stable_id.clone();
+        let meta = TaskMeta::for_issue(10, Some(stable));
+        store::write_meta(dir.path(), branch, &meta).unwrap();
+
+        let resolved = resolve_target_agent(
+            dir.path(),
+            branch,
+            AgentRole::Implementer,
+            std::slice::from_ref(&agent),
+        );
+        assert_eq!(resolved.as_deref(), Some("main:0.2"));
+    }
+
+    #[test]
+    fn test_resolve_missing_meta() {
+        let dir = tempfile::tempdir().unwrap();
+        let resolved = resolve_target_agent(dir.path(), "nonexistent", AgentRole::Implementer, &[]);
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn test_resolve_missing_agent_id() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch = "feat/a";
+        // meta exists but agent_id is None
+        let meta = TaskMeta::for_issue(10, None);
+        store::write_meta(dir.path(), branch, &meta).unwrap();
+        let resolved = resolve_target_agent(dir.path(), branch, AgentRole::Implementer, &[]);
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn test_resolve_reviewer_role() {
+        let dir = tempfile::tempdir().unwrap();
+        let branch = "feat/a";
+        let agent = make_agent("review:0.0");
+        let mut meta = TaskMeta::for_issue(10, Some("impl:0.0".into()));
+        meta.review_agent_id = Some("review:0.0".into());
+        store::write_meta(dir.path(), branch, &meta).unwrap();
+
+        let resolved = resolve_target_agent(
+            dir.path(),
+            branch,
+            AgentRole::Reviewer,
+            std::slice::from_ref(&agent),
+        );
+        assert_eq!(resolved.as_deref(), Some("review:0.0"));
+    }
+
+    #[test]
+    fn test_is_agent_online() {
+        let mut agent = make_agent("x");
+        agent.status = AgentStatus::Idle;
+        assert!(is_agent_online(&agent));
+
+        agent.status = AgentStatus::Offline;
+        assert!(!is_agent_online(&agent));
+
+        agent.status = AgentStatus::Unknown;
+        assert!(!is_agent_online(&agent));
+    }
+
+    #[test]
+    fn test_resolve_agent_offline_still_returns_target() {
+        // Resolver does not filter by status — online check is a separate step
+        let dir = tempfile::tempdir().unwrap();
+        let branch = "feat/a";
+        let mut agent = make_agent("main:0.2");
+        agent.status = AgentStatus::Offline;
+        let meta = TaskMeta::for_issue(10, Some("main:0.2".into()));
+        store::write_meta(dir.path(), branch, &meta).unwrap();
+
+        let resolved = resolve_target_agent(
+            dir.path(),
+            branch,
+            AgentRole::Implementer,
+            std::slice::from_ref(&agent),
+        );
+        assert_eq!(resolved.as_deref(), Some("main:0.2"));
+        assert!(!is_agent_online(&agent));
+    }
+}

--- a/crates/tmai-core/src/auto_action/service.rs
+++ b/crates/tmai-core/src/auto_action/service.rs
@@ -1,0 +1,846 @@
+//! AutoActionExecutor service — consumes `CoreEvent`s and either directly
+//! instructs a target worker via a `PromptReady` event, or emits
+//! `GuardrailExceeded` when retry limits are reached.
+
+use std::future::Future;
+use std::path::{Path, PathBuf};
+use std::pin::Pin;
+use std::sync::Arc;
+
+use tokio::sync::broadcast;
+use tracing::{debug, info, warn};
+
+/// Pinned, boxed future returning `Option<String>` — used as the return type
+/// of `GithubApi` methods so the trait stays dyn-compatible without dragging
+/// in `async-trait` as a dependency.
+pub type GhFuture<'a> = Pin<Box<dyn Future<Output = Option<String>> + Send + 'a>>;
+
+use crate::agents::MonitoredAgent;
+use crate::api::{CoreEvent, GuardrailKind};
+use crate::config::{EventHandling, OrchestratorNotifySettings};
+use crate::orchestrator_notify::SharedNotifySettings;
+use crate::state::SharedState;
+use crate::task_meta::{store as meta_store, SharedGuardrailsSettings};
+
+use super::resolver::{find_agent_by_id, is_agent_online, resolve_target_agent, AgentRole};
+use super::templates::{render, AutoActionTemplates};
+use super::tracker::AutoActionTracker;
+
+/// Abstraction over the subset of GitHub APIs AutoActionExecutor uses,
+/// injected so integration tests can stub out real `gh` invocations.
+pub trait GithubApi: Send + Sync + 'static {
+    /// Fetch the failure log text for the most recent failed CI run on `branch`.
+    /// Returns `None` if no failed run is found or the log can't be fetched.
+    fn fetch_ci_failure_log<'a>(&'a self, repo_dir: &'a str, branch: &'a str) -> GhFuture<'a>;
+
+    /// Fetch review / conversation comments on `pr_number`, joined as human-readable text.
+    fn fetch_pr_comments<'a>(&'a self, repo_dir: &'a str, pr_number: u64) -> GhFuture<'a>;
+}
+
+/// Default `GithubApi` implementation that shells out to `gh` via `crate::github`.
+pub struct RealGithubApi;
+
+impl GithubApi for RealGithubApi {
+    fn fetch_ci_failure_log<'a>(&'a self, repo_dir: &'a str, branch: &'a str) -> GhFuture<'a> {
+        Box::pin(async move {
+            let summary = crate::github::list_checks(repo_dir, branch).await?;
+            let run_id = summary.checks.iter().find_map(|c| {
+                let failed = matches!(
+                    c.conclusion,
+                    Some(crate::github::CiConclusion::Failure)
+                        | Some(crate::github::CiConclusion::TimedOut)
+                        | Some(crate::github::CiConclusion::Cancelled)
+                );
+                if failed {
+                    c.run_id
+                } else {
+                    None
+                }
+            })?;
+            let log = crate::github::get_ci_failure_log(repo_dir, run_id).await?;
+            Some(log.log_text)
+        })
+    }
+
+    fn fetch_pr_comments<'a>(&'a self, repo_dir: &'a str, pr_number: u64) -> GhFuture<'a> {
+        Box::pin(async move {
+            let comments = crate::github::get_pr_comments(repo_dir, pr_number).await?;
+            if comments.is_empty() {
+                return None;
+            }
+            let joined = comments
+                .iter()
+                .map(|c| {
+                    let path = c
+                        .path
+                        .as_deref()
+                        .map(|p| format!(" [{p}]"))
+                        .unwrap_or_default();
+                    format!("- @{}{}: {}", c.author, path, c.body.trim())
+                })
+                .collect::<Vec<_>>()
+                .join("\n");
+            Some(joined)
+        })
+    }
+}
+
+/// Event-driven service that, when configured, instructs workers directly
+/// in response to `CoreEvent`s — replacing the orchestrator's manual
+/// routing for routine CI / review cycles.
+pub struct AutoActionExecutor;
+
+impl AutoActionExecutor {
+    /// Spawn the executor as a background task.
+    ///
+    /// Mirrors the lifecycle of `OrchestratorNotifier`: reads settings fresh
+    /// on each event, handles `Lagged` gracefully, exits on channel close.
+    pub fn spawn(
+        state: SharedState,
+        mut event_rx: broadcast::Receiver<CoreEvent>,
+        event_tx: broadcast::Sender<CoreEvent>,
+        notify_settings: SharedNotifySettings,
+        guardrails: SharedGuardrailsSettings,
+        templates: Arc<parking_lot::RwLock<AutoActionTemplates>>,
+        github: Arc<dyn GithubApi>,
+    ) -> tokio::task::JoinHandle<()> {
+        let tracker = Arc::new(AutoActionTracker::new());
+
+        tokio::spawn(async move {
+            loop {
+                match event_rx.recv().await {
+                    Ok(event) => {
+                        let ns = notify_settings.read().clone();
+                        Self::handle_event(
+                            &state,
+                            &event_tx,
+                            &ns,
+                            &guardrails,
+                            &templates,
+                            &tracker,
+                            github.as_ref(),
+                            &event,
+                        )
+                        .await;
+                    }
+                    Err(broadcast::error::RecvError::Lagged(n)) => {
+                        debug!(skipped = n, "AutoActionExecutor lagged, skipping events");
+                    }
+                    Err(broadcast::error::RecvError::Closed) => {
+                        debug!("Event channel closed, stopping AutoActionExecutor");
+                        break;
+                    }
+                }
+            }
+        })
+    }
+
+    /// Handle one event.  Exposed `pub(crate)` so integration tests can drive
+    /// the dispatcher without spinning up the background task.
+    #[allow(clippy::too_many_arguments)]
+    pub(crate) async fn handle_event(
+        state: &SharedState,
+        event_tx: &broadcast::Sender<CoreEvent>,
+        notify: &OrchestratorNotifySettings,
+        guardrails: &SharedGuardrailsSettings,
+        templates: &Arc<parking_lot::RwLock<AutoActionTemplates>>,
+        tracker: &Arc<AutoActionTracker>,
+        github: &dyn GithubApi,
+        event: &CoreEvent,
+    ) {
+        match event {
+            CoreEvent::PrCiFailed {
+                pr_number,
+                title,
+                failed_details,
+            } => {
+                if notify.on_ci_failed != EventHandling::AutoAction {
+                    return;
+                }
+                Self::handle_ci_failed(
+                    state,
+                    event_tx,
+                    guardrails,
+                    templates,
+                    tracker,
+                    github,
+                    *pr_number,
+                    title,
+                    failed_details,
+                )
+                .await;
+            }
+
+            CoreEvent::PrReviewFeedback {
+                pr_number,
+                title,
+                comments_summary,
+            } => {
+                if notify.on_pr_comment != EventHandling::AutoAction {
+                    return;
+                }
+                Self::handle_review_feedback(
+                    state,
+                    event_tx,
+                    guardrails,
+                    templates,
+                    tracker,
+                    github,
+                    *pr_number,
+                    title,
+                    comments_summary,
+                )
+                .await;
+            }
+
+            CoreEvent::PrClosed {
+                pr_number, branch, ..
+            } => {
+                tracker.reset_ci(branch);
+                tracker.reset_review(*pr_number);
+            }
+
+            _ => {}
+        }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_ci_failed(
+        state: &SharedState,
+        event_tx: &broadcast::Sender<CoreEvent>,
+        guardrails: &SharedGuardrailsSettings,
+        templates: &Arc<parking_lot::RwLock<AutoActionTemplates>>,
+        tracker: &Arc<AutoActionTracker>,
+        github: &dyn GithubApi,
+        pr_number: u64,
+        title: &str,
+        failed_details: &str,
+    ) {
+        // Resolve branch + project root from state / task-meta
+        let Some((project_root, branch)) = resolve_branch_for_pr(state, pr_number) else {
+            warn!(
+                pr = pr_number,
+                "AutoAction: no branch/project resolved for PrCiFailed; skipping"
+            );
+            return;
+        };
+
+        // Resolve target implementer
+        let agents = snapshot_agents(state);
+        let Some(target) =
+            resolve_target_agent(&project_root, &branch, AgentRole::Implementer, &agents)
+        else {
+            warn!(
+                pr = pr_number,
+                branch = %branch,
+                "AutoAction: no implementer agent resolved — falling back to orchestrator notify"
+            );
+            fallback_notify(
+                event_tx,
+                format!(
+                    "[tmai AutoAction fallback] CI failed on PR #{pr_number} ({title}, branch {branch}) \
+                     but no implementer agent was found. Please re-dispatch or intervene."
+                ),
+                format!("pr-{pr_number}"),
+            );
+            return;
+        };
+
+        // Offline-fallback
+        if let Some(agent) = find_agent_by_id(&agents, &target) {
+            if !is_agent_online(agent) {
+                warn!(
+                    pr = pr_number,
+                    target = %target,
+                    "AutoAction: target implementer offline — falling back to orchestrator notify"
+                );
+                fallback_notify(
+                    event_tx,
+                    format!(
+                        "[tmai AutoAction fallback] CI failed on PR #{pr_number} ({title}, branch {branch}). \
+                         Implementer agent \"{target}\" is offline."
+                    ),
+                    format!("pr-{pr_number}"),
+                );
+                return;
+            }
+        }
+
+        // Guardrail check
+        let count = tracker.increment_ci(&branch);
+        let limit = guardrails.read().max_ci_retries;
+        if count > limit {
+            info!(
+                branch = %branch,
+                count,
+                limit,
+                "AutoAction: CI retries limit exceeded — halting and escalating"
+            );
+            let _ = event_tx.send(CoreEvent::GuardrailExceeded {
+                guardrail: GuardrailKind::CiRetries,
+                branch: branch.clone(),
+                pr_number: Some(pr_number),
+                count,
+                limit,
+            });
+            return;
+        }
+
+        // Enrich failure details with the failure log when available
+        let detailed = match github
+            .fetch_ci_failure_log(project_root_str(&project_root), &branch)
+            .await
+        {
+            Some(log) => {
+                if log.trim().is_empty() {
+                    failed_details.to_string()
+                } else {
+                    format!("{failed_details}\n\n--- CI log ---\n{log}")
+                }
+            }
+            None => failed_details.to_string(),
+        };
+
+        let tpl = templates.read().effective_ci_failed();
+        let pr_str = pr_number.to_string();
+        let prompt = render(
+            &tpl,
+            &[
+                ("pr_number", pr_str.as_str()),
+                ("title", title),
+                ("branch", branch.as_str()),
+                ("failed_details", detailed.as_str()),
+            ],
+        );
+
+        info!(
+            pr = pr_number,
+            target = %target,
+            "AutoAction: dispatching CiFailed guidance to implementer"
+        );
+        let _ = event_tx.send(CoreEvent::PromptReady { target, prompt });
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    async fn handle_review_feedback(
+        state: &SharedState,
+        event_tx: &broadcast::Sender<CoreEvent>,
+        guardrails: &SharedGuardrailsSettings,
+        templates: &Arc<parking_lot::RwLock<AutoActionTemplates>>,
+        tracker: &Arc<AutoActionTracker>,
+        github: &dyn GithubApi,
+        pr_number: u64,
+        title: &str,
+        comments_summary: &str,
+    ) {
+        let Some((project_root, branch)) = resolve_branch_for_pr(state, pr_number) else {
+            warn!(
+                pr = pr_number,
+                "AutoAction: no branch/project resolved for PrReviewFeedback; skipping"
+            );
+            return;
+        };
+
+        let agents = snapshot_agents(state);
+        let Some(target) =
+            resolve_target_agent(&project_root, &branch, AgentRole::Implementer, &agents)
+        else {
+            warn!(
+                pr = pr_number,
+                branch = %branch,
+                "AutoAction: no implementer agent resolved for review feedback — fallback"
+            );
+            fallback_notify(
+                event_tx,
+                format!(
+                    "[tmai AutoAction fallback] Review feedback on PR #{pr_number} ({title}) \
+                     but no implementer agent was found. Please re-dispatch or intervene."
+                ),
+                format!("pr-{pr_number}"),
+            );
+            return;
+        };
+
+        if let Some(agent) = find_agent_by_id(&agents, &target) {
+            if !is_agent_online(agent) {
+                warn!(
+                    pr = pr_number,
+                    target = %target,
+                    "AutoAction: target implementer offline for review feedback — fallback"
+                );
+                fallback_notify(
+                    event_tx,
+                    format!(
+                        "[tmai AutoAction fallback] Review feedback on PR #{pr_number} ({title}). \
+                         Implementer agent \"{target}\" is offline."
+                    ),
+                    format!("pr-{pr_number}"),
+                );
+                return;
+            }
+        }
+
+        let count = tracker.increment_review(pr_number);
+        let limit = guardrails.read().max_review_loops;
+        if count > limit {
+            info!(
+                pr = pr_number,
+                count, limit, "AutoAction: review-loop limit exceeded — halting and escalating"
+            );
+            let _ = event_tx.send(CoreEvent::GuardrailExceeded {
+                guardrail: GuardrailKind::ReviewLoops,
+                branch: branch.clone(),
+                pr_number: Some(pr_number),
+                count,
+                limit,
+            });
+            return;
+        }
+
+        // Fetch the full comment text (falls back to summary)
+        let full = github
+            .fetch_pr_comments(project_root_str(&project_root), pr_number)
+            .await
+            .unwrap_or_else(|| comments_summary.to_string());
+
+        let tpl = templates.read().effective_review_feedback();
+        let pr_str = pr_number.to_string();
+        let prompt = render(
+            &tpl,
+            &[
+                ("pr_number", pr_str.as_str()),
+                ("title", title),
+                ("branch", branch.as_str()),
+                ("comments_summary", full.as_str()),
+            ],
+        );
+
+        info!(
+            pr = pr_number,
+            target = %target,
+            "AutoAction: dispatching review-feedback guidance to implementer"
+        );
+        let _ = event_tx.send(CoreEvent::PromptReady { target, prompt });
+    }
+}
+
+/// Snapshot currently-tracked agents (clone out of the lock).
+fn snapshot_agents(state: &SharedState) -> Vec<MonitoredAgent> {
+    state.read().agents.values().cloned().collect()
+}
+
+/// Resolve `(project_root, branch)` for a PR by consulting in-memory agents
+/// first (fast path), then persisted `.task-meta/` files (fallback).
+fn resolve_branch_for_pr(state: &SharedState, pr_number: u64) -> Option<(PathBuf, String)> {
+    let (branch_from_agent, project_roots) = {
+        let s = state.read();
+        let branch = s
+            .agents
+            .values()
+            .find(|a| a.pr_number == Some(pr_number))
+            .and_then(|a| a.git_branch.clone());
+        let roots: Vec<PathBuf> = s.registered_projects.iter().map(PathBuf::from).collect();
+        (branch, roots)
+    };
+
+    if project_roots.is_empty() {
+        return None;
+    }
+
+    if let Some(branch) = branch_from_agent {
+        // Prefer the project root whose .task-meta/ has this branch; else first
+        for root in &project_roots {
+            if meta_store::read_meta(root, &branch).is_some() {
+                return Some((root.clone(), branch));
+            }
+        }
+        return Some((project_roots[0].clone(), branch));
+    }
+
+    // Fallback: scan task-meta files for a matching pr number
+    for root in &project_roots {
+        for (branch, meta) in meta_store::scan_all(root) {
+            if meta.pr == Some(pr_number) {
+                return Some((root.clone(), branch));
+            }
+        }
+    }
+
+    None
+}
+
+fn project_root_str(p: &Path) -> &str {
+    p.to_str().unwrap_or("")
+}
+
+/// Emit a synthetic notification so the orchestrator learns about a fallback.
+///
+/// We intentionally do NOT re-route the original event here — that would
+/// double-count against guardrails.  Instead we emit a plain `PromptReady`
+/// with a short explanation, addressed at a pseudo-target that any attached
+/// notifier / WebUI tail can surface.
+fn fallback_notify(
+    event_tx: &broadcast::Sender<CoreEvent>,
+    message: String,
+    pseudo_target: String,
+) {
+    let _ = event_tx.send(CoreEvent::PromptReady {
+        target: pseudo_target,
+        prompt: message,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::{AgentStatus, AgentType, MonitoredAgent};
+    use crate::config::GuardrailsSettings;
+    use crate::state::AppState;
+    use crate::task_meta::store::TaskMeta;
+    use std::sync::Mutex;
+
+    // ── Test doubles ────────────────────────────────────────────────
+
+    #[derive(Default)]
+    struct StubGithub {
+        ci_log: Mutex<Option<String>>,
+        pr_comments: Mutex<Option<String>>,
+    }
+
+    impl GithubApi for StubGithub {
+        fn fetch_ci_failure_log<'a>(
+            &'a self,
+            _repo_dir: &'a str,
+            _branch: &'a str,
+        ) -> GhFuture<'a> {
+            let v = self.ci_log.lock().unwrap().clone();
+            Box::pin(async move { v })
+        }
+        fn fetch_pr_comments<'a>(&'a self, _repo_dir: &'a str, _pr_number: u64) -> GhFuture<'a> {
+            let v = self.pr_comments.lock().unwrap().clone();
+            Box::pin(async move { v })
+        }
+    }
+
+    fn insert_agent(
+        state: &SharedState,
+        target: &str,
+        branch: &str,
+        pr: Option<u64>,
+        status: AgentStatus,
+    ) -> String {
+        let mut s = state.write();
+        let mut agent = MonitoredAgent::new(
+            target.to_string(),
+            AgentType::ClaudeCode,
+            String::new(),
+            "/tmp".to_string(),
+            0,
+            target.to_string(),
+            String::new(),
+            0,
+            0,
+        );
+        agent.status = status;
+        agent.git_branch = Some(branch.to_string());
+        agent.pr_number = pr;
+        let stable_id = agent.stable_id.clone();
+        s.agents.insert(target.to_string(), agent);
+        stable_id
+    }
+
+    fn make_harness(
+        state: &SharedState,
+        root: &Path,
+    ) -> (
+        broadcast::Sender<CoreEvent>,
+        broadcast::Receiver<CoreEvent>,
+        SharedGuardrailsSettings,
+        Arc<parking_lot::RwLock<AutoActionTemplates>>,
+        Arc<AutoActionTracker>,
+    ) {
+        {
+            let mut s = state.write();
+            s.registered_projects = vec![root.to_string_lossy().to_string()];
+        }
+        let (tx, rx) = broadcast::channel(32);
+        let g = Arc::new(parking_lot::RwLock::new(GuardrailsSettings::default()));
+        let t = Arc::new(parking_lot::RwLock::new(AutoActionTemplates::defaults()));
+        let tr = Arc::new(AutoActionTracker::new());
+        (tx, rx, g, t, tr)
+    }
+
+    fn settings_with(
+        on_ci_failed: EventHandling,
+        on_pr_comment: EventHandling,
+    ) -> OrchestratorNotifySettings {
+        let mut s = OrchestratorNotifySettings::default();
+        s.on_ci_failed = on_ci_failed;
+        s.on_pr_comment = on_pr_comment;
+        s
+    }
+
+    async fn drain(rx: &mut broadcast::Receiver<CoreEvent>) -> Vec<CoreEvent> {
+        let mut out = Vec::new();
+        while let Ok(ev) = rx.try_recv() {
+            out.push(ev);
+        }
+        out
+    }
+
+    // ── CiFailed ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_ci_failed_autoaction_emits_prompt() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::shared();
+        insert_agent(&state, "main:0.1", "feat/x", Some(10), AgentStatus::Idle);
+        let meta = TaskMeta::for_issue(10, Some("main:0.1".into()));
+        meta_store::write_meta(dir.path(), "feat/x", &meta).unwrap();
+
+        let (tx, mut rx, g, tpl, tr) = make_harness(&state, dir.path());
+        let gh = Arc::new(StubGithub::default());
+        *gh.ci_log.lock().unwrap() = Some("=== pytest failed ===".to_string());
+        let ns = settings_with(EventHandling::AutoAction, EventHandling::NotifyOrchestrator);
+
+        let event = CoreEvent::PrCiFailed {
+            pr_number: 10,
+            title: "Add feature".into(),
+            failed_details: "1/3 checks failed".into(),
+        };
+        AutoActionExecutor::handle_event(&state, &tx, &ns, &g, &tpl, &tr, gh.as_ref(), &event)
+            .await;
+
+        let events = drain(&mut rx).await;
+        let prompt = events
+            .iter()
+            .find_map(|e| match e {
+                CoreEvent::PromptReady { target, prompt } => Some((target.clone(), prompt.clone())),
+                _ => None,
+            })
+            .expect("PromptReady emitted");
+        assert_eq!(prompt.0, "main:0.1");
+        assert!(prompt.1.contains("PR #10"));
+        assert!(prompt.1.contains("feat/x"));
+        assert!(prompt.1.contains("pytest failed"));
+    }
+
+    #[tokio::test]
+    async fn test_ci_failed_notify_mode_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::shared();
+        insert_agent(&state, "main:0.1", "feat/x", Some(10), AgentStatus::Idle);
+        let meta = TaskMeta::for_issue(10, Some("main:0.1".into()));
+        meta_store::write_meta(dir.path(), "feat/x", &meta).unwrap();
+
+        let (tx, mut rx, g, tpl, tr) = make_harness(&state, dir.path());
+        let gh = Arc::new(StubGithub::default());
+        let ns = settings_with(EventHandling::NotifyOrchestrator, EventHandling::AutoAction);
+
+        let event = CoreEvent::PrCiFailed {
+            pr_number: 10,
+            title: "x".into(),
+            failed_details: "d".into(),
+        };
+        AutoActionExecutor::handle_event(&state, &tx, &ns, &g, &tpl, &tr, gh.as_ref(), &event)
+            .await;
+
+        let events = drain(&mut rx).await;
+        assert!(
+            events
+                .iter()
+                .all(|e| !matches!(e, CoreEvent::PromptReady { .. })),
+            "no PromptReady when event is NotifyOrchestrator mode"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ci_failed_offline_agent_fallback() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::shared();
+        insert_agent(&state, "main:0.1", "feat/x", Some(10), AgentStatus::Offline);
+        let meta = TaskMeta::for_issue(10, Some("main:0.1".into()));
+        meta_store::write_meta(dir.path(), "feat/x", &meta).unwrap();
+
+        let (tx, mut rx, g, tpl, tr) = make_harness(&state, dir.path());
+        let gh = Arc::new(StubGithub::default());
+        let ns = settings_with(EventHandling::AutoAction, EventHandling::AutoAction);
+
+        let event = CoreEvent::PrCiFailed {
+            pr_number: 10,
+            title: "x".into(),
+            failed_details: "d".into(),
+        };
+        AutoActionExecutor::handle_event(&state, &tx, &ns, &g, &tpl, &tr, gh.as_ref(), &event)
+            .await;
+
+        let events = drain(&mut rx).await;
+        let fallback = events.iter().find_map(|e| match e {
+            CoreEvent::PromptReady { prompt, .. } => Some(prompt.clone()),
+            _ => None,
+        });
+        assert!(
+            fallback.unwrap_or_default().contains("offline"),
+            "offline fallback notification emitted"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_ci_failed_guardrail_exceeded() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::shared();
+        insert_agent(&state, "main:0.1", "feat/x", Some(10), AgentStatus::Idle);
+        let meta = TaskMeta::for_issue(10, Some("main:0.1".into()));
+        meta_store::write_meta(dir.path(), "feat/x", &meta).unwrap();
+
+        let (tx, mut rx, g, tpl, tr) = make_harness(&state, dir.path());
+        g.write().max_ci_retries = 2;
+        let gh = Arc::new(StubGithub::default());
+        let ns = settings_with(EventHandling::AutoAction, EventHandling::NotifyOrchestrator);
+
+        let event = CoreEvent::PrCiFailed {
+            pr_number: 10,
+            title: "x".into(),
+            failed_details: "d".into(),
+        };
+
+        // Under limit: 2 prompts
+        for _ in 0..2 {
+            AutoActionExecutor::handle_event(&state, &tx, &ns, &g, &tpl, &tr, gh.as_ref(), &event)
+                .await;
+        }
+        // 3rd exceeds
+        AutoActionExecutor::handle_event(&state, &tx, &ns, &g, &tpl, &tr, gh.as_ref(), &event)
+            .await;
+
+        let events = drain(&mut rx).await;
+        let prompts = events
+            .iter()
+            .filter(|e| matches!(e, CoreEvent::PromptReady { .. }))
+            .count();
+        let guardrails = events
+            .iter()
+            .filter(|e| matches!(e, CoreEvent::GuardrailExceeded { .. }))
+            .count();
+        assert_eq!(prompts, 2);
+        assert_eq!(guardrails, 1);
+
+        // Further triggers remain halted
+        AutoActionExecutor::handle_event(&state, &tx, &ns, &g, &tpl, &tr, gh.as_ref(), &event)
+            .await;
+        let events = drain(&mut rx).await;
+        assert!(events
+            .iter()
+            .all(|e| !matches!(e, CoreEvent::PromptReady { .. })));
+    }
+
+    // ── ReviewFeedback ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_review_feedback_autoaction_emits_prompt() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::shared();
+        insert_agent(&state, "main:0.2", "feat/y", Some(11), AgentStatus::Idle);
+        let meta = TaskMeta::for_issue(11, Some("main:0.2".into()));
+        meta_store::write_meta(dir.path(), "feat/y", &meta).unwrap();
+
+        let (tx, mut rx, g, tpl, tr) = make_harness(&state, dir.path());
+        let gh = Arc::new(StubGithub::default());
+        *gh.pr_comments.lock().unwrap() = Some("- @alice: please rename foo".to_string());
+        let ns = settings_with(EventHandling::NotifyOrchestrator, EventHandling::AutoAction);
+
+        let event = CoreEvent::PrReviewFeedback {
+            pr_number: 11,
+            title: "Y".into(),
+            comments_summary: "1 comment".into(),
+        };
+        AutoActionExecutor::handle_event(&state, &tx, &ns, &g, &tpl, &tr, gh.as_ref(), &event)
+            .await;
+
+        let events = drain(&mut rx).await;
+        let (target, prompt) = events
+            .iter()
+            .find_map(|e| match e {
+                CoreEvent::PromptReady { target, prompt } => Some((target.clone(), prompt.clone())),
+                _ => None,
+            })
+            .expect("PromptReady emitted");
+        assert_eq!(target, "main:0.2");
+        assert!(prompt.contains("alice"));
+        assert!(prompt.contains("PR #11"));
+    }
+
+    #[tokio::test]
+    async fn test_review_feedback_guardrail_exceeded() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::shared();
+        insert_agent(&state, "main:0.2", "feat/y", Some(11), AgentStatus::Idle);
+        let meta = TaskMeta::for_issue(11, Some("main:0.2".into()));
+        meta_store::write_meta(dir.path(), "feat/y", &meta).unwrap();
+
+        let (tx, mut rx, g, tpl, tr) = make_harness(&state, dir.path());
+        g.write().max_review_loops = 1;
+        let gh = Arc::new(StubGithub::default());
+        let ns = settings_with(EventHandling::NotifyOrchestrator, EventHandling::AutoAction);
+
+        let event = CoreEvent::PrReviewFeedback {
+            pr_number: 11,
+            title: "Y".into(),
+            comments_summary: "c".into(),
+        };
+
+        AutoActionExecutor::handle_event(&state, &tx, &ns, &g, &tpl, &tr, gh.as_ref(), &event)
+            .await;
+        AutoActionExecutor::handle_event(&state, &tx, &ns, &g, &tpl, &tr, gh.as_ref(), &event)
+            .await;
+
+        let events = drain(&mut rx).await;
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(e, CoreEvent::PromptReady { .. }))
+                .count(),
+            1
+        );
+        assert_eq!(
+            events
+                .iter()
+                .filter(|e| matches!(
+                    e,
+                    CoreEvent::GuardrailExceeded {
+                        guardrail: GuardrailKind::ReviewLoops,
+                        ..
+                    }
+                ))
+                .count(),
+            1
+        );
+    }
+
+    // ── PrClosed reset ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn test_pr_closed_resets_trackers() {
+        let dir = tempfile::tempdir().unwrap();
+        let state = AppState::shared();
+        let (tx, _rx, g, tpl, tr) = make_harness(&state, dir.path());
+
+        tr.increment_ci("feat/z");
+        tr.increment_review(42);
+        assert_eq!(tr.ci_count("feat/z"), 1);
+        assert_eq!(tr.review_count(42), 1);
+
+        let gh = Arc::new(StubGithub::default());
+        let ns = settings_with(EventHandling::AutoAction, EventHandling::AutoAction);
+        let event = CoreEvent::PrClosed {
+            pr_number: 42,
+            title: "Z".into(),
+            branch: "feat/z".into(),
+        };
+        AutoActionExecutor::handle_event(&state, &tx, &ns, &g, &tpl, &tr, gh.as_ref(), &event)
+            .await;
+
+        assert_eq!(tr.ci_count("feat/z"), 0);
+        assert_eq!(tr.review_count(42), 0);
+    }
+}

--- a/crates/tmai-core/src/auto_action/templates.rs
+++ b/crates/tmai-core/src/auto_action/templates.rs
@@ -1,0 +1,130 @@
+//! AutoAction prompt templates — prompts sent directly to target workers.
+
+use serde::{Deserialize, Serialize};
+
+/// Built-in default template for CI-failed → implementer.
+fn default_ci_failed_implementer() -> String {
+    "CI check failed on PR #{{pr_number}} ({{title}}, branch {{branch}}).\n\n\
+     {{failed_details}}\n\n\
+     Please investigate the failure, fix the root cause, and push the fix."
+        .to_string()
+}
+
+/// Built-in default template for review-feedback → implementer.
+fn default_review_feedback_implementer() -> String {
+    "Review feedback received on PR #{{pr_number}} ({{title}}):\n\n\
+     {{comments_summary}}\n\n\
+     Please address these comments and push the fix."
+        .to_string()
+}
+
+/// Templates rendered by AutoActionExecutor before sending prompts to workers.
+///
+/// Each template uses `{{var}}` placeholders.  Empty strings fall back to
+/// the built-in default (see `defaults()`).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AutoActionTemplates {
+    /// Prompt sent to the implementer agent when CI fails.
+    /// Empty string → fall back to built-in default at render time.
+    #[serde(default)]
+    pub ci_failed_implementer: String,
+
+    /// Prompt sent to the implementer agent when review feedback arrives.
+    /// Empty string → fall back to built-in default at render time.
+    #[serde(default)]
+    pub review_feedback_implementer: String,
+}
+
+impl AutoActionTemplates {
+    /// Return templates pre-populated with built-in default prompts.
+    pub fn defaults() -> Self {
+        Self {
+            ci_failed_implementer: default_ci_failed_implementer(),
+            review_feedback_implementer: default_review_feedback_implementer(),
+        }
+    }
+
+    /// Effective CI-failed template — custom value if non-empty, else built-in default.
+    pub fn effective_ci_failed(&self) -> String {
+        if self.ci_failed_implementer.is_empty() {
+            default_ci_failed_implementer()
+        } else {
+            self.ci_failed_implementer.clone()
+        }
+    }
+
+    /// Effective review-feedback template — custom value if non-empty, else built-in default.
+    pub fn effective_review_feedback(&self) -> String {
+        if self.review_feedback_implementer.is_empty() {
+            default_review_feedback_implementer()
+        } else {
+            self.review_feedback_implementer.clone()
+        }
+    }
+}
+
+/// Expand `{{var}}` placeholders in `template` with `vars` substitutions.
+///
+/// Missing variables are left as-is so operators can spot unfilled tokens.
+pub fn render(template: &str, vars: &[(&str, &str)]) -> String {
+    let mut result = template.to_string();
+    for (key, value) in vars {
+        result = result.replace(&format!("{{{{{key}}}}}"), value);
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_render_basic() {
+        let out = render(
+            "PR #{{pr_number}} on {{branch}}",
+            &[("pr_number", "42"), ("branch", "feat/x")],
+        );
+        assert_eq!(out, "PR #42 on feat/x");
+    }
+
+    #[test]
+    fn test_render_missing_var_left_intact() {
+        let out = render("PR #{{pr_number}} — {{missing}}", &[("pr_number", "42")]);
+        assert_eq!(out, "PR #42 — {{missing}}");
+    }
+
+    #[test]
+    fn test_render_empty_template() {
+        assert_eq!(render("", &[("x", "y")]), "");
+    }
+
+    #[test]
+    fn test_effective_ci_failed_falls_back() {
+        let tpl = AutoActionTemplates::default();
+        assert!(tpl.effective_ci_failed().contains("{{pr_number}}"));
+    }
+
+    #[test]
+    fn test_effective_ci_failed_custom_wins() {
+        let tpl = AutoActionTemplates {
+            ci_failed_implementer: "custom {{pr_number}}".into(),
+            review_feedback_implementer: String::new(),
+        };
+        assert_eq!(tpl.effective_ci_failed(), "custom {{pr_number}}");
+    }
+
+    #[test]
+    fn test_defaults_non_empty() {
+        let tpl = AutoActionTemplates::defaults();
+        assert!(!tpl.ci_failed_implementer.is_empty());
+        assert!(!tpl.review_feedback_implementer.is_empty());
+    }
+
+    #[test]
+    fn test_serde_roundtrip_default_is_empty() {
+        let tpl = AutoActionTemplates::default();
+        let s = toml::to_string(&tpl).unwrap();
+        let decoded: AutoActionTemplates = toml::from_str(&s).unwrap();
+        assert_eq!(decoded, tpl);
+    }
+}

--- a/crates/tmai-core/src/auto_action/tracker.rs
+++ b/crates/tmai-core/src/auto_action/tracker.rs
@@ -1,0 +1,123 @@
+//! In-memory counters for AutoAction attempts, used to enforce guardrails.
+//!
+//! Counts are per-branch (CI retries) or per-PR (review loops).  Reset on
+//! `PrClosed` or explicit reset call.  State is memory-only — matches the
+//! existing PR monitor's in-memory design.
+
+use std::collections::HashMap;
+
+use parking_lot::Mutex;
+
+/// Tracks AutoAction attempt counts for guardrail enforcement.
+#[derive(Debug, Default)]
+pub struct AutoActionTracker {
+    ci_retries: Mutex<HashMap<String, u64>>,
+    review_loops: Mutex<HashMap<u64, u64>>,
+}
+
+impl AutoActionTracker {
+    /// Create a new, empty tracker.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Increment and return the CI-retry count for `branch`.
+    pub fn increment_ci(&self, branch: &str) -> u64 {
+        let mut map = self.ci_retries.lock();
+        let entry = map.entry(branch.to_string()).or_insert(0);
+        *entry += 1;
+        *entry
+    }
+
+    /// Increment and return the review-loop count for `pr_number`.
+    pub fn increment_review(&self, pr_number: u64) -> u64 {
+        let mut map = self.review_loops.lock();
+        let entry = map.entry(pr_number).or_insert(0);
+        *entry += 1;
+        *entry
+    }
+
+    /// Clear the CI-retry counter for `branch`.
+    pub fn reset_ci(&self, branch: &str) {
+        self.ci_retries.lock().remove(branch);
+    }
+
+    /// Clear the review-loop counter for `pr_number`.
+    pub fn reset_review(&self, pr_number: u64) {
+        self.review_loops.lock().remove(&pr_number);
+    }
+
+    /// Read the current CI-retry count (for tests / introspection).
+    #[allow(dead_code)]
+    pub fn ci_count(&self, branch: &str) -> u64 {
+        self.ci_retries.lock().get(branch).copied().unwrap_or(0)
+    }
+
+    /// Read the current review-loop count (for tests / introspection).
+    #[allow(dead_code)]
+    pub fn review_count(&self, pr_number: u64) -> u64 {
+        self.review_loops
+            .lock()
+            .get(&pr_number)
+            .copied()
+            .unwrap_or(0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+
+    #[test]
+    fn test_increment_ci() {
+        let t = AutoActionTracker::new();
+        assert_eq!(t.increment_ci("feat/x"), 1);
+        assert_eq!(t.increment_ci("feat/x"), 2);
+        assert_eq!(t.increment_ci("feat/y"), 1);
+    }
+
+    #[test]
+    fn test_increment_review() {
+        let t = AutoActionTracker::new();
+        assert_eq!(t.increment_review(10), 1);
+        assert_eq!(t.increment_review(10), 2);
+        assert_eq!(t.increment_review(11), 1);
+    }
+
+    #[test]
+    fn test_reset_ci() {
+        let t = AutoActionTracker::new();
+        t.increment_ci("feat/x");
+        t.increment_ci("feat/x");
+        t.reset_ci("feat/x");
+        assert_eq!(t.ci_count("feat/x"), 0);
+        assert_eq!(t.increment_ci("feat/x"), 1);
+    }
+
+    #[test]
+    fn test_reset_review() {
+        let t = AutoActionTracker::new();
+        t.increment_review(10);
+        t.reset_review(10);
+        assert_eq!(t.review_count(10), 0);
+    }
+
+    #[test]
+    fn test_concurrent_increment() {
+        let t = Arc::new(AutoActionTracker::new());
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let t = Arc::clone(&t);
+            handles.push(std::thread::spawn(move || {
+                for _ in 0..100 {
+                    t.increment_ci("feat/x");
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(t.ci_count("feat/x"), 800);
+    }
+}

--- a/crates/tmai-core/src/config/settings.rs
+++ b/crates/tmai-core/src/config/settings.rs
@@ -866,6 +866,10 @@ pub struct OrchestratorSettings {
     #[serde(default)]
     pub guardrails: GuardrailsSettings,
 
+    /// Templates used when `EventHandling::AutoAction` directly instructs a worker
+    #[serde(default)]
+    pub auto_action_templates: crate::auto_action::AutoActionTemplates,
+
     /// Enable automatic PR/CI status monitoring with notifications
     #[serde(default)]
     pub pr_monitor_enabled: bool,
@@ -1157,6 +1161,7 @@ impl Default for OrchestratorSettings {
             rules: OrchestratorRules::default(),
             notify: OrchestratorNotifySettings::default(),
             guardrails: GuardrailsSettings::default(),
+            auto_action_templates: crate::auto_action::AutoActionTemplates::default(),
             pr_monitor_enabled: false,
             pr_monitor_interval_secs: default_pr_monitor_interval(),
         }

--- a/crates/tmai-core/src/lib.rs
+++ b/crates/tmai-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod agents;
 pub mod api;
 pub mod audit;
+pub mod auto_action;
 pub mod auto_approve;
 pub mod auto_cleanup;
 pub mod codex_ws;

--- a/src/main.rs
+++ b/src/main.rs
@@ -241,9 +241,28 @@ async fn run_tmux_mode(settings: Settings, _cli: Config) -> Result<()> {
     tmai_core::task_meta::TaskMetaService::spawn(
         app.shared_state(),
         core.subscribe(),
-        guardrails_settings,
+        guardrails_settings.clone(),
         core.event_sender(),
     );
+
+    // Start AutoActionExecutor (directly instructs workers on configured events)
+    if settings.orchestrator.enabled {
+        let auto_action_notify = std::sync::Arc::new(parking_lot::RwLock::new(
+            settings.orchestrator.notify.clone(),
+        ));
+        let auto_action_templates = std::sync::Arc::new(parking_lot::RwLock::new(
+            settings.orchestrator.auto_action_templates.clone(),
+        ));
+        tmai_core::auto_action::AutoActionExecutor::spawn(
+            app.shared_state(),
+            core.subscribe(),
+            core.event_sender(),
+            auto_action_notify,
+            guardrails_settings,
+            auto_action_templates,
+            std::sync::Arc::new(tmai_core::auto_action::RealGithubApi),
+        );
+    }
 
     // Restore in-memory issue/PR associations from persisted .task-meta/ files
     tmai_core::task_meta::restore_from_disk(&app.shared_state(), &settings.project_paths());
@@ -446,9 +465,29 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
     tmai_core::task_meta::TaskMetaService::spawn(
         state.clone(),
         core.subscribe(),
-        guardrails_settings,
+        guardrails_settings.clone(),
         core.event_sender(),
     );
+
+    // Start AutoActionExecutor (directly instructs workers on configured events)
+    if settings.orchestrator.enabled {
+        let auto_action_notify = std::sync::Arc::new(parking_lot::RwLock::new(
+            settings.orchestrator.notify.clone(),
+        ));
+        let auto_action_templates = std::sync::Arc::new(parking_lot::RwLock::new(
+            settings.orchestrator.auto_action_templates.clone(),
+        ));
+        tmai_core::auto_action::AutoActionExecutor::spawn(
+            state.clone(),
+            core.subscribe(),
+            core.event_sender(),
+            auto_action_notify,
+            guardrails_settings,
+            auto_action_templates,
+            std::sync::Arc::new(tmai_core::auto_action::RealGithubApi),
+        );
+        eprintln!("tmai: auto-action executor started");
+    }
 
     // Restore in-memory issue/PR associations from persisted .task-meta/ files
     tmai_core::task_meta::restore_from_disk(&state, &settings.project_paths());

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1627,6 +1627,7 @@ pub async fn update_orchestrator_settings(
                     .unwrap_or(g.escalate_to_human_after),
             }
         },
+        auto_action_templates: current.auto_action_templates.clone(),
         pr_monitor_enabled: req.pr_monitor_enabled.unwrap_or(current.pr_monitor_enabled),
         pr_monitor_interval_secs: req
             .pr_monitor_interval_secs


### PR DESCRIPTION
## Summary

Part **2/3** of #364. Adds the `auto_action` module + `AutoActionExecutor` background service that directly instructs implementer workers for routine CI / review cycles, replacing manual orchestrator routing when an event is configured as `EventHandling::AutoAction` (introduced in PR-A, b3139a8).

- **Handlers (MVP):** `PrCiFailed` → implementer, `PrReviewFeedback` → implementer. Target is resolved via `.task-meta/{branch}.json` → `agent_id`, then matched against running agents by id / target / stable_id / pty_session_id.
- **Enrichment:** `PrCiFailed` augments the event's `failed_details` with `get_ci_failure_log` (best-effort, falls back to the summary). `PrReviewFeedback` pulls the full comment text via `get_pr_comments`.
- **Guardrails:** per-branch CI retry counter and per-PR review-loop counter. When `max_ci_retries` / `max_review_loops` is exceeded, the executor halts and emits `CoreEvent::GuardrailExceeded`, which `OrchestratorNotifier` always escalates to the human regardless of per-event config.
- **Fallbacks:** missing task-meta, missing `agent_id`, or offline target agent all produce a synthetic `PromptReady` with an operator-facing explanation so the gap is surfaced rather than silently dropped.
- **PrClosed** resets both trackers.
- **Mutual exclusion:** `OrchestratorNotifier` already skips events configured as `AutoAction` (PR-A); `AutoActionExecutor` skips events NOT configured as `AutoAction`. Both subscribe to the same broadcast.

### Config

New field `OrchestratorSettings::auto_action_templates: AutoActionTemplates` with `ci_failed_implementer` and `review_feedback_implementer` fields. Empty values fall back to built-in defaults at render time, keeping serde round-trips clean.

### Testability

`GithubApi` trait (boxed-future based — no `async-trait` dep) abstracts the two `gh` calls we make. Tests drive `AutoActionExecutor::handle_event` directly with a `StubGithub` double.

### Wiring

Service is started alongside `OrchestratorNotifier` in both legacy and WebUI `main.rs` branches.

## Deferred (PR-C)

- `PrCiPassed` → `dispatch_review` auto-dispatch
- WebUI 3-way radio + inline template editor
- `AgentRole::Reviewer`-targeted handlers beyond the enum definition

## Test plan

- [x] `cargo fmt` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test -p tmai-core auto_action` — 29 passing (tracker, resolver, templates, service)
- [x] Full `cargo test -p tmai-core` — 940 passing; two pre-existing flakes unrelated to this PR (`pty::session::tests::test_spawn_echo`, `detectors::claude_code::tests::test_multi_select_with_trailing_empty_lines`) that pass in isolation.
- [ ] End-to-end smoke against a real `gh`-backed repo (left for reviewer environment)

## Test gap

`RealGithubApi` itself has no direct unit test; it is only exercised at runtime against the real `gh` binary. The `GithubApi` trait lets us introduce mocks later without further refactoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 自動アクション実行エンジンを追加しました。CI失敗やプルリクエストレビューフィードバックに自動的に対応します。
  * 自動化されたプロンプトのテンプレート機能を追加し、カスタマイズ可能な応答メッセージに対応しました。
  * 自動アクションの実行回数を追跡するガードレール機能を実装しました。過度な自動化を防ぎます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->