### PR TITLE
feat: configurable worker model per agent type / role / dispatch (#435)

### DIFF
--- a/crates/tmai-core/src/config/mod.rs
+++ b/crates/tmai-core/src/config/mod.rs
@@ -5,8 +5,9 @@ pub use claude_settings::{
     ClaudeSettings, ClaudeSettingsCache, SpinnerVerbsConfig, SpinnerVerbsMode,
 };
 pub use settings::{
-    AuditCommand, AutoApproveSettings, CodexWsConnection, CodexWsSettings, Command, Config,
-    CreateProcessSettings, EventHandling, ExfilDetectionSettings, GuardrailsSettings,
-    NotifyTemplates, OrchestratorNotifySettings, OrchestratorRules, OrchestratorSettings,
-    PrMonitorScope, ProjectConfig, RuleSettings, Settings, TeamSettings,
+    AgentModelSettings, AuditCommand, AutoApproveSettings, CodexWsConnection, CodexWsSettings,
+    Command, Config, CreateProcessSettings, EventHandling, ExfilDetectionSettings,
+    GuardrailsSettings, NotifyTemplates, OrchestratorNotifySettings, OrchestratorRules,
+    OrchestratorSettings, PrMonitorScope, ProjectConfig, RuleSettings, Settings, SpawnRole,
+    SpawnSettings, TeamSettings,
 };

--- a/crates/tmai-core/src/config/settings.rs
+++ b/crates/tmai-core/src/config/settings.rs
@@ -825,6 +825,94 @@ pub struct SpawnSettings {
     /// `"default"` (or any non-`claude` command) to skip injection.
     #[serde(default = "default_worker_permission_mode")]
     pub worker_permission_mode: String,
+
+    /// Per-agent-type model configuration for Claude Code workers.
+    #[serde(default)]
+    pub claude: AgentModelSettings,
+
+    /// Per-agent-type model configuration for Codex CLI workers.
+    #[serde(default)]
+    pub codex: AgentModelSettings,
+
+    /// Per-agent-type model configuration for Gemini CLI workers.
+    #[serde(default)]
+    pub gemini: AgentModelSettings,
+}
+
+/// Per-agent-type model selection settings.
+///
+/// Each field is optional. Resolution falls back through the chain:
+/// per-dispatch override → role-specific → `default_model` → no flag
+/// (CLI uses its own default).
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct AgentModelSettings {
+    /// Model used when no role-specific override applies (e.g. implementer,
+    /// reviewer, or any role without a dedicated field).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub default_model: Option<String>,
+
+    /// Model used when the spawn role is `Orchestrator`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub orchestrator_model: Option<String>,
+}
+
+/// Role of a spawned agent — governs which field of `AgentModelSettings` is
+/// consulted after the per-dispatch override is checked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SpawnRole {
+    /// Orchestrator role (`spawn_orchestrator`).
+    Orchestrator,
+    /// Implementer role (`dispatch_issue`, `spawn_worktree`, `spawn_agent`).
+    Implementer,
+    /// Reviewer role (`dispatch_review`).
+    Reviewer,
+}
+
+impl SpawnSettings {
+    /// Resolve the model name to inject for a spawn given the agent type,
+    /// role, and an optional per-dispatch override.
+    ///
+    /// Resolution order (highest priority wins):
+    /// 1. `override_model` (per-dispatch argument)
+    /// 2. Role-specific field (e.g. `orchestrator_model` when role is
+    ///    `Orchestrator`)
+    /// 3. `default_model` on the agent-type table
+    /// 4. `None` — caller omits the flag so the CLI uses its user-global default
+    ///
+    /// `agent_type` is matched against the CLI command name
+    /// (`"claude"`, `"codex"`, `"gemini"`); unknown values return `None`.
+    pub fn resolve_model(
+        &self,
+        agent_type: &str,
+        role: SpawnRole,
+        override_model: Option<&str>,
+    ) -> Option<String> {
+        // Empty / whitespace-only strings are treated as unset at every layer
+        // so a user can blank a config field via the WebUI to fall through to
+        // the CLI's user-global default.
+        let normalize = |opt: Option<&String>| -> Option<String> {
+            opt.map(|s| s.trim().to_string()).filter(|s| !s.is_empty())
+        };
+        if let Some(m) = override_model {
+            let trimmed = m.trim();
+            if !trimmed.is_empty() {
+                return Some(trimmed.to_string());
+            }
+        }
+        let agent_cfg = match agent_type {
+            "claude" => &self.claude,
+            "codex" => &self.codex,
+            "gemini" => &self.gemini,
+            _ => return None,
+        };
+        match role {
+            SpawnRole::Orchestrator => normalize(agent_cfg.orchestrator_model.as_ref())
+                .or_else(|| normalize(agent_cfg.default_model.as_ref())),
+            SpawnRole::Implementer | SpawnRole::Reviewer => {
+                normalize(agent_cfg.default_model.as_ref())
+            }
+        }
+    }
 }
 
 /// Default tmux window name for spawned agents
@@ -848,6 +936,9 @@ impl Default for SpawnSettings {
             use_tmux_window: false,
             tmux_window_name: default_spawn_window_name(),
             worker_permission_mode: default_worker_permission_mode(),
+            claude: AgentModelSettings::default(),
+            codex: AgentModelSettings::default(),
+            gemini: AgentModelSettings::default(),
         }
     }
 }
@@ -2345,5 +2436,155 @@ mod tests {
             // Other project entry must still be present.
             assert!(reloaded.project.iter().any(|p| p.path == "/other"));
         });
+    }
+
+    // ── Spawn model resolution (#435) ──
+
+    #[test]
+    fn resolve_model_falls_through_to_none_by_default() {
+        let s = SpawnSettings::default();
+        assert_eq!(
+            s.resolve_model("claude", SpawnRole::Implementer, None),
+            None
+        );
+        assert_eq!(
+            s.resolve_model("claude", SpawnRole::Orchestrator, None),
+            None
+        );
+        assert_eq!(s.resolve_model("codex", SpawnRole::Reviewer, None), None);
+    }
+
+    #[test]
+    fn resolve_model_uses_default_when_set() {
+        let mut s = SpawnSettings::default();
+        s.claude.default_model = Some("claude-sonnet-4-6".to_string());
+        assert_eq!(
+            s.resolve_model("claude", SpawnRole::Implementer, None),
+            Some("claude-sonnet-4-6".to_string())
+        );
+        assert_eq!(
+            s.resolve_model("claude", SpawnRole::Reviewer, None),
+            Some("claude-sonnet-4-6".to_string())
+        );
+        // Orchestrator falls back to default when orchestrator_model unset.
+        assert_eq!(
+            s.resolve_model("claude", SpawnRole::Orchestrator, None),
+            Some("claude-sonnet-4-6".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_model_orchestrator_override_takes_precedence_over_default() {
+        let mut s = SpawnSettings::default();
+        s.claude.default_model = Some("claude-sonnet-4-6".to_string());
+        s.claude.orchestrator_model = Some("claude-opus-4-6".to_string());
+        // Orchestrator → orchestrator_model wins over default_model.
+        assert_eq!(
+            s.resolve_model("claude", SpawnRole::Orchestrator, None),
+            Some("claude-opus-4-6".to_string())
+        );
+        // Other roles still see default_model.
+        assert_eq!(
+            s.resolve_model("claude", SpawnRole::Implementer, None),
+            Some("claude-sonnet-4-6".to_string())
+        );
+        assert_eq!(
+            s.resolve_model("claude", SpawnRole::Reviewer, None),
+            Some("claude-sonnet-4-6".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_model_per_dispatch_override_wins() {
+        let mut s = SpawnSettings::default();
+        s.claude.default_model = Some("claude-sonnet-4-6".to_string());
+        s.claude.orchestrator_model = Some("claude-opus-4-6".to_string());
+        // Override beats both orchestrator_model and default_model.
+        assert_eq!(
+            s.resolve_model("claude", SpawnRole::Orchestrator, Some("claude-haiku-4-5")),
+            Some("claude-haiku-4-5".to_string())
+        );
+        assert_eq!(
+            s.resolve_model("claude", SpawnRole::Implementer, Some("claude-haiku-4-5")),
+            Some("claude-haiku-4-5".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_model_blank_override_treated_as_unset() {
+        let mut s = SpawnSettings::default();
+        s.claude.default_model = Some("claude-sonnet-4-6".to_string());
+        // Empty / whitespace overrides must not mask the config default.
+        assert_eq!(
+            s.resolve_model("claude", SpawnRole::Implementer, Some("")),
+            Some("claude-sonnet-4-6".to_string())
+        );
+        assert_eq!(
+            s.resolve_model("claude", SpawnRole::Implementer, Some("   ")),
+            Some("claude-sonnet-4-6".to_string())
+        );
+    }
+
+    #[test]
+    fn resolve_model_per_agent_type_independent() {
+        let mut s = SpawnSettings::default();
+        s.claude.default_model = Some("claude-sonnet-4-6".to_string());
+        s.codex.default_model = Some("o3".to_string());
+        s.gemini.default_model = Some("gemini-2.5-flash".to_string());
+        assert_eq!(
+            s.resolve_model("claude", SpawnRole::Implementer, None),
+            Some("claude-sonnet-4-6".to_string())
+        );
+        assert_eq!(
+            s.resolve_model("codex", SpawnRole::Implementer, None),
+            Some("o3".to_string())
+        );
+        assert_eq!(
+            s.resolve_model("gemini", SpawnRole::Implementer, None),
+            Some("gemini-2.5-flash".to_string())
+        );
+        // Unknown agent types never resolve a model (no-flag fallthrough).
+        assert_eq!(
+            s.resolve_model("opencode", SpawnRole::Implementer, None),
+            None
+        );
+        assert_eq!(s.resolve_model("bash", SpawnRole::Implementer, None), None);
+    }
+
+    #[test]
+    fn spawn_settings_round_trip_through_toml() {
+        let toml_src = r#"
+use_tmux_window = false
+tmux_window_name = "tmai-agents"
+worker_permission_mode = "acceptEdits"
+
+[claude]
+default_model = "claude-sonnet-4-6"
+orchestrator_model = "claude-opus-4-6"
+
+[codex]
+default_model = "o3"
+
+[gemini]
+"#;
+        let parsed: SpawnSettings = toml::from_str(toml_src).expect("parse");
+        assert_eq!(
+            parsed.claude.default_model.as_deref(),
+            Some("claude-sonnet-4-6")
+        );
+        assert_eq!(
+            parsed.claude.orchestrator_model.as_deref(),
+            Some("claude-opus-4-6")
+        );
+        assert_eq!(parsed.codex.default_model.as_deref(), Some("o3"));
+        assert_eq!(parsed.codex.orchestrator_model, None);
+        assert_eq!(parsed.gemini.default_model, None);
+
+        // Serialize back and re-parse — values must survive.
+        let encoded = toml::to_string(&parsed).expect("encode");
+        let reparsed: SpawnSettings = toml::from_str(&encoded).expect("reparse");
+        assert_eq!(parsed.claude, reparsed.claude);
+        assert_eq!(parsed.codex, reparsed.codex);
+        assert_eq!(parsed.gemini, reparsed.gemini);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -840,6 +840,7 @@ impl tmai_core::auto_action::ReviewDispatcher for ReviewDispatcherImpl {
                 24,
                 80,
                 tmai_core::api::ActionOrigin::system("auto_action"),
+                None,
             )
             .await
             {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -143,6 +143,11 @@ pub struct SpawnAgentParams {
     /// Initial prompt to send after the agent starts (optional)
     #[serde(default)]
     pub prompt: Option<String>,
+    /// Per-dispatch model override (e.g. `claude-sonnet-4-6`). When omitted,
+    /// resolution falls through to `[spawn.<type>].default_model` and then to
+    /// the CLI's user-global default.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -163,6 +168,9 @@ pub struct SpawnWorktreeParams {
     /// Initial prompt to send after the agent starts (optional)
     #[serde(default)]
     pub prompt: Option<String>,
+    /// Per-dispatch model override. See `SpawnAgentParams::model`.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -190,6 +198,9 @@ pub struct DispatchIssueParams {
     /// Extra instructions appended after the auto-generated issue prompt
     #[serde(default)]
     pub additional_instructions: Option<String>,
+    /// Per-dispatch model override. See `SpawnAgentParams::model`.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -202,6 +213,9 @@ pub struct DispatchReviewParams {
     /// Extra review instructions (e.g., "focus on security", "check error handling")
     #[serde(default)]
     pub additional_instructions: Option<String>,
+    /// Per-dispatch model override. See `SpawnAgentParams::model`.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -218,6 +232,9 @@ pub struct SpawnOrchestratorParams {
     /// Additional instructions appended to the composed orchestrator prompt
     #[serde(default)]
     pub additional_instructions: Option<String>,
+    /// Per-dispatch model override. See `SpawnAgentParams::model`.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 #[derive(Debug, serde::Deserialize, schemars::JsonSchema)]
@@ -517,6 +534,9 @@ impl TmaiMcpServer {
         if let Some(prompt) = &p.prompt {
             body["initial_prompt"] = serde_json::json!(prompt);
         }
+        if let Some(model) = &p.model {
+            body["model"] = serde_json::json!(model);
+        }
         self.client.post_json_or_error("/spawn", &body)
     }
 
@@ -545,6 +565,9 @@ impl TmaiMcpServer {
         if let Some(prompt) = &p.prompt {
             body["initial_prompt"] = serde_json::json!(prompt);
         }
+        if let Some(model) = &p.model {
+            body["model"] = serde_json::json!(model);
+        }
         self.client.post_json_or_error("/spawn/worktree", &body)
     }
 
@@ -558,6 +581,9 @@ impl TmaiMcpServer {
         }
         if let Some(ref extra) = p.additional_instructions {
             body["additional_instructions"] = serde_json::json!(extra);
+        }
+        if let Some(ref model) = p.model {
+            body["model"] = serde_json::json!(model);
         }
         self.client.post_json_or_error("/orchestrator/spawn", &body)
     }
@@ -594,6 +620,9 @@ impl TmaiMcpServer {
         if let Some(extra) = &p.additional_instructions {
             body["additional_instructions"] = serde_json::json!(extra);
         }
+        if let Some(model) = &p.model {
+            body["model"] = serde_json::json!(model);
+        }
         self.client.post_json_or_error("/spawn/worktree", &body)
     }
 
@@ -614,6 +643,9 @@ impl TmaiMcpServer {
         });
         if let Some(extra) = &p.additional_instructions {
             body["additional_instructions"] = serde_json::json!(extra);
+        }
+        if let Some(model) = &p.model {
+            body["model"] = serde_json::json!(model);
         }
         self.client.post_json_or_error("/review/dispatch", &body)
     }

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -992,6 +992,9 @@ pub struct WorktreeLaunchRequestBody {
     #[serde(default)]
     #[allow(dead_code)]
     pub session: Option<String>,
+    /// Per-dispatch model override. See `SpawnRequest::model`.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 /// Launch an agent in a worktree.
@@ -1039,12 +1042,21 @@ pub async fn launch_agent_in_worktree(
     };
 
     // Build args — pass initial prompt as first positional argument if provided
-    let args = match req.initial_prompt {
+    let mut args: Vec<String> = match req.initial_prompt {
         Some(ref prompt) if !prompt.is_empty() => vec![prompt.clone()],
         _ => vec![],
     };
 
-    // Worktree already exists — just cd into it and launch the agent
+    // Worktree already exists — just cd into it and launch the agent.
+    // Implementer role: `/worktrees/launch` re-launches an agent in an
+    // existing worktree, which is always an implementer spawn.
+    inject_model_flag(
+        &core,
+        command,
+        tmai_core::config::SpawnRole::Implementer,
+        req.model.as_deref(),
+        &mut args,
+    );
     let spawn_req = SpawnRequest {
         command: command.to_string(),
         args,
@@ -1052,6 +1064,7 @@ pub async fn launch_agent_in_worktree(
         rows: default_rows(),
         cols: default_cols(),
         force_pty: false,
+        model: None,
     };
 
     let use_tmux = {
@@ -1255,6 +1268,23 @@ pub struct SpawnSettingsResponse {
     pub tmux_window_name: String,
     /// Permission mode injected for dispatched workers
     pub worker_permission_mode: String,
+    /// Per-agent-type model configuration (Claude Code)
+    pub claude: tmai_core::config::AgentModelSettings,
+    /// Per-agent-type model configuration (Codex CLI)
+    pub codex: tmai_core::config::AgentModelSettings,
+    /// Per-agent-type model configuration (Gemini CLI)
+    pub gemini: tmai_core::config::AgentModelSettings,
+}
+
+/// Update payload for an `AgentModelSettings` subsection.
+/// `None` leaves the existing value untouched; an empty string clears the
+/// field so resolution falls through to the CLI's default.
+#[derive(Debug, Deserialize, Default)]
+pub struct AgentModelSettingsUpdate {
+    #[serde(default)]
+    pub default_model: Option<String>,
+    #[serde(default)]
+    pub orchestrator_model: Option<String>,
 }
 
 /// Request body for updating spawn settings
@@ -1269,6 +1299,15 @@ pub struct UpdateSpawnSettingsRequest {
     /// `"acceptEdits"`, or `"dontAsk"`. Empty / missing keeps current.
     #[serde(default)]
     pub worker_permission_mode: Option<String>,
+    /// Per-agent model settings (Claude Code)
+    #[serde(default)]
+    pub claude: Option<AgentModelSettingsUpdate>,
+    /// Per-agent model settings (Codex CLI)
+    #[serde(default)]
+    pub codex: Option<AgentModelSettingsUpdate>,
+    /// Per-agent model settings (Gemini CLI)
+    #[serde(default)]
+    pub gemini: Option<AgentModelSettingsUpdate>,
 }
 
 /// GET /api/settings/spawn — get spawn settings
@@ -1279,13 +1318,16 @@ pub async fn get_spawn_settings(State(core): State<Arc<TmaiCore>>) -> Json<Spawn
         (state.spawn_in_tmux, state.spawn_tmux_window_name.clone())
     };
     let tmux_available = is_tmux_available();
-    let worker_permission_mode = core.settings().spawn.worker_permission_mode.clone();
+    let spawn = core.settings().spawn.clone();
 
     Json(SpawnSettingsResponse {
         use_tmux_window,
         tmux_available,
         tmux_window_name,
-        worker_permission_mode,
+        worker_permission_mode: spawn.worker_permission_mode,
+        claude: spawn.claude,
+        codex: spawn.codex,
+        gemini: spawn.gemini,
     })
 }
 
@@ -1333,6 +1375,14 @@ pub async fn update_spawn_settings(
         }
     }
 
+    // Persist per-agent model configuration. Each `[spawn.<type>]` subtable
+    // has two optional fields; `Some("")` clears the field, `None` leaves it
+    // untouched. Resolution falls through to the CLI default when both are
+    // unset.
+    persist_model_setting("claude", req.claude.as_ref());
+    persist_model_setting("codex", req.codex.as_ref());
+    persist_model_setting("gemini", req.gemini.as_ref());
+
     // Reload live settings from config.toml
     core.reload_settings();
 
@@ -1343,6 +1393,31 @@ pub async fn update_spawn_settings(
         req.worker_permission_mode,
     );
     Json(serde_json::json!({"ok": true}))
+}
+
+/// Persist `[spawn.<agent>]` model fields from an update payload.
+///
+/// `None` for a field means "keep current"; `Some("")` clears it (writes an
+/// empty string so reload sees `default_model = ""`, then the resolver
+/// trims-checks and falls through to the CLI default).
+fn persist_model_setting(agent: &str, update: Option<&AgentModelSettingsUpdate>) {
+    let Some(u) = update else { return };
+    if let Some(ref v) = u.default_model {
+        tmai_core::config::Settings::save_toml_nested_value(
+            "spawn",
+            agent,
+            "default_model",
+            toml_edit::Value::from(v.as_str()),
+        );
+    }
+    if let Some(ref v) = u.orchestrator_model {
+        tmai_core::config::Settings::save_toml_nested_value(
+            "spawn",
+            agent,
+            "orchestrator_model",
+            toml_edit::Value::from(v.as_str()),
+        );
+    }
 }
 
 // =========================================================
@@ -2125,6 +2200,41 @@ pub struct SpawnRequest {
     /// Force PTY spawn even when tmux mode is enabled (e.g., for worktree)
     #[serde(default)]
     pub force_pty: bool,
+    /// Per-dispatch model override (highest priority in the resolution chain).
+    /// When empty/unset, falls through to `[spawn.<type>].default_model` or the
+    /// CLI's user-global default. Only applied for recognised AI CLIs
+    /// (`claude` / `codex` / `gemini`).
+    #[serde(default)]
+    pub model: Option<String>,
+}
+
+/// Resolve the effective `--model` name for an AI CLI spawn and, if one
+/// resolves, prepend `--model <name>` to `args`.
+///
+/// Only the `claude` / `codex` / `gemini` commands carry a `--model` flag
+/// today, so this is a no-op for shells and unrecognised commands. Pushing
+/// to the front keeps any trailing prompt positional untouched.
+fn inject_model_flag(
+    core: &Arc<TmaiCore>,
+    command: &str,
+    role: tmai_core::config::SpawnRole,
+    override_model: Option<&str>,
+    args: &mut Vec<String>,
+) {
+    let base = command.split('/').next_back().unwrap_or(command);
+    if !matches!(base, "claude" | "codex" | "gemini") {
+        return;
+    }
+    let resolved = core
+        .settings()
+        .spawn
+        .resolve_model(base, role, override_model);
+    if let Some(name) = resolved {
+        if !name.is_empty() {
+            args.insert(0, name);
+            args.insert(0, "--model".to_string());
+        }
+    }
 }
 
 /// Default working directory for spawn
@@ -2155,7 +2265,7 @@ pub struct SpawnResponse {
 /// POST /api/spawn — spawn an agent (tmux window or PTY session)
 pub async fn spawn_agent(
     State(core): State<Arc<TmaiCore>>,
-    Json(req): Json<SpawnRequest>,
+    Json(mut req): Json<SpawnRequest>,
 ) -> Result<Json<SpawnResponse>, (StatusCode, Json<serde_json::Value>)> {
     // Validate command (whitelist to prevent arbitrary execution)
     let allowed_commands = ["claude", "codex", "gemini", "bash", "sh", "zsh"];
@@ -2177,6 +2287,16 @@ pub async fn spawn_agent(
             &format!("Directory does not exist: {}", req.cwd),
         ));
     }
+
+    // Resolve and inject --model flag. /api/spawn is treated as an
+    // implementer spawn — spawn_orchestrator uses its own dedicated endpoint.
+    inject_model_flag(
+        &core,
+        &req.command,
+        tmai_core::config::SpawnRole::Implementer,
+        req.model.as_deref(),
+        &mut req.args,
+    );
 
     // Check if we should spawn in tmux
     let use_tmux = {
@@ -2482,6 +2602,9 @@ pub struct SpawnOrchestratorRequest {
     /// Additional instructions appended to the composed prompt
     #[serde(default)]
     pub additional_instructions: Option<String>,
+    /// Per-dispatch model override. See `SpawnRequest::model`.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 /// POST /api/orchestrator/spawn — spawn an orchestrator agent with composed prompt
@@ -2507,14 +2630,29 @@ pub async fn spawn_orchestrator(
         }
     }
 
-    // Spawn as a regular claude agent with the composed prompt as the initial argument
+    // Spawn as a regular claude agent with the composed prompt as the initial argument.
+    // Orchestrator role consults [spawn.claude].orchestrator_model with
+    // fallback to default_model (see SpawnSettings::resolve_model).
+    let mut args: Vec<String> = Vec::new();
+    if let Some(model) = core.settings().spawn.resolve_model(
+        "claude",
+        tmai_core::config::SpawnRole::Orchestrator,
+        req.model.as_deref(),
+    ) {
+        if !model.is_empty() {
+            args.push("--model".to_string());
+            args.push(model);
+        }
+    }
+    args.push(prompt);
     let spawn_req = SpawnRequest {
         command: "claude".to_string(),
-        args: vec![prompt],
+        args,
         cwd: cwd.clone(),
         rows: default_rows(),
         cols: default_cols(),
         force_pty: false,
+        model: None,
     };
 
     // Respect tmux mode: use tmux window when available, fall back to PTY
@@ -3107,6 +3245,9 @@ pub struct DispatchReviewRequest {
     pub rows: u16,
     #[serde(default = "default_cols")]
     pub cols: u16,
+    /// Per-dispatch model override. See `SpawnRequest::model`.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 /// POST /api/review/dispatch — spawn a review agent for a pull request
@@ -3124,6 +3265,7 @@ pub async fn dispatch_review(
         req.rows,
         req.cols,
         origin,
+        req.model,
     )
     .await
     .map(Json)
@@ -3133,6 +3275,7 @@ pub async fn dispatch_review(
 /// Core dispatch_review implementation shared by the HTTP handler and the
 /// AutoActionExecutor `ReviewDispatcher` impl. Returns `(StatusCode, message)`
 /// on failure so callers can map it to their own error type.
+#[allow(clippy::too_many_arguments)]
 pub async fn perform_dispatch_review(
     core: Arc<TmaiCore>,
     pr_number: u64,
@@ -3141,6 +3284,7 @@ pub async fn perform_dispatch_review(
     rows: u16,
     cols: u16,
     origin: ActionOrigin,
+    model_override: Option<String>,
 ) -> Result<SpawnResponse, (StatusCode, String)> {
     // Validate cwd
     if !std::path::Path::new(&cwd).is_dir() {
@@ -3265,6 +3409,18 @@ pub async fn perform_dispatch_review(
     let project_cwd = cwd.clone();
     let worktree_path = wt_result.path.clone();
     let mut args: Vec<String> = Vec::new();
+    // Reviewer role resolves [spawn.claude].default_model (no dedicated
+    // reviewer_model in v1 per #435).
+    if let Some(model) = core.settings().spawn.resolve_model(
+        "claude",
+        tmai_core::config::SpawnRole::Reviewer,
+        model_override.as_deref(),
+    ) {
+        if !model.is_empty() {
+            args.push("--model".to_string());
+            args.push(model);
+        }
+    }
     let worker_mode = core.settings().spawn.worker_permission_mode.clone();
     if !worker_mode.is_empty() && worker_mode != "default" {
         args.push("--permission-mode".to_string());
@@ -3278,6 +3434,7 @@ pub async fn perform_dispatch_review(
         rows,
         cols,
         force_pty: false,
+        model: None,
     };
 
     let use_tmux = {
@@ -3377,6 +3534,9 @@ pub struct WorktreeSpawnRequest {
     pub rows: u16,
     #[serde(default = "default_cols")]
     pub cols: u16,
+    /// Per-dispatch model override. See `SpawnRequest::model`.
+    #[serde(default)]
+    pub model: Option<String>,
 }
 
 /// POST /api/spawn/worktree — create git worktree then spawn claude in it
@@ -3447,6 +3607,18 @@ pub async fn spawn_worktree(
     // by default; user-configurable via [spawn].worker_permission_mode). The
     // flag is omitted when set to "default" so Claude Code uses its own default.
     let mut args: Vec<String> = Vec::new();
+    // Implementer role (dispatch_issue / spawn_worktree both treat spawns as
+    // implementer workers per #435).
+    if let Some(model) = core.settings().spawn.resolve_model(
+        "claude",
+        tmai_core::config::SpawnRole::Implementer,
+        req.model.as_deref(),
+    ) {
+        if !model.is_empty() {
+            args.push("--model".to_string());
+            args.push(model);
+        }
+    }
     let worker_mode = core.settings().spawn.worker_permission_mode.clone();
     if !worker_mode.is_empty() && worker_mode != "default" {
         args.push("--permission-mode".to_string());
@@ -3465,6 +3637,7 @@ pub async fn spawn_worktree(
         rows: req.rows,
         cols: req.cols,
         force_pty: false,
+        model: None,
     };
 
     // Resolve the effective base branch for metadata
@@ -5271,6 +5444,7 @@ mod tests {
                     rows: 24,
                     cols: 80,
                     force_pty: false,
+                    model: None,
                 };
                 spawn_in_pty(&core_clone, &req).await
             }));
@@ -5319,5 +5493,119 @@ mod tests {
 
         let Json(resp) = get_auto_approve_settings(axum::extract::State(core)).await;
         assert!(!resp.rules.allow_tmai_mcp);
+    }
+
+    // ── #435 inject_model_flag ──
+
+    fn build_core_with(settings: tmai_core::config::Settings) -> Arc<TmaiCore> {
+        let state = test_app_state();
+        let runtime: Arc<dyn tmai_core::runtime::RuntimeAdapter> =
+            Arc::new(tmai_core::runtime::StandaloneAdapter::new());
+        let cmd = CommandSender::new(None, runtime, state.clone());
+        Arc::new(
+            TmaiCoreBuilder::new(settings)
+                .with_state(state)
+                .with_command_sender(Arc::new(cmd))
+                .build(),
+        )
+    }
+
+    #[test]
+    fn inject_model_flag_prepends_model_when_resolved() {
+        let mut settings = tmai_core::config::Settings::default();
+        settings.spawn.claude.default_model = Some("claude-sonnet-4-6".to_string());
+        let core = build_core_with(settings);
+
+        let mut args = vec!["the-prompt".to_string()];
+        inject_model_flag(
+            &core,
+            "claude",
+            tmai_core::config::SpawnRole::Implementer,
+            None,
+            &mut args,
+        );
+        assert_eq!(
+            args,
+            vec![
+                "--model".to_string(),
+                "claude-sonnet-4-6".to_string(),
+                "the-prompt".to_string(),
+            ],
+            "model flag must precede the prompt positional"
+        );
+    }
+
+    #[test]
+    fn inject_model_flag_orchestrator_uses_role_specific_model() {
+        let mut settings = tmai_core::config::Settings::default();
+        settings.spawn.claude.default_model = Some("claude-sonnet-4-6".to_string());
+        settings.spawn.claude.orchestrator_model = Some("claude-opus-4-6".to_string());
+        let core = build_core_with(settings);
+
+        let mut args: Vec<String> = Vec::new();
+        inject_model_flag(
+            &core,
+            "claude",
+            tmai_core::config::SpawnRole::Orchestrator,
+            None,
+            &mut args,
+        );
+        assert_eq!(
+            args,
+            vec!["--model".to_string(), "claude-opus-4-6".to_string()]
+        );
+    }
+
+    #[test]
+    fn inject_model_flag_per_dispatch_override_wins() {
+        let mut settings = tmai_core::config::Settings::default();
+        settings.spawn.claude.default_model = Some("claude-sonnet-4-6".to_string());
+        let core = build_core_with(settings);
+
+        let mut args: Vec<String> = Vec::new();
+        inject_model_flag(
+            &core,
+            "claude",
+            tmai_core::config::SpawnRole::Implementer,
+            Some("claude-haiku-4-5"),
+            &mut args,
+        );
+        assert_eq!(
+            args,
+            vec!["--model".to_string(), "claude-haiku-4-5".to_string()]
+        );
+    }
+
+    #[test]
+    fn inject_model_flag_noop_for_unknown_command() {
+        // Shells and unknown commands do not accept --model; the helper must
+        // leave args untouched even when the user has set per-agent defaults.
+        let mut settings = tmai_core::config::Settings::default();
+        settings.spawn.claude.default_model = Some("claude-sonnet-4-6".to_string());
+        let core = build_core_with(settings);
+
+        let mut args = vec!["arg".to_string()];
+        inject_model_flag(
+            &core,
+            "bash",
+            tmai_core::config::SpawnRole::Implementer,
+            None,
+            &mut args,
+        );
+        assert_eq!(args, vec!["arg".to_string()]);
+    }
+
+    #[test]
+    fn inject_model_flag_noop_when_no_resolution() {
+        let core = build_core_with(tmai_core::config::Settings::default());
+        let mut args = vec!["the-prompt".to_string()];
+        inject_model_flag(
+            &core,
+            "claude",
+            tmai_core::config::SpawnRole::Implementer,
+            None,
+            &mut args,
+        );
+        assert_eq!(args, vec!["the-prompt".to_string()]);
     }
 }


### PR DESCRIPTION
Closes #435.

## Summary

Adds a four-tier model resolution chain so the orchestrator can run on Opus while implementers/reviewers default to a cheaper model:

1. **Per-dispatch override** — optional `model` argument on `dispatch_issue`, `dispatch_review`, `spawn_agent`, `spawn_worktree`, `spawn_orchestrator` (HTTP body **and** MCP tool param)
2. **Role-specific** — `[spawn.<type>].orchestrator_model`
3. **Type default** — `[spawn.<type>].default_model`
4. **CLI default** — falls through to no `--model` flag (current behaviour)

Subtables added: `[spawn.claude]`, `[spawn.codex]`, `[spawn.gemini]`. Other role-specific fields (`implementer_model` / `reviewer_model`) are deferred per the issue.

## Notes

- All three CLIs accept the same `--model <name>` flag, so injection uses one helper.
- Empty / whitespace strings collapse to "unset" at every layer so a user can blank a field via `PUT /api/settings/spawn` to fall back to the CLI default.
- `inject_model_flag()` is a no-op for `bash` / `sh` / `zsh` and unrecognised commands.
- `perform_dispatch_review` gains a trailing `model_override: Option<String>`. Pre-existing `tmai-app` build error in `crates/tmai-app/src/events.rs` (non-exhaustive `CoreEvent` match) is unrelated and reproduces on `main`.
- WebUI does not currently render a spawn-settings panel; the issue calls out a panel as "later, editable later" — endpoints are exposed and ready when one is added.

## Test plan

- [x] `cargo test -p tmai-core --lib config::` — 7 new resolver/round-trip tests pass
- [x] `cargo test -p tmai --lib web::api::tests::inject_model` — 5 new arg-injection tests pass
- [x] `cargo clippy -p tmai -p tmai-core --no-deps -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Pre-existing `tmai-app` build break confirmed unrelated (reproduces on stashed `main`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)