### PR TITLE
feat: warn or auto-rebase when spawning branch from stale main (#334)

### DIFF
--- a/crates/tmai-core/src/worktree/mod.rs
+++ b/crates/tmai-core/src/worktree/mod.rs
@@ -10,5 +10,6 @@ pub use ops::{
     check_worktree_clean, create_worktree, delete_worktree, move_to_worktree, run_setup_commands,
 };
 pub use types::{
-    WorktreeCreateRequest, WorktreeDeleteRequest, WorktreeMoveRequest, WorktreeOpsError,
+    BaseStalenessReport, WorktreeCreateRequest, WorktreeCreateResult, WorktreeDeleteRequest,
+    WorktreeMoveRequest, WorktreeOpsError,
 };

--- a/crates/tmai-core/src/worktree/ops.rs
+++ b/crates/tmai-core/src/worktree/ops.rs
@@ -10,12 +10,17 @@ use tokio::process::Command;
 use crate::git::is_valid_worktree_name;
 
 use super::types::{
-    WorktreeCreateRequest, WorktreeCreateResult, WorktreeDeleteRequest, WorktreeMoveRequest,
-    WorktreeOpsError,
+    BaseStalenessReport, WorktreeCreateRequest, WorktreeCreateResult, WorktreeDeleteRequest,
+    WorktreeMoveRequest, WorktreeOpsError,
 };
 
 /// Timeout for git worktree commands
 const GIT_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Timeout for the optional `git fetch origin <base>` performed before
+/// branching. Network operations are slower than local plumbing, so this
+/// gets a longer budget than `GIT_TIMEOUT`.
+const FETCH_BASE_TIMEOUT: Duration = Duration::from_secs(20);
 
 /// Create a new git worktree under `.claude/worktrees/<name>/`
 ///
@@ -54,6 +59,16 @@ pub async fn create_worktree(
 
     let worktree_path = worktree_dir.to_string_lossy().to_string();
 
+    // Resolve the effective base ref. When `auto_fetch_base` is on and the
+    // requested base is a normal branch (i.e. `origin/<base>` exists), we
+    // best-effort fetch and — if local lags — branch off `origin/<base>`
+    // so the new worktree starts from the latest upstream commit (#334).
+    let (effective_base, staleness) = match req.base_branch.as_deref() {
+        Some(base) if req.auto_fetch_base => resolve_fresh_base(&req.repo_path, base).await,
+        Some(base) => (Some(base.to_string()), None),
+        None => (None, None),
+    };
+
     // Build git worktree add command
     let mut args = vec![
         "-C".to_string(),
@@ -64,7 +79,7 @@ pub async fn create_worktree(
         req.branch_name.clone(),
         worktree_path.clone(),
     ];
-    if let Some(ref base) = req.base_branch {
+    if let Some(ref base) = effective_base {
         args.push(base.clone());
     }
 
@@ -85,7 +100,94 @@ pub async fn create_worktree(
     Ok(WorktreeCreateResult {
         path: worktree_path,
         branch: req.branch_name.clone(),
+        staleness,
     })
+}
+
+/// Best-effort: fetch `origin/<base>` and decide whether to branch off it.
+///
+/// Returns `(effective_base_ref, staleness_report)`:
+/// - When `origin/<base>` does not exist (no remote, branch never pushed,
+///   shallow clone, etc.) we silently fall back to the requested local ref
+///   so callers without a configured `origin` still work.
+/// - When `origin/<base>` exists and local `<base>` is behind, we return
+///   `origin/<base>` as the ref to branch from plus a populated report so
+///   the caller can surface a notification.
+/// - When local `<base>` is up-to-date we return the local ref unchanged
+///   (avoiding unnecessary detached-HEAD-style refs in the new branch).
+async fn resolve_fresh_base(
+    repo_path: &str,
+    base: &str,
+) -> (Option<String>, Option<BaseStalenessReport>) {
+    // Defense in depth: only run when the base name is shaped like a
+    // branch ref. `is_safe_git_ref` is also enforced upstream, but we may
+    // be passed something like a SHA — `origin/<sha>` is meaningless, so
+    // skip the fetch and use the literal ref.
+    if !crate::git::is_safe_git_ref(base) {
+        return (Some(base.to_string()), None);
+    }
+
+    let origin_ref = format!("origin/{}", base);
+
+    // Fetch — best-effort. Failures (no network, no `origin`, auth issue)
+    // must NOT abort worktree creation; we simply fall back to local.
+    let _ = tokio::time::timeout(
+        FETCH_BASE_TIMEOUT,
+        Command::new("git")
+            .args(["-C", repo_path, "fetch", "origin", base])
+            .output(),
+    )
+    .await;
+
+    // Verify origin/<base> resolves (it won't if there's no remote tracking
+    // branch, e.g. a freshly init'd repo without push).
+    let verify = tokio::time::timeout(
+        GIT_TIMEOUT,
+        Command::new("git")
+            .args(["-C", repo_path, "rev-parse", "--verify", &origin_ref])
+            .output(),
+    )
+    .await;
+    let origin_ok = matches!(verify, Ok(Ok(o)) if o.status.success());
+    if !origin_ok {
+        return (Some(base.to_string()), None);
+    }
+
+    // Count commits in origin/<base> not yet in local <base>.
+    let range = format!("{}..{}", base, origin_ref);
+    let count = tokio::time::timeout(
+        GIT_TIMEOUT,
+        Command::new("git")
+            .args(["-C", repo_path, "rev-list", "--count", &range])
+            .output(),
+    )
+    .await;
+    let behind: usize = match count {
+        Ok(Ok(out)) if out.status.success() => String::from_utf8_lossy(&out.stdout)
+            .trim()
+            .parse()
+            .unwrap_or(0),
+        _ => 0,
+    };
+
+    if behind == 0 {
+        (Some(base.to_string()), None)
+    } else {
+        tracing::warn!(
+            base = base,
+            behind = behind,
+            "Local base branch is behind origin; branching new worktree from {} instead",
+            origin_ref
+        );
+        (
+            Some(origin_ref.clone()),
+            Some(BaseStalenessReport {
+                base_branch: base.to_string(),
+                behind,
+                used_ref: origin_ref,
+            }),
+        )
+    }
 }
 
 /// Delete a git worktree
@@ -314,6 +416,7 @@ pub async fn move_to_worktree(
     Ok(WorktreeCreateResult {
         path: worktree_path,
         branch: req.branch_name.clone(),
+        staleness: None,
     })
 }
 
@@ -542,6 +645,7 @@ mod tests {
             branch_name: "feat-test".to_string(),
             dir_name: None,
             base_branch: None,
+            auto_fetch_base: false,
         };
 
         let result = create_worktree(&req).await;
@@ -563,6 +667,7 @@ mod tests {
             branch_name: "feat-from-main".to_string(),
             dir_name: None,
             base_branch: Some("HEAD".to_string()),
+            auto_fetch_base: false,
         };
 
         let result = create_worktree(&req).await;
@@ -576,6 +681,7 @@ mod tests {
             branch_name: "bad; rm -rf /".to_string(),
             dir_name: None,
             base_branch: None,
+            auto_fetch_base: false,
         };
 
         let result = create_worktree(&req).await;
@@ -589,6 +695,7 @@ mod tests {
             branch_name: "valid-name".to_string(),
             dir_name: None,
             base_branch: Some("--exec=evil".to_string()),
+            auto_fetch_base: false,
         };
 
         let result = create_worktree(&req).await;
@@ -605,6 +712,7 @@ mod tests {
             branch_name: "feat-dup".to_string(),
             dir_name: None,
             base_branch: None,
+            auto_fetch_base: false,
         };
 
         // First create succeeds
@@ -625,6 +733,7 @@ mod tests {
             branch_name: "feat-delete-me".to_string(),
             dir_name: None,
             base_branch: None,
+            auto_fetch_base: false,
         };
         create_worktree(&create_req).await.unwrap();
 
@@ -669,6 +778,7 @@ mod tests {
             branch_name: "feat-orphan".to_string(),
             dir_name: None,
             base_branch: None,
+            auto_fetch_base: false,
         };
         let wt = create_worktree(&create_req).await.unwrap();
 
@@ -714,6 +824,7 @@ mod tests {
             branch_name: "feat-dirty".to_string(),
             dir_name: None,
             base_branch: None,
+            auto_fetch_base: false,
         };
         let wt = create_worktree(&create_req).await.unwrap();
 
@@ -753,6 +864,7 @@ mod tests {
             branch_name: "feat-force".to_string(),
             dir_name: None,
             base_branch: None,
+            auto_fetch_base: false,
         };
         let wt = create_worktree(&create_req).await.unwrap();
 
@@ -1000,5 +1112,223 @@ mod tests {
 
         let result = move_to_worktree(&req).await;
         assert!(matches!(result, Err(WorktreeOpsError::AlreadyExists(_))));
+    }
+
+    // -----------------------------------------------------------------
+    // Staleness handling (issue #334)
+    // -----------------------------------------------------------------
+
+    /// Build a clone-of-clone topology that simulates a real `origin`.
+    ///
+    /// Returns `(clone_tmp, bare_tmp, upstream_tmp, clone_path, upstream_path)`.
+    /// All three TempDirs MUST be kept alive by the caller for the duration
+    /// of the test — drop them and the underlying directories vanish, which
+    /// breaks any subsequent `git` calls that hold paths into them.
+    async fn init_repo_with_origin() -> (TempDir, TempDir, TempDir, PathBuf, PathBuf) {
+        // Upstream: a normal repo that we will then clone --bare from.
+        // Doing it this way (vs. `init --bare` + commits via a working tree)
+        // sidesteps the need for a separate seeding worktree for the bare repo.
+        let upstream_tmp = TempDir::new().unwrap();
+        let upstream = upstream_tmp.path().to_path_buf();
+        let upstream_str = upstream.to_string_lossy().to_string();
+        Command::new("git")
+            .args(["-C", &upstream_str, "init", "-b", "main"])
+            .output()
+            .await
+            .unwrap();
+        Command::new("git")
+            .args(["-C", &upstream_str, "config", "user.email", "u@u.com"])
+            .output()
+            .await
+            .unwrap();
+        Command::new("git")
+            .args(["-C", &upstream_str, "config", "user.name", "U"])
+            .output()
+            .await
+            .unwrap();
+        tokio::fs::write(upstream.join("README.md"), "init\n")
+            .await
+            .unwrap();
+        Command::new("git")
+            .args(["-C", &upstream_str, "add", "."])
+            .output()
+            .await
+            .unwrap();
+        Command::new("git")
+            .args(["-C", &upstream_str, "commit", "-m", "init"])
+            .output()
+            .await
+            .unwrap();
+
+        // Bare mirror that the working clone will use as `origin`.
+        let bare_tmp = TempDir::new().unwrap();
+        let bare = bare_tmp.path().join("origin.git");
+        Command::new("git")
+            .args(["clone", "--bare", &upstream_str, &bare.to_string_lossy()])
+            .output()
+            .await
+            .unwrap();
+
+        // Working clone — this is what `create_worktree` will operate on.
+        let clone_tmp = TempDir::new().unwrap();
+        let clone = clone_tmp.path().join("repo");
+        Command::new("git")
+            .args(["clone", &bare.to_string_lossy(), &clone.to_string_lossy()])
+            .output()
+            .await
+            .unwrap();
+        let clone_str = clone.to_string_lossy().to_string();
+        Command::new("git")
+            .args(["-C", &clone_str, "config", "user.email", "c@c.com"])
+            .output()
+            .await
+            .unwrap();
+        Command::new("git")
+            .args(["-C", &clone_str, "config", "user.name", "C"])
+            .output()
+            .await
+            .unwrap();
+
+        (clone_tmp, bare_tmp, upstream_tmp, clone, upstream)
+    }
+
+    /// Push a new commit to the bare origin via the `upstream` working tree
+    /// so the working `clone` falls behind `origin/main`.
+    async fn advance_origin(upstream: &Path, bare: &Path, marker: &str) {
+        let upstream_str = upstream.to_string_lossy().to_string();
+        tokio::fs::write(upstream.join(format!("{marker}.txt")), marker)
+            .await
+            .unwrap();
+        Command::new("git")
+            .args(["-C", &upstream_str, "add", "."])
+            .output()
+            .await
+            .unwrap();
+        Command::new("git")
+            .args(["-C", &upstream_str, "commit", "-m", marker])
+            .output()
+            .await
+            .unwrap();
+        Command::new("git")
+            .args(["-C", &upstream_str, "push", &bare.to_string_lossy(), "main"])
+            .output()
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_create_worktree_stale_base_uses_origin() {
+        let (_clone_tmp, _bare_tmp_keep, _upstream_tmp, clone, _upstream) =
+            init_repo_with_origin().await;
+        let bare_keep = _bare_tmp_keep.path().join("origin.git");
+        advance_origin(&_upstream, &bare_keep, "ahead1").await;
+        advance_origin(&_upstream, &bare_keep, "ahead2").await;
+
+        let repo_path = clone.to_string_lossy().to_string();
+
+        let req = WorktreeCreateRequest {
+            repo_path: repo_path.clone(),
+            branch_name: "feat-stale".to_string(),
+            dir_name: None,
+            base_branch: Some("main".to_string()),
+            auto_fetch_base: true,
+        };
+
+        let res = create_worktree(&req).await.unwrap();
+        let report = res.staleness.expect("staleness should have been reported");
+        assert_eq!(report.base_branch, "main");
+        assert_eq!(report.behind, 2, "should detect 2 commits behind");
+        assert_eq!(report.used_ref, "origin/main");
+
+        // The created worktree's HEAD must contain the upstream commits — it
+        // was branched off origin/main, not the stale local main.
+        let log = Command::new("git")
+            .args(["-C", &res.path, "log", "--format=%s"])
+            .output()
+            .await
+            .unwrap();
+        let log_str = String::from_utf8_lossy(&log.stdout);
+        assert!(
+            log_str.contains("ahead1") && log_str.contains("ahead2"),
+            "worktree HEAD missing upstream commits; log:\n{}",
+            log_str
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_worktree_up_to_date_no_staleness() {
+        let (_clone_tmp, _bare_tmp_keep, _upstream_tmp, clone, _upstream) =
+            init_repo_with_origin().await;
+        let repo_path = clone.to_string_lossy().to_string();
+
+        let req = WorktreeCreateRequest {
+            repo_path: repo_path.clone(),
+            branch_name: "feat-fresh".to_string(),
+            dir_name: None,
+            base_branch: Some("main".to_string()),
+            auto_fetch_base: true,
+        };
+
+        let res = create_worktree(&req).await.unwrap();
+        assert!(
+            res.staleness.is_none(),
+            "no staleness expected when local is up-to-date, got: {:?}",
+            res.staleness
+        );
+    }
+
+    #[tokio::test]
+    async fn test_create_worktree_no_origin_falls_back_silently() {
+        // No remote configured at all — must not fail.
+        let (_tmp, repo) = init_test_repo().await;
+        let repo_path = repo.to_string_lossy().to_string();
+
+        let req = WorktreeCreateRequest {
+            repo_path: repo_path.clone(),
+            branch_name: "feat-no-origin".to_string(),
+            dir_name: None,
+            base_branch: Some("main".to_string()),
+            auto_fetch_base: true,
+        };
+
+        let res = create_worktree(&req).await.unwrap();
+        assert!(res.staleness.is_none());
+        assert_eq!(res.branch, "feat-no-origin");
+    }
+
+    #[tokio::test]
+    async fn test_create_worktree_auto_fetch_disabled_skips_check() {
+        // When auto_fetch_base = false, we must not even attempt the fetch
+        // — preserves legacy behavior for callers (e.g. the TUI) that branch
+        // off the local HEAD intentionally.
+        let (_clone_tmp, _bare_tmp_keep, _upstream_tmp, clone, _upstream) =
+            init_repo_with_origin().await;
+        let bare_keep = _bare_tmp_keep.path().join("origin.git");
+        advance_origin(&_upstream, &bare_keep, "ahead").await;
+
+        let repo_path = clone.to_string_lossy().to_string();
+        let req = WorktreeCreateRequest {
+            repo_path: repo_path.clone(),
+            branch_name: "feat-skip".to_string(),
+            dir_name: None,
+            base_branch: Some("main".to_string()),
+            auto_fetch_base: false,
+        };
+
+        let res = create_worktree(&req).await.unwrap();
+        assert!(res.staleness.is_none(), "no check should run");
+
+        // HEAD must NOT include the upstream commit because we never fetched.
+        let log = Command::new("git")
+            .args(["-C", &res.path, "log", "--format=%s"])
+            .output()
+            .await
+            .unwrap();
+        let log_str = String::from_utf8_lossy(&log.stdout);
+        assert!(
+            !log_str.contains("ahead"),
+            "worktree should be on stale main; log:\n{}",
+            log_str
+        );
     }
 }

--- a/crates/tmai-core/src/worktree/types.rs
+++ b/crates/tmai-core/src/worktree/types.rs
@@ -13,6 +13,11 @@ pub struct WorktreeCreateRequest {
     pub dir_name: Option<String>,
     /// Branch to fork from (default: HEAD)
     pub base_branch: Option<String>,
+    /// When true and `base_branch` is a real branch (not HEAD/SHA), fetch
+    /// `origin/<base>` first and — if local `<base>` is behind — silently
+    /// branch off `origin/<base>` instead so the new worktree starts from
+    /// the latest upstream commit. Prevents PR-from-stale-base conflicts (#334).
+    pub auto_fetch_base: bool,
 }
 
 /// Worktree deletion request
@@ -91,6 +96,28 @@ pub struct WorktreeCreateResult {
     pub path: String,
     /// Branch name
     pub branch: String,
+    /// When the request had `auto_fetch_base = true` and the local base
+    /// branch was found to be behind origin, this records what was detected
+    /// and how the request was handled. `None` means no staleness was
+    /// observed (or the check did not run).
+    pub staleness: Option<BaseStalenessReport>,
+}
+
+/// Describes a stale local base branch that was bypassed at worktree creation.
+///
+/// Returned when `auto_fetch_base` is set and the local `base_branch` was
+/// found to be `behind` commits behind `origin/<base_branch>` after a fetch.
+/// In this case the worktree is created from `origin/<base_branch>` instead
+/// of the local ref, so the new branch starts from the latest upstream tip.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BaseStalenessReport {
+    /// The base branch name as the caller requested it (e.g. "main").
+    pub base_branch: String,
+    /// Number of commits the local base was behind `origin/<base>`.
+    pub behind: usize,
+    /// Resolved ref actually passed to `git worktree add`
+    /// (e.g. "origin/main").
+    pub used_ref: String,
 }
 
 #[cfg(test)]
@@ -104,6 +131,7 @@ mod tests {
             branch_name: "feat-auth".to_string(),
             dir_name: None,
             base_branch: Some("main".to_string()),
+            auto_fetch_base: false,
         };
         assert_eq!(req.repo_path, "/home/user/project");
         assert_eq!(req.branch_name, "feat-auth");

--- a/src/ui/app.rs
+++ b/src/ui/app.rs
@@ -1723,6 +1723,7 @@ impl App {
                                 branch_name,
                                 dir_name: None,
                                 base_branch: None,
+                                auto_fetch_base: false,
                             };
                             tokio::spawn(async move {
                                 match core.create_worktree(&req).await {

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -3405,6 +3405,10 @@ pub async fn perform_dispatch_review(
         branch_name: worktree_name.clone(),
         dir_name: None,
         base_branch: Some(format!("origin/{base_branch}")),
+        // dispatch_review already pinned the base to origin/<base> above
+        // and just ran an explicit fetch, so the staleness rerun would be
+        // redundant work.
+        auto_fetch_base: false,
     };
 
     let wt_result = tmai_core::worktree::create_worktree(&wt_req)
@@ -3615,12 +3619,15 @@ pub async fn spawn_worktree(
         ));
     }
 
-    // Create git worktree using tmai-core
+    // Create git worktree using tmai-core. Enable auto_fetch_base so a stale
+    // local base branch (#334) gets bypassed in favour of `origin/<base>`,
+    // preventing the new worktree from starting on outdated commits.
     let wt_req = tmai_core::worktree::WorktreeCreateRequest {
         repo_path: req.cwd.clone(),
         branch_name: resolved_name.clone(),
         dir_name: None,
         base_branch: req.base_branch.clone(),
+        auto_fetch_base: true,
     };
 
     let wt_result = tmai_core::worktree::create_worktree(&wt_req)
@@ -3628,11 +3635,31 @@ pub async fn spawn_worktree(
         .map_err(|e| json_error(StatusCode::BAD_REQUEST, &e.to_string()))?;
 
     tracing::info!(
-        "API: created worktree '{}' at {} (branch: {})",
+        "API: created worktree '{}' at {} (branch: {}, staleness: {:?})",
         resolved_name,
         wt_result.path,
-        wt_result.branch
+        wt_result.branch,
+        wt_result.staleness,
     );
+
+    // Surface a stale-base warning to the orchestrator so it knows the
+    // worktree was branched off `origin/<base>` rather than the local ref.
+    // Without this signal the orchestrator could not explain why the new
+    // branch already contains "unexpected" commits relative to the local
+    // tree it observes.
+    if let Some(ref report) = wt_result.staleness {
+        let _ = core.event_sender().send(CoreEvent::ActionPerformed {
+            origin: origin.clone(),
+            action: "spawn_worktree_stale_base".to_string(),
+            summary: format!(
+                "Local '{base}' was {behind} commit(s) behind {used}; worktree '{name}' was branched off {used} instead.",
+                base = report.base_branch,
+                behind = report.behind,
+                used = report.used_ref,
+                name = resolved_name,
+            ),
+        });
+    }
 
     // Poller-driven SoT: trigger immediate worktree rescan so
     // `/api/worktrees` reflects the new worktree on the next tick without


### PR DESCRIPTION
## Summary
- `spawn_worktree` / `dispatch_issue` now opt into auto-fetching `origin/<base>` and bypass a stale local base by branching off the upstream ref directly, so new PRs no longer open with merge conflicts that silently kill CI (#334).
- Surfaces a `CoreEvent::ActionPerformed { action: "spawn_worktree_stale_base", ... }` notification whenever the bypass kicks in, so the orchestrator hears about it instead of having to reverse-engineer "unexpected" commits on the new branch.
- New `WorktreeCreateRequest::auto_fetch_base` is opt-in; `dispatch_review` (already pins `origin/<base>`) and the TUI manual-create path keep it off to preserve current semantics.

## Test plan
- [x] `cargo test -p tmai-core --lib worktree::` — 30 tests pass, including 4 new staleness scenarios (stale base uses origin, up-to-date is no-op, no-origin falls back silently, opt-out skips the check).
- [x] `cargo test -p tmai --lib` — 156 tests pass, no regressions in the web spawn handler.
- [x] `cargo check -p tmai-core -p tmai --tests` clean.
- [x] `cargo fmt` / clippy clean for the changed code paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ワークツリー作成時にベースブランチの遅延を自動検出し、ローカルブランチがリモートに遅れている場合はリモートブランチを使用するようになりました。
  * 遅延検出時に詳細情報（ブランチ名、コミット差分数、使用したRef）がレポートされるようになりました。

* **Chores**
  * ワークツリー作成時の処理を最適化し、冗長なフェッチを削減しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->