### PR TITLE
fix(tests): align fixtures + test with regenerated wire contract

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -84,9 +84,9 @@
       ]
     },
     "DetectionSource": {
-      "description": "How a state transition was detected.",
+      "description": "How a state transition was detected. Wire format is snake_case to match the contract-layer enums; PascalCase names are kept only as serde aliases on deserialize (see the Rust type's docstring).",
       "type": "string",
-      "enum": ["HttpHook", "IpcSocket", "WebSocket", "CapturePane"]
+      "enum": ["http_hook", "ipc_socket", "web_socket", "capture_pane"]
     },
     "GuardrailKind": {
       "description": "Type of guardrail that was exceeded.",

--- a/api-spec/tests/fixtures/corevents/invalid/vendor-availability-bad-state.json
+++ b/api-spec/tests/fixtures/corevents/invalid/vendor-availability-bad-state.json
@@ -3,5 +3,5 @@
   "vendor": "anthropic",
   "old": { "state": "typo_state" },
   "new": { "state": "available" },
-  "detected_via": "HttpHook"
+  "detected_via": "http_hook"
 }

--- a/api-spec/tests/fixtures/corevents/valid/vendor-availability-changed.json
+++ b/api-spec/tests/fixtures/corevents/valid/vendor-availability-changed.json
@@ -4,5 +4,5 @@
   "account": "team-main",
   "old": { "state": "available" },
   "new": { "state": "rate_limited", "resume_at": "2026-04-18T12:34:56Z" },
-  "detected_via": "HttpHook"
+  "detected_via": "http_hook"
 }

--- a/clients/react/src/components/agent/__tests__/PreviewPanel-queue.test.tsx
+++ b/clients/react/src/components/agent/__tests__/PreviewPanel-queue.test.tsx
@@ -36,7 +36,7 @@ const QUEUED: QueuedPrompt[] = [
     id: "q1",
     prompt: "run the tests",
     queued_at: "2026-04-20T10:00:00Z",
-    origin: { kind: "Agent", id: "main:0.0", is_orchestrator: true },
+    origin: { kind: "Agent", id: "main:0.0", is_orchestrator: true, cwd: null },
   },
 ];
 

--- a/clients/react/src/types/generated/ActionOrigin.ts
+++ b/clients/react/src/types/generated/ActionOrigin.ts
@@ -6,34 +6,41 @@
  * Used by the orchestrator notification middleware to provide context
  * about what triggered a side-effect API call.
  */
-export type ActionOrigin =
-  | {
-      kind: "Human";
-      /**
-       * Which interface: "webui", "tui", "mobile", "cli", etc.
-       */
-      interface: string;
-      /**
-       * Caller working directory — the currently-selected project root.
-       * Omitted when no project is selected (server accepts missing field via serde default).
-       */
-      cwd?: string;
-    }
-  | {
-      kind: "Agent";
-      /**
-       * Agent target ID (e.g., "main:0.0")
-       */
-      id: string;
-      /**
-       * Whether this agent is the orchestrator
-       */
-      is_orchestrator: boolean;
-    }
-  | {
-      kind: "System";
-      /**
-       * Subsystem name (e.g., "auto_cleanup", "pr_monitor")
-       */
-      subsystem: string;
-    };
+export type ActionOrigin = { "kind": "Human", 
+/**
+ * Which interface: "webui", "tui", "mobile", "cli", etc.
+ */
+interface: string, 
+/**
+ * Working directory of the UI request, used for project-scope routing (#89).
+ *
+ * The WebUI/TUI passes the cwd from the request body so
+ * `OrchestratorNotifier::source_project_scope` can scope notifications
+ * without needing the caller to be tracked in `state.agents`.
+ */
+cwd: string | null, } | { "kind": "Agent", 
+/**
+ * Agent target ID (e.g., "main:0.0")
+ */
+id: string, 
+/**
+ * Whether this agent is the orchestrator
+ */
+is_orchestrator: boolean, 
+/**
+ * Caller working directory at origin creation time (MCP loopback only).
+ *
+ * Set by `TmaiHttpClient::from_runtime` via `std::env::current_dir()` so
+ * `OrchestratorNotifier::source_project_scope` can resolve the project
+ * root when the MCP agent ID is not tracked in `state.agents` (#75).
+ */
+cwd: string | null, } | { "kind": "System", 
+/**
+ * Subsystem name (e.g., "auto_cleanup", "pr_monitor")
+ */
+subsystem: string, 
+/**
+ * Working directory of the originating subsystem process, used for
+ * project-scope routing (#89).
+ */
+cwd: string | null, };


### PR DESCRIPTION
## Summary

bot PR [#510](https://github.com/trust-delta/tmai/pull/510) (first run of the gen-spec-pr workflow on tmai-core) exposed three stale references to pre-migration contract shapes. Fixing them unblocks #510's CI.

## Changes

- **`DetectionSource` fixtures** (`api-spec/tests/fixtures/corevents/{valid,invalid}/vendor-availability-*.json`) — the enum serializes as `snake_case` now per the type's docstring (PascalCase is only a deserialization alias kept for persisted `MonitoredAgent` round-trips). Two fixtures still had `"HttpHook"`; updated to `"http_hook"`.
- **`ActionOrigin::Agent` fixture** (`clients/react/src/components/agent/__tests__/PreviewPanel-queue.test.tsx:39`) — `cwd: string | null` (#75) is exported as a required field by ts-rs. The test's `QUEUED[0].origin` predated the field; added `cwd: null` so tsc type-checks.

## Ordering

Merge this, then trigger the tmai-core `gen-spec-pr` workflow again via `workflow_dispatch` — the force-pushed #510 will pick up these fixture/test updates from hub main and its build+validate jobs should flip to green.

## Test plan

- [x] Local: `cp /tmp/new-corevents.schema.json api-spec/corevents.schema.json && node api-spec/tests/validate.mjs` (against the bot PR's regenerated schema) — all 11 valid + 4 invalid fixtures pass
- [ ] **After merge + workflow dispatch**: #510's `build` and `validate` jobs turn green

🤖 Generated with [Claude Code](https://claude.com/claude-code)