### PR TITLE
feat: move Agent state debounce server-side (eliminate Idle↔Processing UI noise) (#424)

### DIFF
--- a/crates/tmai-core/src/api/core.rs
+++ b/crates/tmai-core/src/api/core.rs
@@ -57,6 +57,14 @@ pub struct TmaiCore {
     defer_registry: Arc<DeferRegistry>,
     /// Codex WebSocket sender registry for bidirectional control
     codex_ws_senders: RwLock<Option<CodexWsSenderRegistry>>,
+    /// Last agent-list fingerprint used to dedup `CoreEvent::AgentsUpdated`.
+    ///
+    /// The poller already debounces sub-threshold phase flips (see
+    /// `debounce_threshold()` in `monitor/poller.rs`), so the snapshot
+    /// returned by `list_agents()` is already post-debounce. Gating
+    /// event emission on fingerprint equality ensures subscribers never
+    /// see spurious `AgentsUpdated` notifications when nothing changed.
+    pub(crate) last_agents_fingerprint: RwLock<String>,
 }
 
 impl TmaiCore {
@@ -93,6 +101,7 @@ impl TmaiCore {
             transcript_registry,
             defer_registry,
             codex_ws_senders: RwLock::new(None),
+            last_agents_fingerprint: RwLock::new(String::new()),
         }
     }
 

--- a/crates/tmai-core/src/api/events.rs
+++ b/crates/tmai-core/src/api/events.rs
@@ -326,8 +326,57 @@ impl TmaiCore {
     ///
     /// Called by external consumers (e.g. TUI main loop) after processing
     /// `PollMessage::AgentsUpdated`. Ignored if no subscribers are listening.
+    ///
+    /// Emits `CoreEvent::AgentsUpdated` only when the post-debounce agent
+    /// snapshot actually changed since the previous emission. Because the
+    /// poller already collapses sub-threshold phase flips via
+    /// `debounce_threshold()`, this fingerprint check means sub-threshold
+    /// Idle↔Processing blips never become `AgentsUpdated` events — the UI
+    /// sees a single stable signal per real transition.
     pub fn notify_agents_updated(&self) {
+        let fingerprint = self.compute_agents_fingerprint();
+        let changed = {
+            let mut last = self.last_agents_fingerprint.write();
+            if *last == fingerprint {
+                false
+            } else {
+                *last = fingerprint;
+                true
+            }
+        };
+        if changed {
+            let _ = self.event_sender().send(CoreEvent::AgentsUpdated);
+        }
+    }
+
+    /// Force-emit `CoreEvent::AgentsUpdated` and refresh the fingerprint,
+    /// bypassing the dedup check. Used by tests and in rare cases where a
+    /// subscriber needs an unconditional refresh signal.
+    pub fn notify_agents_updated_force(&self) {
+        let fingerprint = self.compute_agents_fingerprint();
+        *self.last_agents_fingerprint.write() = fingerprint;
         let _ = self.event_sender().send(CoreEvent::AgentsUpdated);
+    }
+
+    /// Build a fingerprint over the current agent list, excluding volatile
+    /// fields (`last_update`) that change every poll regardless of phase.
+    ///
+    /// Matches the prior SSE-side dedup in `src/web/events.rs`; moving it
+    /// here means all subscribers (TUI, Tauri, MCP, SSE) share one consistent
+    /// debounced signal.
+    fn compute_agents_fingerprint(&self) -> String {
+        let agents = self.list_agents();
+        let stripped: Vec<serde_json::Value> = agents
+            .iter()
+            .filter_map(|a| {
+                let mut v = serde_json::to_value(a).ok()?;
+                if let Some(obj) = v.as_object_mut() {
+                    obj.remove("last_update");
+                }
+                Some(v)
+            })
+            .collect();
+        serde_json::to_string(&stripped).unwrap_or_default()
     }
 
     /// Notify subscribers that team data was updated.
@@ -392,6 +441,43 @@ mod tests {
 
         let event = rx.recv().await.unwrap();
         assert!(matches!(event, CoreEvent::TeamsUpdated));
+    }
+
+    #[tokio::test]
+    async fn test_notify_agents_updated_dedups_same_fingerprint() {
+        // With no state change between calls the fingerprint is identical,
+        // so the second notify_agents_updated() must NOT emit an event.
+        let core = TmaiCoreBuilder::new(Settings::default()).build();
+        let mut rx = core.subscribe();
+
+        core.notify_agents_updated();
+        let first = rx.recv().await.unwrap();
+        assert!(matches!(first, CoreEvent::AgentsUpdated));
+
+        // Second call with no state change: no event expected.
+        core.notify_agents_updated();
+        let pending = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+        assert!(
+            pending.is_err(),
+            "duplicate AgentsUpdated should be suppressed when fingerprint is unchanged"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_notify_agents_updated_force_bypasses_dedup() {
+        let core = TmaiCoreBuilder::new(Settings::default()).build();
+        let mut rx = core.subscribe();
+
+        core.notify_agents_updated();
+        let _ = rx.recv().await.unwrap();
+
+        // force-variant must emit even when fingerprint is unchanged.
+        core.notify_agents_updated_force();
+        let forced = tokio::time::timeout(std::time::Duration::from_millis(50), rx.recv()).await;
+        assert!(
+            matches!(forced, Ok(Ok(CoreEvent::AgentsUpdated))),
+            "force-variant should bypass fingerprint dedup"
+        );
     }
 
     #[test]

--- a/crates/tmai-core/src/monitor/poller.rs
+++ b/crates/tmai-core/src/monitor/poller.rs
@@ -2713,4 +2713,157 @@ mod tests {
             "interval must be <= 100 to maintain audit coverage"
         );
     }
+
+    // ── debounce_threshold policy ──
+
+    #[test]
+    fn test_debounce_threshold_idle_processing_oscillation_500ms() {
+        assert_eq!(
+            debounce_threshold("idle", "processing"),
+            Duration::from_millis(500),
+        );
+        assert_eq!(
+            debounce_threshold("processing", "idle"),
+            Duration::from_millis(500),
+        );
+    }
+
+    #[test]
+    fn test_debounce_threshold_awaiting_approval_is_immediate() {
+        // Approval must surface to the UI immediately — latency is user-visible.
+        assert_eq!(
+            debounce_threshold("idle", "awaiting_approval"),
+            Duration::from_millis(0),
+        );
+        assert_eq!(
+            debounce_threshold("processing", "awaiting_approval"),
+            Duration::from_millis(0),
+        );
+    }
+
+    #[test]
+    fn test_debounce_threshold_post_approval_fast() {
+        // User action after an approval prompt clears should not be
+        // held behind the full oscillation debounce.
+        assert!(debounce_threshold("awaiting_approval", "processing") < Duration::from_millis(500),);
+    }
+
+    // ── emit_audit_events debounce behaviour ──
+
+    fn make_poller() -> Poller {
+        let settings = Settings::default();
+        let state = AppState::shared();
+        let ipc_registry = Arc::new(parking_lot::RwLock::new(std::collections::HashMap::new()));
+        let hook_registry = crate::hooks::new_hook_registry();
+        let runtime: Arc<dyn crate::runtime::RuntimeAdapter> =
+            Arc::new(crate::runtime::StandaloneAdapter::new());
+        Poller::new(settings, state, runtime, ipc_registry, hook_registry, None)
+    }
+
+    fn make_monitored_agent(id: &str, status: AgentStatus) -> MonitoredAgent {
+        let mut a = MonitoredAgent::new(
+            id.to_string(),
+            AgentType::ClaudeCode,
+            "Test Title".to_string(),
+            "/home/user/project".to_string(),
+            1234,
+            "main".to_string(),
+            "window0".to_string(),
+            0,
+            0,
+        );
+        a.status = status;
+        a
+    }
+
+    /// Sub-threshold Idle→Processing→Idle blip must not commit a transition.
+    /// The committed status (and therefore the agent's exported status on
+    /// this tick) stays at Idle until the 500ms threshold is met.
+    #[test]
+    fn test_debounce_suppresses_sub_threshold_idle_processing_blip() {
+        let mut poller = make_poller();
+
+        // Tick 1: agent appears as Idle. AgentAppeared commits Idle immediately.
+        let mut tick1 = vec![make_monitored_agent("main:0.1", AgentStatus::Idle)];
+        poller.emit_audit_events(&mut tick1);
+        assert_eq!(
+            poller.previous_statuses.get("main:0.1").unwrap().status,
+            "idle"
+        );
+
+        // Tick 2: Processing detected briefly (the blip).
+        let mut tick2 = vec![make_monitored_agent(
+            "main:0.1",
+            AgentStatus::Processing {
+                activity: Activity::Thinking,
+            },
+        )];
+        poller.emit_audit_events(&mut tick2);
+
+        // Committed status must still be Idle — Processing is only pending.
+        assert_eq!(
+            poller.previous_statuses.get("main:0.1").unwrap().status,
+            "idle",
+            "sub-threshold Processing must not yet be committed"
+        );
+        // Poller must override agent.status back to Idle so the exported
+        // snapshot hides the flicker from downstream consumers.
+        assert!(
+            matches!(tick2[0].status, AgentStatus::Idle),
+            "agent.status must be overridden to committed Idle during debounce window"
+        );
+
+        // Tick 3 (immediately after): back to Idle. Pending transition must
+        // be cancelled, committed remains Idle — the blip leaves no trace.
+        let mut tick3 = vec![make_monitored_agent("main:0.1", AgentStatus::Idle)];
+        poller.emit_audit_events(&mut tick3);
+        assert_eq!(
+            poller.previous_statuses.get("main:0.1").unwrap().status,
+            "idle",
+            "post-blip committed status must remain Idle"
+        );
+        assert!(
+            !poller.pending_transitions.contains_key("main:0.1"),
+            "pending transition must be cleared once agent returns to committed status"
+        );
+    }
+
+    /// `awaiting_approval` has a 0ms debounce — it commits on the first tick
+    /// because approval latency is user-visible.
+    #[test]
+    fn test_awaiting_approval_commits_immediately_bypassing_debounce() {
+        let mut poller = make_poller();
+
+        // Start committed at Idle.
+        let mut tick1 = vec![make_monitored_agent("main:0.1", AgentStatus::Idle)];
+        poller.emit_audit_events(&mut tick1);
+        assert_eq!(
+            poller.previous_statuses.get("main:0.1").unwrap().status,
+            "idle"
+        );
+
+        // AwaitingApproval must commit on the very next tick, no debounce wait.
+        let approval_status = AgentStatus::AwaitingApproval {
+            approval_type: ApprovalCategory::ShellCommand,
+            details: "ls".to_string(),
+            interaction: None,
+        };
+        let mut tick2 = vec![make_monitored_agent("main:0.1", approval_status)];
+        poller.emit_audit_events(&mut tick2);
+
+        assert_eq!(
+            poller.previous_statuses.get("main:0.1").unwrap().status,
+            "awaiting_approval",
+            "awaiting_approval must commit immediately (0ms threshold)"
+        );
+        assert!(
+            !poller.pending_transitions.contains_key("main:0.1"),
+            "awaiting_approval must not be left pending"
+        );
+        // Agent's exported status must carry the approval through (not overridden).
+        assert!(matches!(
+            tick2[0].status,
+            AgentStatus::AwaitingApproval { .. }
+        ));
+    }
 }

--- a/src/web/events.rs
+++ b/src/web/events.rs
@@ -25,22 +25,6 @@ fn build_agents_json(core: &TmaiCore) -> String {
     serde_json::to_string(&agents).unwrap_or_else(|_| "[]".to_string())
 }
 
-/// Build agents JSON for change-detection comparison (excludes volatile fields like last_update)
-fn build_agents_fingerprint(core: &TmaiCore) -> String {
-    let agents = core.list_agents();
-    let stripped: Vec<serde_json::Value> = agents
-        .iter()
-        .filter_map(|a| {
-            let mut v = serde_json::to_value(a).ok()?;
-            if let Some(obj) = v.as_object_mut() {
-                obj.remove("last_update");
-            }
-            Some(v)
-        })
-        .collect();
-    serde_json::to_string(&stripped).unwrap_or_default()
-}
-
 /// Build teams JSON from TmaiCore raw state
 #[allow(deprecated)]
 fn build_teams_json(core: &TmaiCore) -> String {
@@ -63,12 +47,15 @@ pub async fn events(State(core): State<Arc<TmaiCore>>) -> impl IntoResponse {
 
     tokio::spawn(async move {
         let mut event_rx = core.subscribe();
-        let mut last_agents_fingerprint = String::new();
         let mut last_teams_json = String::new();
 
-        // Send initial state immediately
+        // Send initial state immediately. Per-subscriber dedup for agents
+        // is no longer needed here — `TmaiCore::notify_agents_updated()`
+        // now gates `CoreEvent::AgentsUpdated` on a post-debounce
+        // fingerprint change (see `api/events.rs`), so every arriving
+        // broadcast represents a real state delta. We only need to send
+        // the initial snapshot on connect and re-sync on Lagged.
         let agents_json = build_agents_json(&core);
-        let agents_fingerprint = build_agents_fingerprint(&core);
         let teams_json = build_teams_json(&core);
 
         if !agents_json.is_empty() && agents_json != "[]" {
@@ -76,7 +63,6 @@ pub async fn events(State(core): State<Arc<TmaiCore>>) -> impl IntoResponse {
             if tx.send(Ok(event)).await.is_err() {
                 return;
             }
-            last_agents_fingerprint = agents_fingerprint;
         }
         if !teams_json.is_empty() && teams_json != "[]" {
             let event = Event::default().event("teams").data(&teams_json);
@@ -97,14 +83,12 @@ pub async fn events(State(core): State<Arc<TmaiCore>>) -> impl IntoResponse {
                     match result {
                         Ok(CoreEvent::AgentsUpdated) | Ok(CoreEvent::AgentStatusChanged { .. })
                         | Ok(CoreEvent::AgentAppeared { .. }) | Ok(CoreEvent::AgentDisappeared { .. }) => {
-                            let fingerprint = build_agents_fingerprint(&core);
-                            if fingerprint != last_agents_fingerprint {
-                                let agents_json = build_agents_json(&core);
-                                let event = Event::default().event("agents").data(&agents_json);
-                                if tx.send(Ok(event)).await.is_err() {
-                                    return;
-                                }
-                                last_agents_fingerprint = fingerprint;
+                            // Core-side dedup means every arriving event is a
+                            // real delta; forward the current snapshot directly.
+                            let agents_json = build_agents_json(&core);
+                            let event = Event::default().event("agents").data(&agents_json);
+                            if tx.send(Ok(event)).await.is_err() {
+                                return;
                             }
                         }
                         Ok(CoreEvent::TeamsUpdated) => {
@@ -359,14 +343,10 @@ pub async fn events(State(core): State<Arc<TmaiCore>>) -> impl IntoResponse {
                                 return;
                             }
                             // Also refresh agent list since targets changed
-                            let fingerprint = build_agents_fingerprint(&core);
-                            if fingerprint != last_agents_fingerprint {
-                                let agents_json = build_agents_json(&core);
-                                let event = Event::default().event("agents").data(&agents_json);
-                                if tx.send(Ok(event)).await.is_err() {
-                                    return;
-                                }
-                                last_agents_fingerprint = fingerprint;
+                            let agents_json = build_agents_json(&core);
+                            let event = Event::default().event("agents").data(&agents_json);
+                            if tx.send(Ok(event)).await.is_err() {
+                                return;
                             }
                         }
                         Ok(CoreEvent::ActionPerformed { ref origin, ref action, ref summary }) => {
@@ -392,15 +372,13 @@ pub async fn events(State(core): State<Arc<TmaiCore>>) -> impl IntoResponse {
                         }
                         Err(RecvError::Lagged(skipped)) => {
                             tracing::debug!(skipped, "SSE subscriber lagged, re-sending full state");
-                            // Re-send full state on lag
-                            let fingerprint = build_agents_fingerprint(&core);
-                            if fingerprint != last_agents_fingerprint {
-                                let agents_json = build_agents_json(&core);
-                                let event = Event::default().event("agents").data(&agents_json);
-                                if tx.send(Ok(event)).await.is_err() {
-                                    return;
-                                }
-                                last_agents_fingerprint = fingerprint;
+                            // Re-send full state on lag unconditionally —
+                            // we can't tell which events were dropped, so
+                            // push a fresh snapshot to resync the client.
+                            let agents_json = build_agents_json(&core);
+                            let event = Event::default().event("agents").data(&agents_json);
+                            if tx.send(Ok(event)).await.is_err() {
+                                return;
                             }
                             let teams_json = build_teams_json(&core);
                             if teams_json != last_teams_json {


### PR DESCRIPTION
## Summary

- Promote the per-subscriber agent-list fingerprint dedup from `src/web/events.rs` into `TmaiCore::notify_agents_updated()`, so sub-threshold phase flips never become a `CoreEvent::AgentsUpdated`.
- The poller already collapses Idle↔Processing oscillation via `debounce_threshold()` and overrides `agent.status` to the committed value during the pending window. Snapshot endpoints (`/api/agents`) therefore reflect post-debounce state, matching what SSE pushes.
- WebUI (`useAgents.ts`) already renders straight from SSE push — no client-side agent-state debounce existed to remove. `useWorktrees` keeps its own GET-rate-limit debounce (separate concern).
- `awaiting_approval` keeps its 0ms threshold so interactive transitions still surface immediately.

Closes #424.

## Behaviour change

| Before | After |
|---|---|
| `notify_agents_updated()` fires every 500ms regardless of state | Only fires when post-debounce fingerprint changes |
| SSE handler computes per-connection fingerprint and dedups before sending | Forwards every `AgentsUpdated` directly; trusts core-side dedup |
| Sub-threshold blip wastes broadcast slots even though SSE drops it | Sub-threshold blip never enters the broadcast channel |

## Test plan

- [x] `cargo test -p tmai-core --lib` — 1014 passed
- [x] `cargo test -p tmai --lib` — 143 passed
- [x] `cargo fmt`, `cargo clippy -p tmai-core -p tmai` clean for changed files
- [x] New unit tests:
  - `test_debounce_suppresses_sub_threshold_idle_processing_blip` — 500ms Idle→Processing→Idle blip leaves committed Idle untouched
  - `test_awaiting_approval_commits_immediately_bypassing_debounce` — approval surfaces on the very next tick
  - `test_debounce_threshold_*` — policy assertions (oscillation 500ms, approval 0ms, post-approval fast)
  - `test_notify_agents_updated_dedups_same_fingerprint` — duplicate emission suppressed
  - `test_notify_agents_updated_force_bypasses_dedup` — force-variant always emits

## Notes

- Pre-existing `cargo clippy` errors in `tmai-app` (non-exhaustive `CoreEvent` match in `crates/tmai-app/src/events.rs`) and other crates are unrelated to this PR.
- TUI consumes `PollMessage::AgentsUpdated` and calls `notify_agents_updated()` with no debounce of its own — it now benefits from the same core-side dedup automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)