### PR TITLE
fix: exclude title from agents fingerprint (kill spinner-driven SSE churn)

### DIFF
--- a/crates/tmai-core/src/api/events.rs
+++ b/crates/tmai-core/src/api/events.rs
@@ -389,7 +389,13 @@ impl TmaiCore {
     }
 
     /// Build a fingerprint over the current agent list, excluding volatile
-    /// fields (`last_update`) that change every poll regardless of phase.
+    /// fields that change on every poll regardless of real state transitions:
+    ///   - `last_update`: a wall-clock timestamp that tracks the poll loop, not state.
+    ///   - `title`: Claude Code prefixes the session title with an animated
+    ///     braille/symbol spinner glyph (e.g. ⠂ → ⠐ → ✳) that ticks several
+    ///     times per second. Without excluding it, every spinner frame looked
+    ///     like a real state delta and produced a 1-2 Hz `AgentsUpdated` stream
+    ///     that drove the WebUI into a self-DoS re-render loop.
     ///
     /// Matches the prior SSE-side dedup in `src/web/events.rs`; moving it
     /// here means all subscribers (TUI, Tauri, MCP, SSE) share one consistent
@@ -402,6 +408,7 @@ impl TmaiCore {
                 let mut v = serde_json::to_value(a).ok()?;
                 if let Some(obj) = v.as_object_mut() {
                     obj.remove("last_update");
+                    obj.remove("title");
                 }
                 Some(v)
             })


### PR DESCRIPTION
## Summary

- User-reproducible: open a Branch graph or agent Preview for a project with an active Claude Code agent → tab goes "Not responding" within seconds.
- Root cause, confirmed via SSE stream capture (measured 1.3 Hz `agents` events on an idle box with 2 agents): `compute_agents_fingerprint()` already excludes `last_update` but still includes `title`. Claude Code prefixes session titles with an animated braille/symbol spinner glyph (⠂/⠐/✳/…) that ticks 2–4×/s. Every spinner frame → new fingerprint → `CoreEvent::AgentsUpdated` → SSE broadcast → React re-render cascade.
- #481 / #482 / #483 memoized individual BranchGraph subtrees (LaneGraph, ActionPanel) and trimmed prop-churn. That reduced the blast radius but couldn't stop React from re-running at the `agents` prop boundary — only fixing it at the source does.

## Change

- One-line addition in `compute_agents_fingerprint`: remove `title` before fingerprinting, same mechanism as the existing `last_update` exclusion.
- Doc comment updated to record why.
- No API change; all subscribers (SSE/TUI/Tauri/MCP) share the same debounced signal and automatically benefit.

## Tradeoff

- UI's `title` display now only refreshes when **any other** field triggers an `AgentsUpdated` (phase / status / target / branch / etc.). For a real user-visible title change (session renamed, prompt subject updated), the next status flip propagates it. Sub-threshold spinner animation never propagates — which is the whole point.

## Verification

- `cargo +1.95.0 clippy -- -D warnings` — clean.
- `cargo test -p tmai-core api::events` — 7/7 pass, including existing `test_notify_agents_updated_dedups_same_fingerprint`.

## Test plan

- [ ] Rebuild tmai, open the Branch graph for the orchestrator project — tab stays responsive while spinner continues in sidebar.
- [ ] Confirm agent preview still updates when a real status transition fires (Processing → Idle, Idle → AwaitingApproval).
- [ ] Confirm `tmai` log no longer emits `AgentsUpdated` at 1–2 Hz on an idle system (check with `grep agents_updated` or SSE curl: `timeout 15 curl -sN /api/events?token=… | grep -c '^event: agents'` should be low single digits, not ~20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * エージェント更新イベントの不要な発火を削減し、システムの応答性を向上させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->