### PR TITLE
ci: detect / prevent bundle drift before merge (React #527 recurrence) (#437)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,15 @@ jobs:
         run: npx tsc --noEmit
       - name: Build
         run: pnpm build
+      - name: Verify committed bundle matches fresh build (drift check)
+        working-directory: ${{ github.workspace }}
+        run: |
+          if ! git diff --exit-code -- src/web/assets/; then
+            echo "::error::src/web/assets/ drifted from a fresh build of crates/tmai-app/web. Rebuild locally (cd crates/tmai-app/web && pnpm install --frozen-lockfile && pnpm build) and commit the result."
+            echo "--- git diff --stat ---"
+            git diff --stat -- src/web/assets/
+            exit 1
+          fi
 
   guard:
     name: gitignore guard


### PR DESCRIPTION
## Summary

- Adds a bundle drift check to the `frontend-check` CI job so worker-local pnpm state can't quietly ship a `src/web/assets/` bundle that diverges from what `pnpm-lock.yaml` should produce on a clean build.
- After `pnpm install --frozen-lockfile && pnpm build`, CI runs `git diff --exit-code -- src/web/assets/`. Non-empty diff → hard fail with the diff stat and a `::error::` annotation telling the author what to rebuild.
- Closes #437.

## Context

Two black-screen incidents in one day (#421, #436) caused by this exact class of drift: each worker runs `pnpm install && pnpm run build` in its worktree, and small cache/timing differences let the committed bundle diverge from main's lockfile. CI only verified the build succeeded, not that the committed bundle matched a fresh build.

## Design notes

- Integrated into the existing `frontend-check` job rather than a new job — it already does `pnpm install --frozen-lockfile` and `pnpm build`, so the drift check is just one extra `git diff` step (adds ~0s runtime).
- The check runs from `${{ github.workspace }}` (not the job's default `crates/tmai-app/web` working-directory) so git operates on the repo root.
- Skipped the "bump lockfile without rebuilding" guard and main-branch scheduled check from the issue's optional section — can add later if this class of drift reappears.

## Verification

- **Local:** `pnpm install --frozen-lockfile && pnpm build` reproduces committed `src/web/assets/` exactly on this branch → `git diff` empty.
- **Local:** appending 1 byte to `src/web/assets/index.html` → `git diff --exit-code` exits non-zero.
- **CI with intentional drift** ([run 24353456652](https://github.com/trust-delta/tmai/actions/runs/24353456652)): `frontend-check` failed at the new step as intended, printing the offending diff and the `::error::` annotation. All other jobs passed.
- **CI clean** ([run 24353542691](https://github.com/trust-delta/tmai/actions/runs/24353542691)): all jobs green, including the new drift check.

## Test plan

- [x] Local clean build → no diff.
- [x] Local drift → diff surfaces.
- [x] CI fails on intentional drift (run 24353456652).
- [x] CI passes after revert (run 24353542691).

🤖 Generated with [Claude Code](https://claude.com/claude-code)