### PR TITLE
feat(ci): Phase 1 — release bundle + build/validate/pages workflow skeletons

### DIFF
--- a/.github/workflows/build-ratatui.yml
+++ b/.github/workflows/build-ratatui.yml
@@ -1,0 +1,46 @@
+name: Build ratatui
+
+on:
+  pull_request:
+    paths:
+      - "clients/ratatui/**"
+      - "api-spec/**"
+      - ".github/workflows/build-ratatui.yml"
+  push:
+    branches: [main]
+    paths:
+      - "clients/ratatui/**"
+      - ".github/workflows/build-ratatui.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy, rustfmt
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: clients/ratatui
+
+      - name: Format check
+        working-directory: clients/ratatui
+        run: cargo fmt --check
+
+      - name: Clippy
+        working-directory: clients/ratatui
+        run: cargo clippy --all-targets -- -D warnings
+
+      - name: Test
+        working-directory: clients/ratatui
+        run: cargo test
+
+      - name: Build
+        working-directory: clients/ratatui
+        run: cargo build --release

--- a/.github/workflows/build-ratatui.yml
+++ b/.github/workflows/build-ratatui.yml
@@ -5,12 +5,10 @@ on:
     paths:
       - "clients/ratatui/**"
       - "api-spec/**"
-      - ".github/workflows/build-ratatui.yml"
   push:
     branches: [main]
     paths:
       - "clients/ratatui/**"
-      - ".github/workflows/build-ratatui.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -1,0 +1,52 @@
+name: Build React WebUI
+
+on:
+  pull_request:
+    paths:
+      - "clients/react/**"
+      - "api-spec/**"
+      - ".github/workflows/build-react.yml"
+  push:
+    branches: [main]
+    paths:
+      - "clients/react/**"
+      - ".github/workflows/build-react.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: clients/react/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: clients/react
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check
+        working-directory: clients/react
+        run: pnpm tsc --noEmit
+
+      - name: Lint
+        working-directory: clients/react
+        run: pnpm lint
+
+      - name: Test
+        working-directory: clients/react
+        run: pnpm test
+
+      - name: Build
+        working-directory: clients/react
+        run: pnpm build

--- a/.github/workflows/build-react.yml
+++ b/.github/workflows/build-react.yml
@@ -5,12 +5,10 @@ on:
     paths:
       - "clients/react/**"
       - "api-spec/**"
-      - ".github/workflows/build-react.yml"
   push:
     branches: [main]
     paths:
       - "clients/react/**"
-      - ".github/workflows/build-react.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -28,16 +28,19 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: "20"
+          cache: npm
+          cache-dependency-path: api-spec/package-lock.json
 
-      - name: Install Redocly CLI
-        run: npm install -g @redocly/cli
+      - name: Install API spec dependencies
+        working-directory: api-spec
+        run: npm ci
 
       - name: Build static docs
         shell: bash
         run: |
           set -euo pipefail
           mkdir -p _site
-          npx @redocly/cli build-docs api-spec/openapi.json --output _site/index.html
+          ./api-spec/node_modules/.bin/redocly build-docs api-spec/openapi.json --output _site/index.html
           if [[ -d api-spec/docs ]]; then
             cp -R api-spec/docs/. _site/
           fi

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,53 @@
+name: GitHub Pages (API spec docs)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "api-spec/**"
+      - ".github/workflows/pages.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Install Redocly CLI
+        run: npm install -g @redocly/cli
+
+      - name: Build static docs
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p _site
+          npx @redocly/cli build-docs api-spec/openapi.json --output _site/index.html
+          if [[ -d api-spec/docs ]]; then
+            cp -R api-spec/docs/. _site/
+          fi
+
+      - uses: actions/configure-pages@v5
+
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: _site
+
+      - id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - "api-spec/**"
-      - ".github/workflows/pages.yml"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,286 @@
+name: Release
+
+# tmai bundle release. Triggered by v* tag push on this (hub) repo.
+#
+# Flow:
+#   1. fetch-core   — download tmai-core binary for each target from tmai-core private Release
+#                     (tag: core-v<versions.toml:core>)
+#   2. build-webui  — pnpm build clients/react/ → dist/
+#   3. build-ratatui — cargo build clients/ratatui/ per matrix target
+#   4. bundle        — assemble 1 tarball per target (bin/tmai + bin/tmai-ratatui +
+#                      share/tmai/webui/ + share/tmai/api-spec/ + LICENSE + README)
+#   5. publish       — create/update GitHub Release on this repo, upload assets
+#
+# Secrets required:
+#   - TMAI_CORE_ARTIFACT_TOKEN — fine-grained PAT with `contents:read` on trust-delta/tmai-core
+#
+# NOTE: Phase 1 skeleton. Until Phase 2 lands clients/ and api-spec/ into this repo,
+# tag pushes will fail the build stages. Do not cut v* tags before Phase 2 completes.
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Manual version (without v prefix) for dry-run"
+        required: true
+
+permissions:
+  contents: write
+
+jobs:
+  fetch-core:
+    name: Fetch tmai-core binary (${{ matrix.target }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Read core version from versions.toml
+        id: versions
+        shell: bash
+        run: |
+          set -euo pipefail
+          core=$(grep -E '^core[[:space:]]*=' versions.toml | sed -E 's/.*"([^"]+)".*/\1/')
+          if [[ -z "${core}" || "${core}" == "0.0.0" ]]; then
+            echo "::error::versions.toml:core is unset or placeholder (0.0.0)"
+            exit 1
+          fi
+          echo "core=${core}" >> "$GITHUB_OUTPUT"
+
+      - name: Download tmai-core binary from private Release
+        env:
+          GH_TOKEN: ${{ secrets.TMAI_CORE_ARTIFACT_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          core_version="${{ steps.versions.outputs.core }}"
+          tag="core-v${core_version}"
+          asset="tmai-${core_version}-${{ matrix.target }}.tar.gz"
+          mkdir -p core-artifacts
+          gh release download "${tag}" \
+            --repo trust-delta/tmai-core \
+            --pattern "${asset}" \
+            --dir core-artifacts/
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: core-${{ matrix.target }}
+          path: core-artifacts/
+
+  build-webui:
+    name: Build WebUI dist
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: clients/react/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: clients/react
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        working-directory: clients/react
+        run: pnpm build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: webui-dist
+          path: clients/react/dist/
+
+  build-ratatui:
+    name: Build ratatui (${{ matrix.target }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: false
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            cross: true
+          - target: aarch64-apple-darwin
+            os: macos-14
+            cross: false
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: clients/ratatui
+          key: release-ratatui-${{ matrix.target }}
+
+      - name: Install cross
+        if: matrix.cross
+        run: cargo install cross --locked
+
+      - name: Build (native)
+        if: ${{ !matrix.cross }}
+        working-directory: clients/ratatui
+        run: cargo build --release --target ${{ matrix.target }}
+
+      - name: Build (cross)
+        if: matrix.cross
+        working-directory: clients/ratatui
+        run: cross build --release --target ${{ matrix.target }}
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: ratatui-${{ matrix.target }}
+          path: clients/ratatui/target/${{ matrix.target }}/release/tmai-ratatui
+
+  bundle:
+    name: Bundle (${{ matrix.target }})
+    needs: [fetch-core, build-webui, build-ratatui]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - aarch64-unknown-linux-gnu
+          - aarch64-apple-darwin
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          fi
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: core-${{ matrix.target }}
+          path: downloads/core/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: webui-dist
+          path: downloads/webui/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: ratatui-${{ matrix.target }}
+          path: downloads/ratatui/
+
+      - name: Assemble tarball
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${{ steps.version.outputs.version }}"
+          target="${{ matrix.target }}"
+          staging="tmai-v${version}"
+
+          mkdir -p \
+            "${staging}/bin" \
+            "${staging}/share/tmai/webui" \
+            "${staging}/share/tmai/api-spec"
+
+          # Extract core binary from tmai-core tarball.
+          # tmai-core's current tarball layout places `tmai` under staging/tmai/tmai
+          # (see tmai-core/.github/workflows/release.yml — `tar czf "${staging}.tar.gz" "${staging}"`).
+          # Flatten it here.
+          core_tarball=$(ls downloads/core/*.tar.gz | head -1)
+          tar xzf "${core_tarball}" -C downloads/core/
+          core_bin=$(find downloads/core/ -type f -name tmai -perm -u+x | head -1)
+          cp "${core_bin}" "${staging}/bin/tmai"
+          chmod +x "${staging}/bin/tmai"
+
+          # Copy ratatui binary (single file artifact).
+          cp downloads/ratatui/tmai-ratatui "${staging}/bin/"
+          chmod +x "${staging}/bin/tmai-ratatui"
+
+          # Copy WebUI dist (recursive).
+          cp -R downloads/webui/. "${staging}/share/tmai/webui/"
+
+          # Copy api-spec reference snapshots.
+          cp api-spec/openapi.json "${staging}/share/tmai/api-spec/"
+          cp api-spec/corevents.schema.json "${staging}/share/tmai/api-spec/"
+
+          # Top-level docs.
+          cp LICENSE "${staging}/"
+          cp README.md "${staging}/"
+
+          # Archive + checksum.
+          archive="tmai-v${version}-${target}.tar.gz"
+          tar czf "${archive}" "${staging}"
+          shasum -a 256 "${archive}" > "${archive}.sha256"
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: bundle-${{ matrix.target }}
+          path: |
+            tmai-v${{ steps.version.outputs.version }}-${{ matrix.target }}.tar.gz
+            tmai-v${{ steps.version.outputs.version }}-${{ matrix.target }}.tar.gz.sha256
+
+  publish:
+    name: Publish GitHub Release
+    needs: bundle
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version
+        id: version
+        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+
+      - uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+          pattern: bundle-*
+          merge-multiple: true
+
+      - name: Create or update Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          tag="v${{ steps.version.outputs.version }}"
+          notes="Automated tmai bundle release for ${tag}."
+
+          if ! gh release view "${tag}" >/dev/null 2>&1; then
+            gh release create "${tag}" \
+              --title "tmai ${tag}" \
+              --notes "${notes}" \
+              --draft=false \
+              --prerelease=false
+          fi
+
+          gh release upload "${tag}" \
+            --clobber \
+            artifacts/*.tar.gz \
+            artifacts/*.tar.gz.sha256

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ on:
         required: true
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   fetch-core:
@@ -44,17 +44,31 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Read core version from versions.toml
+      - name: Read versions from versions.toml
         id: versions
         shell: bash
         run: |
           set -euo pipefail
-          core=$(grep -E '^core[[:space:]]*=' versions.toml | sed -E 's/.*"([^"]+)".*/\1/')
-          if [[ -z "${core}" || "${core}" == "0.0.0" ]]; then
-            echo "::error::versions.toml:core is unset or placeholder (0.0.0)"
-            exit 1
-          fi
-          echo "core=${core}" >> "$GITHUB_OUTPUT"
+          read_version() {
+            local key="$1"
+            local val
+            val=$(grep -E "^${key}[[:space:]]*=" versions.toml | sed -E 's/.*"([^"]+)".*/\1/')
+            if [[ -z "${val}" || "${val}" == "0.0.0" ]]; then
+              echo "::error::versions.toml:${key} is unset or placeholder (0.0.0)" >&2
+              return 1
+            fi
+            printf '%s' "${val}"
+          }
+          core=$(read_version core)
+          react=$(read_version react)
+          ratatui=$(read_version ratatui)
+          api_spec=$(read_version api_spec)
+          {
+            echo "core=${core}"
+            echo "react=${react}"
+            echo "ratatui=${ratatui}"
+            echo "api_spec=${api_spec}"
+          } >> "$GITHUB_OUTPUT"
 
       - name: Download tmai-core binary from private Release
         env:
@@ -172,11 +186,17 @@ jobs:
         id: version
         shell: bash
         run: |
+          set -euo pipefail
           if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
-            echo "version=${{ github.event.inputs.version }}" >> "$GITHUB_OUTPUT"
+            version="${{ github.event.inputs.version }}"
           else
-            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+            version="${GITHUB_REF#refs/tags/v}"
           fi
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid release version: ${version}"
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/download-artifact@v4
         with:
@@ -255,7 +275,15 @@ jobs:
 
       - name: Extract version
         id: version
-        run: echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+        shell: bash
+        run: |
+          set -euo pipefail
+          version="${GITHUB_REF#refs/tags/v}"
+          if [[ ! "${version}" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid release version: ${version}"
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
 
       - uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/types-drift.yml
+++ b/.github/workflows/types-drift.yml
@@ -1,0 +1,39 @@
+name: Types Drift Check
+
+# Ensures that generated TypeScript types under clients/react/src/types/generated/
+# and the hand-written WebUI code stay in sync. Any PR touching either the
+# generated types or the api-spec is gated on a successful type check.
+
+on:
+  pull_request:
+    paths:
+      - "api-spec/**"
+      - "clients/react/src/types/generated/**"
+      - ".github/workflows/types-drift.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: pnpm
+          cache-dependency-path: clients/react/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: clients/react
+        run: pnpm install --frozen-lockfile
+
+      - name: Type check (fails if generated types break the build)
+        working-directory: clients/react
+        run: pnpm tsc --noEmit

--- a/.github/workflows/types-drift.yml
+++ b/.github/workflows/types-drift.yml
@@ -9,7 +9,6 @@ on:
     paths:
       - "api-spec/**"
       - "clients/react/src/types/generated/**"
-      - ".github/workflows/types-drift.yml"
 
 permissions:
   contents: read

--- a/.github/workflows/validate-spec.yml
+++ b/.github/workflows/validate-spec.yml
@@ -1,0 +1,39 @@
+name: Validate API Spec
+
+on:
+  pull_request:
+    paths:
+      - "api-spec/**"
+      - ".github/workflows/validate-spec.yml"
+  push:
+    branches: [main]
+    paths:
+      - "api-spec/**"
+      - ".github/workflows/validate-spec.yml"
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+          cache-dependency-path: api-spec/package-lock.json
+
+      - name: Install dependencies
+        working-directory: api-spec
+        run: npm ci
+
+      - name: Redocly lint
+        working-directory: api-spec
+        run: npx @redocly/cli lint openapi.json
+
+      - name: AJV validate fixtures
+        working-directory: api-spec
+        run: node tests/validate.mjs

--- a/.github/workflows/validate-spec.yml
+++ b/.github/workflows/validate-spec.yml
@@ -4,12 +4,10 @@ on:
   pull_request:
     paths:
       - "api-spec/**"
-      - ".github/workflows/validate-spec.yml"
   push:
     branches: [main]
     paths:
       - "api-spec/**"
-      - ".github/workflows/validate-spec.yml"
 
 permissions:
   contents: read

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@ web/tsconfig.tsbuildinfo
 crates/tmai-app/web/node_modules/
 crates/tmai-app/web/tsconfig.tsbuildinfo
 
+# dev/tmai-app branch source tree — lives only on dev/tmai-app, should not
+# surface as untracked when hub branches are checked out in the same worktree.
+/crates/tmai-app/
+
 # AI assistants
 CLAUDE.md
 .claude/

--- a/versions.toml
+++ b/versions.toml
@@ -1,0 +1,12 @@
+# Bundle version pin for tmai release tarball assembly.
+# Read by .github/workflows/release.yml during `v*` tag builds.
+# Each key points to the exact upstream version that ships bundled in a given
+# tmai release.
+#
+# Phase 1 placeholder values — real versions land with Phase 2 (monorepo
+# integration) and Phase 4 (first dry-run release).
+
+core = "0.0.0"      # tmai-core private Release (core-v* tag)
+react = "0.0.0"     # clients/react package version
+ratatui = "0.0.0"   # clients/ratatui crate version
+api_spec = "0.0.0"  # api-spec/openapi.json info.version


### PR DESCRIPTION
## Summary

Phase 1 skeleton for the 2026-04-21 monorepo re-consolidation (tmai-core private + tmai hub = release subject). Puts the release pipeline scaffolding on this repo ahead of Phase 2 (subtree integration of `clients/react/`, `clients/ratatui/`, and `api-spec/`).

Paired with the tmai-core-side change that retargets `core-v*` tags to an internal Release (separate PR on the private repo).

## Contents

- `versions.toml` — flat TOML pinning `core` / `react` / `ratatui` / `api_spec` versions. Placeholder `0.0.0` until Phase 2.
- `.github/workflows/release.yml` — `v*` tag → fetch-core (private Release via PAT) → build-webui + build-ratatui matrix → bundle → publish
- `.github/workflows/validate-spec.yml` — AJV + Redocly lint for api-spec
- `.github/workflows/build-react.yml` — pnpm install / type-check / lint / test / build
- `.github/workflows/build-ratatui.yml` — cargo fmt / clippy / test / build
- `.github/workflows/types-drift.yml` — TS build integrity when generated types or api-spec change
- `.github/workflows/pages.yml` — api-spec → Redocly docs → GitHub Pages

## Runtime impact

**None.** All workflows are gated on `paths:` filters or tag triggers whose targets (`clients/`, `api-spec/`, `v*` tags) do not yet exist in this repo. Phase 2 (subtree add) lights them up.

## Secrets required before first real release

- \`TMAI_CORE_ARTIFACT_TOKEN\` — fine-grained PAT with \`contents:read\` on \`trust-delta/tmai-core\` (for release.yml fetch-core step)
- GitHub Pages enabled on this repo + environment \`github-pages\`

## Deferred (Phase 1b, separate session)

- \`/api/version\` endpoint on tmai-core (runtime version negotiation)
- Dedicated \`gen-openapi\` / \`gen-schema\` / \`gen-mcp-snapshot\` / \`gen-ts-types\` bin crates on tmai-core, plus the \`gen-spec-pr.yml\` workflow that pushes their output as a PR to this repo

## Test plan

- [ ] Merge Phase 1 PR here + paired tmai-core PR without cutting any v* / core-v* tag (skeletons stay dormant)
- [ ] After Phase 2 subtree integration, confirm build-react / build-ratatui / validate-spec pick up their new targets on a pseudo-PR
- [ ] After Phase 4, dry-run \`core-v0.0.1\` → \`v0.0.1\` end-to-end in a fork before the real cut

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * CI/CD パイプラインの自動化ワークフローを追加しました。複数のクライアント（Ratatui、React）のビルド、テスト、リリース処理を自動化します。
  * API仕様の検証と自動デプロイメント機能を追加しました。
  * 型定義ドリフト検出機能を追加し、破損した型定義を検出します。
  * バージョン管理とリリースアーティファクト構成用の設定ファイルを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->