### PR TITLE
fix: exclude statusline-hook counters from agents fingerprint

### DIFF
--- a/crates/tmai-core/src/api/events.rs
+++ b/crates/tmai-core/src/api/events.rs
@@ -389,26 +389,49 @@ impl TmaiCore {
     }
 
     /// Build a fingerprint over the current agent list, excluding volatile
-    /// fields that change on every poll regardless of real state transitions:
-    ///   - `last_update`: a wall-clock timestamp that tracks the poll loop, not state.
+    /// fields that change on every poll regardless of real state transitions.
+    /// Keeping any of these in the fingerprint makes `AgentsUpdated` fire at
+    /// sub-threshold cadence (sometimes several Hz) and drives WebUI
+    /// consumers — BranchGraph, PreviewPanel — into a self-DoS re-render
+    /// loop that marks the Chrome tab Unresponsive within seconds.
+    ///
+    /// Excluded fields and why:
+    ///   - `last_update`: wall-clock poll timestamp, not state.
     ///   - `title`: Claude Code prefixes the session title with an animated
-    ///     braille/symbol spinner glyph (e.g. ⠂ → ⠐ → ✳) that ticks several
-    ///     times per second. Without excluding it, every spinner frame looked
-    ///     like a real state delta and produced a 1-2 Hz `AgentsUpdated` stream
-    ///     that drove the WebUI into a self-DoS re-render loop.
+    ///     spinner glyph (⠂/⠐/✳/…) that ticks several times per second.
+    ///   - `cost_usd`, `duration_ms`, `lines_added`, `lines_removed`,
+    ///     `context_used_pct`, `context_window_size`: statusline-hook
+    ///     counters that monotonically progress every tool call. They
+    ///     reflect activity but never a state transition the UI needs to
+    ///     re-layout for.
+    ///   - `cursor_x`, `cursor_y`: terminal cursor position, changes on
+    ///     every keystroke / redraw.
     ///
     /// Matches the prior SSE-side dedup in `src/web/events.rs`; moving it
     /// here means all subscribers (TUI, Tauri, MCP, SSE) share one consistent
     /// debounced signal.
     fn compute_agents_fingerprint(&self) -> String {
+        const VOLATILE_FIELDS: &[&str] = &[
+            "last_update",
+            "title",
+            "cost_usd",
+            "duration_ms",
+            "lines_added",
+            "lines_removed",
+            "context_used_pct",
+            "context_window_size",
+            "cursor_x",
+            "cursor_y",
+        ];
         let agents = self.list_agents();
         let stripped: Vec<serde_json::Value> = agents
             .iter()
             .filter_map(|a| {
                 let mut v = serde_json::to_value(a).ok()?;
                 if let Some(obj) = v.as_object_mut() {
-                    obj.remove("last_update");
-                    obj.remove("title");
+                    for f in VOLATILE_FIELDS {
+                        obj.remove(*f);
+                    }
                 }
                 Some(v)
             })


### PR DESCRIPTION
## Summary

Follow-up to #484 / #485. User reported projects with an active Claude Code agent still wedged even after those fixes; the correlation was "project with a running agent" (typically the tmai project with the orchestrator in it) rather than "project with PRs / issues / many branches" per se.

Root cause: `compute_agents_fingerprint` only excluded `last_update` and `title`. The Claude Code statusline hook updates several counter fields on every tool call — `cost_usd`, `duration_ms`, `lines_added`, `lines_removed`, `context_used_pct`, `context_window_size` — plus `cursor_x` / `cursor_y` on every keystroke/redraw. Those updates kept flipping the fingerprint, kicking a fresh `AgentsUpdated` each time, and driving the WebUI into the same re-render cascade #481–#485 tried to absorb downstream.

Projects **without** an active agent had no statusline updates, so their SSE stream was quiet and their panels opened fine. Orchestrator's own project received a statusline update every tool call it dispatched — exactly the observed "self-DoS on the project that contains the orchestrator".

## Change

Promote the volatile-field list to a `const VOLATILE_FIELDS` array in `compute_agents_fingerprint` and strip all of the statusline-hook counters + cursor coordinates alongside `last_update` and `title`:

```rust
const VOLATILE_FIELDS: &[&str] = &[
    "last_update",
    "title",
    "cost_usd",
    "duration_ms",
    "lines_added",
    "lines_removed",
    "context_used_pct",
    "context_window_size",
    "cursor_x",
    "cursor_y",
];
```

All subscribers (SSE / TUI / Tauri / MCP) share one debounced signal.

## Tradeoff

These fields are still served on demand via HTTP endpoints (`/api/agents`, usage views, etc.) and arrive in the *initial* SSE payload on subscribe. They just no longer trigger an extra `AgentsUpdated` event when they are the only thing that changed. Real state transitions (status/phase/target/branch/etc.) still fire normally and carry the latest values with them.

## Verification

- `cargo +1.95.0 clippy -- -D warnings` — clean.
- `cargo test -p tmai-core api::events` — 7/7 pass, including existing dedup test.

## Test plan

- [ ] Rebuild tmai, open Branch graph / Preview for the tmai project (orchestrator active) — confirm tab stays responsive through sustained orchestrator activity.
- [ ] Confirm real status transitions (Idle → Processing → AwaitingApproval) still propagate to the UI.
- [ ] Confirm `curl -sN /api/events | grep -c '^event: agents'` counts are in single digits over 15 seconds on an idle+busy mix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)