### PR TITLE
fix: dedup review feedback by review_count and document CI latest-wins

### DIFF
--- a/crates/tmai-core/src/api/events.rs
+++ b/crates/tmai-core/src/api/events.rs
@@ -260,6 +260,12 @@ pub enum CoreEvent {
         title: String,
         /// Summary of review comments
         comments_summary: String,
+        /// Monotonic review count from PR state — distinguishes
+        /// back-to-back ChangesRequested transitions so the notifier
+        /// can dedupe on `(pr_number, review_count)` instead of
+        /// collapsing distinct rounds into one entry.
+        #[serde(default)]
+        review_count: u64,
     },
 
     /// A PR was closed (merged or closed without merging)

--- a/crates/tmai-core/src/auto_action/service.rs
+++ b/crates/tmai-core/src/auto_action/service.rs
@@ -208,6 +208,7 @@ impl AutoActionExecutor {
                 pr_number,
                 title,
                 comments_summary,
+                ..
             } => {
                 if notify.on_pr_comment != EventHandling::AutoAction {
                     return;
@@ -1023,6 +1024,7 @@ mod tests {
             pr_number: 11,
             title: "Y".into(),
             comments_summary: "1 comment".into(),
+            review_count: 1,
         };
         AutoActionExecutor::handle_event(
             &state,
@@ -1068,6 +1070,7 @@ mod tests {
             pr_number: 11,
             title: "Y".into(),
             comments_summary: "c".into(),
+            review_count: 1,
         };
 
         AutoActionExecutor::handle_event(

--- a/crates/tmai-core/src/github/pr_monitor.rs
+++ b/crates/tmai-core/src/github/pr_monitor.rs
@@ -153,6 +153,7 @@ impl PrMonitor {
                             pr_number: pr.number,
                             title: pr.title.clone(),
                             comments_summary,
+                            review_count: current_state.reviews,
                         };
                         self.emit_event(&notif);
                         notifications.push(notif);
@@ -222,10 +223,12 @@ impl PrMonitor {
                 pr_number,
                 title,
                 comments_summary,
+                review_count,
             } => CoreEvent::PrReviewFeedback {
                 pr_number: *pr_number,
                 title: title.clone(),
                 comments_summary: comments_summary.clone(),
+                review_count: *review_count,
             },
             PrNotification::Closed {
                 pr_number,
@@ -354,6 +357,7 @@ impl PrMonitor {
                 pr_number,
                 title,
                 comments_summary,
+                ..
             } => {
                 format!(
                     "[PR Monitor] PR #{} \"{}\" has review feedback: {}",
@@ -400,6 +404,7 @@ pub enum PrNotification {
         pr_number: u64,
         title: String,
         comments_summary: String,
+        review_count: u64,
     },
     /// PR disappeared from open list (merged or closed)
     Closed {
@@ -586,6 +591,7 @@ mod tests {
             pr_number: 10,
             title: "Fix bug".to_string(),
             comments_summary: "Please fix the typo".to_string(),
+            review_count: 1,
         };
         let prompt = PrMonitor::format_prompt(&notif);
         assert!(prompt.contains("review feedback"));

--- a/crates/tmai-core/src/orchestrator_notify/service.rs
+++ b/crates/tmai-core/src/orchestrator_notify/service.rs
@@ -358,7 +358,10 @@ impl OrchestratorNotifier {
                         ("summary", checks_summary.as_str()),
                     ],
                 );
-                Some((msg, format!("pr-{pr_number}")))
+                // Intentional: CI latest-wins. A fresh CI pass on the same PR
+                // (after a re-run) supersedes any earlier pending notification
+                // in the busy-buffer; no value in queuing multiple CI states.
+                Some((msg, format!("pr-{pr_number}-ci")))
             }
 
             CoreEvent::PrCiFailed {
@@ -381,13 +384,17 @@ impl OrchestratorNotifier {
                         ("failed_details", failed_details.as_str()),
                     ],
                 );
-                Some((msg, format!("pr-{pr_number}")))
+                // Intentional: CI latest-wins (see PrCiPassed for rationale).
+                // Uses the same `pr-{N}-ci` key so pass/fail on the same PR
+                // collapse to one entry — whichever state is most recent wins.
+                Some((msg, format!("pr-{pr_number}-ci")))
             }
 
             CoreEvent::PrReviewFeedback {
                 pr_number,
                 title,
                 comments_summary,
+                review_count,
             } => {
                 if settings.on_pr_comment != EventHandling::NotifyOrchestrator {
                     return None;
@@ -404,7 +411,11 @@ impl OrchestratorNotifier {
                         ("comments_summary", comments_summary.as_str()),
                     ],
                 );
-                Some((msg, format!("pr-{pr_number}")))
+                // Distinct review rounds (ChangesRequested → dismissed → ChangesRequested)
+                // get distinct keys so back-to-back rounds don't overwrite each other in
+                // the busy-buffer. CI state dedup remains pr-level (latest-wins) because
+                // a fresh CI failure supersedes any stale earlier failure notification.
+                Some((msg, format!("pr-{pr_number}-review-{review_count}")))
             }
 
             CoreEvent::PrClosed {
@@ -890,6 +901,74 @@ mod tests {
             result.is_none(),
             "PR closed should respect on_pr_closed flag"
         );
+    }
+
+    #[test]
+    fn test_review_feedback_dedup_key_includes_review_count() {
+        // Distinct review rounds on the same PR must produce distinct dedup
+        // keys so the busy-buffer keeps both entries instead of collapsing
+        // them. Without review_count in the key, a second ChangesRequested
+        // transition on the same PR (after dismissal) would overwrite the
+        // first entry silently.
+        let state = AppState::shared();
+        let settings = OrchestratorNotifySettings::default();
+
+        let first = CoreEvent::PrReviewFeedback {
+            pr_number: 42,
+            title: "feat: x".to_string(),
+            comments_summary: "round 1".to_string(),
+            review_count: 1,
+        };
+        let second = CoreEvent::PrReviewFeedback {
+            pr_number: 42,
+            title: "feat: x".to_string(),
+            comments_summary: "round 2".to_string(),
+            review_count: 2,
+        };
+
+        let (_, k1) = OrchestratorNotifier::build_notification(&first, &settings, &state).unwrap();
+        let (_, k2) = OrchestratorNotifier::build_notification(&second, &settings, &state).unwrap();
+
+        assert_ne!(k1, k2, "distinct review rounds must produce distinct keys");
+        assert!(k1.contains("review-1"));
+        assert!(k2.contains("review-2"));
+    }
+
+    #[test]
+    fn test_ci_dedup_key_is_stable_latest_wins() {
+        // CI pass/fail on the same PR share a single `pr-{N}-ci` dedup key
+        // by design. When orchestrator is busy and CI flips state multiple
+        // times, only the most recent CI status reaches the orchestrator on
+        // flush — the older, superseded notification is intentionally dropped.
+        // This test locks that invariant so future refactors don't split the
+        // CI key without consideration.
+        let state = AppState::shared();
+        let settings = OrchestratorNotifySettings::default();
+
+        let failed = CoreEvent::PrCiFailed {
+            pr_number: 42,
+            title: "feat: x".to_string(),
+            failed_details: "lint".to_string(),
+        };
+        let passed = CoreEvent::PrCiPassed {
+            pr_number: 42,
+            title: "feat: x".to_string(),
+            checks_summary: "all green".to_string(),
+        };
+
+        let (_, k_fail) =
+            OrchestratorNotifier::build_notification(&failed, &settings, &state).unwrap();
+        // PrCiPassed is OFF by default; flip to NotifyOrchestrator for the test.
+        let mut settings_with_pass = settings.clone();
+        settings_with_pass.on_ci_passed = EventHandling::NotifyOrchestrator;
+        let (_, k_pass) =
+            OrchestratorNotifier::build_notification(&passed, &settings_with_pass, &state).unwrap();
+
+        assert_eq!(
+            k_fail, k_pass,
+            "CI pass and fail on the same PR must share one dedup key (latest-wins)"
+        );
+        assert_eq!(k_fail, "pr-42-ci");
     }
 
     #[test]

--- a/crates/tmai-core/src/task_meta/service.rs
+++ b/crates/tmai-core/src/task_meta/service.rs
@@ -610,6 +610,7 @@ mod tests {
             pr_number: 20,
             title: "API endpoints".to_string(),
             comments_summary: "needs more tests".to_string(),
+            review_count: 5,
         };
         TaskMetaService::handle_event(&state, &event, &g, &tx);
 

--- a/src/web/events.rs
+++ b/src/web/events.rs
@@ -304,11 +304,12 @@ pub async fn events(State(core): State<Arc<TmaiCore>>) -> impl IntoResponse {
                                 return;
                             }
                         }
-                        Ok(CoreEvent::PrReviewFeedback { pr_number, title, comments_summary }) => {
+                        Ok(CoreEvent::PrReviewFeedback { pr_number, title, comments_summary, review_count }) => {
                             let data = serde_json::json!({
                                 "pr_number": pr_number,
                                 "title": title,
                                 "comments_summary": comments_summary,
+                                "review_count": review_count,
                             });
                             let event = Event::default()
                                 .event("pr_review_feedback")


### PR DESCRIPTION
## Summary

- `OrchestratorNotifier` busy-buffer used `pr-{N}` as the dedup key for `PrReviewFeedback`, which silently collapsed back-to-back `ChangesRequested` transitions (review dismissed → changes requested again) into a single buffered entry, dropping the earlier review round.
- Add `review_count: u64` to `CoreEvent::PrReviewFeedback` (populated from `PrState.reviews` by the PR monitor), and fold it into the dedup key as `pr-{N}-review-{count}` so distinct rounds survive flush.
- `PrCiFailed` / `PrCiPassed` intentionally continue to share `pr-{N}-ci` — latest-wins is the desired behaviour when CI flips state on the same PR. Comment blocks and a regression test (`test_ci_dedup_key_is_stable_latest_wins`) lock the invariant so future refactors don't split the key without consideration.

## Background

Post-merge review after #374 flagged that the new busy-buffer's dedup logic was only discriminating by PR number. Same-PR review-feedback rounds are rare (review_decision transition driven) but observed in practice when a reviewer dismisses their own review and re-requests changes. This PR closes that gap without touching CI behaviour.

Relates to the code review conducted right after #374 merged.

## Test plan

- [x] `cargo test -p tmai-core orchestrator_notify` — all 52 tests pass (includes 2 new: `test_review_feedback_dedup_key_includes_review_count`, `test_ci_dedup_key_is_stable_latest_wins`)
- [x] `cargo check` — no warnings
- [x] `cargo clippy -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] Manual verify: existing tests that emit `PrReviewFeedback` updated to include `review_count` (auto_action tests, task_meta tests, pr_monitor tests)

Note: `detectors::claude_code::tests::test_multi_select_with_trailing_empty_lines` is failing on `main` as well (unrelated pre-existing flake to be filed separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)