### PR TITLE
fix: self-heal api.json when it disappears at runtime

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,7 @@ async fn run_tmux_mode(settings: Settings, _cli: Config) -> Result<()> {
         if let Err(e) = tmai::mcp::client::write_api_info(settings.web.port, &token) {
             eprintln!("tmai: warning: failed to write API info: {e}");
         }
+        tmai::mcp::client::spawn_api_info_watchdog(settings.web.port, token.clone());
     }
 
     // Start orchestrator notifier if enabled
@@ -423,6 +424,7 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
     if let Err(e) = tmai::mcp::client::write_api_info(port, &token) {
         eprintln!("tmai: warning: failed to write API info: {e}");
     }
+    tmai::mcp::client::spawn_api_info_watchdog(port, token.clone());
 
     let url = format!("http://localhost:{port}/?token={token}");
     eprintln!("tmai: web server running at {url}");

--- a/src/mcp/client.rs
+++ b/src/mcp/client.rs
@@ -55,6 +55,37 @@ pub fn remove_api_info() {
     let _ = std::fs::remove_file(api_info_path());
 }
 
+/// Spawn a background task that rewrites `api.json` whenever it disappears.
+///
+/// api.json has been observed going missing while tmai is still running
+/// (root cause undetermined — no code path in the tmai binary removes it
+/// while the main loop is live). MCP clients depend on the file to
+/// discover port+token, so the watchdog makes the file self-healing.
+/// Noop while the file exists; writes exactly the same port+token the
+/// parent already uses. Task runs for the lifetime of the tokio runtime.
+pub fn spawn_api_info_watchdog(port: u16, token: String) {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(std::time::Duration::from_secs(5));
+        interval.tick().await; // skip first fire
+        loop {
+            interval.tick().await;
+            if !api_info_path().exists() {
+                match write_api_info(port, &token) {
+                    Ok(()) => {
+                        tracing::info!(
+                            path = %api_info_path().display(),
+                            "api.json watchdog: rewrote missing connection file"
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!("api.json watchdog: rewrite failed: {e}");
+                    }
+                }
+            }
+        }
+    });
+}
+
 /// HTTP client for tmai's Web API.
 /// Re-reads `api.json` on every request so that token and port changes
 /// (e.g. after tmai restart) are picked up transparently.
@@ -364,6 +395,30 @@ mod tests {
         remove_api_info();
         let result = TmaiHttpClient::from_runtime();
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn watchdog_rewrite_step_restores_missing_file() {
+        // Covers the core of spawn_api_info_watchdog: when api.json is gone,
+        // calling write_api_info with the original port/token recreates it
+        // with the same contents a client would expect. We exercise the
+        // write step directly (the periodic tokio interval is an
+        // integration concern not worth the async scaffolding in a unit
+        // test).
+        let _lock = API_FILE_LOCK.lock().unwrap();
+
+        write_api_info(5000, "watchdog-token").unwrap();
+        remove_api_info();
+        assert!(!api_info_path().exists());
+
+        write_api_info(5000, "watchdog-token").unwrap();
+        assert!(api_info_path().exists());
+
+        let info = TmaiHttpClient::read_connection_info().unwrap();
+        assert_eq!(info.port, 5000);
+        assert_eq!(info.token, "watchdog-token");
+
+        remove_api_info();
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- \`\$XDG_RUNTIME_DIR/tmai/api.json\` has been observed going missing multiple times while tmai's parent process is still alive. MCP clients then cannot reconnect (they read port+token from this file) even though the HTTP API keeps answering.
- Audit of every subcommand entrypoint (\`mcp\`, \`wrap\`, \`audit\`, \`codex-hook\`, \`init\`, \`uninit\`, \`tmux\`, \`webui\`) shows the **only** code path that deletes the file is the shutdown cleanup at \`src/main.rs:651\`, and that path was verified not to be reached during the most recent incident (current tmai process alive, single IPC-server-started line in the log, no shutdown messages).
- Root cause of the disappearance remains unidentified — no tmai.log trace, no concurrent process with delete access, no systemd tmpfiles cleanup, no external \`rm\` observed. Keeping the investigation open, but self-healing is safe and cheap.

## Fix

Add a tokio background task (\`mcp::client::spawn_api_info_watchdog\`) that polls once every 5s. If \`api.json\` is absent, it calls \`write_api_info\` with the same port+token the parent process is already using. Noop while the file is present.

Spawned from both \`run_webui_mode\` (\`src/main.rs:425\`) and \`run_tmux_mode\` (\`src/main.rs:212\`), right after the initial \`write_api_info\` call.

## Why not something stronger

Considered and rejected for now:
- **SIGHUP handler** — still requires user action, easy to forget.
- **IPC API for port/token** — solves the problem properly (MCP client would never need api.json at all) but is a larger architectural change; filed as a follow-up candidate.

## Test plan

- [x] \`cargo test -p tmai --lib mcp::client\` — 8 passed including new \`watchdog_rewrite_step_restores_missing_file\` (exercises the write step; the tokio interval itself is an integration concern not worth async test scaffolding).
- [x] \`cargo clippy --all-targets -- -D warnings\` — clean
- [x] \`cargo fmt --check\` — clean
- [ ] Manual: start tmai, delete api.json manually, confirm the file is recreated within ~5 seconds with the same port+token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)