### PR TITLE
feat: auto-restore is_orchestrator flag across tmai restart and /resume (#380)

### DIFF
--- a/crates/tmai-core/src/api/actions.rs
+++ b/crates/tmai-core/src/api/actions.rs
@@ -923,6 +923,8 @@ impl TmaiCore {
     ///
     /// Any previous orchestrator for the same project is automatically demoted.
     /// Emits `AgentsUpdated` so all subscribers (WebUI, notifier) reflect the change.
+    /// Persists the `(project_path, claude_session_id)` record so the flag is
+    /// auto-restored across tmai restarts (#380).
     pub fn set_orchestrator(&self, id: &str) -> Result<(), ApiError> {
         let target = self.resolve_agent_key(id)?;
 
@@ -934,6 +936,14 @@ impl TmaiCore {
             .get(&target)
             .map(|a| a.cwd.clone())
             .unwrap_or_default();
+
+        // Preferred project path for persistence: git_common_dir when present,
+        // otherwise cwd.
+        let project_for_persist = state
+            .agents
+            .get(&target)
+            .and_then(|a| a.git_common_dir.clone())
+            .unwrap_or_else(|| project.clone());
 
         // Demote any existing orchestrator for the same project
         for agent in state.agents.values_mut() {
@@ -947,9 +957,109 @@ impl TmaiCore {
             agent.is_orchestrator = true;
         }
 
+        // Persist the identity record (Tier 1 bootstrap) if a store handle
+        // and session_id are available.
+        let store_handle = state.orchestrator_state.clone();
+        let pane_id = state.target_to_pane_id.get(&target).cloned();
         drop(state);
+
+        if let Some(store) = store_handle {
+            let session_id = pane_id.and_then(|pid| {
+                self.session_pane_map().read().iter().find_map(|(sid, p)| {
+                    if p == &pid {
+                        Some(sid.clone())
+                    } else {
+                        None
+                    }
+                })
+            });
+            if let Some(sid) = session_id {
+                let mut w = store.write();
+                if let Err(e) = w.upsert_and_save(&project_for_persist, &sid) {
+                    tracing::warn!(error = %e, "failed to persist orchestrator state on set_orchestrator");
+                }
+            } else {
+                tracing::debug!(
+                    target = %target,
+                    "set_orchestrator: no Claude session_id resolvable — record not persisted",
+                );
+            }
+        }
+
         self.notify_agents_updated();
         Ok(())
+    }
+
+    /// Apply a poll-batch update to the shared state and attempt orchestrator
+    /// flag auto-restoration for every newly-inserted agent (#380).
+    ///
+    /// Mirrors `AppState::update_agents` and returns the same `TargetChange` list
+    /// so callers can emit `AgentTargetChanged` events. Newly-detected agents
+    /// that match a persisted orchestrator record (Tier 1) or single-candidate
+    /// Tier 2 criteria are silently promoted.
+    pub fn apply_agents_poll_update(
+        &self,
+        agents: Vec<crate::agents::MonitoredAgent>,
+    ) -> Vec<crate::state::TargetChange> {
+        let new_ids: Vec<String> = {
+            let s = self.state().read();
+            agents
+                .iter()
+                .filter(|a| !s.agents.contains_key(&a.id))
+                .map(|a| a.id.clone())
+                .collect()
+        };
+
+        let target_changes = {
+            let mut s = self.state().write();
+            let changes = s.update_agents(agents);
+            s.clear_error();
+            changes
+        };
+
+        if !new_ids.is_empty() {
+            let store_handle = self.state().read().orchestrator_state.clone();
+            if let Some(store) = store_handle {
+                let mut s = self.state().write();
+                for id in &new_ids {
+                    let outcome = crate::orchestrator_state::try_restore_agent(
+                        &mut s,
+                        id,
+                        &store,
+                        self.session_pane_map(),
+                    );
+                    match outcome {
+                        crate::orchestrator_state::restore::RestoreOutcome::Tier1Exact => {
+                            tracing::info!(
+                                target = %id,
+                                "orchestrator flag auto-restored (Tier 1 exact match)",
+                            );
+                        }
+                        crate::orchestrator_state::restore::RestoreOutcome::Tier2RotateSession => {
+                            tracing::info!(
+                                target = %id,
+                                "orchestrator flag auto-restored (Tier 2 session rotation)",
+                            );
+                        }
+                        crate::orchestrator_state::restore::RestoreOutcome::NoAction => {}
+                    }
+                }
+            }
+        }
+
+        target_changes
+    }
+
+    /// Refresh the `last_seen` timestamp on every persisted orchestrator record
+    /// whose agent is currently online. Intended to be called periodically
+    /// from the polling loop (#380).
+    pub fn refresh_orchestrator_last_seen(&self) {
+        let store_handle = self.state().read().orchestrator_state.clone();
+        let Some(store) = store_handle else {
+            return;
+        };
+        let s = self.state().read();
+        crate::orchestrator_state::update_last_seen_for_online(&s, &store, self.session_pane_map());
     }
 
     /// Compose a system prompt from orchestrator settings.

--- a/crates/tmai-core/src/lib.rs
+++ b/crates/tmai-core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod hooks;
 pub mod ipc;
 pub mod monitor;
 pub mod orchestrator_notify;
+pub mod orchestrator_state;
 pub mod pty;
 pub mod pty_inject;
 pub mod runtime;

--- a/crates/tmai-core/src/orchestrator_state/mod.rs
+++ b/crates/tmai-core/src/orchestrator_state/mod.rs
@@ -1,0 +1,22 @@
+//! Persist orchestrator identity across tmai restarts and Claude Code `/resume`.
+//!
+//! Each orchestrator is identified by `(project_path, claude_session_id)`.
+//! The store is persisted to `$XDG_STATE_HOME/tmai/orchestrators.json`
+//! (fallback: `~/.local/state/tmai/orchestrators.json`) with `0600` permissions.
+//!
+//! - Tier 1 (exact match): a newly-detected agent whose
+//!   `(project_path, claude_session_id)` tuple matches a persisted record
+//!   is silently promoted to orchestrator.
+//! - Tier 2 (/resume fallback): when the `claude_session_id` has changed
+//!   (common after `/resume`) but the project matches a recent record and
+//!   there is exactly one non-worktree candidate, the new agent is promoted
+//!   and the record's session_id is rotated.
+
+pub mod persist;
+pub mod restore;
+
+pub use persist::{
+    default_store_path, new_shared, OrchestratorRecord, OrchestratorStore, SharedOrchestratorStore,
+    DEFAULT_TTL_DAYS, TIER2_RECENCY_HOURS,
+};
+pub use restore::{try_restore_agent, update_last_seen_for_online};

--- a/crates/tmai-core/src/orchestrator_state/persist.rs
+++ b/crates/tmai-core/src/orchestrator_state/persist.rs
@@ -1,0 +1,340 @@
+//! Persistence for orchestrator identity records.
+
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
+use chrono::{DateTime, Duration, Utc};
+use parking_lot::RwLock;
+use serde::{Deserialize, Serialize};
+
+/// Default TTL for records — entries older than this are pruned on read.
+pub const DEFAULT_TTL_DAYS: i64 = 30;
+
+/// Default recency window for Tier 2 restore.
+pub const TIER2_RECENCY_HOURS: i64 = 24;
+
+/// Single persisted orchestrator identity record.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct OrchestratorRecord {
+    /// Absolute path to the project (e.g. git_common_dir or cwd).
+    pub project_path: String,
+    /// Claude Code `session_id` observed when the record was last updated.
+    pub claude_session_id: String,
+    /// Wall-clock timestamp of the last update.
+    pub last_seen: DateTime<Utc>,
+}
+
+/// Persisted store of orchestrator records.
+#[derive(Debug, Clone)]
+pub struct OrchestratorStore {
+    path: PathBuf,
+    pub(crate) records: Vec<OrchestratorRecord>,
+    ttl: Duration,
+}
+
+/// Shared handle for injection into `AppState` and other services.
+pub type SharedOrchestratorStore = Arc<RwLock<OrchestratorStore>>;
+
+impl OrchestratorStore {
+    /// Create an empty in-memory store backed by the given path.
+    /// The file is NOT read — call [`Self::load`] to populate.
+    pub fn new(path: PathBuf) -> Self {
+        Self {
+            path,
+            records: Vec::new(),
+            ttl: Duration::days(DEFAULT_TTL_DAYS),
+        }
+    }
+
+    /// Override the TTL. Primarily useful in tests.
+    pub fn with_ttl(mut self, ttl: Duration) -> Self {
+        self.ttl = ttl;
+        self
+    }
+
+    /// Load records from disk, applying TTL pruning. Missing file is treated
+    /// as an empty store and is not an error.
+    pub fn load(path: PathBuf) -> Self {
+        let mut store = Self::new(path);
+        store.reload_from_disk();
+        store
+    }
+
+    /// Re-read the backing file from disk and prune expired records.
+    pub fn reload_from_disk(&mut self) {
+        if !self.path.exists() {
+            self.records = Vec::new();
+            return;
+        }
+        match std::fs::read_to_string(&self.path) {
+            Ok(body) => match serde_json::from_str::<Vec<OrchestratorRecord>>(&body) {
+                Ok(mut recs) => {
+                    let cutoff = Utc::now() - self.ttl;
+                    recs.retain(|r| r.last_seen >= cutoff);
+                    self.records = recs;
+                }
+                Err(e) => {
+                    tracing::warn!(path = %self.path.display(), error = %e, "failed to parse orchestrators.json — ignoring");
+                    self.records = Vec::new();
+                }
+            },
+            Err(e) => {
+                tracing::warn!(path = %self.path.display(), error = %e, "failed to read orchestrators.json — ignoring");
+                self.records = Vec::new();
+            }
+        }
+    }
+
+    /// Path to the backing file.
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+
+    /// All records currently held in memory.
+    pub fn records(&self) -> &[OrchestratorRecord] {
+        &self.records
+    }
+
+    /// Prune expired records in place. Returns the number removed.
+    pub fn prune(&mut self) -> usize {
+        let cutoff = Utc::now() - self.ttl;
+        let before = self.records.len();
+        self.records.retain(|r| r.last_seen >= cutoff);
+        before - self.records.len()
+    }
+
+    /// Find a record matching an exact `(project_path, session_id)` tuple.
+    pub fn find_exact(&self, project_path: &str, session_id: &str) -> Option<&OrchestratorRecord> {
+        self.records
+            .iter()
+            .find(|r| r.project_path == project_path && r.claude_session_id == session_id)
+    }
+
+    /// All records for a given project.
+    pub fn records_for_project(&self, project_path: &str) -> Vec<&OrchestratorRecord> {
+        self.records
+            .iter()
+            .filter(|r| r.project_path == project_path)
+            .collect()
+    }
+
+    /// Upsert a record — updates `last_seen` if an entry with the same
+    /// `(project_path, claude_session_id)` exists, otherwise inserts.
+    /// Persists to disk and returns the I/O result.
+    pub fn upsert_and_save(&mut self, project_path: &str, session_id: &str) -> std::io::Result<()> {
+        self.upsert_in_memory(project_path, session_id);
+        self.save()
+    }
+
+    /// In-memory upsert without touching disk. Exposed for bulk updates
+    /// (e.g. the poller refreshing `last_seen` for many orchestrators).
+    pub fn upsert_in_memory(&mut self, project_path: &str, session_id: &str) {
+        let now = Utc::now();
+        if let Some(rec) = self
+            .records
+            .iter_mut()
+            .find(|r| r.project_path == project_path && r.claude_session_id == session_id)
+        {
+            rec.last_seen = now;
+        } else {
+            self.records.push(OrchestratorRecord {
+                project_path: project_path.to_string(),
+                claude_session_id: session_id.to_string(),
+                last_seen: now,
+            });
+        }
+    }
+
+    /// Rotate the session_id for an existing record (Tier 2 restore). If no
+    /// record for `project_path` with `old_session_id` exists the call is a no-op.
+    pub fn rotate_session(
+        &mut self,
+        project_path: &str,
+        old_session_id: &str,
+        new_session_id: &str,
+    ) {
+        let now = Utc::now();
+        if let Some(rec) = self
+            .records
+            .iter_mut()
+            .find(|r| r.project_path == project_path && r.claude_session_id == old_session_id)
+        {
+            rec.claude_session_id = new_session_id.to_string();
+            rec.last_seen = now;
+        }
+    }
+
+    /// Persist the records to disk atomically, prune first, 0600 on unix.
+    pub fn save(&mut self) -> std::io::Result<()> {
+        self.prune();
+        if let Some(parent) = self.path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
+        let body = serde_json::to_vec_pretty(&self.records)
+            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+
+        let tmp_path = self.path.with_extension("json.tmp");
+        {
+            let mut opts = std::fs::OpenOptions::new();
+            opts.create(true).write(true).truncate(true);
+            #[cfg(unix)]
+            {
+                use std::os::unix::fs::OpenOptionsExt;
+                opts.mode(0o600);
+            }
+            let mut f = opts.open(&tmp_path)?;
+            f.write_all(&body)?;
+            f.sync_all()?;
+        }
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            let perms = std::fs::Permissions::from_mode(0o600);
+            std::fs::set_permissions(&tmp_path, perms)?;
+        }
+        std::fs::rename(&tmp_path, &self.path)?;
+        Ok(())
+    }
+}
+
+/// Resolve the default path for the orchestrator state file.
+///
+/// Prefers `$XDG_STATE_HOME/tmai/orchestrators.json`; falls back to
+/// `~/.local/state/tmai/orchestrators.json`, then to the current directory.
+pub fn default_store_path() -> PathBuf {
+    if let Some(state_dir) = dirs::state_dir() {
+        return state_dir.join("tmai").join("orchestrators.json");
+    }
+    if let Some(home) = dirs::home_dir() {
+        return home
+            .join(".local")
+            .join("state")
+            .join("tmai")
+            .join("orchestrators.json");
+    }
+    PathBuf::from("orchestrators.json")
+}
+
+/// Build a shared store for the default path, loading any existing records.
+pub fn new_shared() -> SharedOrchestratorStore {
+    Arc::new(RwLock::new(OrchestratorStore::load(default_store_path())))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::tempdir;
+
+    fn mk_store(dir: &Path) -> OrchestratorStore {
+        OrchestratorStore::new(dir.join("orchestrators.json"))
+    }
+
+    #[test]
+    fn test_upsert_inserts_new_record() {
+        let dir = tempdir().unwrap();
+        let mut s = mk_store(dir.path());
+        s.upsert_and_save("/proj", "sess-1").unwrap();
+        assert_eq!(s.records().len(), 1);
+        assert_eq!(s.records()[0].project_path, "/proj");
+        assert_eq!(s.records()[0].claude_session_id, "sess-1");
+    }
+
+    #[test]
+    fn test_upsert_updates_existing_record() {
+        let dir = tempdir().unwrap();
+        let mut s = mk_store(dir.path());
+        s.upsert_and_save("/proj", "sess-1").unwrap();
+        let first_seen = s.records()[0].last_seen;
+        // Small delay to ensure timestamp differs on fast systems
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        s.upsert_and_save("/proj", "sess-1").unwrap();
+        assert_eq!(s.records().len(), 1);
+        assert!(s.records()[0].last_seen >= first_seen);
+    }
+
+    #[test]
+    fn test_roundtrip_save_and_load() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("orchestrators.json");
+        {
+            let mut s = OrchestratorStore::new(path.clone());
+            s.upsert_and_save("/a", "s1").unwrap();
+            s.upsert_and_save("/b", "s2").unwrap();
+        }
+        let loaded = OrchestratorStore::load(path);
+        assert_eq!(loaded.records().len(), 2);
+    }
+
+    #[test]
+    fn test_ttl_pruning_on_read() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("orchestrators.json");
+        // Seed file with two records: one fresh, one 60 days old.
+        let records = vec![
+            OrchestratorRecord {
+                project_path: "/fresh".into(),
+                claude_session_id: "fresh-sess".into(),
+                last_seen: Utc::now(),
+            },
+            OrchestratorRecord {
+                project_path: "/stale".into(),
+                claude_session_id: "stale-sess".into(),
+                last_seen: Utc::now() - Duration::days(60),
+            },
+        ];
+        std::fs::write(&path, serde_json::to_vec(&records).unwrap()).unwrap();
+
+        let loaded = OrchestratorStore::load(path);
+        assert_eq!(loaded.records().len(), 1);
+        assert_eq!(loaded.records()[0].project_path, "/fresh");
+    }
+
+    #[test]
+    fn test_rotate_session() {
+        let dir = tempdir().unwrap();
+        let mut s = mk_store(dir.path());
+        s.upsert_and_save("/proj", "old-sess").unwrap();
+        s.rotate_session("/proj", "old-sess", "new-sess");
+        assert_eq!(s.records().len(), 1);
+        assert_eq!(s.records()[0].claude_session_id, "new-sess");
+    }
+
+    #[test]
+    fn test_multi_orchestrator_per_project() {
+        let dir = tempdir().unwrap();
+        let mut s = mk_store(dir.path());
+        s.upsert_and_save("/proj", "sess-1").unwrap();
+        s.upsert_and_save("/proj", "sess-2").unwrap();
+        let for_proj = s.records_for_project("/proj");
+        assert_eq!(for_proj.len(), 2);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn test_file_permissions_are_0600() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempdir().unwrap();
+        let mut s = mk_store(dir.path());
+        s.upsert_and_save("/proj", "sess-1").unwrap();
+        let meta = std::fs::metadata(s.path()).unwrap();
+        let mode = meta.permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "file mode must be 0600, got {:o}", mode);
+    }
+
+    #[test]
+    fn test_load_missing_file_is_empty_ok() {
+        let dir = tempdir().unwrap();
+        let s = OrchestratorStore::load(dir.path().join("does-not-exist.json"));
+        assert!(s.records().is_empty());
+    }
+
+    #[test]
+    fn test_load_corrupt_file_is_empty() {
+        let dir = tempdir().unwrap();
+        let path = dir.path().join("orchestrators.json");
+        std::fs::write(&path, "not-json").unwrap();
+        let s = OrchestratorStore::load(path);
+        assert!(s.records().is_empty());
+    }
+}

--- a/crates/tmai-core/src/orchestrator_state/restore.rs
+++ b/crates/tmai-core/src/orchestrator_state/restore.rs
@@ -1,0 +1,629 @@
+//! Tier 1 / Tier 2 orchestrator flag restoration logic.
+//!
+//! Callers invoke [`try_restore_agent`] after a new agent is first inserted
+//! into `AppState::agents`, passing the Claude Code session_id lookup map
+//! so the restore logic can identify the agent's session.
+
+use std::collections::HashMap;
+
+use chrono::{Duration, Utc};
+
+use super::persist::{SharedOrchestratorStore, TIER2_RECENCY_HOURS};
+use crate::hooks::registry::SessionPaneMap;
+use crate::state::AppState;
+
+/// Result of a single restore attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RestoreOutcome {
+    /// No action — no record matched or criteria unmet.
+    NoAction,
+    /// Tier 1 exact match: `(project_path, session_id)` already recorded.
+    Tier1Exact,
+    /// Tier 2 session-id rotation: project matched a recent record whose
+    /// previous session is absent; the record has been rotated to the new
+    /// session_id.
+    Tier2RotateSession,
+}
+
+/// Look up the Claude Code session_id for an agent target by reversing
+/// the `session_id → pane_id` map via `AppState::target_to_pane_id`.
+fn lookup_session_id(
+    state: &AppState,
+    agent_target: &str,
+    session_pane_map: &SessionPaneMap,
+) -> Option<String> {
+    let pane_id = state.target_to_pane_id.get(agent_target)?.clone();
+    let map = session_pane_map.read();
+    map.iter().find_map(|(sid, pid)| {
+        if pid == &pane_id {
+            Some(sid.clone())
+        } else {
+            None
+        }
+    })
+}
+
+/// Project path for an agent — prefer `git_common_dir`, else `cwd`.
+fn project_path_for(state: &AppState, agent_target: &str) -> Option<String> {
+    let agent = state.agents.get(agent_target)?;
+    Some(
+        agent
+            .git_common_dir
+            .clone()
+            .unwrap_or_else(|| agent.cwd.clone()),
+    )
+}
+
+/// Count currently-online agents whose session_id matches `session_id` and
+/// project path matches `project_path`.
+fn is_session_online(
+    state: &AppState,
+    session_pane_map: &SessionPaneMap,
+    project_path: &str,
+    session_id: &str,
+) -> bool {
+    // Build pane_id → target reverse map for the subset of agents in project.
+    let candidate_pane_ids: Vec<String> = state
+        .target_to_pane_id
+        .iter()
+        .filter_map(|(target, pane_id)| {
+            state.agents.get(target).and_then(|a| {
+                let proj = a.git_common_dir.clone().unwrap_or_else(|| a.cwd.clone());
+                if proj == project_path {
+                    Some(pane_id.clone())
+                } else {
+                    None
+                }
+            })
+        })
+        .collect();
+    let map = session_pane_map.read();
+    if let Some(pane_id) = map.get(session_id) {
+        candidate_pane_ids.iter().any(|p| p == pane_id)
+    } else {
+        false
+    }
+}
+
+/// All non-worktree online agents in the given project (candidates for Tier 2).
+fn non_worktree_project_agents(state: &AppState, project_path: &str) -> Vec<String> {
+    state
+        .agents
+        .iter()
+        .filter(|(_, a)| {
+            let proj = a.git_common_dir.clone().unwrap_or_else(|| a.cwd.clone());
+            proj == project_path && !a.is_worktree.unwrap_or(false)
+        })
+        .map(|(id, _)| id.clone())
+        .collect()
+}
+
+/// Attempt to restore `is_orchestrator=true` on `agent_target` using the
+/// persisted store. Returns the outcome.
+///
+/// This function promotes the agent flag in state and rotates or touches the
+/// persisted record as needed; it also persists to disk on a successful
+/// restore.
+pub fn try_restore_agent(
+    state: &mut AppState,
+    agent_target: &str,
+    store: &SharedOrchestratorStore,
+    session_pane_map: &SessionPaneMap,
+) -> RestoreOutcome {
+    // Skip if already orchestrator.
+    if state
+        .agents
+        .get(agent_target)
+        .map(|a| a.is_orchestrator)
+        .unwrap_or(false)
+    {
+        return RestoreOutcome::NoAction;
+    }
+
+    let Some(project_path) = project_path_for(state, agent_target) else {
+        return RestoreOutcome::NoAction;
+    };
+
+    // Skip worktree agents — only the main-repo orchestrator is restored.
+    let is_worktree = state
+        .agents
+        .get(agent_target)
+        .and_then(|a| a.is_worktree)
+        .unwrap_or(false);
+    if is_worktree {
+        return RestoreOutcome::NoAction;
+    }
+
+    let session_id = lookup_session_id(state, agent_target, session_pane_map);
+
+    // --- Tier 1 — exact match on (project_path, session_id) ---
+    if let Some(ref sid) = session_id {
+        let has_exact = store.read().find_exact(&project_path, sid).is_some();
+        if has_exact {
+            if let Some(agent) = state.agents.get_mut(agent_target) {
+                agent.is_orchestrator = true;
+            }
+            // Touch last_seen + persist (ignore I/O errors — we already
+            // applied the flag in memory).
+            let mut w = store.write();
+            if let Err(e) = w.upsert_and_save(&project_path, sid) {
+                tracing::warn!(error = %e, "failed to persist orchestrator state after Tier 1 restore");
+            }
+            return RestoreOutcome::Tier1Exact;
+        }
+    }
+
+    // --- Tier 2 — /resume fallback ---
+    // Requires: at least one recent record for project, its previous session
+    // is not currently online, and exactly one non-worktree candidate exists.
+    let cutoff = Utc::now() - Duration::hours(TIER2_RECENCY_HOURS);
+    let recent_record: Option<(String, String)> = {
+        let r = store.read();
+        let mut recents: Vec<&super::persist::OrchestratorRecord> = r
+            .records_for_project(&project_path)
+            .into_iter()
+            .filter(|rec| rec.last_seen >= cutoff)
+            .collect();
+        recents.sort_by_key(|rec| std::cmp::Reverse(rec.last_seen));
+        recents
+            .first()
+            .map(|rec| (rec.project_path.clone(), rec.claude_session_id.clone()))
+    };
+    let Some((rec_project, rec_session)) = recent_record else {
+        return RestoreOutcome::NoAction;
+    };
+
+    // Don't Tier-2-restore if the recorded session_id matches the new agent's
+    // session_id — Tier 1 would have caught it; arriving here implies either
+    // no session_id was resolvable or it differs.
+    if let Some(ref sid) = session_id {
+        if sid == &rec_session {
+            return RestoreOutcome::NoAction;
+        }
+    }
+
+    // Recorded session must not be online (stale session implies /resume).
+    if is_session_online(state, session_pane_map, &rec_project, &rec_session) {
+        return RestoreOutcome::NoAction;
+    }
+
+    // Must have no other online orchestrator for this project already.
+    let any_other_orchestrator = state.agents.iter().any(|(id, a)| {
+        if id == agent_target {
+            return false;
+        }
+        if !a.is_orchestrator {
+            return false;
+        }
+        let proj = a.git_common_dir.clone().unwrap_or_else(|| a.cwd.clone());
+        proj == project_path
+    });
+    if any_other_orchestrator {
+        return RestoreOutcome::NoAction;
+    }
+
+    // Exactly one non-worktree candidate (this agent).
+    let candidates = non_worktree_project_agents(state, &project_path);
+    if candidates.len() != 1 || candidates[0] != agent_target {
+        return RestoreOutcome::NoAction;
+    }
+
+    // Promote + rotate the record (or touch if session_id was unresolvable).
+    if let Some(agent) = state.agents.get_mut(agent_target) {
+        agent.is_orchestrator = true;
+    }
+    let mut w = store.write();
+    if let Some(ref sid) = session_id {
+        w.rotate_session(&rec_project, &rec_session, sid);
+    } else {
+        // Keep the record's session_id but update last_seen.
+        w.upsert_in_memory(&rec_project, &rec_session);
+    }
+    if let Err(e) = w.save() {
+        tracing::warn!(error = %e, "failed to persist orchestrator state after Tier 2 restore");
+    }
+    RestoreOutcome::Tier2RotateSession
+}
+
+/// Refresh `last_seen` on every persisted record that matches a currently-online
+/// orchestrator. Intended to be called periodically from the polling loop.
+pub fn update_last_seen_for_online(
+    state: &AppState,
+    store: &SharedOrchestratorStore,
+    session_pane_map: &SessionPaneMap,
+) {
+    // Collect (project_path, session_id) for each online orchestrator.
+    let mut online: Vec<(String, String)> = Vec::new();
+    // Build pane_id → session_id reverse map once.
+    let pane_to_session: HashMap<String, String> = {
+        let m = session_pane_map.read();
+        m.iter()
+            .map(|(sid, pid)| (pid.clone(), sid.clone()))
+            .collect()
+    };
+    for (target, agent) in &state.agents {
+        if !agent.is_orchestrator {
+            continue;
+        }
+        let project_path = agent
+            .git_common_dir
+            .clone()
+            .unwrap_or_else(|| agent.cwd.clone());
+        if let Some(pane_id) = state.target_to_pane_id.get(target) {
+            if let Some(sid) = pane_to_session.get(pane_id) {
+                online.push((project_path, sid.clone()));
+            }
+        }
+    }
+    if online.is_empty() {
+        return;
+    }
+    let mut w = store.write();
+    for (proj, sid) in &online {
+        w.upsert_in_memory(proj, sid);
+    }
+    if let Err(e) = w.save() {
+        tracing::warn!(error = %e, "failed to persist orchestrator state during last_seen refresh");
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::agents::{AgentType, MonitoredAgent};
+    use crate::hooks::new_session_pane_map;
+    use crate::orchestrator_state::persist::OrchestratorStore;
+    use parking_lot::RwLock;
+    use std::sync::Arc;
+    use tempfile::TempDir;
+
+    struct Ctx {
+        _dir: TempDir,
+        state: AppState,
+        store: SharedOrchestratorStore,
+        spm: SessionPaneMap,
+    }
+
+    fn make_agent(target: &str, cwd: &str, is_worktree: Option<bool>) -> MonitoredAgent {
+        let mut a = MonitoredAgent::new(
+            target.to_string(),
+            AgentType::ClaudeCode,
+            "Title".into(),
+            cwd.into(),
+            100,
+            "main".into(),
+            "win".into(),
+            0,
+            0,
+        );
+        a.is_worktree = is_worktree;
+        a.git_common_dir = Some(cwd.into());
+        a
+    }
+
+    fn setup() -> Ctx {
+        let dir = TempDir::new().unwrap();
+        let store_path = dir.path().join("orchestrators.json");
+        let store = Arc::new(RwLock::new(OrchestratorStore::new(store_path)));
+        let spm = new_session_pane_map();
+        Ctx {
+            _dir: dir,
+            state: AppState::new(),
+            store,
+            spm,
+        }
+    }
+
+    /// Insert agent into state and register its pane_id + session_id mapping
+    /// so the restore module can look up the session_id.
+    fn register_agent(
+        ctx: &mut Ctx,
+        target: &str,
+        cwd: &str,
+        is_worktree: Option<bool>,
+        pane_id: &str,
+        session_id: &str,
+    ) {
+        let agent = make_agent(target, cwd, is_worktree);
+        ctx.state.agents.insert(target.to_string(), agent);
+        ctx.state
+            .target_to_pane_id
+            .insert(target.to_string(), pane_id.to_string());
+        ctx.spm
+            .write()
+            .insert(session_id.to_string(), pane_id.to_string());
+    }
+
+    #[test]
+    fn tier1_exact_match_restores() {
+        let mut ctx = setup();
+        ctx.store
+            .write()
+            .upsert_and_save("/proj", "sess-abc")
+            .unwrap();
+
+        register_agent(
+            &mut ctx,
+            "main:0.0",
+            "/proj",
+            Some(false),
+            "pane-1",
+            "sess-abc",
+        );
+
+        let out = try_restore_agent(&mut ctx.state, "main:0.0", &ctx.store, &ctx.spm);
+        assert_eq!(out, RestoreOutcome::Tier1Exact);
+        assert!(ctx.state.agents["main:0.0"].is_orchestrator);
+    }
+
+    #[test]
+    fn tier1_no_match_does_nothing() {
+        let mut ctx = setup();
+        ctx.store
+            .write()
+            .upsert_and_save("/other-proj", "sess-xyz")
+            .unwrap();
+
+        register_agent(
+            &mut ctx,
+            "main:0.0",
+            "/proj",
+            Some(false),
+            "pane-1",
+            "sess-abc",
+        );
+
+        let out = try_restore_agent(&mut ctx.state, "main:0.0", &ctx.store, &ctx.spm);
+        assert_eq!(out, RestoreOutcome::NoAction);
+        assert!(!ctx.state.agents["main:0.0"].is_orchestrator);
+    }
+
+    #[test]
+    fn tier2_single_candidate_resume_restores_and_rotates() {
+        let mut ctx = setup();
+        // Record has OLD session_id
+        ctx.store
+            .write()
+            .upsert_and_save("/proj", "old-sess")
+            .unwrap();
+
+        // Agent came back with NEW session_id (post-/resume)
+        register_agent(
+            &mut ctx,
+            "main:0.0",
+            "/proj",
+            Some(false),
+            "pane-1",
+            "new-sess",
+        );
+
+        let out = try_restore_agent(&mut ctx.state, "main:0.0", &ctx.store, &ctx.spm);
+        assert_eq!(out, RestoreOutcome::Tier2RotateSession);
+        assert!(ctx.state.agents["main:0.0"].is_orchestrator);
+
+        // Record rotated to new session_id
+        let r = ctx.store.read();
+        assert_eq!(r.records().len(), 1);
+        assert_eq!(r.records()[0].claude_session_id, "new-sess");
+    }
+
+    #[test]
+    fn tier2_rejects_multi_candidate() {
+        let mut ctx = setup();
+        ctx.store
+            .write()
+            .upsert_and_save("/proj", "old-sess")
+            .unwrap();
+
+        // Two non-worktree candidates in same project
+        register_agent(
+            &mut ctx,
+            "main:0.0",
+            "/proj",
+            Some(false),
+            "pane-1",
+            "new-sess",
+        );
+        register_agent(
+            &mut ctx,
+            "main:0.1",
+            "/proj",
+            Some(false),
+            "pane-2",
+            "another-sess",
+        );
+
+        let out = try_restore_agent(&mut ctx.state, "main:0.0", &ctx.store, &ctx.spm);
+        assert_eq!(out, RestoreOutcome::NoAction);
+        assert!(!ctx.state.agents["main:0.0"].is_orchestrator);
+    }
+
+    #[test]
+    fn tier2_rejects_stale_last_seen() {
+        let mut ctx = setup();
+        // Seed a stale record (48h old — beyond 24h Tier2 cutoff but within 30d TTL)
+        {
+            let mut w = ctx.store.write();
+            w.upsert_in_memory("/proj", "old-sess");
+            let now = Utc::now();
+            w.records[0].last_seen = now - Duration::hours(48);
+            w.save().unwrap();
+        }
+
+        register_agent(
+            &mut ctx,
+            "main:0.0",
+            "/proj",
+            Some(false),
+            "pane-1",
+            "new-sess",
+        );
+
+        let out = try_restore_agent(&mut ctx.state, "main:0.0", &ctx.store, &ctx.spm);
+        assert_eq!(out, RestoreOutcome::NoAction);
+        assert!(!ctx.state.agents["main:0.0"].is_orchestrator);
+    }
+
+    #[test]
+    fn tier2_rejects_when_recorded_session_still_online() {
+        let mut ctx = setup();
+        ctx.store
+            .write()
+            .upsert_and_save("/proj", "old-sess")
+            .unwrap();
+
+        // Old session agent STILL ONLINE
+        register_agent(
+            &mut ctx,
+            "main:0.0",
+            "/proj",
+            Some(false),
+            "pane-1",
+            "old-sess",
+        );
+        // New-session agent candidate
+        register_agent(
+            &mut ctx,
+            "main:0.1",
+            "/proj",
+            Some(false),
+            "pane-2",
+            "new-sess",
+        );
+
+        let out = try_restore_agent(&mut ctx.state, "main:0.1", &ctx.store, &ctx.spm);
+        assert_eq!(out, RestoreOutcome::NoAction);
+        assert!(!ctx.state.agents["main:0.1"].is_orchestrator);
+    }
+
+    #[test]
+    fn tier2_rejects_when_existing_orchestrator_present() {
+        let mut ctx = setup();
+        ctx.store
+            .write()
+            .upsert_and_save("/proj", "old-sess")
+            .unwrap();
+
+        // Some other agent is already orchestrator for project
+        register_agent(
+            &mut ctx,
+            "main:0.0",
+            "/proj",
+            Some(false),
+            "pane-1",
+            "other-sess",
+        );
+        ctx.state
+            .agents
+            .get_mut("main:0.0")
+            .unwrap()
+            .is_orchestrator = true;
+        register_agent(
+            &mut ctx,
+            "main:0.1",
+            "/proj",
+            Some(false),
+            "pane-2",
+            "new-sess",
+        );
+
+        let out = try_restore_agent(&mut ctx.state, "main:0.1", &ctx.store, &ctx.spm);
+        assert_eq!(out, RestoreOutcome::NoAction);
+        assert!(!ctx.state.agents["main:0.1"].is_orchestrator);
+    }
+
+    #[test]
+    fn worktree_agent_is_skipped() {
+        let mut ctx = setup();
+        ctx.store
+            .write()
+            .upsert_and_save("/proj", "sess-1")
+            .unwrap();
+
+        register_agent(
+            &mut ctx,
+            "main:0.0",
+            "/proj",
+            Some(true),
+            "pane-1",
+            "sess-1",
+        );
+
+        let out = try_restore_agent(&mut ctx.state, "main:0.0", &ctx.store, &ctx.spm);
+        assert_eq!(out, RestoreOutcome::NoAction);
+        assert!(!ctx.state.agents["main:0.0"].is_orchestrator);
+    }
+
+    #[test]
+    fn multi_orchestrator_both_tier1_restore() {
+        let mut ctx = setup();
+        ctx.store
+            .write()
+            .upsert_and_save("/proj", "sess-a")
+            .unwrap();
+        ctx.store
+            .write()
+            .upsert_and_save("/proj", "sess-b")
+            .unwrap();
+
+        register_agent(
+            &mut ctx,
+            "main:0.0",
+            "/proj",
+            Some(false),
+            "pane-1",
+            "sess-a",
+        );
+        register_agent(
+            &mut ctx,
+            "main:0.1",
+            "/proj",
+            Some(false),
+            "pane-2",
+            "sess-b",
+        );
+
+        let o0 = try_restore_agent(&mut ctx.state, "main:0.0", &ctx.store, &ctx.spm);
+        let o1 = try_restore_agent(&mut ctx.state, "main:0.1", &ctx.store, &ctx.spm);
+        assert_eq!(o0, RestoreOutcome::Tier1Exact);
+        assert_eq!(o1, RestoreOutcome::Tier1Exact);
+        assert!(ctx.state.agents["main:0.0"].is_orchestrator);
+        assert!(ctx.state.agents["main:0.1"].is_orchestrator);
+    }
+
+    #[test]
+    fn update_last_seen_refreshes_online_orchestrators() {
+        let mut ctx = setup();
+        // Pre-seed with OLD last_seen
+        {
+            let mut w = ctx.store.write();
+            w.upsert_in_memory("/proj", "sess-1");
+            w.records[0].last_seen = Utc::now() - Duration::hours(5);
+            w.save().unwrap();
+        }
+        let before = ctx.store.read().records()[0].last_seen;
+
+        register_agent(
+            &mut ctx,
+            "main:0.0",
+            "/proj",
+            Some(false),
+            "pane-1",
+            "sess-1",
+        );
+        ctx.state
+            .agents
+            .get_mut("main:0.0")
+            .unwrap()
+            .is_orchestrator = true;
+
+        update_last_seen_for_online(&ctx.state, &ctx.store, &ctx.spm);
+
+        let after = ctx.store.read().records()[0].last_seen;
+        assert!(after > before);
+    }
+}

--- a/crates/tmai-core/src/state/mod.rs
+++ b/crates/tmai-core/src/state/mod.rs
@@ -3,6 +3,6 @@ mod store;
 pub use store::{
     AppState, ConfirmAction, ConfirmationState, CreateProcessState, CreateProcessStep, DirItem,
     InputMode, InputState, MonitorScope, PendingAgentMetadata, PlacementType, RepoWorktreeInfo,
-    SelectionState, SharedState, SortBy, TeamSnapshot, TreeEntry, ViewState, WebState,
-    WorktreeDetail,
+    SelectionState, SharedState, SortBy, TargetChange, TeamSnapshot, TreeEntry, ViewState,
+    WebState, WorktreeDetail,
 };

--- a/crates/tmai-core/src/state/store.rs
+++ b/crates/tmai-core/src/state/store.rs
@@ -554,6 +554,12 @@ pub struct AppState {
     /// between the producer (notifier busy branch) and the consumer
     /// (flush-on-idle / flush-on-appear).
     pub orchestrator_notify_buffer: Option<crate::orchestrator_notify::SharedNotifyBuffer>,
+
+    /// Shared handle to the persisted orchestrator identity store.
+    /// Populated at tmai startup from `$XDG_STATE_HOME/tmai/orchestrators.json`.
+    /// Used to auto-restore `is_orchestrator=true` across tmai restart and
+    /// Claude Code `/resume` (#380).
+    pub orchestrator_state: Option<crate::orchestrator_state::SharedOrchestratorStore>,
 }
 
 impl AppState {
@@ -601,6 +607,7 @@ impl AppState {
             guardrails_settings: None,
             auto_action_templates: None,
             orchestrator_notify_buffer: None,
+            orchestrator_state: None,
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -277,6 +277,13 @@ async fn run_tmux_mode(settings: Settings, _cli: Config) -> Result<()> {
     // Restore in-memory issue/PR associations from persisted .task-meta/ files
     tmai_core::task_meta::restore_from_disk(&app.shared_state(), &settings.project_paths());
 
+    // Load persisted orchestrator identity store (#380) — enables auto-restore
+    // of is_orchestrator across tmai restart and Claude Code /resume.
+    {
+        let orch_store = tmai_core::orchestrator_state::new_shared();
+        app.shared_state().write().orchestrator_state = Some(orch_store);
+    }
+
     // Start Codex CLI app-server WebSocket connections if configured
     if !settings.codex_ws.connections.is_empty() {
         let codex_ws_service = tmai_core::codex_ws::CodexWsService::new(
@@ -511,6 +518,13 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
     // Restore in-memory issue/PR associations from persisted .task-meta/ files
     tmai_core::task_meta::restore_from_disk(&state, &settings.project_paths());
 
+    // Load persisted orchestrator identity store (#380) — enables auto-restore
+    // of is_orchestrator across tmai restart and Claude Code /resume.
+    {
+        let orch_store = tmai_core::orchestrator_state::new_shared();
+        state.write().orchestrator_state = Some(orch_store);
+    }
+
     // Start Codex CLI app-server WebSocket connections if configured
     if !settings.codex_ws.connections.is_empty() {
         let codex_ws_service = tmai_core::codex_ws::CodexWsService::new(
@@ -598,18 +612,19 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
     let mut pty_sync_interval = tokio::time::interval(std::time::Duration::from_secs(2));
     pty_sync_interval.tick().await; // skip first tick
 
+    // Periodic refresh for orchestrator last_seen (#380) — touches the
+    // persisted record every 60s for every online orchestrator so TTL pruning
+    // doesn't reap active sessions.
+    let mut orch_last_seen_interval = tokio::time::interval(std::time::Duration::from_secs(60));
+    orch_last_seen_interval.tick().await; // skip first tick
+
     // Main loop: process poll messages and update state until shutdown
     loop {
         tokio::select! {
             msg = poll_rx.recv() => {
                 match msg {
                     Some(tmai_core::monitor::PollMessage::AgentsUpdated(agents)) => {
-                        let target_changes = {
-                            let mut s = state.write();
-                            let changes = s.update_agents(agents);
-                            s.clear_error();
-                            changes
-                        };
+                        let target_changes = core.apply_agents_poll_update(agents);
                         // Emit events for PID-based target migrations
                         for tc in target_changes {
                             tracing::info!(
@@ -639,6 +654,9 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
                 if core.sync_pty_sessions() {
                     core.notify_agents_updated();
                 }
+            }
+            _ = orch_last_seen_interval.tick() => {
+                core.refresh_orchestrator_last_seen();
             }
             _ = tokio::signal::ctrl_c() => {
                 eprintln!("\ntmai: shutting down...");

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -375,7 +375,9 @@ impl App {
             while let Ok(msg) = poll_rx.try_recv() {
                 match msg {
                     PollMessage::AgentsUpdated(agents) => {
-                        let target_changes = {
+                        let target_changes = if let Some(ref core) = self.core {
+                            core.apply_agents_poll_update(agents)
+                        } else {
                             let mut state = self.state.write();
                             let changes = state.update_agents(agents);
                             state.clear_error();


### PR DESCRIPTION
Closes #380.

## Summary

- New `orchestrator_state` module persists orchestrator identity to `$XDG_STATE_HOME/tmai/orchestrators.json` (fallback `~/.local/state/tmai/orchestrators.json`), keyed by `(project_path, claude_session_id)`, so `is_orchestrator=true` survives tmai restart and Claude Code `/resume`.
- **Tier 1** — exact `(project, session_id)` match silently promotes a newly-detected agent.
- **Tier 2** — `/resume` fallback: if exactly one non-worktree candidate in the project has no prior orchestrator online and a recent (<24h) record exists, promote the agent and rotate the record's `session_id` to the new value.
- 30-day TTL pruning on read; `0600` permissions on unix; atomic write via `.tmp` + rename.
- `set_orchestrator` (REST/MCP) persists the record; main loop refreshes `last_seen` every 60s for every online orchestrator.

## Design notes

- Store is shared as a single `Arc<RwLock<OrchestratorStore>>` stashed on `AppState::orchestrator_state`; every consumer clones that same Arc (addresses the CoderRabbit sharing bug pattern from #373/#374).
- Hook point: new `TmaiCore::apply_agents_poll_update(agents)` wraps `AppState::update_agents` and runs Tier1/Tier2 restore for freshly-inserted agents. The WebUI main loop and tmux TUI both call it; tests of `update_agents` are untouched.
- Session-id resolution goes through `SessionPaneMap` (reversing `session_id → pane_id`), with `target_to_pane_id` on `AppState` giving target → pane_id.
- Tier 2 rejection guards: multi-candidate, stale `last_seen`, recorded session still online, or any other online orchestrator already present for the project.

## Tests

All in `crates/tmai-core/src/orchestrator_state/` (19 tests, all passing):

- Persist: upsert/insert/update, save+load round-trip, 30-day TTL pruning on read, session rotation, multi-orchestrator per project, 0600 file permissions, missing/corrupt file = empty.
- Restore: Tier 1 exact match, Tier 1 no-match, Tier 2 `/resume` rotation, Tier 2 rejection (multi-candidate / stale last_seen / recorded session online / existing orchestrator present), worktree skip, multi-orchestrator Tier 1, online-orchestrator `last_seen` refresh.

## Test plan

- [x] `cargo test -p tmai-core orchestrator_state` → 19 passed
- [x] `cargo clippy --all-targets -- -D warnings` → clean
- [x] `cargo fmt --check` → clean
- [x] `cargo build` → clean
- [ ] Manual: kill tmai after `set_orchestrator`, restart, confirm flag is re-applied on first poll
- [ ] Manual: run `/resume` in the orchestrator session, confirm Tier 2 rotation silently restores the flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

* **New Features**
  * オーケストレータの割当が永続化され、アプリ再起動後も復元されます
  * Claude Codeセッションの再開時にオーケストレータ役割を自動復元（優先/フォールバックの復元処理を含む）
  * オーケストレータの最終アクティビティ情報が定期更新（60秒間隔の更新）

* **Refactor**
  * 状態更新フローと永続化の統合により、エージェント更新処理が一元化されました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->