### PR TITLE
feat(api-spec): mirror /api/version endpoint

### DIFF
--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "1.8.0"
+    "version": "1.9.0"
   },
   "servers": [
     {
@@ -179,6 +179,40 @@
           },
           "5XX": {
             "description": "Unexpected internal failure. Body is a `TmaiError` with `code: \"Internal\"` unless a more specific downstream code applies.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TmaiError" }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/version": {
+      "get": {
+        "tags": ["meta"],
+        "summary": "Runtime version info",
+        "description": "Returns the versions of the four independently-versioned bundle components so clients can detect drift between what they were compiled against and what they are actually talking to. `tmai_version` and `api_spec_version` are populated only when the server runs from a hub-assembled bundle (env-var injection at launch); a standalone `cargo run` returns them as `null`, which is expected, not an error.",
+        "operationId": "get_version",
+        "responses": {
+          "200": {
+            "description": "Version metadata for the bundle.",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/VersionResponse" }
+              }
+            }
+          },
+          "4XX": {
+            "description": "Request failed at a tmai contract boundary (e.g. invalid auth token).",
+            "content": {
+              "application/json": {
+                "schema": { "$ref": "#/components/schemas/TmaiError" }
+              }
+            }
+          },
+          "5XX": {
+            "description": "Unexpected internal failure.",
             "content": {
               "application/json": {
                 "schema": { "$ref": "#/components/schemas/TmaiError" }
@@ -450,6 +484,29 @@
             "description": "Worktree path (from git)"
           }
         }
+      },
+      "VersionResponse": {
+        "type": "object",
+        "description": "Versions of the four independently-versioned bundle components. `core_version` and `error_taxonomy_version` are always present (owned by tmai-core itself); `tmai_version` and `api_spec_version` are nullable because they're injected by the hub release pipeline via env vars and absent in a standalone `cargo run`.",
+        "required": ["core_version", "error_taxonomy_version"],
+        "properties": {
+          "tmai_version": {
+            "type": ["string", "null"],
+            "description": "Version of the outer tmai bundle (hub release tag, e.g. `\"2.0.0\"`). Null when tmai-core runs standalone."
+          },
+          "core_version": {
+            "type": "string",
+            "description": "Version of the tmai-core engine (`env!(\"CARGO_PKG_VERSION\")`)."
+          },
+          "api_spec_version": {
+            "type": ["string", "null"],
+            "description": "Version of the api-spec contract (`api-spec/openapi.json:info.version`) the hub pinned for this bundle. Null when tmai-core runs standalone."
+          },
+          "error_taxonomy_version": {
+            "type": "string",
+            "description": "Version of the `ErrorCode` / `TmaiError` taxonomy. Bumped when variants or semantics change."
+          }
+        }
       }
     }
   },
@@ -461,6 +518,10 @@
     {
       "name": "prompt-queue",
       "description": "Per-agent send-prompt queue — enumerate and cancel queued prompts before delivery"
+    },
+    {
+      "name": "meta",
+      "description": "Runtime introspection — bundle versions, capability probes"
     }
   ]
 }

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -188,7 +188,7 @@
         }
       }
     },
-    "/version": {
+    "/api/version": {
       "get": {
         "tags": ["meta"],
         "summary": "Runtime version info",

--- a/versions.toml
+++ b/versions.toml
@@ -10,4 +10,4 @@
 core = "0.0.0"      # tmai-core private Release (core-v* tag) — Phase 1b
 react = "1.0.0"     # clients/react/package.json version
 ratatui = "0.1.0"   # clients/ratatui/Cargo.toml version
-api_spec = "1.8.0"  # api-spec/openapi.json info.version
+api_spec = "1.9.0"  # api-spec/openapi.json info.version


### PR DESCRIPTION
## Summary

Paired follow-up to [trust-delta/tmai-core#100](https://github.com/trust-delta/tmai-core/pull/100). Mirrors the runtime \`/api/version\` endpoint in the contract so clients can depend on the shape.

## Changes

- \`api-spec/openapi.json\`
  - \`/version\` path (GET) with \`VersionResponse\` \$ref
  - \`VersionResponse\` schema: 4 fields (core_version / error_taxonomy_version required; tmai_version / api_spec_version nullable for env-injected values)
  - \`meta\` tag for runtime-introspection endpoints
  - 4XX / 5XX TmaiError responses to match existing path conventions
  - \`info.version\` 1.8.0 → 1.9.0 (non-breaking addition)
- \`versions.toml\` — \`api_spec\` pin bumped to 1.9.0 in lockstep

## Local verification

- [x] \`redocly lint openapi.json\` — valid, no warnings
- [x] \`node tests/validate.mjs\` — all fixtures pass
- [ ] CI \`validate-spec\` confirms the same

## Contract ramp note

Hand-edited for now. Phase 1b's \`gen-openapi\` bin crate on tmai-core will eventually own this file and push PRs automatically, per the monorepo-reconsolidation plan.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ランタイム情報取得用の新しい `/version` エンドポイントが追加されました。このエンドポイントを使用して、APIコア、API仕様、タイムスタンプ情報などのバージョン情報を確認できます。

* **更新**
  * API仕様をバージョン 1.9.0 にアップデートしました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->