### PR TITLE
test: test_multi_select_with_trailing_empty_lines fails on main (#395)

### DIFF
--- a/crates/tmai-core/src/detectors/claude_code/tests.rs
+++ b/crates/tmai-core/src/detectors/claude_code/tests.rs
@@ -711,15 +711,10 @@ Enter to select · ↑/↓ to navigate · Esc to cancel\n\
     } = status
     {
         assert!(matches!(approval_type, ApprovalCategory::UserQuestion));
-        if let Some(InteractionMode::SingleSelect {
-            choices,
-            cursor_position,
-        }) = interaction
-        {
+        if let Some(InteractionMode::MultiSelect { choices }) = interaction {
             assert_eq!(choices.len(), 6, "Expected 6 choices, got {:?}", choices);
-            assert_eq!(cursor_position, 1);
         } else {
-            panic!("Expected SingleSelect interaction, got {:?}", interaction);
+            panic!("Expected MultiSelect interaction, got {:?}", interaction);
         }
     }
 }


### PR DESCRIPTION
## Summary

- Fixes #395. The test asserted `SingleSelect`, but the fixture is a multi-select UI (`[ ]` checkboxes, test name "multi_select") and the detector correctly reports `MultiSelect`.
- Root cause: the mechanical refactor in #296 (ApprovalType → ApprovalCategory + InteractionMode) substituted `SingleSelect` into every choice fixture, including this one. The original test explicitly noted that the Japanese UI lacks the English multi-select keywords — the detector has since been improved to recognize `[ ]` checkboxes visually, so the test must follow.
- Update the expectation to `MultiSelect` to match both the fixture intent and current detector behavior.

## Test plan

- [x] `cargo test -p tmai-core detectors::claude_code::tests::test_multi_select_with_trailing_empty_lines` passes
- [x] `cargo test -p tmai-core --lib` — 1004 passed, 0 failed
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Tests**
  * マルチセレクト機能に関するテストケースの検証ロジックを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->