### PR TITLE
feat: inject current-state summary into orchestrator spawn prompt (#381)

### DIFF
--- a/crates/tmai-app/web/src/lib/api-http.ts
+++ b/crates/tmai-app/web/src/lib/api-http.ts
@@ -658,6 +658,8 @@ export interface OrchestratorSettings {
   pr_monitor_interval_secs: number;
   pr_monitor_exclude_authors: string[];
   pr_monitor_scope: PrMonitorScope;
+  /** Append a live state summary to the orchestrator's spawn prompt (#381) */
+  inject_state_snapshot: boolean;
   /** Whether this is a per-project override (true) or global fallback (false) */
   is_project_override: boolean;
 }
@@ -1073,6 +1075,7 @@ export const api = {
       pr_monitor_interval_secs?: number;
       pr_monitor_exclude_authors?: string[];
       pr_monitor_scope?: PrMonitorScope;
+      inject_state_snapshot?: boolean;
     },
     project?: string,
   ) =>

--- a/crates/tmai-app/web/src/lib/api-tauri.ts
+++ b/crates/tmai-app/web/src/lib/api-tauri.ts
@@ -218,6 +218,7 @@ export const api = {
       pr_monitor_interval_secs?: number;
       pr_monitor_exclude_authors?: string[];
       pr_monitor_scope?: PrMonitorScope;
+      inject_state_snapshot?: boolean;
     },
     project?: string,
   ) => httpApi.updateOrchestratorSettings(params, project),

--- a/crates/tmai-core/src/api/actions.rs
+++ b/crates/tmai-core/src/api/actions.rs
@@ -1135,6 +1135,39 @@ impl TmaiCore {
 
         parts.join("\n")
     }
+
+    /// Compose an orchestrator prompt and, when the resolved settings enable
+    /// it, append a current-state snapshot (open PRs, active agents, recent
+    /// merges on `main`, open issues) so a freshly-spawned orchestrator does
+    /// not need to burn initial turns on state reconstruction (#381).
+    ///
+    /// Snapshot collection goes through existing facade methods and shells
+    /// out only to `git log` / `gh`; any individual source failing is
+    /// treated as an empty section so spawn never aborts on snapshot
+    /// generation (matches #381 graceful-degradation requirement).
+    pub async fn compose_orchestrator_prompt_with_state(
+        &self,
+        project_path: Option<&str>,
+    ) -> String {
+        let mut prompt = self.compose_orchestrator_prompt(project_path);
+
+        let include = self
+            .settings()
+            .resolve_orchestrator(project_path)
+            .inject_state_snapshot;
+        let Some(path) = project_path else {
+            return prompt;
+        };
+        if !include {
+            return prompt;
+        }
+
+        let data = super::state_snapshot::collect(self, path).await;
+        let snapshot = super::state_snapshot::format(&data);
+        prompt.push_str("\n\n");
+        prompt.push_str(&snapshot);
+        prompt
+    }
 }
 
 #[cfg(test)]
@@ -1740,6 +1773,32 @@ mod tests {
         assert!(prompt.contains("tmai MCP tools"));
         // No rules section with empty rules
         assert!(!prompt.contains("Workflow rules:"));
+    }
+
+    #[tokio::test]
+    async fn test_compose_with_state_disabled_matches_legacy() {
+        // When inject_state_snapshot is off, the async path must return the
+        // exact same prompt as the sync composer — this preserves legacy
+        // behaviour for power users who opted out via config (#381).
+        let mut settings = Settings::default();
+        settings.orchestrator.inject_state_snapshot = false;
+        let core = TmaiCoreBuilder::new(settings).build();
+
+        let legacy = core.compose_orchestrator_prompt(Some("/tmp"));
+        let with_state = core
+            .compose_orchestrator_prompt_with_state(Some("/tmp"))
+            .await;
+        assert_eq!(legacy, with_state);
+        assert!(!with_state.contains("Current state snapshot"));
+    }
+
+    #[tokio::test]
+    async fn test_compose_with_state_without_project_path_skips_snapshot() {
+        // No project_path means we cannot scope the snapshot; skip injection
+        // rather than leak cross-project state (#381 scope-by-cwd rule).
+        let core = TmaiCoreBuilder::new(Settings::default()).build();
+        let prompt = core.compose_orchestrator_prompt_with_state(None).await;
+        assert!(!prompt.contains("Current state snapshot"));
     }
 
     #[test]

--- a/crates/tmai-core/src/api/mod.rs
+++ b/crates/tmai-core/src/api/mod.rs
@@ -28,6 +28,7 @@ pub mod events;
 #[cfg(feature = "openapi")]
 pub mod openapi;
 mod queries;
+mod state_snapshot;
 pub mod types;
 mod worktree_guard;
 

--- a/crates/tmai-core/src/api/state_snapshot.rs
+++ b/crates/tmai-core/src/api/state_snapshot.rs
@@ -1,0 +1,425 @@
+//! Compose a concise project state snapshot for injection into an
+//! orchestrator's spawn prompt (#381).
+//!
+//! Splits data collection (async — gh / git shell-outs) from formatting
+//! (pure, unit-testable). A freshly-spawned orchestrator would otherwise
+//! burn its first turns running `list_agents` / `list_prs` to reconstruct
+//! the same state tmai already knows about.
+
+use crate::agents::AgentStatus;
+use crate::api::types::AgentSnapshot;
+use crate::api::TmaiCore;
+use crate::github::{self, CheckStatus, IssueInfo, PrInfo, ReviewDecision};
+
+/// Maximum items shown per list before truncation.
+const MAX_ITEMS: usize = 10;
+
+/// Hard cap on the rendered snapshot size so injection never overwhelms
+/// the prompt budget the operator configured on the orchestrator role.
+const MAX_TOTAL_BYTES: usize = 4096;
+
+/// Number of recent commits on the configured base branch to surface.
+const RECENT_COMMITS: usize = 5;
+
+/// Base branch used for the "recent merges" section. `main` is the tmai
+/// convention; projects that use a different base will get an empty
+/// section (degrades gracefully — we don't block spawn on it).
+const DEFAULT_BASE_BRANCH: &str = "main";
+
+/// Flattened data for rendering. Keeping this as a plain struct lets the
+/// formatter be exercised without touching gh/git.
+#[derive(Debug, Default)]
+pub(crate) struct SnapshotData {
+    pub open_prs: Vec<PrRow>,
+    pub active_agents: Vec<AgentRow>,
+    pub recent_merges: Vec<String>,
+    pub open_issues: Vec<IssueRow>,
+}
+
+#[derive(Debug)]
+pub(crate) struct PrRow {
+    pub number: u64,
+    pub title: String,
+    pub is_draft: bool,
+    pub ci: &'static str,
+    pub review: &'static str,
+}
+
+#[derive(Debug)]
+pub(crate) struct AgentRow {
+    pub display_name: String,
+    pub role: &'static str,
+    pub status: String,
+    pub tag: Option<String>,
+}
+
+#[derive(Debug)]
+pub(crate) struct IssueRow {
+    pub number: u64,
+    pub title: String,
+}
+
+/// Gather the snapshot for `project_path`. Any individual source failing
+/// (gh offline, repo without a `main` branch, etc.) is treated as an
+/// empty section so spawn never aborts on snapshot collection (#381
+/// graceful-degradation requirement).
+pub(crate) async fn collect(core: &TmaiCore, project_path: &str) -> SnapshotData {
+    let open_prs = github::list_open_prs(project_path)
+        .await
+        .map(prs_from_map)
+        .unwrap_or_default();
+
+    let active_agents = core
+        .list_agents_by_project(project_path)
+        .into_iter()
+        .map(agent_row)
+        .collect();
+
+    let recent_merges = recent_merges(project_path, DEFAULT_BASE_BRANCH, RECENT_COMMITS).await;
+
+    let open_issues = github::list_issues(project_path)
+        .await
+        .map(issues_from_vec)
+        .unwrap_or_default();
+
+    SnapshotData {
+        open_prs,
+        active_agents,
+        recent_merges,
+        open_issues,
+    }
+}
+
+fn prs_from_map(map: std::collections::HashMap<String, PrInfo>) -> Vec<PrRow> {
+    let mut rows: Vec<PrRow> = map
+        .into_values()
+        .map(|pr| PrRow {
+            number: pr.number,
+            title: pr.title,
+            is_draft: pr.is_draft,
+            ci: check_status_label(pr.check_status.as_ref()),
+            review: review_decision_label(pr.review_decision.as_ref()),
+        })
+        .collect();
+    // Highest PR number first — proxy for "most recent work".
+    rows.sort_by(|a, b| b.number.cmp(&a.number));
+    rows
+}
+
+fn issues_from_vec(issues: Vec<IssueInfo>) -> Vec<IssueRow> {
+    let mut rows: Vec<IssueRow> = issues
+        .into_iter()
+        .map(|i| IssueRow {
+            number: i.number,
+            title: i.title,
+        })
+        .collect();
+    rows.sort_by(|a, b| b.number.cmp(&a.number));
+    rows
+}
+
+fn agent_row(a: AgentSnapshot) -> AgentRow {
+    let tag = match (a.issue_number, a.pr_number) {
+        (Some(n), _) => Some(format!("issue #{n}")),
+        (None, Some(n)) => Some(format!("PR #{n}")),
+        _ => None,
+    };
+    AgentRow {
+        display_name: a.display_name,
+        role: if a.is_orchestrator {
+            "orchestrator"
+        } else {
+            "worker"
+        },
+        status: status_label(&a.status).to_string(),
+        tag,
+    }
+}
+
+fn status_label(s: &AgentStatus) -> &'static str {
+    match s {
+        AgentStatus::Idle => "Idle",
+        AgentStatus::Processing { .. } => "Working",
+        AgentStatus::AwaitingApproval { .. } => "AwaitingApproval",
+        AgentStatus::Error { .. } => "Error",
+        AgentStatus::Offline => "Offline",
+        AgentStatus::Unknown => "Unknown",
+    }
+}
+
+fn check_status_label(s: Option<&CheckStatus>) -> &'static str {
+    match s {
+        Some(CheckStatus::Success) => "passed",
+        Some(CheckStatus::Failure) => "failed",
+        Some(CheckStatus::Pending) => "pending",
+        Some(CheckStatus::Unknown) | None => "unknown",
+    }
+}
+
+fn review_decision_label(r: Option<&ReviewDecision>) -> &'static str {
+    match r {
+        Some(ReviewDecision::Approved) => "approved",
+        Some(ReviewDecision::ChangesRequested) => "changes-requested",
+        Some(ReviewDecision::ReviewRequired) => "review-required",
+        Some(ReviewDecision::Unknown) | None => "no-review",
+    }
+}
+
+/// Read `git log --oneline -n N <base_branch>` from the project path.
+/// Returns an empty Vec on any failure (missing git, unknown branch, etc.).
+async fn recent_merges(repo_dir: &str, base_branch: &str, n: usize) -> Vec<String> {
+    let output = tokio::process::Command::new("git")
+        .args([
+            "-C",
+            repo_dir,
+            "log",
+            "--oneline",
+            "-n",
+            &n.to_string(),
+            base_branch,
+        ])
+        .output()
+        .await;
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    String::from_utf8_lossy(&output.stdout)
+        .lines()
+        .map(|s| s.to_string())
+        .collect()
+}
+
+/// Render the snapshot as markdown. Total size is capped at
+/// [`MAX_TOTAL_BYTES`] so pathological state can't blow the prompt budget.
+pub(crate) fn format(data: &SnapshotData) -> String {
+    let mut out = String::new();
+    out.push_str("## Current state snapshot (as of spawn)\n");
+
+    render_prs(&mut out, &data.open_prs);
+    render_agents(&mut out, &data.active_agents);
+    render_merges(&mut out, &data.recent_merges);
+    render_issues(&mut out, &data.open_issues);
+
+    if out.len() > MAX_TOTAL_BYTES {
+        // Cut on a char boundary — `…` is the only multi-byte char we emit,
+        // so a naive `String::truncate` at a byte index could panic.
+        truncate_on_char_boundary(&mut out, MAX_TOTAL_BYTES);
+        out.push_str("\n… (snapshot truncated)\n");
+    }
+
+    out
+}
+
+fn render_prs(out: &mut String, prs: &[PrRow]) {
+    out.push_str(&format!("\n### Open PRs ({})\n", prs.len()));
+    if prs.is_empty() {
+        out.push_str("- none currently\n");
+        return;
+    }
+    for pr in prs.iter().take(MAX_ITEMS) {
+        let draft = if pr.is_draft { " [draft]" } else { "" };
+        out.push_str(&format!(
+            "- #{} {}{} — CI {}, review {}\n",
+            pr.number, pr.title, draft, pr.ci, pr.review,
+        ));
+    }
+    if prs.len() > MAX_ITEMS {
+        out.push_str(&format!("- … and {} more\n", prs.len() - MAX_ITEMS));
+    }
+}
+
+fn render_agents(out: &mut String, agents: &[AgentRow]) {
+    out.push_str(&format!("\n### Active agents ({})\n", agents.len()));
+    if agents.is_empty() {
+        out.push_str("- none currently\n");
+        return;
+    }
+    for a in agents.iter().take(MAX_ITEMS) {
+        let tag = a
+            .tag
+            .as_ref()
+            .map(|t| format!(" [{t}]"))
+            .unwrap_or_default();
+        out.push_str(&format!(
+            "- {} — {}{} ({})\n",
+            a.display_name, a.role, tag, a.status,
+        ));
+    }
+    if agents.len() > MAX_ITEMS {
+        out.push_str(&format!("- … and {} more\n", agents.len() - MAX_ITEMS));
+    }
+}
+
+fn render_merges(out: &mut String, merges: &[String]) {
+    out.push_str(&format!(
+        "\n### Recent merges (last {} commits on {})\n",
+        merges.len(),
+        DEFAULT_BASE_BRANCH,
+    ));
+    if merges.is_empty() {
+        out.push_str("- none currently\n");
+        return;
+    }
+    for line in merges {
+        out.push_str(&format!("- {line}\n"));
+    }
+}
+
+fn render_issues(out: &mut String, issues: &[IssueRow]) {
+    out.push_str(&format!("\n### Open issues ({})\n", issues.len()));
+    if issues.is_empty() {
+        out.push_str("- none currently\n");
+        return;
+    }
+    for i in issues.iter().take(MAX_ITEMS) {
+        out.push_str(&format!("- #{} {}\n", i.number, i.title));
+    }
+    if issues.len() > MAX_ITEMS {
+        out.push_str(&format!("- … and {} more\n", issues.len() - MAX_ITEMS));
+    }
+}
+
+fn truncate_on_char_boundary(s: &mut String, max_len: usize) {
+    if s.len() <= max_len {
+        return;
+    }
+    let mut cut = max_len;
+    while cut > 0 && !s.is_char_boundary(cut) {
+        cut -= 1;
+    }
+    s.truncate(cut);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pr_row(n: u64) -> PrRow {
+        PrRow {
+            number: n,
+            title: format!("feat: thing {n}"),
+            is_draft: false,
+            ci: "passed",
+            review: "no-review",
+        }
+    }
+
+    fn issue_row(n: u64) -> IssueRow {
+        IssueRow {
+            number: n,
+            title: format!("issue {n}"),
+        }
+    }
+
+    #[test]
+    fn format_includes_snapshot_header() {
+        let out = format(&SnapshotData::default());
+        assert!(out.starts_with("## Current state snapshot"));
+    }
+
+    #[test]
+    fn empty_project_renders_gracefully() {
+        let out = format(&SnapshotData::default());
+        // Every section must appear with a "none currently" line — otherwise
+        // the orchestrator sees a blank block and guesses it's an injection
+        // bug rather than "truly nothing to do".
+        assert!(out.contains("### Open PRs (0)"));
+        assert!(out.contains("### Active agents (0)"));
+        assert!(out.contains("### Recent merges"));
+        assert!(out.contains("### Open issues (0)"));
+        assert_eq!(out.matches("- none currently").count(), 4);
+    }
+
+    #[test]
+    fn truncates_long_pr_list_with_ellipsis_suffix() {
+        // `collect` hands us PRs sorted highest-number first — emulate that
+        // ordering so the take(10) window matches what the prompt actually
+        // sees in production.
+        let prs: Vec<PrRow> = (1..=30).rev().map(pr_row).collect();
+        let data = SnapshotData {
+            open_prs: prs,
+            ..Default::default()
+        };
+        let out = format(&data);
+        assert!(out.contains("### Open PRs (30)"));
+        assert!(out.contains("#30 feat: thing 30"));
+        assert!(out.contains("#21 feat: thing 21"));
+        // 11th entry (#20) must not render directly — it belongs in the
+        // collapsed tail.
+        assert!(!out.contains("- #20 feat: thing 20"));
+        assert!(out.contains("- … and 20 more"));
+    }
+
+    #[test]
+    fn truncates_long_issue_list() {
+        let issues: Vec<IssueRow> = (1..=15).rev().map(issue_row).collect();
+        let data = SnapshotData {
+            open_issues: issues,
+            ..Default::default()
+        };
+        let out = format(&data);
+        assert!(out.contains("### Open issues (15)"));
+        assert!(out.contains("- … and 5 more"));
+    }
+
+    #[test]
+    fn pr_line_includes_draft_and_status() {
+        let data = SnapshotData {
+            open_prs: vec![PrRow {
+                number: 42,
+                title: "wip: stuff".into(),
+                is_draft: true,
+                ci: "failed",
+                review: "changes-requested",
+            }],
+            ..Default::default()
+        };
+        let out = format(&data);
+        assert!(out.contains("- #42 wip: stuff [draft] — CI failed, review changes-requested"));
+    }
+
+    #[test]
+    fn total_size_is_capped() {
+        // Even after per-list truncation, pathologically long PR titles can
+        // still push the snapshot past the prompt budget. Ten entries × a
+        // 1000-char title yields >10KB; the byte-cap fallback must catch it.
+        let prs: Vec<PrRow> = (1..=10)
+            .rev()
+            .map(|n| PrRow {
+                number: n,
+                title: "x".repeat(1000),
+                is_draft: false,
+                ci: "passed",
+                review: "no-review",
+            })
+            .collect();
+        let data = SnapshotData {
+            open_prs: prs,
+            ..Default::default()
+        };
+        let out = format(&data);
+        assert!(
+            out.len() <= MAX_TOTAL_BYTES + 64,
+            "snapshot {} > cap {}",
+            out.len(),
+            MAX_TOTAL_BYTES,
+        );
+        assert!(out.contains("(snapshot truncated)"));
+    }
+
+    #[test]
+    fn status_label_maps_variants() {
+        assert_eq!(status_label(&AgentStatus::Idle), "Idle");
+        assert_eq!(status_label(&AgentStatus::Offline), "Offline");
+        assert_eq!(status_label(&AgentStatus::Unknown), "Unknown");
+        assert_eq!(
+            status_label(&AgentStatus::Error {
+                message: "boom".into()
+            }),
+            "Error"
+        );
+    }
+}

--- a/crates/tmai-core/src/config/settings.rs
+++ b/crates/tmai-core/src/config/settings.rs
@@ -909,6 +909,13 @@ pub struct OrchestratorSettings {
     /// events from repos the user isn't actively working on.
     #[serde(default)]
     pub pr_monitor_scope: PrMonitorScope,
+
+    /// Append a concise project state summary (open PRs, active agents,
+    /// recent merges, open issues) to the composed orchestrator prompt on
+    /// spawn (#381). Keeps a freshly-spawned orchestrator from burning
+    /// initial turns on `list_agents` / `list_prs` state reconstruction.
+    #[serde(default = "default_true")]
+    pub inject_state_snapshot: bool,
 }
 
 /// Scope filter for PR Monitor spawning.
@@ -1266,6 +1273,7 @@ impl Default for OrchestratorSettings {
             pr_monitor_interval_secs: default_pr_monitor_interval(),
             pr_monitor_exclude_authors: default_pr_monitor_exclude_authors(),
             pr_monitor_scope: PrMonitorScope::default(),
+            inject_state_snapshot: true,
         }
     }
 }
@@ -1896,6 +1904,9 @@ mod tests {
         assert!(settings.rules.merge.is_empty());
         assert!(settings.rules.review.is_empty());
         assert!(settings.rules.custom.is_empty());
+        // #381: on by default so a freshly-spawned orchestrator gets
+        // situational awareness without any opt-in.
+        assert!(settings.inject_state_snapshot);
     }
 
     #[test]
@@ -2233,6 +2244,7 @@ mod tests {
         orch.pr_monitor_interval_secs = 91;
         orch.pr_monitor_exclude_authors = vec!["someone[bot]".into(), "otherbot".into()];
         orch.pr_monitor_scope = PrMonitorScope::All;
+        orch.inject_state_snapshot = false;
         orch
     }
 

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1371,6 +1371,8 @@ pub struct OrchestratorSettingsResponse {
     pub pr_monitor_interval_secs: u64,
     pub pr_monitor_exclude_authors: Vec<String>,
     pub pr_monitor_scope: tmai_core::config::PrMonitorScope,
+    /// Append a live state summary to the orchestrator's spawn prompt (#381)
+    pub inject_state_snapshot: bool,
     /// Whether this is a per-project override (true) or global fallback (false)
     pub is_project_override: bool,
 }
@@ -1468,6 +1470,8 @@ pub struct UpdateOrchestratorSettingsRequest {
     pub pr_monitor_exclude_authors: Option<Vec<String>>,
     #[serde(default)]
     pub pr_monitor_scope: Option<tmai_core::config::PrMonitorScope>,
+    #[serde(default)]
+    pub inject_state_snapshot: Option<bool>,
 }
 
 /// Guardrails settings update request (all fields optional for partial updates)
@@ -1631,6 +1635,7 @@ pub async fn get_orchestrator_settings(
         pr_monitor_interval_secs: orch.pr_monitor_interval_secs,
         pr_monitor_exclude_authors: orch.pr_monitor_exclude_authors.clone(),
         pr_monitor_scope: orch.pr_monitor_scope,
+        inject_state_snapshot: orch.inject_state_snapshot,
         is_project_override: is_override,
     })
 }
@@ -1803,6 +1808,9 @@ pub async fn update_orchestrator_settings(
             .pr_monitor_exclude_authors
             .unwrap_or_else(|| current.pr_monitor_exclude_authors.clone()),
         pr_monitor_scope: req.pr_monitor_scope.unwrap_or(current.pr_monitor_scope),
+        inject_state_snapshot: req
+            .inject_state_snapshot
+            .unwrap_or(current.inject_state_snapshot),
     };
     drop(settings);
 
@@ -2498,8 +2506,12 @@ pub async fn spawn_orchestrator(
         ));
     }
 
-    // Compose orchestrator prompt from settings (with per-project override)
-    let mut prompt = core.compose_orchestrator_prompt(Some(&cwd));
+    // Compose orchestrator prompt from settings (with per-project override).
+    // `_with_state` variant appends a live snapshot (open PRs/agents/merges/
+    // issues) when `inject_state_snapshot` is on — see #381.
+    let mut prompt = core
+        .compose_orchestrator_prompt_with_state(Some(&cwd))
+        .await;
     if let Some(ref extra) = req.additional_instructions {
         if !extra.is_empty() {
             prompt.push_str("\n\n");


### PR DESCRIPTION
## Summary
- A freshly-spawned orchestrator used to burn its first few turns running `list_agents` / `list_prs` / `list_issues` to rebuild state tmai already knew about. This PR appends a concise markdown snapshot (open PRs, active agents, recent merges on `main`, open issues) to the composed role prompt on spawn, so the orchestrator can act meaningfully on the first message.
- New `OrchestratorSettings.inject_state_snapshot` flag (default `true`) lets power users opt out via config or the `/api/settings/orchestrator` PUT.
- Snapshot collection uses existing facade methods (`list_open_prs`, `list_agents_by_project`, `list_issues`) plus a `git log` shell-out for recent merges. Any individual source failing degrades to a "none currently" section — spawn never aborts on snapshot generation.
- Formatter truncates each list at 10 items with a `… and N more` tail and caps the total rendered size at ~4 KB so pathological state can't blow the prompt budget.

Resolves #381.

## Test plan
- [x] `cargo test -p tmai-core --lib api::state_snapshot` — 7 new formatter unit tests (empty project, truncation past 10, draft/review/CI formatting, 4 KB byte cap, status label mapping)
- [x] `cargo test -p tmai-core --lib compose_orchestrator` + `test_compose_with_state_*` — disabled flag matches legacy output; missing `project_path` skips injection
- [x] `cargo test -p tmai-core --lib save_project_orchestrator` — full round-trip coverage already asserts every field; `sample_non_default_orch` now toggles `inject_state_snapshot = false` so the new field is exercised on save+reload for both the global and per-project paths
- [x] `cargo fmt --all` / `cargo clippy -p tmai-core -p tmai --lib --no-deps -- -D warnings`
- [ ] Manual smoke: spawn an orchestrator in a repo with open PRs/issues via `/api/orchestrator/spawn`, confirm the composed prompt contains `## Current state snapshot (as of spawn)` with the expected sections

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * オーケストレーター設定に状態スナップショット注入機能を追加しました。この設定を有効にすると、オーケストレーターのプロンプト生成時に、オープンPR、アクティブなエージェント、最近のマージ、オープンアイシューなどの現在の状態情報が自動的に含まれるようになります。デフォルトでは有効です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->