### PR TITLE
bug: send_prompt MCP tool sometimes leaves prompt unsubmitted (missing Enter) (#384)

### DIFF
--- a/crates/tmai-core/src/api/actions.rs
+++ b/crates/tmai-core/src/api/actions.rs
@@ -254,10 +254,32 @@ impl TmaiCore {
         Ok(())
     }
 
+    /// Type `text` into an agent's input and submit it with a guaranteed Enter.
+    ///
+    /// Builds on [`send_text`](Self::send_text) (which already types text and
+    /// sends one Enter) and appends a safety-net second Enter after a delay.
+    /// Claude Code's TUI treats multi-line bursts as a paste and can absorb the
+    /// first Enter into the paste buffer instead of submitting; sending a second
+    /// Enter after paste-detection has timed out guarantees submission.
+    ///
+    /// The extra Enter is a no-op when the input buffer is already empty (i.e.
+    /// when the first Enter did submit), so callers can rely on a single submit
+    /// per call in the common case.
+    pub async fn deliver_prompt(&self, id: &str, text: &str) -> Result<(), ApiError> {
+        self.send_text(id, text).await?;
+        let target = self.resolve_agent_key(id)?;
+        let cmd = self.require_command_sender()?;
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        cmd.send_keys(&target, "Enter")?;
+        Ok(())
+    }
+
     /// Send a prompt to an agent with status-aware behavior.
     ///
-    /// - **Idle**: sends the prompt immediately (text + Enter).
-    /// - **Offline** (stopped): sends the prompt to restart the agent.
+    /// - **Idle**: submits the prompt immediately (text + Enter, with a safety-net
+    ///   second Enter so multi-line content is not left unsubmitted by Claude
+    ///   Code's paste detection).
+    /// - **Offline** (stopped): submits the prompt to restart the agent.
     /// - **Processing**: queues the prompt (max 5); delivered when agent becomes Idle.
     /// - **Other** (AwaitingApproval, Error, Unknown): queues like Processing.
     ///
@@ -285,7 +307,7 @@ impl TmaiCore {
 
         match status {
             AgentStatus::Idle | AgentStatus::Offline => {
-                self.send_text(&target, prompt).await?;
+                self.deliver_prompt(&target, prompt).await?;
                 let action = if status.is_idle() {
                     "sent"
                 } else {
@@ -1201,6 +1223,42 @@ mod tests {
         let text = "x".repeat(MAX_TEXT_LENGTH);
         let result = core.send_text("main:0.0", &text).await;
         assert!(!matches!(result, Err(ApiError::InvalidInput { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_deliver_prompt_too_long() {
+        let agent = test_agent("main:0.0", AgentStatus::Idle);
+        let core = make_core_with_agents(vec![agent]);
+        let long_text = "x".repeat(MAX_TEXT_LENGTH + 1);
+        let result = core.deliver_prompt("main:0.0", &long_text).await;
+        assert!(matches!(result, Err(ApiError::InvalidInput { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_deliver_prompt_not_found() {
+        let core = TmaiCoreBuilder::new(Settings::default()).build();
+        let result = core.deliver_prompt("nonexistent", "hello").await;
+        assert!(matches!(result, Err(ApiError::AgentNotFound { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_deliver_prompt_virtual_agent() {
+        let mut agent = test_agent("main:0.0", AgentStatus::Idle);
+        agent.is_virtual = true;
+        let core = make_core_with_agents(vec![agent]);
+        let result = core.deliver_prompt("main:0.0", "hello").await;
+        assert!(matches!(result, Err(ApiError::VirtualAgent { .. })));
+    }
+
+    #[tokio::test]
+    async fn test_deliver_prompt_multiline_no_command_sender() {
+        // Without a CommandSender, deliver_prompt should fail at the send_text stage
+        // (before any Enter is issued), proving that validation happens before typing.
+        let agent = test_agent("main:0.0", AgentStatus::Idle);
+        let core = make_core_with_agents(vec![agent]);
+        let multiline = "line1\nline2\n```rust\nfn main() {}\n```\nend";
+        let result = core.deliver_prompt("main:0.0", multiline).await;
+        assert!(matches!(result, Err(ApiError::NoCommandSender)));
     }
 
     #[test]

--- a/crates/tmai-core/src/command_sender.rs
+++ b/crates/tmai-core/src/command_sender.rs
@@ -276,6 +276,24 @@ mod tests {
     }
 
     #[test]
+    fn send_variant_keys_literal_preserves_newlines() {
+        // Multi-line content must not be converted into multiple Enters — the
+        // caller is responsible for appending Enter explicitly when submitting.
+        let payload = "line1\nline2\n```\nfn main() {}\n```";
+        let bytes = SendVariant::KeysLiteral.to_pty_bytes(payload);
+        assert_eq!(bytes, payload.as_bytes());
+    }
+
+    #[test]
+    fn send_variant_text_and_enter_single_trailing_cr_for_multiline() {
+        // Exactly one trailing \r is appended, regardless of embedded newlines.
+        let payload = "line1\nline2";
+        let bytes = SendVariant::TextAndEnter.to_pty_bytes(payload);
+        assert_eq!(bytes, b"line1\nline2\r");
+        assert_eq!(bytes.iter().filter(|&&b| b == b'\r').count(), 1);
+    }
+
+    #[test]
     fn send_variant_names() {
         assert_eq!(SendVariant::Keys.name(), "send_keys");
         assert_eq!(SendVariant::KeysLiteral.name(), "send_keys_literal");

--- a/src/main.rs
+++ b/src/main.rs
@@ -560,7 +560,7 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
             while let Ok(event) = event_rx.recv().await {
                 if let tmai_core::api::CoreEvent::PromptReady { target, prompt } = event {
                     tracing::info!("Delivering queued prompt to agent {}", target);
-                    if let Err(e) = core.send_text(&target, &prompt).await {
+                    if let Err(e) = core.deliver_prompt(&target, &prompt).await {
                         tracing::warn!("Failed to deliver queued prompt to {}: {}", target, e);
                     }
                 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -403,11 +403,16 @@ impl TmaiMcpServer {
         )
     }
 
-    /// Send a prompt to an agent with status-aware delivery. If the agent is idle, the prompt is
-    /// sent immediately. If the agent is processing, the prompt is queued (max 5) and delivered
-    /// automatically when the agent becomes idle. If the agent is stopped/offline, the prompt is
-    /// sent to restart it. Only agents within the same project scope can receive prompts.
-    #[tool(description = "Send a prompt to an agent (queues if busy, delivers when idle)")]
+    /// Send a prompt to an agent with status-aware delivery. The prompt is submitted
+    /// (typed into the agent's input and followed by Enter). If the agent is idle, the
+    /// prompt is submitted immediately. If the agent is processing, the prompt is
+    /// queued (max 5) and submitted automatically when the agent becomes idle. If the
+    /// agent is stopped/offline, the prompt is submitted to restart it. Contrast with
+    /// `send_text`, which only types into the terminal without a reliable submit.
+    /// Only agents within the same project scope can receive prompts.
+    #[tool(
+        description = "Send and submit a prompt to an agent (queues if busy, delivers when idle; Enter is appended)"
+    )]
     fn send_prompt(&self, Parameters(p): Parameters<SendPromptParams>) -> String {
         if let Some(err) = self.validate_project_scope(&p.id) {
             return err;

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -471,7 +471,7 @@ impl App {
                                 let core = core.clone();
                                 tokio::spawn(async move {
                                     tracing::info!("Delivering queued prompt to agent {}", target);
-                                    if let Err(e) = core.send_text(&target, &prompt).await {
+                                    if let Err(e) = core.deliver_prompt(&target, &prompt).await {
                                         tracing::warn!(
                                             "Failed to deliver queued prompt to {}: {}",
                                             target,


### PR DESCRIPTION
## Summary

- Fixes #384: `mcp__tmai__send_prompt` would occasionally leave a multi-line markdown prompt sitting in Claude Code's input buffer without submitting, because the TUI's paste-detection absorbed the trailing Enter into the paste.
- Adds `TmaiCore::deliver_prompt` (wraps `send_text` + safety-net second Enter after 150ms) and routes the idle/offline branch of `send_prompt` plus the queued-delivery paths (TUI + headless bin) through it, so submission is guaranteed on every transport (PTY session / IPC / tmux send-keys / PTY inject).
- Updates the `send_prompt` MCP tool description to make the "Enter is appended" contract explicit versus buffer-only `send_text`.

## Why this fix

Claude Code's input widget treats rapid multi-line input as a paste and can swallow a single trailing Enter. The previous documented workaround — manually calling `send_key(id, "Enter")` after `send_prompt` — proves a second Enter, sent after paste-detection times out, reliably submits. `deliver_prompt` formalises this; the extra Enter is a no-op when the buffer is already empty, so single-line prompts still submit exactly once.

## Test plan

- [x] `cargo test -p tmai-core api::actions::tests` — new `deliver_prompt_*` validation tests pass (too-long, not-found, virtual agent, multi-line falls through to `NoCommandSender`)
- [x] `cargo test -p tmai-core command_sender::tests` — new tests confirm `KeysLiteral` preserves embedded newlines and `TextAndEnter` yields exactly one trailing `\r` for multi-line payloads
- [x] `cargo test` full workspace (one pre-existing detector test failure unrelated to this change)
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [ ] Manual: dispatch a worker, `send_prompt` multi-line markdown, confirm `Idle → Working` without a follow-up `send_key`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * プロンプト送信の信頼性を向上させました。アイドル状態またはオフライン状態のエージェントへのプロンプト送信時に、追加のセーフティメカニズムを実装し、送信確認が確実に行われるようになりました。

* **ドキュメント**
  * プロンプト送信機能の説明を更新し、送信動作の詳細を明確にしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->