### PR TITLE
fix: resolve Rust 1.95 clippy regressions blocking CI

### DIFF
--- a/crates/tmai-core/src/api/state_snapshot.rs
+++ b/crates/tmai-core/src/api/state_snapshot.rs
@@ -102,7 +102,7 @@ fn prs_from_map(map: std::collections::HashMap<String, PrInfo>) -> Vec<PrRow> {
         })
         .collect();
     // Highest PR number first — proxy for "most recent work".
-    rows.sort_by(|a, b| b.number.cmp(&a.number));
+    rows.sort_by_key(|r| std::cmp::Reverse(r.number));
     rows
 }
 
@@ -114,7 +114,7 @@ fn issues_from_vec(issues: Vec<IssueInfo>) -> Vec<IssueRow> {
             title: i.title,
         })
         .collect();
-    rows.sort_by(|a, b| b.number.cmp(&a.number));
+    rows.sort_by_key(|r| std::cmp::Reverse(r.number));
     rows
 }
 

--- a/crates/tmai-core/src/audit/analyze.rs
+++ b/crates/tmai-core/src/audit/analyze.rs
@@ -111,7 +111,7 @@ pub fn compute_stats(events: &[AuditEvent]) -> AuditStats {
 
     // Sort rules by count descending
     let mut rule_hits: Vec<(String, usize)> = rule_map.into_iter().collect();
-    rule_hits.sort_by(|a, b| b.1.cmp(&a.1));
+    rule_hits.sort_by_key(|x| std::cmp::Reverse(x.1));
     stats.rule_hits = rule_hits;
 
     stats
@@ -158,7 +158,7 @@ pub fn compute_misdetections(events: &[AuditEvent], limit: usize) -> Misdetectio
 
     // Sort rules by frequency descending
     let mut by_rule: Vec<(String, usize)> = rule_map.into_iter().collect();
-    by_rule.sort_by(|a, b| b.1.cmp(&a.1));
+    by_rule.sort_by_key(|x| std::cmp::Reverse(x.1));
     summary.by_rule = by_rule;
 
     // Most recent first, limited
@@ -205,11 +205,11 @@ pub fn compute_disagreements(events: &[AuditEvent], limit: usize) -> Disagreemen
 
     // Sort by frequency descending
     let mut by_capture_rule: Vec<(String, usize)> = rule_map.into_iter().collect();
-    by_capture_rule.sort_by(|a, b| b.1.cmp(&a.1));
+    by_capture_rule.sort_by_key(|x| std::cmp::Reverse(x.1));
     summary.by_capture_rule = by_capture_rule;
 
     let mut by_pane: Vec<(String, usize)> = pane_map.into_iter().collect();
-    by_pane.sort_by(|a, b| b.1.cmp(&a.1));
+    by_pane.sort_by_key(|x| std::cmp::Reverse(x.1));
     summary.by_pane = by_pane;
 
     // Most recent first, limited
@@ -295,7 +295,7 @@ pub fn compute_validation_stats(events: &[AuditEvent]) -> ValidationSummary {
 
     // Sort rules by frequency descending
     let mut by_rule: Vec<(String, usize)> = rule_map.into_iter().collect();
-    by_rule.sort_by(|a, b| b.1.cmp(&a.1));
+    by_rule.sort_by_key(|x| std::cmp::Reverse(x.1));
     summary.capture_disagreements_by_rule = by_rule;
 
     summary

--- a/crates/tmai-core/src/auto_approve/service.rs
+++ b/crates/tmai-core/src/auto_approve/service.rs
@@ -223,12 +223,12 @@ impl AutoApproveService {
                         let tracker = flight_tracker.lock();
                         match tracker.get(target) {
                             Some(FlightStatus::InFlight) => continue,
-                            Some(FlightStatus::Cooldown(since)) => {
-                                if since.elapsed() < cooldown_duration {
-                                    continue;
-                                }
+                            Some(FlightStatus::Cooldown(since))
+                                if since.elapsed() < cooldown_duration =>
+                            {
+                                continue;
                             }
-                            None => {}
+                            _ => {}
                         }
                     }
 

--- a/crates/tmai-core/src/security/scanner.rs
+++ b/crates/tmai-core/src/security/scanner.rs
@@ -82,7 +82,7 @@ impl ConfigAuditScanner {
         }
 
         // Sort by severity descending (Critical first)
-        risks.sort_by(|a, b| b.severity.cmp(&a.severity));
+        risks.sort_by_key(|r| std::cmp::Reverse(r.severity));
 
         ScanResult {
             risks,

--- a/crates/tmai-core/src/session_lookup/lookup.rs
+++ b/crates/tmai-core/src/session_lookup/lookup.rs
@@ -62,7 +62,7 @@ fn list_recent_jsonl_files(project_dir: &PathBuf, max_count: usize) -> Vec<(Path
         .collect();
 
     // Sort by mtime descending (newest first)
-    files.sort_by(|a, b| b.1.cmp(&a.1));
+    files.sort_by_key(|f| std::cmp::Reverse(f.1));
     files.truncate(max_count);
     files
 }

--- a/crates/tmai-core/src/session_lookup/phrase.rs
+++ b/crates/tmai-core/src/session_lookup/phrase.rs
@@ -48,7 +48,7 @@ pub fn extract_phrases(content: &str, max_phrases: usize) -> Vec<String> {
     }
 
     // Sort by score descending (most distinctive first)
-    candidates.sort_by(|a, b| b.0.cmp(&a.0));
+    candidates.sort_by_key(|c| std::cmp::Reverse(c.0));
 
     // Deduplicate similar phrases
     let mut result = Vec::new();

--- a/src/ui/components/team_overview.rs
+++ b/src/ui/components/team_overview.rs
@@ -127,11 +127,7 @@ impl TeamOverview {
                     .iter()
                     .filter(|t| t.status == TaskStatus::InProgress)
                     .count();
-                let percent = if total_tasks > 0 {
-                    (done * 100) / total_tasks
-                } else {
-                    0
-                };
+                let percent = (done * 100).checked_div(total_tasks).unwrap_or(0);
 
                 let bar = Self::build_progress_bar(done, in_progress, total_tasks, 20);
                 lines.push(Line::from(vec![

--- a/src/web/api.rs
+++ b/src/web/api.rs
@@ -1238,7 +1238,7 @@ pub async fn list_directories(
         });
     }
 
-    entries.sort_by(|a, b| a.name.to_lowercase().cmp(&b.name.to_lowercase()));
+    entries.sort_by_key(|a| a.name.to_lowercase());
     Ok(Json(entries))
 }
 


### PR DESCRIPTION
## Summary

- Rust 1.95 stable (released 2026-04-14) introduced new clippy lints that fire on pre-existing code in `main`. As a result, `cargo clippy -- -D warnings` now fails on every branch, blocking all 4 open PRs (#476, #477, #478, #479) on the `clippy` CI job alone — every other check (`check`, `test`, `fmt`, `web-build`, `frontend-check`, CodeRabbit) is green.
- Fixes the 11 lib errors + 2 bin errors so CI passes again. No behavioral change.

## Changes

- `unnecessary_sort_by`: replace `sort_by(|a, b| b.x.cmp(&a.x))` with `sort_by_key(|e| std::cmp::Reverse(e.x))` (9 call sites across `audit/analyze`, `api/state_snapshot`, `security/scanner`, `session_lookup/lookup`, `session_lookup/phrase`, `web/api`).
- `collapsible_match`: fold the nested `if since.elapsed() < cooldown_duration` inside the `Some(FlightStatus::Cooldown(since))` arm into a match guard in `auto_approve::service`.
- `manual_checked_ops`: replace the `if total_tasks > 0 { ... } else { 0 }` division in `ui::components::team_overview` with `checked_div(...).unwrap_or(0)`.

## Verification

- `cargo +1.95.0 clippy -- -D warnings` — clean ✅
- `cargo +1.95.0 test --lib` — 156 passed, 0 failed ✅
- `cargo fmt --check` — clean ✅

## Test plan

- [ ] CI `clippy` job passes
- [ ] CI `test`, `check`, `fmt` remain green
- [ ] After merge: rebase #476/#477/#478/#479 onto main and confirm their `clippy` checks turn green

🤖 Generated with [Claude Code](https://claude.com/claude-code)