### PR TITLE
fix: WebUI keystrokes switch Poller to fast-tick (true root cause)

### DIFF
--- a/crates/tmai-core/src/api/actions.rs
+++ b/crates/tmai-core/src/api/actions.rs
@@ -248,6 +248,8 @@ impl TmaiCore {
         tokio::time::sleep(std::time::Duration::from_millis(50)).await;
         cmd.send_keys(&target, "Enter")?;
 
+        self.state().write().note_webui_keystroke();
+
         self.audit_helper()
             .maybe_emit_input(&target, "input_text", "api_input", None);
 
@@ -373,6 +375,8 @@ impl TmaiCore {
             let cmd = self.require_command_sender()?;
             cmd.send_keys(&target, key)?;
         }
+
+        self.state().write().note_webui_keystroke();
 
         self.audit_helper()
             .maybe_emit_input(&target, "special_key", "api_input", None);

--- a/crates/tmai-core/src/monitor/poller.rs
+++ b/crates/tmai-core/src/monitor/poller.rs
@@ -273,10 +273,16 @@ impl Poller {
         // poll_count is now tracked as self.poll_count for use in poll_once()
 
         loop {
-            // Check if we should stop and get passthrough state
+            // Check if we should stop and get passthrough state. TUI enters
+            // passthrough via `is_passthrough_mode`; WebUI can't flip that
+            // flag (different input subsystem) so we also treat a recent
+            // WebUI keystroke (passthrough/send_text/send_key/send_prompt)
+            // as a fast-interval trigger for 2s after the last event.
             let (should_stop, is_passthrough) = {
                 let state = self.state.read();
-                (!state.running, state.is_passthrough_mode())
+                let tui_passthrough = state.is_passthrough_mode();
+                let webui_passthrough = state.is_webui_keystroke_active(Duration::from_secs(2));
+                (!state.running, tui_passthrough || webui_passthrough)
             };
 
             if should_stop {

--- a/crates/tmai-core/src/state/store.rs
+++ b/crates/tmai-core/src/state/store.rs
@@ -486,6 +486,12 @@ pub struct AppState {
     /// Whether the app is running
     pub running: bool,
 
+    /// Timestamp of the most recent WebUI passthrough-style send
+    /// (passthrough input, send_text, send_key, send_prompt). Used by the
+    /// Poller to switch to the fast tick interval so the preview cache
+    /// reflects keystrokes within tens of ms instead of 500ms.
+    pub last_webui_keystroke_at: Option<std::time::Instant>,
+
     /// Show activity name (tool/verb) during Processing instead of generic "Processing"
     pub show_activity_name: bool,
 
@@ -588,6 +594,7 @@ impl AppState {
             error_message: None,
             last_poll: None,
             running: true,
+            last_webui_keystroke_at: None,
             show_activity_name: true,
             line_wrap: false,
             notification: None,
@@ -1359,6 +1366,21 @@ impl AppState {
     /// Check if in passthrough mode
     pub fn is_passthrough_mode(&self) -> bool {
         self.input.mode == InputMode::Passthrough
+    }
+
+    /// Mark that a WebUI keystroke-like action just happened. Called from
+    /// every REST handler that pushes bytes into an agent (passthrough,
+    /// send_text, send_key, send_prompt) so the Poller can momentarily
+    /// switch to its fast tick interval.
+    pub fn note_webui_keystroke(&mut self) {
+        self.last_webui_keystroke_at = Some(std::time::Instant::now());
+    }
+
+    /// Returns true if a WebUI keystroke-like action happened within the
+    /// given window. Used by the Poller to decide the next tick interval.
+    pub fn is_webui_keystroke_active(&self, window: std::time::Duration) -> bool {
+        self.last_webui_keystroke_at
+            .is_some_and(|t| t.elapsed() < window)
     }
 
     /// Get the input buffer

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -521,6 +521,13 @@ pub async fn passthrough_input(
             .map_err(|e| json_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
     }
 
+    // Tell the Poller to switch to fast-tick mode so the preview cache
+    // reflects this keystroke within ms (instead of 500ms default).
+    {
+        #[allow(deprecated)]
+        core.raw_state().write().note_webui_keystroke();
+    }
+
     Ok(Json(serde_json::json!({"status": "ok"})))
 }
 


### PR DESCRIPTION
## Summary

Deep-trace of the keystroke→preview pipeline (requested: \"経路を徹底調査してください\") revealed the real root cause that #400-#410 kept skirting:

- The Poller only engages its fast tick (\`passthrough_poll_interval_ms = 10ms\` default) when \`AppState::is_passthrough_mode()\` is true — which is the **TUI input-mode flag**.
- WebUI keystrokes go through HTTP handlers (\`/passthrough\`, \`/input\`, \`/key\`, \`/prompt\`) and **never flip that flag**. The Poller therefore stays on its 500ms base tick.
- \`state.last_content_ansi\` lags the actual tmux pane by up to ~500ms. Whatever frontend polling cadence we pick (200ms, 100ms, 50ms) reads the same stale cache → perceived input lag, exactly as reported.

## Fix

- \`AppState\`: add \`last_webui_keystroke_at: Option<Instant>\` + \`note_webui_keystroke()\` + \`is_webui_keystroke_active(window)\`.
- Poller main loop (\`monitor/poller.rs\`): treat \`is_passthrough_mode() || is_webui_keystroke_active(2s)\` as the fast-interval trigger. 2s window auto-expires into the normal interval.
- Call \`note_webui_keystroke()\` from every REST-originated keystroke:
  - \`src/web/api.rs::passthrough_input\`
  - \`TmaiCore::send_text\`
  - \`TmaiCore::send_key\` (PTY + tmux paths)
  - \`send_prompt\` uses \`send_text\` internally, so it's covered.

## Why this is the definitive fix

tmux-side is already immediate (user confirmed: keystrokes visible in tmux at once). The chain from the pane back to the browser is:

\`\`\`
tmux pane ─► Poller capture (every N ms) ─► state cache ─► HTTP /preview ─► setContent ─► innerHTML
\`\`\`

The slowest hop by far was the Poller's N=500ms. With this PR, N drops to 10ms for 2s after each keystroke, so the cache tracks tmux within a single tick and the frontend's 200ms poll sees fresh bytes every time.

## Test plan

- [x] \`cargo build --bin tmai\` / \`cargo clippy -- -D warnings\` / \`cargo fmt\` — clean.
- [ ] Manual: restart tmai, reload Chrome, type in the WebUI prompt. Preview should now reflect each keystroke within ~100-200ms instead of 500ms+.

## Related

- #400/#402/#404/#405/#410 kept the surrounding path clean; this closes the last gap.
- Reverted overlay approach (#406/#407/#409) was working around this, not curing it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * WebUIキーボード入力に対するシステムの応答性が向上しました。入力後約2秒間、ポーリング頻度が上がり、より迅速にシステムが反応するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->