### PR TITLE
refactor: extract GhClient trait to isolate gh CLI dependency (#447)

### DIFF
--- a/crates/tmai-core/src/auto_action/mod.rs
+++ b/crates/tmai-core/src/auto_action/mod.rs
@@ -14,9 +14,7 @@ pub mod templates;
 pub mod tracker;
 
 pub use resolver::{is_agent_online, resolve_target_agent, AgentRole};
-pub use service::{
-    AutoActionExecutor, GithubApi, NoopReviewDispatcher, RealGithubApi, ReviewDispatcher,
-};
+pub use service::{AutoActionExecutor, NoopReviewDispatcher, ReviewDispatcher};
 pub use templates::{render, AutoActionTemplates};
 pub use tracker::AutoActionTracker;
 

--- a/crates/tmai-core/src/auto_action/service.rs
+++ b/crates/tmai-core/src/auto_action/service.rs
@@ -10,14 +10,10 @@ use std::sync::Arc;
 use tokio::sync::broadcast;
 use tracing::{debug, info, warn};
 
-/// Pinned, boxed future returning `Option<String>` — used as the return type
-/// of `GithubApi` methods so the trait stays dyn-compatible without dragging
-/// in `async-trait` as a dependency.
-pub type GhFuture<'a> = Pin<Box<dyn Future<Output = Option<String>> + Send + 'a>>;
-
 use crate::agents::MonitoredAgent;
 use crate::api::{CoreEvent, GuardrailKind};
 use crate::config::{EventHandling, OrchestratorNotifySettings};
+use crate::github::{CiConclusion, GhClient};
 use crate::orchestrator_notify::SharedNotifySettings;
 use crate::state::SharedState;
 use crate::task_meta::{store as meta_store, SharedGuardrailsSettings};
@@ -25,17 +21,6 @@ use crate::task_meta::{store as meta_store, SharedGuardrailsSettings};
 use super::resolver::{find_agent_by_id, is_agent_online, resolve_target_agent, AgentRole};
 use super::templates::{render, AutoActionTemplates};
 use super::tracker::AutoActionTracker;
-
-/// Abstraction over the subset of GitHub APIs AutoActionExecutor uses,
-/// injected so integration tests can stub out real `gh` invocations.
-pub trait GithubApi: Send + Sync + 'static {
-    /// Fetch the failure log text for the most recent failed CI run on `branch`.
-    /// Returns `None` if no failed run is found or the log can't be fetched.
-    fn fetch_ci_failure_log<'a>(&'a self, repo_dir: &'a str, branch: &'a str) -> GhFuture<'a>;
-
-    /// Fetch review / conversation comments on `pr_number`, joined as human-readable text.
-    fn fetch_pr_comments<'a>(&'a self, repo_dir: &'a str, pr_number: u64) -> GhFuture<'a>;
-}
 
 /// Abstraction over `dispatch_review` so AutoActionExecutor can trigger a review-agent
 /// dispatch without depending on the bin crate's HTTP handler directly.
@@ -66,52 +51,63 @@ impl ReviewDispatcher for NoopReviewDispatcher {
     }
 }
 
-/// Default `GithubApi` implementation that shells out to `gh` via `crate::github`.
-pub struct RealGithubApi;
+/// Fetch the failure log text for the most recent failed CI run on `branch`
+/// via a [`GhClient`]. Returns `None` if no failed run exists or the log can
+/// be retrieved. Errors from the underlying trait are swallowed here because
+/// a missing log should fall back to the pre-computed `failed_details`
+/// summary rather than abort the auto-action.
+async fn fetch_ci_failure_log_text(
+    gh: &dyn GhClient,
+    repo_dir: &str,
+    branch: &str,
+) -> Option<String> {
+    let summary = gh.list_checks(repo_dir, branch).await.ok().flatten()?;
+    let run_id = summary.checks.iter().find_map(|c| {
+        let failed = matches!(
+            c.conclusion,
+            Some(CiConclusion::Failure)
+                | Some(CiConclusion::TimedOut)
+                | Some(CiConclusion::Cancelled)
+        );
+        if failed {
+            c.run_id
+        } else {
+            None
+        }
+    })?;
+    let log = gh
+        .get_ci_failure_log(repo_dir, run_id)
+        .await
+        .ok()
+        .flatten()?;
+    Some(log.log_text)
+}
 
-impl GithubApi for RealGithubApi {
-    fn fetch_ci_failure_log<'a>(&'a self, repo_dir: &'a str, branch: &'a str) -> GhFuture<'a> {
-        Box::pin(async move {
-            let summary = crate::github::list_checks(repo_dir, branch).await?;
-            let run_id = summary.checks.iter().find_map(|c| {
-                let failed = matches!(
-                    c.conclusion,
-                    Some(crate::github::CiConclusion::Failure)
-                        | Some(crate::github::CiConclusion::TimedOut)
-                        | Some(crate::github::CiConclusion::Cancelled)
-                );
-                if failed {
-                    c.run_id
-                } else {
-                    None
-                }
-            })?;
-            let log = crate::github::get_ci_failure_log(repo_dir, run_id).await?;
-            Some(log.log_text)
-        })
+/// Fetch PR comments joined as human-readable text. `None` when the PR has
+/// no comments OR the underlying request fails — both cases are equivalent
+/// for auto-action gating (no feedback to relay).
+async fn fetch_pr_comments_text(
+    gh: &dyn GhClient,
+    repo_dir: &str,
+    pr_number: u64,
+) -> Option<String> {
+    let comments = gh.get_pr_comments(repo_dir, pr_number).await.ok()?;
+    if comments.is_empty() {
+        return None;
     }
-
-    fn fetch_pr_comments<'a>(&'a self, repo_dir: &'a str, pr_number: u64) -> GhFuture<'a> {
-        Box::pin(async move {
-            let comments = crate::github::get_pr_comments(repo_dir, pr_number).await?;
-            if comments.is_empty() {
-                return None;
-            }
-            let joined = comments
-                .iter()
-                .map(|c| {
-                    let path = c
-                        .path
-                        .as_deref()
-                        .map(|p| format!(" [{p}]"))
-                        .unwrap_or_default();
-                    format!("- @{}{}: {}", c.author, path, c.body.trim())
-                })
-                .collect::<Vec<_>>()
-                .join("\n");
-            Some(joined)
+    let joined = comments
+        .iter()
+        .map(|c| {
+            let path = c
+                .path
+                .as_deref()
+                .map(|p| format!(" [{p}]"))
+                .unwrap_or_default();
+            format!("- @{}{}: {}", c.author, path, c.body.trim())
         })
-    }
+        .collect::<Vec<_>>()
+        .join("\n");
+    Some(joined)
 }
 
 /// Event-driven service that, when configured, instructs workers directly
@@ -132,7 +128,7 @@ impl AutoActionExecutor {
         notify_settings: SharedNotifySettings,
         guardrails: SharedGuardrailsSettings,
         templates: Arc<parking_lot::RwLock<AutoActionTemplates>>,
-        github: Arc<dyn GithubApi>,
+        github: Arc<dyn GhClient>,
         review_dispatcher: Arc<dyn ReviewDispatcher>,
     ) -> tokio::task::JoinHandle<()> {
         let tracker = Arc::new(AutoActionTracker::new());
@@ -177,7 +173,7 @@ impl AutoActionExecutor {
         guardrails: &SharedGuardrailsSettings,
         templates: &Arc<parking_lot::RwLock<AutoActionTemplates>>,
         tracker: &Arc<AutoActionTracker>,
-        github: &dyn GithubApi,
+        github: &dyn GhClient,
         review_dispatcher: &dyn ReviewDispatcher,
         event: &CoreEvent,
     ) {
@@ -268,7 +264,7 @@ impl AutoActionExecutor {
         event_tx: &broadcast::Sender<CoreEvent>,
         guardrails: &SharedGuardrailsSettings,
         tracker: &Arc<AutoActionTracker>,
-        github: &dyn GithubApi,
+        github: &dyn GhClient,
         review_dispatcher: &dyn ReviewDispatcher,
         pr_number: u64,
         title: &str,
@@ -298,8 +294,7 @@ impl AutoActionExecutor {
         }
 
         // Skip if the PR already has review comments (human or bot)
-        if github
-            .fetch_pr_comments(project_root_str(&project_root), pr_number)
+        if fetch_pr_comments_text(github, project_root_str(&project_root), pr_number)
             .await
             .is_some()
         {
@@ -352,7 +347,7 @@ impl AutoActionExecutor {
         guardrails: &SharedGuardrailsSettings,
         templates: &Arc<parking_lot::RwLock<AutoActionTemplates>>,
         tracker: &Arc<AutoActionTracker>,
-        github: &dyn GithubApi,
+        github: &dyn GhClient,
         pr_number: u64,
         title: &str,
         failed_details: &str,
@@ -428,19 +423,18 @@ impl AutoActionExecutor {
         }
 
         // Enrich failure details with the failure log when available
-        let detailed = match github
-            .fetch_ci_failure_log(project_root_str(&project_root), &branch)
-            .await
-        {
-            Some(log) => {
-                if log.trim().is_empty() {
-                    failed_details.to_string()
-                } else {
-                    format!("{failed_details}\n\n--- CI log ---\n{log}")
+        let detailed =
+            match fetch_ci_failure_log_text(github, project_root_str(&project_root), &branch).await
+            {
+                Some(log) => {
+                    if log.trim().is_empty() {
+                        failed_details.to_string()
+                    } else {
+                        format!("{failed_details}\n\n--- CI log ---\n{log}")
+                    }
                 }
-            }
-            None => failed_details.to_string(),
-        };
+                None => failed_details.to_string(),
+            };
 
         let tpl = templates.read().effective_ci_failed();
         let pr_str = pr_number.to_string();
@@ -469,7 +463,7 @@ impl AutoActionExecutor {
         guardrails: &SharedGuardrailsSettings,
         templates: &Arc<parking_lot::RwLock<AutoActionTemplates>>,
         tracker: &Arc<AutoActionTracker>,
-        github: &dyn GithubApi,
+        github: &dyn GhClient,
         pr_number: u64,
         title: &str,
         comments_summary: &str,
@@ -539,8 +533,7 @@ impl AutoActionExecutor {
         }
 
         // Fetch the full comment text (falls back to summary)
-        let full = github
-            .fetch_pr_comments(project_root_str(&project_root), pr_number)
+        let full = fetch_pr_comments_text(github, project_root_str(&project_root), pr_number)
             .await
             .unwrap_or_else(|| comments_summary.to_string());
 
@@ -677,16 +670,63 @@ mod tests {
     use super::*;
     use crate::agents::{AgentStatus, AgentType, MonitoredAgent};
     use crate::config::GuardrailsSettings;
+    use crate::github::{
+        CheckStatus, CiCheck, CiFailureLog, CiRunStatus, CiSummary, MockGhClient, PrComment,
+    };
     use crate::state::AppState;
     use crate::task_meta::store::TaskMeta;
     use std::sync::Mutex;
 
     // ── Test doubles ────────────────────────────────────────────────
 
-    #[derive(Default)]
-    struct StubGithub {
-        ci_log: Mutex<Option<String>>,
-        pr_comments: Mutex<Option<String>>,
+    /// Build a [`MockGhClient`] that returns `log_text` as the content of the
+    /// most recent failed CI run. Used to exercise `handle_ci_failed`'s log
+    /// enrichment path through the public [`GhClient`] trait.
+    fn mock_gh_with_ci_log(log_text: &str) -> Arc<MockGhClient> {
+        let mock = MockGhClient::new();
+        *mock.list_checks.lock() = Some(CiSummary {
+            branch: "feat/x".into(),
+            checks: vec![CiCheck {
+                name: "test".into(),
+                status: CiRunStatus::Completed,
+                conclusion: Some(CiConclusion::Failure),
+                url: String::new(),
+                started_at: None,
+                completed_at: None,
+                run_id: Some(99),
+            }],
+            rollup: CheckStatus::Failure,
+        });
+        *mock.get_ci_failure_log.lock() = Some(CiFailureLog {
+            run_id: 99,
+            log_text: log_text.to_string(),
+        });
+        Arc::new(mock)
+    }
+
+    /// Build a [`MockGhClient`] seeded with a single PR comment so the
+    /// service's `fetch_pr_comments_text` formats to exactly `expected`.
+    fn mock_gh_with_single_comment(author: &str, body: &str) -> Arc<MockGhClient> {
+        let mock = MockGhClient::new();
+        *mock.get_pr_comments.lock() = Some(vec![PrComment {
+            author: author.to_string(),
+            body: body.to_string(),
+            created_at: String::new(),
+            url: String::new(),
+            comment_type: "comment".into(),
+            path: None,
+            diff_hunk: None,
+        }]);
+        Arc::new(mock)
+    }
+
+    /// [`MockGhClient`] seeded so `get_pr_comments` returns an empty list.
+    /// The `fetch_pr_comments_text` helper therefore produces `None`, which
+    /// is how the service detects "no review feedback yet".
+    fn mock_gh_no_comments() -> Arc<MockGhClient> {
+        let mock = MockGhClient::new();
+        *mock.get_pr_comments.lock() = Some(Vec::new());
+        Arc::new(mock)
     }
 
     #[derive(Default)]
@@ -710,21 +750,6 @@ mod tests {
                     Ok(())
                 }
             })
-        }
-    }
-
-    impl GithubApi for StubGithub {
-        fn fetch_ci_failure_log<'a>(
-            &'a self,
-            _repo_dir: &'a str,
-            _branch: &'a str,
-        ) -> GhFuture<'a> {
-            let v = self.ci_log.lock().unwrap().clone();
-            Box::pin(async move { v })
-        }
-        fn fetch_pr_comments<'a>(&'a self, _repo_dir: &'a str, _pr_number: u64) -> GhFuture<'a> {
-            let v = self.pr_comments.lock().unwrap().clone();
-            Box::pin(async move { v })
         }
     }
 
@@ -805,9 +830,8 @@ mod tests {
         meta_store::write_meta(dir.path(), "feat/x", &meta).unwrap();
 
         let (tx, mut rx, g, tpl, tr) = make_harness(&state, dir.path());
-        let gh = Arc::new(StubGithub::default());
+        let gh = mock_gh_with_ci_log("=== pytest failed ===");
         let dispatcher = Arc::new(StubDispatcher::default());
-        *gh.ci_log.lock().unwrap() = Some("=== pytest failed ===".to_string());
         let ns = settings_with(EventHandling::AutoAction, EventHandling::NotifyOrchestrator);
 
         let event = CoreEvent::PrCiFailed {
@@ -851,7 +875,7 @@ mod tests {
         meta_store::write_meta(dir.path(), "feat/x", &meta).unwrap();
 
         let (tx, mut rx, g, tpl, tr) = make_harness(&state, dir.path());
-        let gh = Arc::new(StubGithub::default());
+        let gh = Arc::new(MockGhClient::new());
         let dispatcher = Arc::new(StubDispatcher::default());
         let ns = settings_with(EventHandling::NotifyOrchestrator, EventHandling::AutoAction);
 
@@ -891,7 +915,7 @@ mod tests {
         meta_store::write_meta(dir.path(), "feat/x", &meta).unwrap();
 
         let (tx, mut rx, g, tpl, tr) = make_harness(&state, dir.path());
-        let gh = Arc::new(StubGithub::default());
+        let gh = Arc::new(MockGhClient::new());
         let dispatcher = Arc::new(StubDispatcher::default());
         let ns = settings_with(EventHandling::AutoAction, EventHandling::AutoAction);
 
@@ -934,7 +958,7 @@ mod tests {
 
         let (tx, mut rx, g, tpl, tr) = make_harness(&state, dir.path());
         g.write().max_ci_retries = 2;
-        let gh = Arc::new(StubGithub::default());
+        let gh = Arc::new(MockGhClient::new());
         let dispatcher = Arc::new(StubDispatcher::default());
         let ns = settings_with(EventHandling::AutoAction, EventHandling::NotifyOrchestrator);
 
@@ -1015,9 +1039,8 @@ mod tests {
         meta_store::write_meta(dir.path(), "feat/y", &meta).unwrap();
 
         let (tx, mut rx, g, tpl, tr) = make_harness(&state, dir.path());
-        let gh = Arc::new(StubGithub::default());
+        let gh = mock_gh_with_single_comment("alice", "please rename foo");
         let dispatcher = Arc::new(StubDispatcher::default());
-        *gh.pr_comments.lock().unwrap() = Some("- @alice: please rename foo".to_string());
         let ns = settings_with(EventHandling::NotifyOrchestrator, EventHandling::AutoAction);
 
         let event = CoreEvent::PrReviewFeedback {
@@ -1062,7 +1085,7 @@ mod tests {
 
         let (tx, mut rx, g, tpl, tr) = make_harness(&state, dir.path());
         g.write().max_review_loops = 1;
-        let gh = Arc::new(StubGithub::default());
+        let gh = Arc::new(MockGhClient::new());
         let dispatcher = Arc::new(StubDispatcher::default());
         let ns = settings_with(EventHandling::NotifyOrchestrator, EventHandling::AutoAction);
 
@@ -1134,7 +1157,7 @@ mod tests {
         assert_eq!(tr.ci_count("feat/z"), 1);
         assert_eq!(tr.review_count(42), 1);
 
-        let gh = Arc::new(StubGithub::default());
+        let gh = Arc::new(MockGhClient::new());
         let dispatcher = Arc::new(StubDispatcher::default());
         let ns = settings_with(EventHandling::AutoAction, EventHandling::AutoAction);
         let event = CoreEvent::PrClosed {
@@ -1177,7 +1200,7 @@ mod tests {
         meta_store::write_meta(dir.path(), "feat/a", &meta).unwrap();
 
         let (tx, mut _rx, g, tpl, tr) = make_harness(&state, dir.path());
-        let gh = Arc::new(StubGithub::default()); // no pr_comments → None
+        let gh = Arc::new(MockGhClient::new()); // no pr_comments → None
         let dispatcher = Arc::new(StubDispatcher::default());
         let ns = settings_with_ci_passed(EventHandling::AutoAction);
 
@@ -1216,7 +1239,7 @@ mod tests {
         meta_store::write_meta(dir.path(), "feat/a", &meta).unwrap();
 
         let (tx, mut _rx, g, tpl, tr) = make_harness(&state, dir.path());
-        let gh = Arc::new(StubGithub::default());
+        let gh = Arc::new(MockGhClient::new());
         let dispatcher = Arc::new(StubDispatcher::default());
         let ns = settings_with_ci_passed(EventHandling::AutoAction);
 
@@ -1253,8 +1276,7 @@ mod tests {
         meta_store::write_meta(dir.path(), "feat/a", &meta).unwrap();
 
         let (tx, mut _rx, g, tpl, tr) = make_harness(&state, dir.path());
-        let gh = Arc::new(StubGithub::default());
-        *gh.pr_comments.lock().unwrap() = Some("- @bob: nit".to_string());
+        let gh = mock_gh_with_single_comment("bob", "nit");
         let dispatcher = Arc::new(StubDispatcher::default());
         let ns = settings_with_ci_passed(EventHandling::AutoAction);
 
@@ -1292,7 +1314,7 @@ mod tests {
 
         let (tx, mut rx, g, tpl, tr) = make_harness(&state, dir.path());
         g.write().max_review_loops = 1;
-        let gh = Arc::new(StubGithub::default());
+        let gh = Arc::new(MockGhClient::new());
         let dispatcher = Arc::new(StubDispatcher::default());
         let ns = settings_with_ci_passed(EventHandling::AutoAction);
 
@@ -1353,7 +1375,7 @@ mod tests {
         meta_store::write_meta(dir.path(), "feat/a", &meta).unwrap();
 
         let (tx, mut _rx, g, tpl, tr) = make_harness(&state, dir.path());
-        let gh = Arc::new(StubGithub::default());
+        let gh = Arc::new(MockGhClient::new());
         let dispatcher = Arc::new(StubDispatcher::default());
         let ns = settings_with_ci_passed(EventHandling::NotifyOrchestrator);
 

--- a/crates/tmai-core/src/github/client.rs
+++ b/crates/tmai-core/src/github/client.rs
@@ -1,0 +1,893 @@
+//! [`GhClient`] trait — abstracts the `gh` CLI so call sites can target the
+//! trait rather than the concrete shell-out, and tests can inject a mock.
+//!
+//! The production implementation [`GhCliClient`] shells out to `gh` exactly as
+//! the previous free functions did (same JSON fields, same timeouts). Errors
+//! are classified into [`GhError`] variants so callers can branch on
+//! `AuthExpired` / `RateLimited` / `GhNotInstalled` without re-parsing stderr.
+//!
+//! The 30s TTL cache is intentionally NOT part of this trait — it wraps the
+//! trait at the `github::mod` layer, keeping this module a pure transport.
+
+use std::collections::{HashMap, HashSet};
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::LazyLock;
+use std::time::Duration;
+
+use tokio::process::Command;
+
+use super::error::GhError;
+use super::{
+    author_login, build_pr_comments, compute_rollup, parse_issue_detail_json, CheckStatus, CiCheck,
+    CiFailureLog, CiSummary, GhMergedPrEntry, GhPrCommentsResponse, GhPrEntry, GhRunEntry,
+    IssueDetail, IssueInfo, MergeMethod, MergeResult, PrChangedFile, PrComment, PrInfo,
+    PrMergeStatus, ReviewAction, ReviewDecision, ReviewResult,
+};
+
+/// Timeout for standard `gh` invocations (list/view/etc.). Mirrors the value
+/// used before the trait extraction.
+const GH_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Longer timeout used for slow operations (log fetch, merge) where 10s is
+/// routinely insufficient on large repos.
+const GH_LONG_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Maximum size for CI failure log output (50KB).
+const CI_LOG_MAX_BYTES: usize = 50 * 1024;
+
+/// Pinned, boxed future returning a `GhError`-typed result. Used throughout
+/// the trait so it stays dyn-compatible without depending on `async-trait`.
+pub type GhFuture<'a, T> = Pin<Box<dyn Future<Output = Result<T, GhError>> + Send + 'a>>;
+
+/// Abstraction over the `gh` CLI. Methods mirror the underlying commands
+/// 1:1 with typed returns and [`GhError`] variants for failure modes.
+///
+/// The production impl is [`GhCliClient`]. Tests can use
+/// [`crate::github::MockGhClient`] to inject canned responses.
+pub trait GhClient: Send + Sync + 'static {
+    fn list_open_prs<'a>(&'a self, repo_dir: &'a str) -> GhFuture<'a, HashMap<String, PrInfo>>;
+
+    fn list_merged_prs<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        local_branches: &'a [String],
+    ) -> GhFuture<'a, HashMap<String, PrInfo>>;
+
+    fn has_merged_pr<'a>(&'a self, repo_dir: &'a str, branch: &'a str) -> GhFuture<'a, bool>;
+
+    fn list_checks<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        branch: &'a str,
+    ) -> GhFuture<'a, Option<CiSummary>>;
+
+    fn list_issues<'a>(&'a self, repo_dir: &'a str) -> GhFuture<'a, Vec<IssueInfo>>;
+
+    fn get_issue_detail<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        issue_number: u64,
+    ) -> GhFuture<'a, Option<IssueDetail>>;
+
+    fn get_pr_comments<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        pr_number: u64,
+    ) -> GhFuture<'a, Vec<PrComment>>;
+
+    fn get_pr_files<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        pr_number: u64,
+    ) -> GhFuture<'a, Vec<PrChangedFile>>;
+
+    fn get_pr_merge_status<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        pr_number: u64,
+    ) -> GhFuture<'a, Option<PrMergeStatus>>;
+
+    fn get_ci_failure_log<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        run_id: u64,
+    ) -> GhFuture<'a, Option<CiFailureLog>>;
+
+    fn rerun_failed_checks<'a>(&'a self, repo_dir: &'a str, run_id: u64) -> GhFuture<'a, ()>;
+
+    fn merge_pr<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        pr_number: u64,
+        method: MergeMethod,
+        delete_branch: bool,
+    ) -> GhFuture<'a, MergeResult>;
+
+    fn review_pr<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        pr_number: u64,
+        action: ReviewAction,
+        body: Option<&'a str>,
+    ) -> GhFuture<'a, ReviewResult>;
+}
+
+/// Production [`GhClient`] implementation that shells out to `gh`.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct GhCliClient;
+
+impl GhCliClient {
+    pub const fn new() -> Self {
+        Self
+    }
+}
+
+/// Process-wide default [`GhCliClient`]. Returned by
+/// [`default_client`] for the module-level free-function wrappers.
+static DEFAULT_CLIENT: LazyLock<GhCliClient> = LazyLock::new(GhCliClient::new);
+
+/// Return a reference to the process-wide default [`GhCliClient`].
+pub(super) fn default_client() -> &'static GhCliClient {
+    &DEFAULT_CLIENT
+}
+
+/// Run `gh <args>` in `repo_dir` with `timeout`. Returns the raw stdout on
+/// success; classifies stderr into [`GhError`] variants on failure.
+async fn run_gh(args: &[&str], repo_dir: &str, timeout: Duration) -> Result<Vec<u8>, GhError> {
+    let spawn_result = tokio::time::timeout(
+        timeout,
+        Command::new("gh").args(args).current_dir(repo_dir).output(),
+    )
+    .await;
+
+    let output = match spawn_result {
+        Err(_) => {
+            return Err(GhError::Other(format!(
+                "gh {} timed out after {}s",
+                args.first().copied().unwrap_or(""),
+                timeout.as_secs()
+            )));
+        }
+        Ok(Err(e)) => return Err(GhError::from_spawn_error(e)),
+        Ok(Ok(out)) => out,
+    };
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+        return Err(GhError::classify_stderr(&stderr));
+    }
+
+    Ok(output.stdout)
+}
+
+fn parse_json<T>(bytes: &[u8]) -> Result<T, GhError>
+where
+    T: for<'de> serde::Deserialize<'de>,
+{
+    serde_json::from_slice(bytes).map_err(|e| GhError::ParseError(e.to_string()))
+}
+
+impl GhClient for GhCliClient {
+    fn list_open_prs<'a>(&'a self, repo_dir: &'a str) -> GhFuture<'a, HashMap<String, PrInfo>> {
+        Box::pin(async move {
+            let stdout = run_gh(
+                &[
+                    "pr",
+                    "list",
+                    "--state",
+                    "open",
+                    "--json",
+                    "number,title,state,headRefName,headRefOid,baseRefName,url,reviewDecision,statusCheckRollup,isDraft,additions,deletions,comments,reviews,author",
+                    "--limit",
+                    "50",
+                ],
+                repo_dir,
+                GH_TIMEOUT,
+            )
+            .await?;
+
+            let entries: Vec<GhPrEntry> = parse_json(&stdout)?;
+            let mut map = HashMap::new();
+            for entry in entries {
+                let check_status = entry
+                    .status_check_rollup
+                    .as_ref()
+                    .map(|checks| compute_rollup(checks));
+
+                let review_decision = entry.review_decision.as_deref().and_then(|s| match s {
+                    "APPROVED" => Some(ReviewDecision::Approved),
+                    "CHANGES_REQUESTED" => Some(ReviewDecision::ChangesRequested),
+                    "REVIEW_REQUIRED" => Some(ReviewDecision::ReviewRequired),
+                    _ => None,
+                });
+
+                let pr = PrInfo {
+                    number: entry.number,
+                    title: entry.title,
+                    state: entry.state,
+                    head_branch: entry.head_ref_name.clone(),
+                    head_sha: entry.head_ref_oid.clone(),
+                    url: entry.url,
+                    base_branch: entry.base_ref_name.clone(),
+                    review_decision,
+                    check_status,
+                    is_draft: entry.is_draft,
+                    additions: entry.additions.unwrap_or(0),
+                    deletions: entry.deletions.unwrap_or(0),
+                    comments: entry.comments.map(|c| c.len() as u64).unwrap_or(0),
+                    reviews: entry.reviews.map(|r| r.len() as u64).unwrap_or(0),
+                    author: author_login(entry.author),
+                    merge_commit_sha: None,
+                };
+                map.insert(entry.head_ref_name, pr);
+            }
+            Ok(map)
+        })
+    }
+
+    fn list_merged_prs<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        local_branches: &'a [String],
+    ) -> GhFuture<'a, HashMap<String, PrInfo>> {
+        Box::pin(async move {
+            if local_branches.is_empty() {
+                return Ok(HashMap::new());
+            }
+
+            let stdout = run_gh(
+                &[
+                    "pr",
+                    "list",
+                    "--state",
+                    "merged",
+                    "--json",
+                    "number,title,headRefName,headRefOid,baseRefName,url,mergeCommit",
+                    "--limit",
+                    "30",
+                ],
+                repo_dir,
+                GH_TIMEOUT,
+            )
+            .await?;
+
+            let entries: Vec<GhMergedPrEntry> = parse_json(&stdout)?;
+            let branch_set: HashSet<&str> = local_branches.iter().map(|s| s.as_str()).collect();
+
+            let mut map = HashMap::new();
+            for entry in entries {
+                if !branch_set.contains(entry.head_ref_name.as_str()) {
+                    continue;
+                }
+                let merge_commit_sha = entry.merge_commit.map(|mc| mc.oid);
+                let pr = PrInfo {
+                    number: entry.number,
+                    title: entry.title,
+                    state: "MERGED".to_string(),
+                    head_branch: entry.head_ref_name.clone(),
+                    head_sha: entry.head_ref_oid,
+                    base_branch: entry.base_ref_name,
+                    url: entry.url,
+                    review_decision: None,
+                    check_status: None,
+                    is_draft: false,
+                    additions: 0,
+                    deletions: 0,
+                    comments: 0,
+                    reviews: 0,
+                    author: String::new(),
+                    merge_commit_sha,
+                };
+                map.insert(entry.head_ref_name, pr);
+            }
+            Ok(map)
+        })
+    }
+
+    fn has_merged_pr<'a>(&'a self, repo_dir: &'a str, branch: &'a str) -> GhFuture<'a, bool> {
+        Box::pin(async move {
+            let stdout = run_gh(
+                &[
+                    "pr", "list", "--state", "merged", "--head", branch, "--json", "number",
+                    "--limit", "1",
+                ],
+                repo_dir,
+                GH_TIMEOUT,
+            )
+            .await?;
+
+            let parsed: Vec<serde_json::Value> = parse_json(&stdout)?;
+            Ok(!parsed.is_empty())
+        })
+    }
+
+    fn list_checks<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        branch: &'a str,
+    ) -> GhFuture<'a, Option<CiSummary>> {
+        Box::pin(async move {
+            if branch.is_empty() || branch.starts_with('-') {
+                return Ok(None);
+            }
+
+            let stdout = run_gh(
+                &[
+                    "run",
+                    "list",
+                    "--branch",
+                    branch,
+                    "--json",
+                    "name,status,conclusion,url,headBranch,createdAt,updatedAt,databaseId",
+                    "--limit",
+                    "10",
+                ],
+                repo_dir,
+                GH_TIMEOUT,
+            )
+            .await?;
+
+            let entries: Vec<GhRunEntry> = parse_json(&stdout)?;
+            let mut seen = HashSet::new();
+            let checks: Vec<CiCheck> = entries
+                .into_iter()
+                .filter(|e| seen.insert(e.name.clone()))
+                .map(|e| CiCheck {
+                    name: e.name,
+                    status: e.status,
+                    conclusion: e.conclusion,
+                    url: e.url,
+                    started_at: e.created_at,
+                    completed_at: e.updated_at,
+                    run_id: e.database_id,
+                })
+                .collect();
+
+            let rollup = compute_rollup(&checks);
+            Ok(Some(CiSummary {
+                branch: branch.to_string(),
+                checks,
+                rollup,
+            }))
+        })
+    }
+
+    fn list_issues<'a>(&'a self, repo_dir: &'a str) -> GhFuture<'a, Vec<IssueInfo>> {
+        Box::pin(async move {
+            let stdout = run_gh(
+                &[
+                    "issue",
+                    "list",
+                    "--state",
+                    "open",
+                    "--json",
+                    "number,title,state,url,labels,assignees",
+                    "--limit",
+                    "50",
+                ],
+                repo_dir,
+                GH_TIMEOUT,
+            )
+            .await?;
+
+            let entries: Vec<super::GhIssueEntry> = parse_json(&stdout)?;
+            Ok(entries
+                .into_iter()
+                .map(|e| IssueInfo {
+                    number: e.number,
+                    title: e.title,
+                    state: e.state,
+                    url: e.url,
+                    labels: e.labels,
+                    assignees: e.assignees.into_iter().map(|a| a.login).collect(),
+                })
+                .collect())
+        })
+    }
+
+    fn get_issue_detail<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        issue_number: u64,
+    ) -> GhFuture<'a, Option<IssueDetail>> {
+        Box::pin(async move {
+            let stdout = run_gh(
+                &[
+                    "issue",
+                    "view",
+                    &issue_number.to_string(),
+                    "--json",
+                    "number,title,state,url,body,labels,assignees,createdAt,updatedAt,comments",
+                ],
+                repo_dir,
+                GH_TIMEOUT,
+            )
+            .await?;
+
+            let val: serde_json::Value = parse_json(&stdout)?;
+            Ok(parse_issue_detail_json(&val))
+        })
+    }
+
+    fn get_pr_comments<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        pr_number: u64,
+    ) -> GhFuture<'a, Vec<PrComment>> {
+        Box::pin(async move {
+            let stdout = run_gh(
+                &[
+                    "pr",
+                    "view",
+                    &pr_number.to_string(),
+                    "--json",
+                    "comments,reviews",
+                ],
+                repo_dir,
+                GH_TIMEOUT,
+            )
+            .await?;
+
+            let resp: GhPrCommentsResponse = parse_json(&stdout)?;
+            Ok(build_pr_comments(resp))
+        })
+    }
+
+    fn get_pr_files<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        pr_number: u64,
+    ) -> GhFuture<'a, Vec<PrChangedFile>> {
+        Box::pin(async move {
+            let stdout = run_gh(
+                &["pr", "view", &pr_number.to_string(), "--json", "files"],
+                repo_dir,
+                GH_TIMEOUT,
+            )
+            .await?;
+
+            #[derive(serde::Deserialize)]
+            struct FilesResponse {
+                files: Vec<GhFileEntry>,
+            }
+
+            #[derive(serde::Deserialize)]
+            struct GhFileEntry {
+                path: String,
+                additions: u64,
+                deletions: u64,
+            }
+
+            let resp: FilesResponse = parse_json(&stdout)?;
+            Ok(resp
+                .files
+                .into_iter()
+                .map(|f| PrChangedFile {
+                    path: f.path,
+                    additions: f.additions,
+                    deletions: f.deletions,
+                })
+                .collect())
+        })
+    }
+
+    fn get_pr_merge_status<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        pr_number: u64,
+    ) -> GhFuture<'a, Option<PrMergeStatus>> {
+        Box::pin(async move {
+            let stdout = run_gh(
+                &[
+                    "pr",
+                    "view",
+                    &pr_number.to_string(),
+                    "--json",
+                    "mergeable,mergeStateStatus,reviewDecision,statusCheckRollup",
+                ],
+                repo_dir,
+                GH_TIMEOUT,
+            )
+            .await?;
+
+            let json: serde_json::Value = parse_json(&stdout)?;
+
+            let mergeable = json
+                .get("mergeable")
+                .and_then(|v| v.as_str())
+                .unwrap_or("UNKNOWN")
+                .to_string();
+            let merge_state_status = json
+                .get("mergeStateStatus")
+                .and_then(|v| v.as_str())
+                .unwrap_or("UNKNOWN")
+                .to_string();
+            let review_decision = json
+                .get("reviewDecision")
+                .and_then(|v| v.as_str())
+                .map(|s| s.to_string());
+
+            let check_status: Option<CheckStatus> = json
+                .get("statusCheckRollup")
+                .and_then(|v| serde_json::from_value::<Vec<super::GhCheckRun>>(v.clone()).ok())
+                .map(|checks| compute_rollup(&checks));
+
+            Ok(Some(PrMergeStatus {
+                mergeable,
+                merge_state_status,
+                review_decision,
+                check_status,
+            }))
+        })
+    }
+
+    fn get_ci_failure_log<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        run_id: u64,
+    ) -> GhFuture<'a, Option<CiFailureLog>> {
+        Box::pin(async move {
+            let stdout = run_gh(
+                &["run", "view", &run_id.to_string(), "--log-failed"],
+                repo_dir,
+                GH_LONG_TIMEOUT,
+            )
+            .await?;
+
+            if stdout.is_empty() {
+                return Ok(None);
+            }
+
+            let text = if stdout.len() > CI_LOG_MAX_BYTES {
+                let truncated = &stdout[..CI_LOG_MAX_BYTES];
+                let s = String::from_utf8_lossy(truncated);
+                format!("{}\n\n... (truncated, showing first 50KB)", s)
+            } else {
+                String::from_utf8_lossy(&stdout).to_string()
+            };
+
+            Ok(Some(CiFailureLog {
+                run_id,
+                log_text: text,
+            }))
+        })
+    }
+
+    fn rerun_failed_checks<'a>(&'a self, repo_dir: &'a str, run_id: u64) -> GhFuture<'a, ()> {
+        Box::pin(async move {
+            let _ = run_gh(
+                &["run", "rerun", &run_id.to_string(), "--failed"],
+                repo_dir,
+                GH_TIMEOUT,
+            )
+            .await?;
+            Ok(())
+        })
+    }
+
+    fn merge_pr<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        pr_number: u64,
+        method: MergeMethod,
+        delete_branch: bool,
+    ) -> GhFuture<'a, MergeResult> {
+        Box::pin(async move {
+            // Pre-flight: check merge readiness (explicit guardrails before we
+            // actually invoke `gh pr merge`, so the caller gets a specific
+            // reason instead of a generic "not mergeable" stderr).
+            if let Ok(Some(status)) = self.get_pr_merge_status(repo_dir, pr_number).await {
+                if status.mergeable == "CONFLICTING" {
+                    return Err(GhError::Other(format!(
+                        "PR #{} has merge conflicts — resolve conflicts before merging",
+                        pr_number
+                    )));
+                }
+                if let Some(CheckStatus::Failure) = status.check_status {
+                    return Err(GhError::Other(format!(
+                        "PR #{} has failing CI checks — fix CI before merging",
+                        pr_number
+                    )));
+                }
+                if let Some(CheckStatus::Pending) = status.check_status {
+                    return Err(GhError::Other(format!(
+                        "PR #{} has pending CI checks — wait for CI to complete before merging",
+                        pr_number
+                    )));
+                }
+            }
+
+            let pr_str = pr_number.to_string();
+            let mut args: Vec<&str> = vec!["pr", "merge", &pr_str, method.as_flag()];
+            if delete_branch {
+                args.push("--delete-branch");
+            }
+
+            // Custom invocation to capture both stdout and stderr regardless of
+            // success (success path surfaces stderr as the human-readable
+            // message).
+            let spawn_result = tokio::time::timeout(
+                GH_LONG_TIMEOUT,
+                Command::new("gh")
+                    .args(&args)
+                    .current_dir(repo_dir)
+                    .output(),
+            )
+            .await;
+
+            let output = match spawn_result {
+                Err(_) => return Err(GhError::Other("gh pr merge timed out".into())),
+                Ok(Err(e)) => return Err(GhError::from_spawn_error(e)),
+                Ok(Ok(o)) => o,
+            };
+
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+
+            if !output.status.success() {
+                return Err(GhError::classify_stderr(&stderr));
+            }
+
+            let message = if stdout.is_empty() { stderr } else { stdout };
+            let method_str = match method {
+                MergeMethod::Squash => "squash",
+                MergeMethod::Merge => "merge",
+                MergeMethod::Rebase => "rebase",
+            };
+
+            Ok(MergeResult {
+                pr_number,
+                merged: true,
+                method: method_str.to_string(),
+                message,
+                branch_deleted: delete_branch,
+                worktree_cleanup: None,
+            })
+        })
+    }
+
+    fn review_pr<'a>(
+        &'a self,
+        repo_dir: &'a str,
+        pr_number: u64,
+        action: ReviewAction,
+        body: Option<&'a str>,
+    ) -> GhFuture<'a, ReviewResult> {
+        Box::pin(async move {
+            let pr_str = pr_number.to_string();
+            let mut args: Vec<&str> = vec!["pr", "review", &pr_str, action.as_flag()];
+            if let Some(body_text) = body {
+                args.push("--body");
+                args.push(body_text);
+            }
+
+            let spawn_result = tokio::time::timeout(
+                GH_TIMEOUT,
+                Command::new("gh")
+                    .args(&args)
+                    .current_dir(repo_dir)
+                    .output(),
+            )
+            .await;
+
+            let output = match spawn_result {
+                Err(_) => return Err(GhError::Other("gh pr review timed out".into())),
+                Ok(Err(e)) => return Err(GhError::from_spawn_error(e)),
+                Ok(Ok(o)) => o,
+            };
+
+            let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+
+            if !output.status.success() {
+                return Err(GhError::classify_stderr(&stderr));
+            }
+
+            let message = if stdout.is_empty() { stderr } else { stdout };
+            let action_str = match action {
+                ReviewAction::Approve => "approve",
+                ReviewAction::RequestChanges => "request_changes",
+                ReviewAction::Comment => "comment",
+            };
+
+            Ok(ReviewResult {
+                pr_number,
+                action: action_str.to_string(),
+                message,
+            })
+        })
+    }
+}
+
+// ─── MockGhClient ────────────────────────────────────────────────────────────
+//
+// A test double exposed to the whole crate (and to integration tests under
+// `tests/` via `pub use`). Each trait method reads a pre-seeded canned
+// response; unset fields return `GhError::Other("not seeded")` so tests fail
+// loudly if they exercise a path that wasn't explicitly mocked.
+
+use parking_lot::Mutex;
+
+/// Canned responses keyed loosely by operation. Only the subset needed by
+/// current tests is expressive; unused fields stay `None` and make the
+/// corresponding trait method return [`GhError::Other`].
+#[derive(Default)]
+pub struct MockGhClient {
+    pub list_open_prs: Mutex<Option<HashMap<String, PrInfo>>>,
+    pub list_merged_prs: Mutex<Option<HashMap<String, PrInfo>>>,
+    pub has_merged_pr: Mutex<Option<bool>>,
+    pub list_checks: Mutex<Option<CiSummary>>,
+    pub list_issues: Mutex<Option<Vec<IssueInfo>>>,
+    pub get_issue_detail: Mutex<Option<IssueDetail>>,
+    pub get_pr_comments: Mutex<Option<Vec<PrComment>>>,
+    pub get_pr_files: Mutex<Option<Vec<PrChangedFile>>>,
+    pub get_pr_merge_status: Mutex<Option<PrMergeStatus>>,
+    pub get_ci_failure_log: Mutex<Option<CiFailureLog>>,
+    pub rerun_failed_checks_ok: Mutex<bool>,
+    pub merge_pr: Mutex<Option<MergeResult>>,
+    pub review_pr: Mutex<Option<ReviewResult>>,
+}
+
+impl MockGhClient {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+fn not_seeded(op: &'static str) -> GhError {
+    GhError::Other(format!("MockGhClient: {op} not seeded"))
+}
+
+impl GhClient for MockGhClient {
+    fn list_open_prs<'a>(&'a self, _repo_dir: &'a str) -> GhFuture<'a, HashMap<String, PrInfo>> {
+        let v = self.list_open_prs.lock().clone();
+        Box::pin(async move { v.ok_or_else(|| not_seeded("list_open_prs")) })
+    }
+
+    fn list_merged_prs<'a>(
+        &'a self,
+        _repo_dir: &'a str,
+        _local_branches: &'a [String],
+    ) -> GhFuture<'a, HashMap<String, PrInfo>> {
+        let v = self.list_merged_prs.lock().clone();
+        Box::pin(async move { v.ok_or_else(|| not_seeded("list_merged_prs")) })
+    }
+
+    fn has_merged_pr<'a>(&'a self, _repo_dir: &'a str, _branch: &'a str) -> GhFuture<'a, bool> {
+        let v = *self.has_merged_pr.lock();
+        Box::pin(async move { v.ok_or_else(|| not_seeded("has_merged_pr")) })
+    }
+
+    fn list_checks<'a>(
+        &'a self,
+        _repo_dir: &'a str,
+        _branch: &'a str,
+    ) -> GhFuture<'a, Option<CiSummary>> {
+        let v = self.list_checks.lock().clone();
+        Box::pin(async move { Ok(v) })
+    }
+
+    fn list_issues<'a>(&'a self, _repo_dir: &'a str) -> GhFuture<'a, Vec<IssueInfo>> {
+        let v = self.list_issues.lock().clone();
+        Box::pin(async move { v.ok_or_else(|| not_seeded("list_issues")) })
+    }
+
+    fn get_issue_detail<'a>(
+        &'a self,
+        _repo_dir: &'a str,
+        _issue_number: u64,
+    ) -> GhFuture<'a, Option<IssueDetail>> {
+        let v = self.get_issue_detail.lock().clone();
+        Box::pin(async move { Ok(v) })
+    }
+
+    fn get_pr_comments<'a>(
+        &'a self,
+        _repo_dir: &'a str,
+        _pr_number: u64,
+    ) -> GhFuture<'a, Vec<PrComment>> {
+        let v = self.get_pr_comments.lock().clone();
+        Box::pin(async move { v.ok_or_else(|| not_seeded("get_pr_comments")) })
+    }
+
+    fn get_pr_files<'a>(
+        &'a self,
+        _repo_dir: &'a str,
+        _pr_number: u64,
+    ) -> GhFuture<'a, Vec<PrChangedFile>> {
+        let v = self.get_pr_files.lock().clone();
+        Box::pin(async move { v.ok_or_else(|| not_seeded("get_pr_files")) })
+    }
+
+    fn get_pr_merge_status<'a>(
+        &'a self,
+        _repo_dir: &'a str,
+        _pr_number: u64,
+    ) -> GhFuture<'a, Option<PrMergeStatus>> {
+        let v = self.get_pr_merge_status.lock().clone();
+        Box::pin(async move { Ok(v) })
+    }
+
+    fn get_ci_failure_log<'a>(
+        &'a self,
+        _repo_dir: &'a str,
+        _run_id: u64,
+    ) -> GhFuture<'a, Option<CiFailureLog>> {
+        let v = self.get_ci_failure_log.lock().clone();
+        Box::pin(async move { Ok(v) })
+    }
+
+    fn rerun_failed_checks<'a>(&'a self, _repo_dir: &'a str, _run_id: u64) -> GhFuture<'a, ()> {
+        let ok = *self.rerun_failed_checks_ok.lock();
+        Box::pin(async move {
+            if ok {
+                Ok(())
+            } else {
+                Err(not_seeded("rerun_failed_checks"))
+            }
+        })
+    }
+
+    fn merge_pr<'a>(
+        &'a self,
+        _repo_dir: &'a str,
+        _pr_number: u64,
+        _method: MergeMethod,
+        _delete_branch: bool,
+    ) -> GhFuture<'a, MergeResult> {
+        let v = self.merge_pr.lock().clone();
+        Box::pin(async move { v.ok_or_else(|| not_seeded("merge_pr")) })
+    }
+
+    fn review_pr<'a>(
+        &'a self,
+        _repo_dir: &'a str,
+        _pr_number: u64,
+        _action: ReviewAction,
+        _body: Option<&'a str>,
+    ) -> GhFuture<'a, ReviewResult> {
+        let v = self.review_pr.lock().clone();
+        Box::pin(async move { v.ok_or_else(|| not_seeded("review_pr")) })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn mock_returns_seeded_issues() {
+        let mock = MockGhClient::new();
+        *mock.list_issues.lock() = Some(vec![IssueInfo {
+            number: 42,
+            title: "test".into(),
+            state: "OPEN".into(),
+            url: "u".into(),
+            labels: Vec::new(),
+            assignees: Vec::new(),
+        }]);
+        let out = mock.list_issues("/tmp").await.unwrap();
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].number, 42);
+    }
+
+    #[tokio::test]
+    async fn mock_surfaces_not_seeded_for_required_ops() {
+        let mock = MockGhClient::new();
+        let err = mock.list_open_prs("/tmp").await.unwrap_err();
+        match err {
+            GhError::Other(s) => assert!(s.contains("not seeded")),
+            _ => panic!("expected Other"),
+        }
+    }
+
+    #[tokio::test]
+    async fn mock_ci_failure_log_optional_defaults_to_none() {
+        // Optional returns default to Ok(None) — loudly-failing "not seeded"
+        // only fires for required-result ops.
+        let mock = MockGhClient::new();
+        let out = mock.get_ci_failure_log("/tmp", 1).await.unwrap();
+        assert!(out.is_none());
+    }
+}

--- a/crates/tmai-core/src/github/error.rs
+++ b/crates/tmai-core/src/github/error.rs
@@ -1,0 +1,137 @@
+//! `GhError` — unified error type for all GitHub operations.
+//!
+//! Variants are derived by classifying `gh` CLI stderr patterns so callers
+//! can react (retry, prompt the user to reauth, surface a clear install
+//! message) without re-parsing free-form text at every site.
+
+use std::io;
+
+/// Error returned by [`crate::github::GhClient`] methods.
+#[derive(Debug, thiserror::Error)]
+pub enum GhError {
+    /// `gh` binary missing from PATH or not executable.
+    ///
+    /// Surfaced as a single "install gh" guidance path instead of each call
+    /// site re-wording the `No such file or directory` message.
+    #[error("gh CLI not installed or not on PATH; see https://cli.github.com/")]
+    GhNotInstalled,
+
+    /// User is not authenticated or their session expired.
+    ///
+    /// `gh` reports this as "authentication required" or
+    /// "HTTP 401: Bad credentials" on stderr. Callers should prompt the user
+    /// to run `gh auth login` / `gh auth refresh`.
+    #[error("gh authentication expired or missing; run `gh auth login` or `gh auth refresh`")]
+    AuthExpired,
+
+    /// GitHub REST / GraphQL rate limit hit. Mapped from "API rate limit
+    /// exceeded" / "secondary rate limit" patterns in stderr.
+    #[error("GitHub API rate limit exceeded; wait and retry")]
+    RateLimited,
+
+    /// TCP/DNS/TLS failure reaching api.github.com.
+    #[error("network error contacting GitHub: {0}")]
+    Network(String),
+
+    /// `gh` exited 0 but its JSON output did not match the expected schema.
+    /// Typically signals a `gh` version skew we did not account for.
+    #[error("failed to parse gh output: {0}")]
+    ParseError(String),
+
+    /// Fallback for `gh` failures that don't fit any other variant. Keeps the
+    /// raw stderr for diagnostics.
+    #[error("{0}")]
+    Other(String),
+}
+
+impl GhError {
+    /// Classify a raw stderr string (trimmed) produced by a failed `gh`
+    /// invocation into the most specific variant. Falls back to
+    /// [`GhError::Other`] preserving the stderr content.
+    ///
+    /// Pattern-matching is intentionally permissive: `gh` wording has drifted
+    /// across releases, so we key off stable substrings rather than exact
+    /// phrases.
+    pub fn classify_stderr(stderr: &str) -> Self {
+        let lower = stderr.to_ascii_lowercase();
+        if lower.contains("authentication required")
+            || lower.contains("gh auth login")
+            || lower.contains("http 401")
+            || lower.contains("bad credentials")
+        {
+            return GhError::AuthExpired;
+        }
+        if lower.contains("rate limit") {
+            return GhError::RateLimited;
+        }
+        if lower.contains("could not resolve host")
+            || lower.contains("network is unreachable")
+            || lower.contains("connection refused")
+            || lower.contains("dial tcp")
+            || lower.contains("context deadline exceeded")
+        {
+            return GhError::Network(stderr.to_string());
+        }
+        GhError::Other(stderr.to_string())
+    }
+
+    /// Classify a spawn/io failure when launching `gh` itself. `NotFound`
+    /// means the binary is absent from PATH; anything else is bucketed as
+    /// network/IO until we see a case that warrants its own variant.
+    pub fn from_spawn_error(err: io::Error) -> Self {
+        if err.kind() == io::ErrorKind::NotFound {
+            GhError::GhNotInstalled
+        } else {
+            GhError::Other(format!("failed to run gh: {err}"))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_auth_expired() {
+        let err = GhError::classify_stderr("gh auth login required");
+        assert!(matches!(err, GhError::AuthExpired));
+        let err = GhError::classify_stderr("HTTP 401: Bad credentials");
+        assert!(matches!(err, GhError::AuthExpired));
+    }
+
+    #[test]
+    fn classify_rate_limited() {
+        let err = GhError::classify_stderr("API rate limit exceeded for user");
+        assert!(matches!(err, GhError::RateLimited));
+    }
+
+    #[test]
+    fn classify_network() {
+        let err = GhError::classify_stderr("could not resolve host: api.github.com");
+        assert!(matches!(err, GhError::Network(_)));
+    }
+
+    #[test]
+    fn classify_other_preserves_stderr() {
+        let err = GhError::classify_stderr("weird gh message");
+        match err {
+            GhError::Other(s) => assert_eq!(s, "weird gh message"),
+            _ => panic!("expected Other"),
+        }
+    }
+
+    #[test]
+    fn from_spawn_error_notfound_maps_to_gh_not_installed() {
+        let io = io::Error::from(io::ErrorKind::NotFound);
+        assert!(matches!(
+            GhError::from_spawn_error(io),
+            GhError::GhNotInstalled
+        ));
+    }
+
+    #[test]
+    fn from_spawn_error_other_kinds_map_to_other() {
+        let io = io::Error::from(io::ErrorKind::PermissionDenied);
+        assert!(matches!(GhError::from_spawn_error(io), GhError::Other(_)));
+    }
+}

--- a/crates/tmai-core/src/github/mod.rs
+++ b/crates/tmai-core/src/github/mod.rs
@@ -1,15 +1,22 @@
-//! GitHub integration via `gh` CLI — fetches PR, CI, and issue data.
+//! GitHub integration — public types, the process-wide TTL cache, and free
+//! functions that delegate to the [`GhClient`] trait.
+//!
+//! The `gh` CLI transport lives in [`mod@client`]; the cache is intentionally
+//! kept at this outer layer so it wraps any [`GhClient`] impl (production or
+//! test). Swapping the default implementation therefore changes transport
+//! only — caching behavior stays constant.
 
+pub mod client;
+pub mod error;
 pub mod pr_monitor;
+
+pub use client::{GhCliClient, GhClient, GhFuture, MockGhClient};
+pub use error::GhError;
 
 use std::collections::HashMap;
 use std::sync::LazyLock;
 use std::time::{Duration, Instant};
-use tokio::process::Command;
 use tokio::sync::RwLock;
-
-/// Timeout for gh CLI commands
-const GH_TIMEOUT: Duration = Duration::from_secs(10);
 
 /// TTL for cached GitHub data
 const CACHE_TTL: Duration = Duration::from_secs(30);
@@ -144,34 +151,34 @@ pub struct PrInfo {
 /// Raw PR data from gh CLI JSON output
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct GhPrEntry {
-    number: u64,
-    title: String,
-    state: String,
-    head_ref_name: String,
-    head_ref_oid: String,
-    base_ref_name: String,
-    url: String,
-    review_decision: Option<String>,
-    status_check_rollup: Option<Vec<GhCheckRun>>,
-    is_draft: bool,
-    additions: Option<u64>,
-    deletions: Option<u64>,
-    comments: Option<Vec<serde_json::Value>>,
-    reviews: Option<Vec<serde_json::Value>>,
+pub(super) struct GhPrEntry {
+    pub(super) number: u64,
+    pub(super) title: String,
+    pub(super) state: String,
+    pub(super) head_ref_name: String,
+    pub(super) head_ref_oid: String,
+    pub(super) base_ref_name: String,
+    pub(super) url: String,
+    pub(super) review_decision: Option<String>,
+    pub(super) status_check_rollup: Option<Vec<GhCheckRun>>,
+    pub(super) is_draft: bool,
+    pub(super) additions: Option<u64>,
+    pub(super) deletions: Option<u64>,
+    pub(super) comments: Option<Vec<serde_json::Value>>,
+    pub(super) reviews: Option<Vec<serde_json::Value>>,
     #[serde(default)]
-    author: Option<GhAuthor>,
+    pub(super) author: Option<GhAuthor>,
 }
 
 /// Individual check run from statusCheckRollup
 #[derive(Debug, serde::Deserialize)]
-struct GhCheckRun {
+pub(super) struct GhCheckRun {
     conclusion: Option<String>,
     status: Option<String>,
 }
 
 /// Trait for types that carry CI check conclusion/status (used by compute_rollup)
-trait CheckRunLike {
+pub(super) trait CheckRunLike {
     fn has_failure_conclusion(&self) -> bool;
     fn has_pending_status(&self) -> bool;
 }
@@ -211,11 +218,9 @@ impl CheckRunLike for CiCheck {
     }
 }
 
-/// Fetch open PRs for a repository using gh CLI (cached with 30s TTL)
-///
-/// Returns a map of head_branch -> PrInfo for quick lookup.
+/// Fetch open PRs for a repository (cached with 30s TTL). Delegates to
+/// [`GhClient::list_open_prs`] on cache miss.
 pub async fn list_open_prs(repo_dir: &str) -> Option<HashMap<String, PrInfo>> {
-    // Check cache first
     {
         let cache_read = GH_CACHE.prs.read().await;
         if let Some(entry) = cache_read.get(repo_dir) {
@@ -225,68 +230,11 @@ pub async fn list_open_prs(repo_dir: &str) -> Option<HashMap<String, PrInfo>> {
         }
     }
 
-    let output = tokio::time::timeout(
-        GH_TIMEOUT,
-        Command::new("gh")
-            .args([
-                "pr",
-                "list",
-                "--state",
-                "open",
-                "--json",
-                "number,title,state,headRefName,headRefOid,baseRefName,url,reviewDecision,statusCheckRollup,isDraft,additions,deletions,comments,reviews,author",
-                "--limit",
-                "50",
-            ])
-            .current_dir(repo_dir)
-            .output(),
-    )
-    .await
-    .ok()
-    .and_then(|r| r.ok())?;
+    let map = client::default_client()
+        .list_open_prs(repo_dir)
+        .await
+        .ok()?;
 
-    if !output.status.success() {
-        return None;
-    }
-
-    let entries: Vec<GhPrEntry> = serde_json::from_slice(&output.stdout).ok()?;
-
-    let mut map = HashMap::new();
-    for entry in entries {
-        let check_status = entry
-            .status_check_rollup
-            .as_ref()
-            .map(|checks| compute_rollup(checks));
-
-        let review_decision = entry.review_decision.as_deref().and_then(|s| match s {
-            "APPROVED" => Some(ReviewDecision::Approved),
-            "CHANGES_REQUESTED" => Some(ReviewDecision::ChangesRequested),
-            "REVIEW_REQUIRED" => Some(ReviewDecision::ReviewRequired),
-            _ => None,
-        });
-
-        let pr = PrInfo {
-            number: entry.number,
-            title: entry.title,
-            state: entry.state,
-            head_branch: entry.head_ref_name.clone(),
-            head_sha: entry.head_ref_oid.clone(),
-            url: entry.url,
-            base_branch: entry.base_ref_name.clone(),
-            review_decision,
-            check_status,
-            is_draft: entry.is_draft,
-            additions: entry.additions.unwrap_or(0),
-            deletions: entry.deletions.unwrap_or(0),
-            comments: entry.comments.map(|c| c.len() as u64).unwrap_or(0),
-            reviews: entry.reviews.map(|r| r.len() as u64).unwrap_or(0),
-            author: author_login(entry.author),
-            merge_commit_sha: None,
-        };
-        map.insert(entry.head_ref_name, pr);
-    }
-
-    // Store in cache
     {
         let mut cache_write = GH_CACHE.prs.write().await;
         cache_write.insert(
@@ -304,20 +252,20 @@ pub async fn list_open_prs(repo_dir: &str) -> Option<HashMap<String, PrInfo>> {
 /// Raw merged PR data from gh CLI JSON output
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
-struct GhMergedPrEntry {
-    number: u64,
-    title: String,
-    head_ref_name: String,
-    head_ref_oid: String,
-    base_ref_name: String,
-    url: String,
-    merge_commit: Option<GhMergeCommit>,
+pub(super) struct GhMergedPrEntry {
+    pub(super) number: u64,
+    pub(super) title: String,
+    pub(super) head_ref_name: String,
+    pub(super) head_ref_oid: String,
+    pub(super) base_ref_name: String,
+    pub(super) url: String,
+    pub(super) merge_commit: Option<GhMergeCommit>,
 }
 
 /// Merge commit info from gh CLI
 #[derive(Debug, serde::Deserialize)]
-struct GhMergeCommit {
-    oid: String,
+pub(super) struct GhMergeCommit {
+    pub(super) oid: String,
 }
 
 /// Fetch recently merged PRs for branches that still exist locally.
@@ -329,71 +277,10 @@ pub async fn list_merged_prs(
     repo_dir: &str,
     local_branches: &[String],
 ) -> Option<HashMap<String, PrInfo>> {
-    if local_branches.is_empty() {
-        return Some(HashMap::new());
-    }
-
-    let output = tokio::time::timeout(
-        GH_TIMEOUT,
-        Command::new("gh")
-            .args([
-                "pr",
-                "list",
-                "--state",
-                "merged",
-                "--json",
-                "number,title,headRefName,headRefOid,baseRefName,url,mergeCommit",
-                "--limit",
-                "30",
-            ])
-            .current_dir(repo_dir)
-            .output(),
-    )
-    .await
-    .ok()
-    .and_then(|r| r.ok())?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let entries: Vec<GhMergedPrEntry> = serde_json::from_slice(&output.stdout).ok()?;
-
-    // Build a set for O(1) lookup
-    let branch_set: std::collections::HashSet<&str> =
-        local_branches.iter().map(|s| s.as_str()).collect();
-
-    let mut map = HashMap::new();
-    for entry in entries {
-        // Only include PRs whose head branch still exists locally
-        if !branch_set.contains(entry.head_ref_name.as_str()) {
-            continue;
-        }
-
-        let merge_commit_sha = entry.merge_commit.map(|mc| mc.oid);
-
-        let pr = PrInfo {
-            number: entry.number,
-            title: entry.title,
-            state: "MERGED".to_string(),
-            head_branch: entry.head_ref_name.clone(),
-            head_sha: entry.head_ref_oid,
-            base_branch: entry.base_ref_name,
-            url: entry.url,
-            review_decision: None,
-            check_status: None,
-            is_draft: false,
-            additions: 0,
-            deletions: 0,
-            comments: 0,
-            reviews: 0,
-            author: String::new(),
-            merge_commit_sha,
-        };
-        map.insert(entry.head_ref_name, pr);
-    }
-
-    Some(map)
+    client::default_client()
+        .list_merged_prs(repo_dir, local_branches)
+        .await
+        .ok()
 }
 
 /// Check if a specific branch has an associated merged PR.
@@ -402,29 +289,10 @@ pub async fn list_merged_prs(
 /// branches that `git branch -d` would refuse to delete.
 /// Returns `true` if at least one merged PR exists for the given branch.
 pub async fn has_merged_pr(repo_dir: &str, branch: &str) -> bool {
-    let output = tokio::time::timeout(
-        GH_TIMEOUT,
-        Command::new("gh")
-            .args([
-                "pr", "list", "--state", "merged", "--head", branch, "--json", "number", "--limit",
-                "1",
-            ])
-            .current_dir(repo_dir)
-            .output(),
-    )
-    .await
-    .ok()
-    .and_then(|r| r.ok());
-
-    match output {
-        Some(o) if o.status.success() => {
-            // Parse JSON array — non-empty means at least one merged PR
-            serde_json::from_slice::<Vec<serde_json::Value>>(&o.stdout)
-                .map(|v| !v.is_empty())
-                .unwrap_or(false)
-        }
-        _ => false,
-    }
+    client::default_client()
+        .has_merged_pr(repo_dir, branch)
+        .await
+        .unwrap_or(false)
 }
 
 /// A single CI check / workflow run
@@ -482,7 +350,7 @@ pub enum MergeMethod {
 
 impl MergeMethod {
     /// Convert to the `gh pr merge` CLI flag
-    fn as_flag(self) -> &'static str {
+    pub(super) fn as_flag(self) -> &'static str {
         match self {
             MergeMethod::Squash => "--squash",
             MergeMethod::Merge => "--merge",
@@ -516,7 +384,7 @@ pub enum ReviewAction {
 
 impl ReviewAction {
     /// Convert to the `gh pr review` CLI flag
-    fn as_flag(self) -> &'static str {
+    pub(super) fn as_flag(self) -> &'static str {
         match self {
             ReviewAction::Approve => "--approve",
             ReviewAction::RequestChanges => "--request-changes",
@@ -552,79 +420,29 @@ pub struct CiSummary {
 #[derive(Debug, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
 #[allow(dead_code)]
-struct GhRunEntry {
-    name: String,
-    status: CiRunStatus,
-    conclusion: Option<CiConclusion>,
-    url: String,
-    head_branch: String,
-    created_at: Option<String>,
-    updated_at: Option<String>,
-    database_id: Option<u64>,
+pub(super) struct GhRunEntry {
+    pub(super) name: String,
+    pub(super) status: CiRunStatus,
+    pub(super) conclusion: Option<CiConclusion>,
+    pub(super) url: String,
+    pub(super) head_branch: String,
+    pub(super) created_at: Option<String>,
+    pub(super) updated_at: Option<String>,
+    pub(super) database_id: Option<u64>,
 }
 
-/// Fetch CI checks for a specific branch
-///
-/// Uses `gh run list --branch <branch>` to get recent workflow runs.
+/// Fetch CI checks for a specific branch. Delegates to
+/// [`GhClient::list_checks`].
 pub async fn list_checks(repo_dir: &str, branch: &str) -> Option<CiSummary> {
-    if branch.is_empty() || branch.starts_with('-') {
-        return None;
-    }
-
-    let output = tokio::time::timeout(
-        GH_TIMEOUT,
-        Command::new("gh")
-            .args([
-                "run",
-                "list",
-                "--branch",
-                branch,
-                "--json",
-                "name,status,conclusion,url,headBranch,createdAt,updatedAt,databaseId",
-                "--limit",
-                "10",
-            ])
-            .current_dir(repo_dir)
-            .output(),
-    )
-    .await
-    .ok()
-    .and_then(|r| r.ok())?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let entries: Vec<GhRunEntry> = serde_json::from_slice(&output.stdout).ok()?;
-
-    // Deduplicate by workflow name (keep most recent = first in list)
-    let mut seen = std::collections::HashSet::new();
-    let checks: Vec<CiCheck> = entries
-        .into_iter()
-        .filter(|e| seen.insert(e.name.clone()))
-        .map(|e| CiCheck {
-            name: e.name,
-            status: e.status,
-            conclusion: e.conclusion,
-            url: e.url,
-            started_at: e.created_at,
-            completed_at: e.updated_at,
-            run_id: e.database_id,
-        })
-        .collect();
-
-    // Compute rollup from individual checks
-    let rollup = compute_rollup(&checks);
-
-    Some(CiSummary {
-        branch: branch.to_string(),
-        checks,
-        rollup,
-    })
+    client::default_client()
+        .list_checks(repo_dir, branch)
+        .await
+        .ok()
+        .flatten()
 }
 
 /// Compute rollup status from a list of checks
-fn compute_rollup<T: CheckRunLike>(checks: &[T]) -> CheckStatus {
+pub(super) fn compute_rollup<T: CheckRunLike>(checks: &[T]) -> CheckStatus {
     if checks.is_empty() {
         return CheckStatus::Unknown;
     }
@@ -681,25 +499,24 @@ pub struct IssueDetail {
 
 /// Raw assignee from `gh issue list`
 #[derive(Debug, serde::Deserialize)]
-struct GhAssignee {
-    login: String,
+pub(super) struct GhAssignee {
+    pub(super) login: String,
 }
 
 /// Raw issue from `gh issue list`
 #[derive(Debug, serde::Deserialize)]
-struct GhIssueEntry {
-    number: u64,
-    title: String,
-    state: String,
-    url: String,
-    labels: Vec<IssueLabel>,
+pub(super) struct GhIssueEntry {
+    pub(super) number: u64,
+    pub(super) title: String,
+    pub(super) state: String,
+    pub(super) url: String,
+    pub(super) labels: Vec<IssueLabel>,
     #[serde(default)]
-    assignees: Vec<GhAssignee>,
+    pub(super) assignees: Vec<GhAssignee>,
 }
 
-/// Fetch open issues for a repository using gh CLI (cached with 30s TTL)
+/// Fetch open issues for a repository (cached with 30s TTL).
 pub async fn list_issues(repo_dir: &str) -> Option<Vec<IssueInfo>> {
-    // Check cache first
     {
         let cache_read = GH_CACHE.issues.read().await;
         if let Some(entry) = cache_read.get(repo_dir) {
@@ -709,45 +526,8 @@ pub async fn list_issues(repo_dir: &str) -> Option<Vec<IssueInfo>> {
         }
     }
 
-    let output = tokio::time::timeout(
-        GH_TIMEOUT,
-        Command::new("gh")
-            .args([
-                "issue",
-                "list",
-                "--state",
-                "open",
-                "--json",
-                "number,title,state,url,labels,assignees",
-                "--limit",
-                "50",
-            ])
-            .current_dir(repo_dir)
-            .output(),
-    )
-    .await
-    .ok()
-    .and_then(|r| r.ok())?;
+    let issues = client::default_client().list_issues(repo_dir).await.ok()?;
 
-    if !output.status.success() {
-        return None;
-    }
-
-    let entries: Vec<GhIssueEntry> = serde_json::from_slice(&output.stdout).ok()?;
-
-    let issues: Vec<IssueInfo> = entries
-        .into_iter()
-        .map(|e| IssueInfo {
-            number: e.number,
-            title: e.title,
-            state: e.state,
-            url: e.url,
-            labels: e.labels,
-            assignees: e.assignees.into_iter().map(|a| a.login).collect(),
-        })
-        .collect();
-
-    // Store in cache
     {
         let mut cache_write = GH_CACHE.issues.write().await;
         cache_write.insert(
@@ -764,33 +544,15 @@ pub async fn list_issues(repo_dir: &str) -> Option<Vec<IssueInfo>> {
 
 /// Fetch detailed information for a single GitHub issue (body, comments, metadata)
 pub async fn get_issue_detail(repo_dir: &str, issue_number: u64) -> Option<IssueDetail> {
-    let output = tokio::time::timeout(
-        GH_TIMEOUT,
-        Command::new("gh")
-            .args([
-                "issue",
-                "view",
-                &issue_number.to_string(),
-                "--json",
-                "number,title,state,url,body,labels,assignees,createdAt,updatedAt,comments",
-            ])
-            .current_dir(repo_dir)
-            .output(),
-    )
-    .await
-    .ok()
-    .and_then(|r| r.ok())?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let val: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
-    parse_issue_detail_json(&val)
+    client::default_client()
+        .get_issue_detail(repo_dir, issue_number)
+        .await
+        .ok()
+        .flatten()
 }
 
 /// Parse gh issue view JSON into IssueDetail
-fn parse_issue_detail_json(val: &serde_json::Value) -> Option<IssueDetail> {
+pub(super) fn parse_issue_detail_json(val: &serde_json::Value) -> Option<IssueDetail> {
     let number = val["number"].as_u64()?;
     let title = val["title"].as_str()?.to_string();
     let state = val["state"].as_str()?.to_string();
@@ -857,90 +619,71 @@ fn parse_issue_detail_json(val: &serde_json::Value) -> Option<IssueDetail> {
 /// Combines conversation comments and review comments into a single timeline,
 /// sorted by created_at.
 pub async fn get_pr_comments(repo_dir: &str, pr_number: u64) -> Option<Vec<PrComment>> {
-    let output = tokio::time::timeout(
-        GH_TIMEOUT,
-        Command::new("gh")
-            .args([
-                "pr",
-                "view",
-                &pr_number.to_string(),
-                "--json",
-                "comments,reviews",
-            ])
-            .current_dir(repo_dir)
-            .output(),
-    )
-    .await
-    .ok()
-    .and_then(|r| r.ok())?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let resp: GhPrCommentsResponse = serde_json::from_slice(&output.stdout).ok()?;
-    Some(build_pr_comments(resp))
+    client::default_client()
+        .get_pr_comments(repo_dir, pr_number)
+        .await
+        .ok()
 }
 
 #[derive(Debug, serde::Deserialize, Default)]
-struct GhPrCommentsResponse {
+pub(super) struct GhPrCommentsResponse {
     #[serde(default)]
-    comments: Vec<GhConversationComment>,
+    pub(super) comments: Vec<GhConversationComment>,
     #[serde(default)]
-    reviews: Vec<GhReview>,
+    pub(super) reviews: Vec<GhReview>,
 }
 
 #[derive(Debug, serde::Deserialize)]
-struct GhAuthor {
+pub(super) struct GhAuthor {
     #[serde(default)]
-    login: String,
+    pub(super) login: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
-struct GhConversationComment {
+pub(super) struct GhConversationComment {
     #[serde(default)]
-    author: Option<GhAuthor>,
+    pub(super) author: Option<GhAuthor>,
     #[serde(default)]
-    body: String,
+    pub(super) body: String,
     #[serde(default, rename = "createdAt")]
-    created_at: String,
+    pub(super) created_at: String,
     #[serde(default)]
-    url: String,
+    pub(super) url: String,
 }
 
 #[derive(Debug, serde::Deserialize)]
-struct GhReview {
+pub(super) struct GhReview {
     #[serde(default)]
-    author: Option<GhAuthor>,
+    pub(super) author: Option<GhAuthor>,
     #[serde(default)]
-    body: String,
+    pub(super) body: String,
     #[serde(default)]
-    state: String,
+    pub(super) state: String,
     #[serde(default, rename = "submittedAt")]
-    submitted_at: Option<String>,
+    pub(super) submitted_at: Option<String>,
     #[serde(default, rename = "createdAt")]
-    created_at: Option<String>,
+    pub(super) created_at: Option<String>,
     #[serde(default)]
-    comments: Vec<GhReviewInlineComment>,
+    pub(super) comments: Vec<GhReviewInlineComment>,
 }
 
 #[derive(Debug, serde::Deserialize)]
-struct GhReviewInlineComment {
+pub(super) struct GhReviewInlineComment {
     #[serde(default)]
-    body: String,
+    pub(super) body: String,
     #[serde(default, rename = "createdAt")]
-    created_at: String,
+    pub(super) created_at: String,
     #[serde(default)]
-    url: String,
+    pub(super) url: String,
     #[serde(default)]
-    path: Option<String>,
+    pub(super) path: Option<String>,
     #[serde(default, rename = "diffHunk")]
-    diff_hunk: Option<String>,
+    pub(super) diff_hunk: Option<String>,
 }
 
 /// Convert a resolved Option<GhAuthor> into the canonical login, preserving
 /// the prior "unknown" fallback for missing or empty authors.
-fn author_login(author: Option<GhAuthor>) -> String {
+pub(super) fn author_login(author: Option<GhAuthor>) -> String {
     author
         .map(|a| a.login)
         .filter(|s| !s.is_empty())
@@ -949,7 +692,7 @@ fn author_login(author: Option<GhAuthor>) -> String {
 
 /// Flatten the deserialized PR comments/reviews into the public `PrComment`
 /// timeline, sorted by created_at.
-fn build_pr_comments(resp: GhPrCommentsResponse) -> Vec<PrComment> {
+pub(super) fn build_pr_comments(resp: GhPrCommentsResponse) -> Vec<PrComment> {
     let mut result = Vec::new();
 
     for c in resp.comments {
@@ -1003,306 +746,73 @@ fn build_pr_comments(resp: GhPrCommentsResponse) -> Vec<PrComment> {
 
 /// Fetch changed files for a pull request
 pub async fn get_pr_files(repo_dir: &str, pr_number: u64) -> Option<Vec<PrChangedFile>> {
-    let output = tokio::time::timeout(
-        GH_TIMEOUT,
-        Command::new("gh")
-            .args(["pr", "view", &pr_number.to_string(), "--json", "files"])
-            .current_dir(repo_dir)
-            .output(),
-    )
-    .await
-    .ok()
-    .and_then(|r| r.ok())?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    #[derive(serde::Deserialize)]
-    struct FilesResponse {
-        files: Vec<GhFileEntry>,
-    }
-
-    #[derive(serde::Deserialize)]
-    struct GhFileEntry {
-        path: String,
-        additions: u64,
-        deletions: u64,
-    }
-
-    let resp: FilesResponse = serde_json::from_slice(&output.stdout).ok()?;
-
-    Some(
-        resp.files
-            .into_iter()
-            .map(|f| PrChangedFile {
-                path: f.path,
-                additions: f.additions,
-                deletions: f.deletions,
-            })
-            .collect(),
-    )
+    client::default_client()
+        .get_pr_files(repo_dir, pr_number)
+        .await
+        .ok()
 }
 
 /// Fetch merge readiness status for a pull request
 pub async fn get_pr_merge_status(repo_dir: &str, pr_number: u64) -> Option<PrMergeStatus> {
-    let output = tokio::time::timeout(
-        GH_TIMEOUT,
-        Command::new("gh")
-            .args([
-                "pr",
-                "view",
-                &pr_number.to_string(),
-                "--json",
-                "mergeable,mergeStateStatus,reviewDecision,statusCheckRollup",
-            ])
-            .current_dir(repo_dir)
-            .output(),
-    )
-    .await
-    .ok()
-    .and_then(|r| r.ok())?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    let json: serde_json::Value = serde_json::from_slice(&output.stdout).ok()?;
-
-    let mergeable = json
-        .get("mergeable")
-        .and_then(|v| v.as_str())
-        .unwrap_or("UNKNOWN")
-        .to_string();
-
-    let merge_state_status = json
-        .get("mergeStateStatus")
-        .and_then(|v| v.as_str())
-        .unwrap_or("UNKNOWN")
-        .to_string();
-
-    let review_decision = json
-        .get("reviewDecision")
-        .and_then(|v| v.as_str())
-        .map(|s| s.to_string());
-
-    // Compute check status from statusCheckRollup using shared compute_rollup()
-    let check_status: Option<CheckStatus> = json
-        .get("statusCheckRollup")
-        .and_then(|v| serde_json::from_value::<Vec<GhCheckRun>>(v.clone()).ok())
-        .map(|checks| compute_rollup(&checks));
-
-    Some(PrMergeStatus {
-        mergeable,
-        merge_state_status,
-        review_decision,
-        check_status,
-    })
+    client::default_client()
+        .get_pr_merge_status(repo_dir, pr_number)
+        .await
+        .ok()
+        .flatten()
 }
 
-/// Maximum size for CI failure log output (50KB)
-const CI_LOG_MAX_BYTES: usize = 50 * 1024;
-
-/// Fetch failure log for a CI run
-///
-/// Uses `gh run view --log-failed` which returns plain text (not JSON).
-/// Output is truncated to 50KB.
+/// Fetch failure log for a CI run. Truncated to 50KB.
 pub async fn get_ci_failure_log(repo_dir: &str, run_id: u64) -> Option<CiFailureLog> {
-    let output = tokio::time::timeout(
-        Duration::from_secs(30), // longer timeout for log fetching
-        Command::new("gh")
-            .args(["run", "view", &run_id.to_string(), "--log-failed"])
-            .current_dir(repo_dir)
-            .output(),
-    )
-    .await
-    .ok()
-    .and_then(|r| r.ok())?;
-
-    if !output.status.success() {
-        return None;
-    }
-
-    if output.stdout.is_empty() {
-        return None;
-    }
-
-    // Truncate to 50KB
-    let text = if output.stdout.len() > CI_LOG_MAX_BYTES {
-        let truncated = &output.stdout[..CI_LOG_MAX_BYTES];
-        // Find last valid UTF-8 boundary
-        let s = String::from_utf8_lossy(truncated);
-        format!("{}\n\n... (truncated, showing first 50KB)", s)
-    } else {
-        String::from_utf8_lossy(&output.stdout).to_string()
-    };
-
-    Some(CiFailureLog {
-        run_id,
-        log_text: text,
-    })
+    client::default_client()
+        .get_ci_failure_log(repo_dir, run_id)
+        .await
+        .ok()
+        .flatten()
 }
 
-/// Re-run failed jobs for a CI workflow run
-///
-/// Uses `gh run rerun <run_id> --failed` to re-trigger only failed jobs.
+/// Re-run failed jobs for a CI workflow run.
 pub async fn rerun_failed_checks(repo_dir: &str, run_id: u64) -> Option<()> {
-    let output = tokio::time::timeout(
-        GH_TIMEOUT,
-        Command::new("gh")
-            .args(["run", "rerun", &run_id.to_string(), "--failed"])
-            .current_dir(repo_dir)
-            .output(),
-    )
-    .await
-    .ok()
-    .and_then(|r| r.ok())?;
-
-    if output.status.success() {
-        Some(())
-    } else {
-        None
-    }
+    client::default_client()
+        .rerun_failed_checks(repo_dir, run_id)
+        .await
+        .ok()
 }
 
-/// Merge a pull request using `gh pr merge`
-///
-/// Checks merge readiness (CI status, mergeable state) before attempting merge.
-/// Optionally deletes the remote branch after successful merge (gh does this by default
-/// with `--delete-branch`).
+/// Merge a pull request. Checks merge readiness first, invalidates the PR
+/// cache on success so the next read reflects the merged state immediately.
 pub async fn merge_pr(
     repo_dir: &str,
     pr_number: u64,
     method: MergeMethod,
     delete_branch: bool,
 ) -> Result<MergeResult, String> {
-    // Pre-flight: check merge readiness
-    if let Some(status) = get_pr_merge_status(repo_dir, pr_number).await {
-        if status.mergeable == "CONFLICTING" {
-            return Err(format!(
-                "PR #{} has merge conflicts — resolve conflicts before merging",
-                pr_number
-            ));
-        }
-        if let Some(CheckStatus::Failure) = status.check_status {
-            return Err(format!(
-                "PR #{} has failing CI checks — fix CI before merging",
-                pr_number
-            ));
-        }
-        if let Some(CheckStatus::Pending) = status.check_status {
-            return Err(format!(
-                "PR #{} has pending CI checks — wait for CI to complete before merging",
-                pr_number
-            ));
-        }
-    }
+    let result = client::default_client()
+        .merge_pr(repo_dir, pr_number, method, delete_branch)
+        .await
+        .map_err(|e| e.to_string())?;
 
-    let mut args = vec![
-        "pr".to_string(),
-        "merge".to_string(),
-        pr_number.to_string(),
-        method.as_flag().to_string(),
-    ];
-    if delete_branch {
-        args.push("--delete-branch".to_string());
-    }
-
-    let output = tokio::time::timeout(
-        Duration::from_secs(30), // longer timeout for merge operations
-        Command::new("gh")
-            .args(&args)
-            .current_dir(repo_dir)
-            .output(),
-    )
-    .await
-    .map_err(|_| "gh pr merge timed out".to_string())?
-    .map_err(|e| format!("Failed to run gh: {}", e))?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-
-    if !output.status.success() {
-        return Err(format!("gh pr merge failed: {}", stderr));
-    }
-
-    // Invalidate PR cache after successful merge
+    // Invalidate PR cache after successful merge — kept here (not on the
+    // trait) so the cache stays a concern of the outer layer and any
+    // GhClient impl can be dropped in without re-implementing invalidation.
     {
         let mut cache = GH_CACHE.prs.write().await;
         cache.remove(repo_dir);
     }
 
-    let message = if stdout.is_empty() {
-        stderr.clone()
-    } else {
-        stdout
-    };
-
-    let method_str = match method {
-        MergeMethod::Squash => "squash",
-        MergeMethod::Merge => "merge",
-        MergeMethod::Rebase => "rebase",
-    };
-
-    Ok(MergeResult {
-        pr_number,
-        merged: true,
-        method: method_str.to_string(),
-        message,
-        branch_deleted: delete_branch,
-        worktree_cleanup: None,
-    })
+    Ok(result)
 }
 
-/// Submit a review on a pull request via `gh pr review`
+/// Submit a review on a pull request via [`GhClient::review_pr`].
 pub async fn review_pr(
     repo_dir: &str,
     pr_number: u64,
     action: ReviewAction,
     body: Option<&str>,
 ) -> Result<ReviewResult, String> {
-    let mut args = vec![
-        "pr".to_string(),
-        "review".to_string(),
-        pr_number.to_string(),
-        action.as_flag().to_string(),
-    ];
-    if let Some(body_text) = body {
-        args.push("--body".to_string());
-        args.push(body_text.to_string());
-    }
-
-    let output = tokio::time::timeout(
-        GH_TIMEOUT,
-        Command::new("gh")
-            .args(&args)
-            .current_dir(repo_dir)
-            .output(),
-    )
-    .await
-    .map_err(|_| "gh pr review timed out".to_string())?
-    .map_err(|e| format!("Failed to run gh: {}", e))?;
-
-    let stdout = String::from_utf8_lossy(&output.stdout).trim().to_string();
-    let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
-
-    if !output.status.success() {
-        return Err(format!("gh pr review failed: {}", stderr));
-    }
-
-    let message = if stdout.is_empty() { stderr } else { stdout };
-
-    let action_str = match action {
-        ReviewAction::Approve => "approve",
-        ReviewAction::RequestChanges => "request_changes",
-        ReviewAction::Comment => "comment",
-    };
-
-    Ok(ReviewResult {
-        pr_number,
-        action: action_str.to_string(),
-        message,
-    })
+    client::default_client()
+        .review_pr(repo_dir, pr_number, action, body)
+        .await
+        .map_err(|e| e.to_string())
 }
 
 /// Extract issue numbers from a branch name

--- a/crates/tmai-core/tests/gh_client_auto_action.rs
+++ b/crates/tmai-core/tests/gh_client_auto_action.rs
@@ -1,0 +1,210 @@
+//! Cross-module integration test for [`tmai_core::github::GhClient`].
+//!
+//! Demonstrates that the trait seam is publicly usable from outside the crate:
+//! a consumer can inject a [`MockGhClient`] into [`AutoActionExecutor::spawn`]
+//! without any privileged access, exercising the PR-CI-failed flow end-to-end
+//! through the real background task plumbing.
+//!
+//! Added for #447 (refactor: extract GhClient trait). Before the refactor the
+//! only way to drive `handle_ci_failed` against a fake GitHub was via the
+//! narrow `GithubApi` adapter defined inside `auto_action`; that lived behind
+//! module-private wiring and could not be reused across crates / integration
+//! tests.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use tmai_core::agents::{AgentStatus, AgentType, MonitoredAgent};
+use tmai_core::api::CoreEvent;
+use tmai_core::auto_action::{AutoActionExecutor, AutoActionTemplates, AutoActionTracker};
+use tmai_core::config::{EventHandling, GuardrailsSettings, OrchestratorNotifySettings};
+use tmai_core::github::{
+    CheckStatus, CiCheck, CiConclusion, CiFailureLog, CiRunStatus, CiSummary, MockGhClient,
+};
+use tmai_core::state::{AppState, SharedState};
+use tmai_core::task_meta::store::{write_meta, TaskMeta};
+use tokio::sync::broadcast;
+
+fn insert_agent(
+    state: &SharedState,
+    target: &str,
+    branch: &str,
+    pr: Option<u64>,
+    status: AgentStatus,
+) {
+    let mut s = state.write();
+    let mut agent = MonitoredAgent::new(
+        target.to_string(),
+        AgentType::ClaudeCode,
+        String::new(),
+        "/tmp".to_string(),
+        0,
+        target.to_string(),
+        String::new(),
+        0,
+        0,
+    );
+    agent.status = status;
+    agent.git_branch = Some(branch.to_string());
+    agent.pr_number = pr;
+    s.agents.insert(target.to_string(), agent);
+}
+
+fn seed_failing_ci(mock: &MockGhClient, log_text: &str) {
+    *mock.list_checks.lock() = Some(CiSummary {
+        branch: "feat/x".into(),
+        checks: vec![CiCheck {
+            name: "test".into(),
+            status: CiRunStatus::Completed,
+            conclusion: Some(CiConclusion::Failure),
+            url: String::new(),
+            started_at: None,
+            completed_at: None,
+            run_id: Some(42),
+        }],
+        rollup: CheckStatus::Failure,
+    });
+    *mock.get_ci_failure_log.lock() = Some(CiFailureLog {
+        run_id: 42,
+        log_text: log_text.to_string(),
+    });
+}
+
+/// Drive the `AutoActionExecutor` via its public `spawn` entry point and wait
+/// for a `PromptReady` to surface, bounded by `timeout`.
+async fn collect_prompt_ready(
+    rx: &mut broadcast::Receiver<CoreEvent>,
+    timeout: Duration,
+) -> Option<(String, String)> {
+    let deadline = tokio::time::Instant::now() + timeout;
+    loop {
+        let remaining = deadline
+            .checked_duration_since(tokio::time::Instant::now())
+            .unwrap_or(Duration::from_millis(0));
+        match tokio::time::timeout(remaining, rx.recv()).await {
+            Ok(Ok(CoreEvent::PromptReady { target, prompt })) => {
+                return Some((target, prompt));
+            }
+            Ok(Ok(_other)) => continue,
+            Ok(Err(_recv_err)) => return None,
+            Err(_elapsed) => return None,
+        }
+    }
+}
+
+#[tokio::test]
+async fn pr_ci_failed_auto_action_uses_mock_gh_log() {
+    let dir = tempfile::tempdir().unwrap();
+    let state = AppState::shared();
+    insert_agent(&state, "main:0.1", "feat/x", Some(10), AgentStatus::Idle);
+    let meta = TaskMeta::for_issue(10, Some("main:0.1".into()));
+    write_meta(dir.path(), "feat/x", &meta).unwrap();
+    {
+        let mut s = state.write();
+        s.registered_projects = vec![dir.path().to_string_lossy().to_string()];
+    }
+
+    let (tx, mut rx) = broadcast::channel::<CoreEvent>(32);
+    let event_rx = tx.subscribe();
+    let guardrails = Arc::new(parking_lot::RwLock::new(GuardrailsSettings::default()));
+    let templates = Arc::new(parking_lot::RwLock::new(AutoActionTemplates::defaults()));
+
+    let mock = Arc::new(MockGhClient::new());
+    seed_failing_ci(&mock, "--- CI LOG EXCERPT ---\nassertion failed at line 42");
+    let dispatcher = Arc::new(tmai_core::auto_action::NoopReviewDispatcher);
+
+    let mut notify = OrchestratorNotifySettings::default();
+    notify.on_ci_failed = EventHandling::AutoAction;
+    let notify_settings = Arc::new(parking_lot::RwLock::new(notify));
+
+    let _handle = AutoActionExecutor::spawn(
+        state.clone(),
+        event_rx,
+        tx.clone(),
+        notify_settings,
+        guardrails,
+        templates,
+        mock.clone(),
+        dispatcher,
+    );
+
+    let event = CoreEvent::PrCiFailed {
+        pr_number: 10,
+        title: "Add feature".into(),
+        failed_details: "1/3 checks failed".into(),
+    };
+    let _ = tx.send(event);
+
+    let (target, prompt) = collect_prompt_ready(&mut rx, Duration::from_secs(2))
+        .await
+        .expect("expected PromptReady from AutoActionExecutor");
+    assert_eq!(target, "main:0.1");
+    // Seeded log must be enriched into the prompt — end-to-end proof the
+    // trait seam reaches get_ci_failure_log on a non-concrete client.
+    assert!(
+        prompt.contains("assertion failed at line 42"),
+        "expected seeded CI log in prompt; got: {prompt}"
+    );
+    assert!(prompt.contains("PR #10"));
+    assert!(prompt.contains("feat/x"));
+    assert!(prompt.contains("1/3 checks failed"));
+}
+
+#[tokio::test]
+async fn pr_ci_failed_auto_action_falls_back_without_log() {
+    // MockGhClient with no seeded list_checks / get_ci_failure_log: the
+    // enrichment path returns None and the prompt falls back to the summary.
+    let dir = tempfile::tempdir().unwrap();
+    let state = AppState::shared();
+    insert_agent(&state, "main:0.2", "feat/y", Some(20), AgentStatus::Idle);
+    let meta = TaskMeta::for_issue(20, Some("main:0.2".into()));
+    write_meta(dir.path(), "feat/y", &meta).unwrap();
+    {
+        let mut s = state.write();
+        s.registered_projects = vec![dir.path().to_string_lossy().to_string()];
+    }
+
+    let (tx, mut rx) = broadcast::channel::<CoreEvent>(32);
+    let event_rx = tx.subscribe();
+    let guardrails = Arc::new(parking_lot::RwLock::new(GuardrailsSettings::default()));
+    let templates = Arc::new(parking_lot::RwLock::new(AutoActionTemplates::defaults()));
+    let mock: Arc<MockGhClient> = Arc::new(MockGhClient::new());
+    let dispatcher = Arc::new(tmai_core::auto_action::NoopReviewDispatcher);
+
+    let mut notify = OrchestratorNotifySettings::default();
+    notify.on_ci_failed = EventHandling::AutoAction;
+    let notify_settings = Arc::new(parking_lot::RwLock::new(notify));
+
+    let _handle = AutoActionExecutor::spawn(
+        state.clone(),
+        event_rx,
+        tx.clone(),
+        notify_settings,
+        guardrails,
+        templates,
+        mock.clone(),
+        dispatcher,
+    );
+
+    let _ = tx.send(CoreEvent::PrCiFailed {
+        pr_number: 20,
+        title: "Fix bug".into(),
+        failed_details: "lint failed".into(),
+    });
+
+    let (_target, prompt) = collect_prompt_ready(&mut rx, Duration::from_secs(2))
+        .await
+        .expect("expected PromptReady fallback prompt");
+    assert!(
+        prompt.contains("lint failed"),
+        "fallback summary must appear in prompt when log unavailable; got: {prompt}"
+    );
+    assert!(!prompt.contains("--- CI log ---"));
+}
+
+// `AutoActionTracker` imported for future integration cases; quiet an unused
+// warning if only a subset of tests are compiled at once.
+#[allow(dead_code)]
+fn _tracker_ref() -> Arc<AutoActionTracker> {
+    Arc::new(AutoActionTracker::new())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -270,7 +270,7 @@ async fn run_tmux_mode(settings: Settings, _cli: Config) -> Result<()> {
             notify_settings,
             guardrails_settings,
             auto_action_templates,
-            std::sync::Arc::new(tmai_core::auto_action::RealGithubApi),
+            std::sync::Arc::new(tmai_core::github::GhCliClient::new()),
             std::sync::Arc::new(ReviewDispatcherImpl::new(core.clone())),
         );
     }
@@ -511,7 +511,7 @@ async fn run_webui_mode(settings: Settings, debug: bool) -> Result<()> {
             notify_settings,
             guardrails_settings,
             auto_action_templates,
-            std::sync::Arc::new(tmai_core::auto_action::RealGithubApi),
+            std::sync::Arc::new(tmai_core::github::GhCliClient::new()),
             std::sync::Arc::new(ReviewDispatcherImpl::new(core.clone())),
         );
         eprintln!("tmai: auto-action executor started");


### PR DESCRIPTION
## Summary

- Introduces a `GhClient` trait in `crates/tmai-core/src/github/client.rs` so the `gh` CLI shell-out is hidden behind a single seam. `GhCliClient` is the production impl; `MockGhClient` is a test double exposed from the crate so consumers (and the new integration test) can inject canned responses without touching the real CLI.
- Adds `GhError` (`GhNotInstalled` / `AuthExpired` / `RateLimited` / `Network` / `ParseError` / `Other`) plus a stderr classifier, so call sites get typed failure modes instead of re-parsing free-form text.
- Replaces the narrow `GithubApi` adapter in `auto_action` with `Arc<dyn GhClient>`. The existing `fetch_ci_failure_log_text` / `fetch_pr_comments_text` helpers now operate on the trait directly; unit tests use `MockGhClient`, and a new `tests/gh_client_auto_action.rs` drives `AutoActionExecutor::spawn` end-to-end through a seeded mock.

## Design notes

- Trait is dyn-compatible via `Pin<Box<dyn Future>>` — no `async-trait` dependency added.
- The 30s TTL cache stays at the `github::mod` layer (not on the trait), so it wraps any `GhClient` impl. `merge_pr`'s cache-invalidation stays in the wrapper too, keeping the trait a pure transport.
- `gh` is retained as the production backend. Replacing with `octocrab` was explicitly out of scope — `gh` handles auth (`gh auth status`), keyring, GHES, and CI runner creds.

## Acceptance criteria (#447)

- [x] `GhClient` trait defined; `GhCliClient` is the production impl.
- [x] Integration test using `MockGhClient` for the PR-CI-failed flow (`crates/tmai-core/tests/gh_client_auto_action.rs`), driving `AutoActionExecutor::spawn` across the public crate boundary.
- [x] Single `GhError` type with `GhNotInstalled`, `AuthExpired`, `RateLimited`, `Network`, `ParseError`, `Other(String)`.
- [x] Existing call sites compile against the trait — `AutoActionExecutor` now takes `Arc<dyn GhClient>` and `src/main.rs` injects `GhCliClient`.

## Test plan

- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test -p tmai-core --lib` — 1053 passed
- [x] `cargo test -p tmai-core --tests` — 2 passed (new integration test)
- [x] `cargo test --all-targets` — 143 bin tests pass
- [ ] Manual: exercise PR-CI-failed auto-action against a real repo after merge to confirm unchanged behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * GitHub クライアント層を再構築し、エラーハンドリングと操作管理を一元化しました。

* **Tests**
  * GitHub クライアント統合のための新しいテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->