### PR TITLE
bug: worker blocked on unmatched auto-approve falls back to Idle badge (should be AwaitingApproval) (#442)

### DIFF
--- a/crates/tmai-core/src/detectors/claude_code/tests.rs
+++ b/crates/tmai-core/src/detectors/claude_code/tests.rs
@@ -1344,3 +1344,68 @@ fn test_effort_icon_not_misdetected_as_spinner() {
         status
     );
 }
+
+// ============================================================
+// Issue #442 regression: compound-command approval persistence
+// ============================================================
+
+/// Build a realistic capture-pane snapshot for a compound `cd && git` Bash
+/// approval prompt (the scenario that produced #442).
+fn compound_command_approval_content() -> String {
+    let content = r#"● Bash(cd /home/trustdelta/works/tmai && git diff main..HEAD -- crates/)
+  ⎿  Interrupted by user
+
+───────────────────────────────────────────────────────────────────────────────
+ Bash command
+ cd /home/trustdelta/works/tmai && git diff main..HEAD -- crates/tmai-core/src/git/
+ Show recent diff against main for the git module
+
+ Do you want to proceed?
+ ❯ 1. Yes
+   2. Yes, and don't ask again for Bash(cd /home/trustdelta/works/tmai && git diff main..HEAD:*) commands in /home/trustdelta/works/tmai
+   3. No (esc)
+
+ Esc to cancel · Tab to add additional instructions
+"#;
+    // Simulate tmux pane height padding that capture-pane adds below the content.
+    let mut padded = content.to_string();
+    for _ in 0..10 {
+        padded.push('\n');
+    }
+    padded
+}
+
+/// Regression test for #442: compound-command approval must be detected as
+/// AwaitingApproval (not fall through to Idle via title_idle_indicator).
+#[test]
+fn test_compound_command_approval_detected() {
+    let detector = ClaudeCodeDetector::new();
+    let content = compound_command_approval_content();
+    // Title shows ✳ (idle indicator) — if approval detection misses the
+    // prompt, the detector would fall through to title_idle_indicator → Idle.
+    let status = detector.detect_status("✳ Claude Code", &content);
+    assert!(
+        matches!(status, AgentStatus::AwaitingApproval { .. }),
+        "Expected AwaitingApproval for compound cd && git prompt, got {:?}",
+        status
+    );
+}
+
+/// Regression test for #442: the detector must be stable across repeated
+/// ticks with unchanged content. If the prompt is visible on tick N, it must
+/// still be AwaitingApproval on tick N+1, N+2, etc. No auto-approve keys are
+/// sent, so the screen content is identical across ticks.
+#[test]
+fn test_compound_command_approval_persists_across_ticks() {
+    let detector = ClaudeCodeDetector::new();
+    let content = compound_command_approval_content();
+    for tick in 0..5 {
+        let status = detector.detect_status("✳ Claude Code", &content);
+        assert!(
+            matches!(status, AgentStatus::AwaitingApproval { .. }),
+            "Tick {}: expected AwaitingApproval, got {:?}",
+            tick,
+            status
+        );
+    }
+}

--- a/crates/tmai-core/src/monitor/poller.rs
+++ b/crates/tmai-core/src/monitor/poller.rs
@@ -2710,6 +2710,51 @@ mod tests {
         );
     }
 
+    /// #442: After auto-approve has exhausted its judgment attempts and
+    /// written `ManualRequired` into the agent's phase, the hook state is
+    /// still `AwaitingApproval` (only a clearing hook event like
+    /// PostToolUse / PermissionDenied / Stop can transition out of it).
+    /// With the user sitting on the prompt indefinitely, the hook appears
+    /// stale by raw freshness. The Tier 1 gate must still honor it — this
+    /// is the exact sequence observed on the #425 worker on 2026-04-13.
+    #[test]
+    fn test_manual_required_preserves_awaiting_approval_through_stale_hook() {
+        use crate::auto_approve::AutoApprovePhase;
+        use crate::hooks::types::{HookState, HookStatus};
+
+        // Scenario: auto-approve has judged (and abstained / rejected) enough
+        // times that phase is ManualRequired. Hook state has not received a
+        // new event for 60s since the permission prompt appeared.
+        let mut hs = HookState::new("s1".into(), None);
+        hs.status = HookStatus::AwaitingApproval;
+        hs.last_tool = Some("Bash".to_string());
+        hs.last_event_at = crate::hooks::types::current_time_millis().saturating_sub(60_000);
+
+        let phase = Some(AutoApprovePhase::ManualRequired(
+            "uncertain: compound command rejected by metacharacter guard".to_string(),
+        ));
+        // phase is purely informational — should not influence the freshness
+        // decision, only the hook status does.
+        let _ = &phase;
+
+        const HOOK_FRESHNESS_MS: u64 = 30_000;
+        let is_fresh_or_awaiting =
+            hs.is_fresh(HOOK_FRESHNESS_MS) || hs.status == HookStatus::AwaitingApproval;
+
+        assert!(
+            is_fresh_or_awaiting,
+            "ManualRequired phase + stale AwaitingApproval hook state must keep Tier 1 active — the prompt is still on screen and the hook ground-truth is the only reliable signal",
+        );
+
+        // Also verify the mapping produces the correct AgentStatus
+        let agent_status = hook_state_to_agent_status(&hs);
+        assert!(
+            matches!(agent_status, AgentStatus::AwaitingApproval { .. }),
+            "hook state must map to AwaitingApproval, got {:?}",
+            agent_status
+        );
+    }
+
     /// #442: Stale Processing hook state is still stale — only AwaitingApproval
     /// gets the exemption. Processing has a natural timeout (missed Stop event)
     /// and must be allowed to fall through for liveness checks.

--- a/crates/tmai-core/src/monitor/poller.rs
+++ b/crates/tmai-core/src/monitor/poller.rs
@@ -585,9 +585,21 @@ impl Poller {
                 // Processing timeout: if Processing with no event for this long,
                 // assume Stop event was missed and check process liveness
                 const PROCESSING_TIMEOUT_MS: u64 = 120_000;
+                // Hook state is "fresh" either when a recent event fired, or when
+                // it reports AwaitingApproval. Approval prompts have no natural
+                // timeout — the user may take minutes or hours — and only a
+                // clearing hook event (PostToolUse / PermissionDenied / Stop)
+                // transitions out of AwaitingApproval. Without this exemption,
+                // a paused-for-approval worker drops to capture-pane detection
+                // after 30s, and any edge case there (compound bash commands,
+                // tall preview boxes) silently misreads the prompt as Idle.
+                // See issue #442.
                 let has_fresh_hook = hook_state
                     .as_ref()
-                    .map(|hs| hs.is_fresh(HOOK_FRESHNESS_MS))
+                    .map(|hs| {
+                        hs.is_fresh(HOOK_FRESHNESS_MS)
+                            || hs.status == crate::hooks::types::HookStatus::AwaitingApproval
+                    })
                     .unwrap_or(false);
 
                 // Optimize capture-pane based on selection and detection source:
@@ -2666,6 +2678,57 @@ mod tests {
                 interaction: None,
             } if details.is_empty()
         ));
+    }
+
+    /// #442: Stale AwaitingApproval hook state must still be treated as "fresh"
+    /// for Tier 1 hook-based detection. Without this, a user who sits on an
+    /// approval prompt for > HOOK_FRESHNESS_MS (30s) would drop to Tier 2/3,
+    /// where edge-case capture-pane parsing (compound bash commands, tall
+    /// preview boxes) can silently misread the screen as Idle.
+    #[test]
+    fn test_awaiting_approval_hook_state_is_always_fresh() {
+        use crate::hooks::types::{HookState, HookStatus};
+
+        // Simulate a hook state that last fired > 30s ago
+        let mut hs = HookState::new("s1".into(), None);
+        hs.status = HookStatus::AwaitingApproval;
+        hs.last_event_at = crate::hooks::types::current_time_millis().saturating_sub(60_000);
+
+        // The freshness exemption used by the Tier 1 gate in `run()`:
+        // hook is fresh within HOOK_FRESHNESS_MS OR currently AwaitingApproval.
+        const HOOK_FRESHNESS_MS: u64 = 30_000;
+        let is_fresh_or_awaiting =
+            hs.is_fresh(HOOK_FRESHNESS_MS) || hs.status == HookStatus::AwaitingApproval;
+
+        assert!(
+            !hs.is_fresh(HOOK_FRESHNESS_MS),
+            "precondition: hook should be stale by raw freshness"
+        );
+        assert!(
+            is_fresh_or_awaiting,
+            "AwaitingApproval must remain active even when raw freshness has expired",
+        );
+    }
+
+    /// #442: Stale Processing hook state is still stale — only AwaitingApproval
+    /// gets the exemption. Processing has a natural timeout (missed Stop event)
+    /// and must be allowed to fall through for liveness checks.
+    #[test]
+    fn test_stale_processing_is_not_auto_fresh() {
+        use crate::hooks::types::{HookState, HookStatus};
+
+        let mut hs = HookState::new("s1".into(), None);
+        hs.status = HookStatus::Processing;
+        hs.last_event_at = crate::hooks::types::current_time_millis().saturating_sub(60_000);
+
+        const HOOK_FRESHNESS_MS: u64 = 30_000;
+        let is_fresh_or_awaiting =
+            hs.is_fresh(HOOK_FRESHNESS_MS) || hs.status == HookStatus::AwaitingApproval;
+
+        assert!(
+            !is_fresh_or_awaiting,
+            "stale Processing must not be treated as fresh — drops through to Tier 2/3 for liveness check"
+        );
     }
 
     /// hook_state_to_agent_status maps Compacting to Processing with Activity::Compacting


### PR DESCRIPTION
## Summary
- Exempt `HookStatus::AwaitingApproval` from the poller's 30s `HOOK_FRESHNESS_MS` timeout. Hook ground-truth now holds until a clearing event (PostToolUse / PermissionDenied / Stop) fires, regardless of how long the user sits on the prompt.
- Without this, a worker paused on a compound-command approval (e.g. `cd /path && git diff ...`) dropped to Tier 2/3 capture-pane detection after 30s, where edge-case prompt parsing (tall preview boxes, long wrapped choice labels) can silently misread the screen as Idle via `title_idle_indicator`.
- Processing's freshness timeout is preserved — it still falls through for liveness checks when a Stop event is missed.

## Why
Closes #442. The orchestrator's control loop assumes `Idle` = "nothing is happening, safe to ignore." Silently downgrading a stuck-on-approval worker to `Idle` breaks stuck-detection and freezes workflows without alarm. Approval prompts have no natural timeout — they persist until the user (or auto-approve) acts — so the 30s staleness heuristic is the wrong primitive for this state.

## Fix direction chosen
Option (1) from the issue: "Treat 'approval prompt visible AND no recent auto-approve send' as a persistent AwaitingApproval state." Implemented at the freshness gate rather than in the detector — this catches the bug at its source (Tier 1 hook state is authoritative when available) without loosening detector heuristics, which risks false-positive AwaitingApproval in other flows.

## Test plan
- [x] `cargo test --lib -p tmai-core` — 1041 tests pass
- [x] `test_compound_command_approval_detected` — regression test: compound `cd && git diff` prompt is detected as `AwaitingApproval` (not falling through title_idle → Idle)
- [x] `test_compound_command_approval_persists_across_ticks` — multi-tick stability: 5 consecutive detector calls on unchanged content all return `AwaitingApproval`
- [x] `test_awaiting_approval_hook_state_is_always_fresh` — stale (60s-old) `AwaitingApproval` hook state is still treated as fresh for Tier 1 detection
- [x] `test_stale_processing_is_not_auto_fresh` — Processing still times out normally; only AwaitingApproval gets the exemption
- [x] `cargo fmt --check` + `cargo clippy` clean

## Scope notes
The issue also proposed option (3): an `auto_approve_phase: Stalled` marker to distinguish "worker done" from "worker waiting on me" in the orchestrator view. That is an orthogonal diagnostic improvement and is not included here — the Tier 1 freshness fix restores correct status surfacing, which is the direct blocker. The Stalled marker can be added as a follow-up if audit events show unresolved cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 複合コマンドの承認プロンプト（例：`cd … && git diff …`）がタイムアウトで無効化されてしまう問題を修正。承認プロンプトが継続している場合でも、適切に認識されるようになりました。
  * 承認待ち状態のフック検出の安定性を向上。

* **Tests**
  * Issue #442 の回帰テストを追加。承認プロンプトが持続する場合の挙動を検証。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->