### PR TITLE
feat: queue orchestrator notifications while operator is typing (#399)

### DIFF
--- a/crates/tmai-core/src/agents/types.rs
+++ b/crates/tmai-core/src/agents/types.rs
@@ -810,6 +810,11 @@ pub struct MonitoredAgent {
     pub issue_number: Option<u64>,
     /// Associated PR number (auto-detected from branch or set manually)
     pub pr_number: Option<u64>,
+    /// Timestamp of the most recent human-originated keystroke into this
+    /// agent's pane. Used by `OrchestratorNotifier` to defer notifications
+    /// while the operator is composing input but has not submitted yet (#399).
+    /// Not serialized — purely an in-memory signal.
+    pub last_human_input_at: Option<std::time::Instant>,
 }
 
 impl MonitoredAgent {
@@ -880,7 +885,23 @@ impl MonitoredAgent {
             is_orchestrator: false,
             issue_number: None,
             pr_number: None,
+            last_human_input_at: None,
         }
+    }
+
+    /// Stamp `last_human_input_at` with the current time. Called from
+    /// `CommandSender` when a keystroke originates from `ActionOrigin::Human`.
+    pub fn note_human_input(&mut self) {
+        self.last_human_input_at = Some(std::time::Instant::now());
+    }
+
+    /// Returns true when the operator is actively composing input into this
+    /// pane (i.e. a Human keystroke landed within the last `grace` window).
+    /// Used by the orchestrator notifier to avoid clobbering in-flight input.
+    pub fn is_operator_typing(&self, grace: std::time::Duration) -> bool {
+        self.last_human_input_at
+            .map(|t| t.elapsed() < grace)
+            .unwrap_or(false)
     }
 
     /// Set the detection source

--- a/crates/tmai-core/src/command_sender.rs
+++ b/crates/tmai-core/src/command_sender.rs
@@ -2,6 +2,7 @@ use anyhow::Result;
 use std::collections::HashMap;
 use std::sync::Arc;
 
+use crate::api::ActionOrigin;
 use crate::codex_ws::CodexWsSender;
 use crate::hooks::registry::HookRegistry;
 use crate::ipc::server::IpcServer;
@@ -154,6 +155,67 @@ impl CommandSender {
     /// Send text + Enter via PTY session → IPC → tmux send-keys → PTY inject
     pub fn send_text_and_enter(&self, target: &str, text: &str) -> Result<()> {
         self.try_send_via_tiers(target, text, SendVariant::TextAndEnter)
+    }
+
+    /// Send keys with an `ActionOrigin`. When the origin is `Human`, stamps
+    /// `last_human_input_at` on the target agent so the orchestrator
+    /// notifier can defer auto-injection while the operator is composing
+    /// input (#399). Non-Human origins behave identically to `send_keys`.
+    pub fn send_keys_with_origin(
+        &self,
+        target: &str,
+        keys: &str,
+        origin: &ActionOrigin,
+    ) -> Result<()> {
+        self.maybe_stamp_human_input(target, origin);
+        self.send_keys(target, keys)
+    }
+
+    /// Origin-aware counterpart of `send_keys_literal`. See
+    /// `send_keys_with_origin` for the "typing marker" semantics (#399).
+    pub fn send_keys_literal_with_origin(
+        &self,
+        target: &str,
+        keys: &str,
+        origin: &ActionOrigin,
+    ) -> Result<()> {
+        self.maybe_stamp_human_input(target, origin);
+        self.send_keys_literal(target, keys)
+    }
+
+    /// Origin-aware counterpart of `send_text_and_enter`. See
+    /// `send_keys_with_origin` for the "typing marker" semantics (#399).
+    pub fn send_text_and_enter_with_origin(
+        &self,
+        target: &str,
+        text: &str,
+        origin: &ActionOrigin,
+    ) -> Result<()> {
+        self.maybe_stamp_human_input(target, origin);
+        self.send_text_and_enter(target, text)
+    }
+
+    /// Stamp `last_human_input_at` on the agent matching `target` iff the
+    /// originating action is `ActionOrigin::Human`. Agent-originated and
+    /// System-originated sends must NOT stamp — otherwise the notifier's
+    /// auto-injection would be self-suppressing.
+    fn maybe_stamp_human_input(&self, target: &str, origin: &ActionOrigin) {
+        if !matches!(origin, ActionOrigin::Human { .. }) {
+            return;
+        }
+        let mut state = self.app_state.write();
+        if let Some(agent) = state.agents.get_mut(target) {
+            agent.note_human_input();
+            return;
+        }
+        // Fallback: match by tmux target field (when the caller passed a
+        // tmux-style "session:win.pane" that isn't the agent map key).
+        for agent in state.agents.values_mut() {
+            if agent.target == target {
+                agent.note_human_input();
+                return;
+            }
+        }
     }
 
     /// Generic 4-tier fallback: PTY session → IPC → RuntimeAdapter → PTY inject
@@ -321,5 +383,123 @@ mod tests {
             .send_text_and_enter("no-such-target", "echo hi")
             .unwrap_err();
         assert!(err.to_string().contains("send_text_and_enter"));
+    }
+
+    /// Build a CommandSender wired to a fresh AppState containing one agent
+    /// whose map key equals `target`. Used by the "typing marker" tests.
+    fn sender_with_agent(target: &str) -> (CommandSender, SharedState) {
+        use crate::agents::{AgentType, MonitoredAgent};
+        use crate::runtime::StandaloneAdapter;
+        use crate::state::AppState;
+        use parking_lot::RwLock;
+
+        let state: SharedState = Arc::new(RwLock::new(AppState::default()));
+        {
+            let mut s = state.write();
+            let agent = MonitoredAgent::new(
+                target.to_string(),
+                AgentType::ClaudeCode,
+                String::new(),
+                "/tmp".to_string(),
+                0,
+                target.to_string(),
+                String::new(),
+                0,
+                0,
+            );
+            s.agents.insert(target.to_string(), agent);
+        }
+        let runtime: Arc<dyn RuntimeAdapter> = Arc::new(StandaloneAdapter::new());
+        let sender = CommandSender::new(None, runtime, state.clone());
+        (sender, state)
+    }
+
+    #[test]
+    fn human_origin_stamps_last_human_input_at() {
+        // Human-originated send marks the agent as "operator is typing".
+        let (sender, state) = sender_with_agent("orch:0.0");
+        let origin = ActionOrigin::webui();
+        // Send fails (no tiers wired) — but stamping runs regardless.
+        let _ = sender.send_keys_literal_with_origin("orch:0.0", "hello", &origin);
+
+        let s = state.read();
+        let agent = s.agents.get("orch:0.0").expect("agent present");
+        assert!(
+            agent.last_human_input_at.is_some(),
+            "Human origin must stamp last_human_input_at"
+        );
+        assert!(
+            agent.is_operator_typing(std::time::Duration::from_secs(5)),
+            "freshly stamped agent must be within typing grace"
+        );
+    }
+
+    #[test]
+    fn agent_origin_does_not_stamp_last_human_input_at() {
+        // Agent-originated sends (tmai auto-injection) must NOT stamp the
+        // typing marker — otherwise the notifier would self-suppress every
+        // subsequent auto-injection.
+        let (sender, state) = sender_with_agent("orch:0.0");
+        let origin = ActionOrigin::agent("orchestrator", true);
+        let _ = sender.send_keys_literal_with_origin("orch:0.0", "hello", &origin);
+
+        let s = state.read();
+        let agent = s.agents.get("orch:0.0").expect("agent present");
+        assert!(
+            agent.last_human_input_at.is_none(),
+            "Agent origin must not stamp last_human_input_at"
+        );
+    }
+
+    #[test]
+    fn system_origin_does_not_stamp_last_human_input_at() {
+        let (sender, state) = sender_with_agent("orch:0.0");
+        let origin = ActionOrigin::system("pr_monitor");
+        let _ = sender.send_keys_with_origin("orch:0.0", "Enter", &origin);
+
+        let s = state.read();
+        let agent = s.agents.get("orch:0.0").expect("agent present");
+        assert!(agent.last_human_input_at.is_none());
+    }
+
+    #[test]
+    fn stamp_falls_back_to_tmux_target_match() {
+        // The agent map key ("orch:0.0") differs from the tmux target the
+        // caller passes ("main:1.2"). The stamping fallback must match via
+        // `agent.target`, so WebUI passthrough (which resolves to the tmux
+        // target) still stamps the correct agent.
+        use crate::agents::{AgentType, MonitoredAgent};
+        use crate::runtime::StandaloneAdapter;
+        use crate::state::AppState;
+        use parking_lot::RwLock;
+
+        let state: SharedState = Arc::new(RwLock::new(AppState::default()));
+        {
+            let mut s = state.write();
+            let mut agent = MonitoredAgent::new(
+                "main:1.2".to_string(),
+                AgentType::ClaudeCode,
+                String::new(),
+                "/tmp".to_string(),
+                0,
+                "main".to_string(),
+                String::new(),
+                1,
+                2,
+            );
+            agent.target = "main:1.2".to_string();
+            s.agents.insert("orch:0.0".to_string(), agent);
+        }
+        let runtime: Arc<dyn RuntimeAdapter> = Arc::new(StandaloneAdapter::new());
+        let sender = CommandSender::new(None, runtime, state.clone());
+
+        let _ = sender.send_keys_literal_with_origin("main:1.2", "a", &ActionOrigin::webui());
+
+        let s = state.read();
+        let agent = s.agents.get("orch:0.0").expect("agent present");
+        assert!(
+            agent.last_human_input_at.is_some(),
+            "stamping must find agent by tmux target field when map key differs"
+        );
     }
 }

--- a/crates/tmai-core/src/config/settings.rs
+++ b/crates/tmai-core/src/config/settings.rs
@@ -1060,6 +1060,13 @@ pub struct OrchestratorNotifySettings {
     /// Oldest is dropped on overflow.
     #[serde(default = "default_buffer_max_messages")]
     pub buffer_max_messages: usize,
+
+    /// Grace window (seconds) after a human keystroke lands in an
+    /// orchestrator pane during which incoming notifications are buffered
+    /// instead of delivered — keeps in-flight operator composition safe
+    /// from auto-injection (#399).
+    #[serde(default = "default_typing_grace_secs")]
+    pub typing_grace_secs: u64,
 }
 
 fn default_buffer_ttl_secs() -> u64 {
@@ -1068,6 +1075,10 @@ fn default_buffer_ttl_secs() -> u64 {
 
 fn default_buffer_max_messages() -> usize {
     20
+}
+
+fn default_typing_grace_secs() -> u64 {
+    5
 }
 
 impl Default for OrchestratorNotifySettings {
@@ -1086,6 +1097,7 @@ impl Default for OrchestratorNotifySettings {
             buffer_when_busy: true,
             buffer_ttl_secs: 600,
             buffer_max_messages: 20,
+            typing_grace_secs: 5,
         }
     }
 }

--- a/crates/tmai-core/src/orchestrator_notify/service.rs
+++ b/crates/tmai-core/src/orchestrator_notify/service.rs
@@ -57,104 +57,187 @@ impl OrchestratorNotifier {
         event_tx: broadcast::Sender<CoreEvent>,
     ) -> tokio::task::JoinHandle<()> {
         tokio::spawn(async move {
+            // Periodic tick drives the "typing grace expired" flush — the
+            // grace timer can lapse with no incoming events (operator stops
+            // typing without submitting), so we can't rely on event-driven
+            // flush alone (#399).
+            let mut tick = tokio::time::interval(std::time::Duration::from_secs(1));
+            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             loop {
-                let event = match event_rx.recv().await {
-                    Ok(event) => event,
-                    Err(broadcast::error::RecvError::Lagged(n)) => {
-                        debug!(skipped = n, "Orchestrator notifier lagged, skipping events");
-                        continue;
+                tokio::select! {
+                    biased;
+                    recv = event_rx.recv() => {
+                        let event = match recv {
+                            Ok(event) => event,
+                            Err(broadcast::error::RecvError::Lagged(n)) => {
+                                debug!(skipped = n, "Orchestrator notifier lagged, skipping events");
+                                continue;
+                            }
+                            Err(broadcast::error::RecvError::Closed) => {
+                                debug!("Event channel closed, stopping orchestrator notifier");
+                                break;
+                            }
+                        };
+                        Self::handle_event(event, &settings, &state, &buffer_handle, &event_tx);
                     }
-                    Err(broadcast::error::RecvError::Closed) => {
-                        debug!("Event channel closed, stopping orchestrator notifier");
-                        break;
+                    _ = tick.tick() => {
+                        Self::flush_expired_typing_graces(&settings, &state, &buffer_handle, &event_tx);
                     }
-                };
-
-                // Handle flush triggers first so a status transition to idle
-                // (or orchestrator appearance) delivers any buffered prompts.
-                Self::maybe_flush_for_event(&event, &state, &buffer_handle, &settings, &event_tx);
-
-                let s = settings.read().clone();
-                let Some((message, source_target)) = Self::build_notification(&event, &s, &state)
-                else {
-                    continue;
-                };
-
-                // Split orchestrators into idle (send now) and busy (buffer).
-                let (idle_targets, busy_targets) = {
-                    let st = state.read();
-                    let mut idle: Vec<String> = Vec::new();
-                    let mut busy: Vec<String> = Vec::new();
-                    for (target, a) in &st.agents {
-                        if !a.is_orchestrator || a.is_virtual {
-                            continue;
-                        }
-                        if *target == source_target {
-                            continue;
-                        }
-                        // Also exclude when source_target matches this
-                        // orchestrator's pane_id (hook events use pane_id,
-                        // not agent map key).
-                        if st.target_to_pane_id.get(target) == Some(&source_target) {
-                            continue;
-                        }
-                        if a.status.is_idle() {
-                            idle.push(target.clone());
-                        } else {
-                            busy.push(target.clone());
-                        }
-                    }
-                    (idle, busy)
-                };
-
-                if idle_targets.is_empty() && busy_targets.is_empty() {
-                    debug!(
-                        message = %message,
-                        "No orchestrator agents to notify"
-                    );
-                    continue;
-                }
-
-                for target in &idle_targets {
-                    info!(
-                        orchestrator = %target,
-                        source = %source_target,
-                        "Sending sub-agent notification to orchestrator"
-                    );
-                    let _ = event_tx.send(CoreEvent::PromptReady {
-                        target: target.clone(),
-                        prompt: message.clone(),
-                    });
-                }
-
-                if s.buffer_when_busy {
-                    let ttl = Duration::from_secs(s.buffer_ttl_secs);
-                    for target in &busy_targets {
-                        debug!(
-                            orchestrator = %target,
-                            source = %source_target,
-                            "Buffering notification for busy orchestrator"
-                        );
-                        buffer::append(
-                            &buffer_handle,
-                            target,
-                            BufferedNotification {
-                                message: message.clone(),
-                                source: source_target.clone(),
-                                timestamp: Instant::now(),
-                            },
-                            ttl,
-                            s.buffer_max_messages,
-                        );
-                    }
-                } else if idle_targets.is_empty() {
-                    debug!(
-                        message = %message,
-                        "No idle orchestrator agents to notify (buffering disabled)"
-                    );
                 }
             }
         })
+    }
+
+    /// Process a single incoming event: handle flush triggers, build the
+    /// notification, then route to idle/busy orchestrators.
+    fn handle_event(
+        event: CoreEvent,
+        settings: &SharedNotifySettings,
+        state: &SharedState,
+        buffer_handle: &SharedNotifyBuffer,
+        event_tx: &broadcast::Sender<CoreEvent>,
+    ) {
+        // Handle flush triggers first so a status transition to idle
+        // (or orchestrator appearance) delivers any buffered prompts.
+        Self::maybe_flush_for_event(&event, state, buffer_handle, settings, event_tx);
+
+        let s = settings.read().clone();
+        let Some((message, source_target)) = Self::build_notification(&event, &s, state) else {
+            return;
+        };
+
+        let typing_grace = std::time::Duration::from_secs(s.typing_grace_secs);
+
+        // Split orchestrators into idle (send now) and busy (buffer).
+        // An orchestrator with an in-flight human composition is treated as
+        // busy even when `status.is_idle()` — auto-injection would otherwise
+        // clobber the operator's half-typed prompt (#399).
+        let (idle_targets, busy_targets) = {
+            let st = state.read();
+            let mut idle: Vec<String> = Vec::new();
+            let mut busy: Vec<String> = Vec::new();
+            for (target, a) in &st.agents {
+                if !a.is_orchestrator || a.is_virtual {
+                    continue;
+                }
+                if *target == source_target {
+                    continue;
+                }
+                // Also exclude when source_target matches this
+                // orchestrator's pane_id (hook events use pane_id,
+                // not agent map key).
+                if st.target_to_pane_id.get(target) == Some(&source_target) {
+                    continue;
+                }
+                if a.status.is_idle() && !a.is_operator_typing(typing_grace) {
+                    idle.push(target.clone());
+                } else {
+                    busy.push(target.clone());
+                }
+            }
+            (idle, busy)
+        };
+
+        if idle_targets.is_empty() && busy_targets.is_empty() {
+            debug!(
+                message = %message,
+                "No orchestrator agents to notify"
+            );
+            return;
+        }
+
+        for target in &idle_targets {
+            info!(
+                orchestrator = %target,
+                source = %source_target,
+                "Sending sub-agent notification to orchestrator"
+            );
+            let _ = event_tx.send(CoreEvent::PromptReady {
+                target: target.clone(),
+                prompt: message.clone(),
+            });
+        }
+
+        if s.buffer_when_busy {
+            let ttl = Duration::from_secs(s.buffer_ttl_secs);
+            for target in &busy_targets {
+                debug!(
+                    orchestrator = %target,
+                    source = %source_target,
+                    "Buffering notification for busy orchestrator"
+                );
+                buffer::append(
+                    buffer_handle,
+                    target,
+                    BufferedNotification {
+                        message: message.clone(),
+                        source: source_target.clone(),
+                        timestamp: Instant::now(),
+                    },
+                    ttl,
+                    s.buffer_max_messages,
+                );
+            }
+        } else if idle_targets.is_empty() {
+            debug!(
+                message = %message,
+                "No idle orchestrator agents to notify (buffering disabled)"
+            );
+        }
+    }
+
+    /// Periodic flush: for each orchestrator with buffered entries, deliver
+    /// them if the orchestrator is idle AND the typing grace window has
+    /// elapsed (i.e., no recent human composition). Keeps auto-injection
+    /// deferred until the operator has finished typing (#399).
+    fn flush_expired_typing_graces(
+        settings: &SharedNotifySettings,
+        state: &SharedState,
+        buffer_handle: &SharedNotifyBuffer,
+        event_tx: &broadcast::Sender<CoreEvent>,
+    ) {
+        let s = settings.read().clone();
+        if !s.buffer_when_busy {
+            return;
+        }
+        let typing_grace = std::time::Duration::from_secs(s.typing_grace_secs);
+        let ttl = Duration::from_secs(s.buffer_ttl_secs);
+
+        // Snapshot the set of target keys that currently have buffered entries.
+        let targets: Vec<String> = buffer_handle.read().keys().cloned().collect();
+
+        for target in targets {
+            // Only flush when the orchestrator is idle AND no longer typing.
+            let eligible = {
+                let st = state.read();
+                match st.agents.get(&target) {
+                    Some(a) => {
+                        a.is_orchestrator
+                            && !a.is_virtual
+                            && a.status.is_idle()
+                            && !a.is_operator_typing(typing_grace)
+                    }
+                    None => false,
+                }
+            };
+            if !eligible {
+                continue;
+            }
+            let entries = buffer::take_for_flush(buffer_handle, &target, ttl);
+            if entries.is_empty() {
+                continue;
+            }
+            let combined = buffer::combine_messages(&entries);
+            info!(
+                orchestrator = %target,
+                count = entries.len(),
+                "Flushing buffered notifications after typing grace expired"
+            );
+            let _ = event_tx.send(CoreEvent::PromptReady {
+                target: target.clone(),
+                prompt: combined,
+            });
+        }
     }
 
     /// Flush buffered notifications for an orchestrator on status→idle
@@ -175,11 +258,20 @@ impl OrchestratorNotifier {
             _ => return,
         };
 
-        // Only flush for orchestrator agents that are currently idle.
+        // Only flush for orchestrator agents that are currently idle AND
+        // not mid-composition — otherwise the flush would clobber the
+        // operator's in-flight input. The periodic tick will re-attempt
+        // once the typing grace window expires (#399).
+        let typing_grace = std::time::Duration::from_secs(settings.read().typing_grace_secs);
         let is_orch_idle = {
             let st = state.read();
             match st.agents.get(target) {
-                Some(a) => a.is_orchestrator && !a.is_virtual && a.status.is_idle(),
+                Some(a) => {
+                    a.is_orchestrator
+                        && !a.is_virtual
+                        && a.status.is_idle()
+                        && !a.is_operator_typing(typing_grace)
+                }
                 None => false,
             }
         };
@@ -1660,5 +1752,187 @@ mod tests {
         let map = buf.read();
         assert_eq!(map.get("orch:a").map(|v| v.len()), Some(1));
         assert_eq!(map.get("orch:b").map(|v| v.len()), Some(1));
+    }
+
+    // ── #399 typing-grace (operator-composing) tests ───────────
+
+    #[tokio::test]
+    async fn test_idle_orchestrator_within_typing_grace_buffers() {
+        // Orchestrator status is Idle but the operator just struck a key
+        // into its pane — notification must be buffered, not delivered
+        // (would otherwise clobber in-flight composition).
+        let state = AppState::shared();
+        insert_agent(&state, "orch:0.0", true, AgentStatus::Idle);
+        insert_agent(&state, "sub:0.0", false, AgentStatus::Idle);
+        {
+            let mut s = state.write();
+            s.agents.get_mut("orch:0.0").unwrap().note_human_input();
+        }
+
+        let core = TmaiCoreBuilder::new(Settings::default()).build();
+        let event_tx = core.event_sender();
+        let event_rx = core.subscribe();
+        let mut listen_rx = core.subscribe();
+
+        let mut ns = OrchestratorNotifySettings::default();
+        ns.typing_grace_secs = 5;
+        let settings = Arc::new(RwLock::new(ns));
+        let buf = super::buffer::new_shared_buffer();
+        let _handle = OrchestratorNotifier::spawn(
+            settings,
+            state.clone(),
+            buf.clone(),
+            event_rx,
+            event_tx.clone(),
+        );
+
+        let _ = event_tx.send(CoreEvent::AgentStopped {
+            target: "sub:0.0".to_string(),
+            cwd: "/tmp".to_string(),
+            last_assistant_message: Some("done".to_string()),
+        });
+
+        // Wait briefly; the notifier must *not* emit PromptReady for the
+        // orchestrator while it's mid-composition.
+        let mut delivered = false;
+        for _ in 0..20 {
+            match tokio::time::timeout(std::time::Duration::from_millis(25), listen_rx.recv()).await
+            {
+                Ok(Ok(CoreEvent::PromptReady { target, .. })) if target == "orch:0.0" => {
+                    delivered = true;
+                    break;
+                }
+                _ => continue,
+            }
+        }
+        assert!(
+            !delivered,
+            "notification must be buffered while operator is typing"
+        );
+        assert_eq!(
+            buf.read().get("orch:0.0").map(|v| v.len()),
+            Some(1),
+            "entry should be in the buffer"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_idle_without_recent_input_delivers_immediately() {
+        // Baseline: no recorded human keystroke → notification delivered
+        // immediately, matching pre-#399 behaviour. Guards against the
+        // typing-grace check accidentally gating the never-typed case.
+        let state = AppState::shared();
+        insert_agent(&state, "orch:0.0", true, AgentStatus::Idle);
+        insert_agent(&state, "sub:0.0", false, AgentStatus::Idle);
+
+        let core = TmaiCoreBuilder::new(Settings::default()).build();
+        let event_tx = core.event_sender();
+        let event_rx = core.subscribe();
+        let mut listen_rx = core.subscribe();
+
+        let settings = Arc::new(RwLock::new(OrchestratorNotifySettings::default()));
+        let _handle = OrchestratorNotifier::spawn(
+            settings,
+            state.clone(),
+            super::buffer::new_shared_buffer(),
+            event_rx,
+            event_tx.clone(),
+        );
+
+        let _ = event_tx.send(CoreEvent::AgentStopped {
+            target: "sub:0.0".to_string(),
+            cwd: "/tmp".to_string(),
+            last_assistant_message: Some("done".to_string()),
+        });
+
+        let mut found = false;
+        for _ in 0..20 {
+            match tokio::time::timeout(std::time::Duration::from_millis(50), listen_rx.recv()).await
+            {
+                Ok(Ok(CoreEvent::PromptReady { target, .. })) if target == "orch:0.0" => {
+                    found = true;
+                    break;
+                }
+                _ => continue,
+            }
+        }
+        assert!(
+            found,
+            "idle orchestrator with no typing marker must receive notification immediately"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_typing_grace_expiry_flushes_buffered_entry() {
+        // Fire a notification while typing is active, then let the grace
+        // window elapse — the periodic tick should flush the buffered
+        // entry to the orchestrator.
+        let state = AppState::shared();
+        insert_agent(&state, "orch:0.0", true, AgentStatus::Idle);
+        insert_agent(&state, "sub:0.0", false, AgentStatus::Idle);
+        {
+            let mut s = state.write();
+            // Stamp a timestamp in the past so the grace window has
+            // already elapsed by the time the tick fires. This keeps the
+            // test fast while still exercising the "typing→flush" path.
+            s.agents.get_mut("orch:0.0").unwrap().last_human_input_at =
+                Some(std::time::Instant::now() - std::time::Duration::from_secs(10));
+        }
+
+        let core = TmaiCoreBuilder::new(Settings::default()).build();
+        let event_tx = core.event_sender();
+        let event_rx = core.subscribe();
+        let mut listen_rx = core.subscribe();
+
+        // Use a very short grace (1s) so the check treats the stamped-10s-ago
+        // timestamp as expired but also exercises the same code path as prod.
+        let mut ns = OrchestratorNotifySettings::default();
+        ns.typing_grace_secs = 1;
+        let settings = Arc::new(RwLock::new(ns));
+        let buf = super::buffer::new_shared_buffer();
+
+        // Pre-seed the buffer as if a prior notification was queued while
+        // typing was in progress. This isolates the "tick flush" behaviour
+        // from the "buffer-on-send" behaviour.
+        buf.write()
+            .entry("orch:0.0".to_string())
+            .or_default()
+            .push(BufferedNotification {
+                message: "queued while typing".to_string(),
+                source: "sub:0.0".to_string(),
+                timestamp: Instant::now(),
+            });
+
+        let _handle = OrchestratorNotifier::spawn(
+            settings,
+            state.clone(),
+            buf.clone(),
+            event_rx,
+            event_tx.clone(),
+        );
+
+        // Wait for the 1-second periodic tick to fire + flush.
+        let mut flushed = false;
+        for _ in 0..40 {
+            match tokio::time::timeout(std::time::Duration::from_millis(100), listen_rx.recv())
+                .await
+            {
+                Ok(Ok(CoreEvent::PromptReady { target, prompt })) if target == "orch:0.0" => {
+                    if prompt.contains("queued while typing") {
+                        flushed = true;
+                        break;
+                    }
+                }
+                _ => continue,
+            }
+        }
+        assert!(
+            flushed,
+            "periodic tick must flush buffered entries once the typing grace elapses"
+        );
+        assert!(
+            buf.read().get("orch:0.0").is_none(),
+            "buffer should be drained after flush"
+        );
     }
 }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -493,6 +493,7 @@ pub async fn set_auto_approve(
 #[allow(deprecated)]
 pub async fn passthrough_input(
     State(core): State<Arc<TmaiCore>>,
+    headers: axum::http::HeaderMap,
     Path(id): Path<String>,
     Json(req): Json<PassthroughRequest>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)> {
@@ -512,12 +513,16 @@ pub async fn passthrough_input(
     let cmd = core
         .raw_command_sender()
         .ok_or_else(|| json_error(StatusCode::INTERNAL_SERVER_ERROR, "No command sender"))?;
+    // Passthrough input is always human-originated (WebUI keystrokes). Use
+    // the origin-aware send so the orchestrator notifier can defer
+    // auto-injection while the operator is composing (#399).
+    let origin = parse_origin(&headers);
     if let Some(ref chars) = req.chars {
-        cmd.send_keys_literal(send_target, chars)
+        cmd.send_keys_literal_with_origin(send_target, chars, &origin)
             .map_err(|e| json_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
     }
     if let Some(ref key) = req.key {
-        cmd.send_keys(send_target, key)
+        cmd.send_keys_with_origin(send_target, key, &origin)
             .map_err(|e| json_error(StatusCode::INTERNAL_SERVER_ERROR, &e.to_string()))?;
     }
 
@@ -1394,6 +1399,9 @@ pub struct NotifySettingsResponse {
     pub buffer_ttl_secs: u64,
     /// Maximum buffered entries per orchestrator (oldest dropped on overflow)
     pub buffer_max_messages: usize,
+    /// Grace window (seconds) during which human keystrokes block
+    /// auto-injection into the same orchestrator pane (#399)
+    pub typing_grace_secs: u64,
 }
 
 /// Template overrides response
@@ -1484,6 +1492,8 @@ pub struct UpdateNotifySettingsRequest {
     pub buffer_ttl_secs: Option<u64>,
     #[serde(default)]
     pub buffer_max_messages: Option<usize>,
+    #[serde(default)]
+    pub typing_grace_secs: Option<u64>,
 }
 
 /// AutoAction template overrides update request (partial)
@@ -1578,6 +1588,7 @@ pub async fn get_orchestrator_settings(
             buffer_when_busy: orch.notify.buffer_when_busy,
             buffer_ttl_secs: orch.notify.buffer_ttl_secs,
             buffer_max_messages: orch.notify.buffer_max_messages,
+            typing_grace_secs: orch.notify.typing_grace_secs,
         },
         guardrails: GuardrailsSettingsResponse {
             max_ci_retries: orch.guardrails.max_ci_retries,
@@ -1713,6 +1724,10 @@ pub async fn update_orchestrator_settings(
                     .as_ref()
                     .and_then(|r| r.buffer_max_messages)
                     .unwrap_or(n.buffer_max_messages),
+                typing_grace_secs: nr
+                    .as_ref()
+                    .and_then(|r| r.typing_grace_secs)
+                    .unwrap_or(n.typing_grace_secs),
             }
         },
         guardrails: {


### PR DESCRIPTION
## Summary

- Track per-agent `last_human_input_at: Option<Instant>` on `MonitoredAgent`; stamp it only when `CommandSender` receives an `ActionOrigin::Human` keystroke, so WebUI passthrough marks the pane as "operator is composing" while agent/system sends stay silent.
- Extend the `OrchestratorNotifier` busy-check so an idle orchestrator is still treated as busy when `is_operator_typing(grace)` returns true — notifications queue into the existing `#372` busy-buffer instead of clobbering half-typed input.
- Add a 1-second periodic tick inside the notifier that flushes buffered entries once the typing grace expires (event-driven flush alone can't see "operator stopped typing without submitting"). Grace window is a configurable `typing_grace_secs` on `OrchestratorNotifySettings` (default 5s).

Resolves #399. Builds on #372/#374's busy-buffer foundation without redesigning it.

## Test plan

- [x] `cargo test -p tmai-core --lib command_sender` — Human origin stamps, Agent/System origins don't, tmux-target fallback works
- [x] `cargo test -p tmai-core --lib orchestrator_notify` — typing window buffers; idle-with-no-stamp still delivers immediately; periodic tick flushes once grace expires
- [x] `cargo fmt --all` + `cargo clippy` clean across the workspace
- [ ] Manual dogfood: type into orchestrator pane mid-composition while PR Monitor emits events; confirm the buffered prompt lands only after Enter or grace expiry

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ユーザー入力の検出機能を追加しました。
  * 入力検出の猶予時間を設定できるようになりました。デフォルトは5秒です。
  * ユーザー入力中は、システム通知の送信を遅延させるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->