### PR TITLE
chore(versions): pin core=2.0.0 and api_spec=2.0.0 (Phase 4 dry-run)

### DIFF
--- a/versions.toml
+++ b/versions.toml
@@ -3,11 +3,10 @@
 # Each key points to the exact upstream version that ships bundled in a given
 # tmai release.
 #
-# core stays 0.0.0 until Phase 1b (tmai-core release.yml ships core-v* tags);
-# release.yml refuses to bundle while any key is 0.0.0, so the placeholder is
-# an active safety net, not a pending TODO.
+# release.yml refuses to bundle while any key is 0.0.0, so placeholders are
+# an active safety net rather than a pending TODO.
 
-core = "0.0.0"      # tmai-core private Release (core-v* tag) — Phase 1b
+core = "2.0.0"      # tmai-core private Release (core-v2.0.0 pushed 2026-04-22)
 react = "1.0.0"     # clients/react/package.json version
 ratatui = "0.1.0"   # clients/ratatui/Cargo.toml version
-api_spec = "1.9.0"  # api-spec/openapi.json info.version
+api_spec = "2.0.0"  # api-spec/openapi.json info.version


### PR DESCRIPTION
## Summary
Pin `versions.toml` ahead of the first Phase 4 dry-run of `release.yml`:

- `core`: `0.0.0` (placeholder) -> `2.0.0`
- `api_spec`: `1.9.0` -> `2.0.0`

The placeholder comment is trimmed to match the new state (versions aren't pending on Phase 1b anymore — Phase 1b/#106/#107 shipped, and the `core-v2.0.0` tag was pushed to trust-delta/tmai-core on 2026-04-22, triggering the private Release build).

`react` (1.0.0) and `ratatui` (0.1.0) are unchanged — they already match the respective source trees.

## Why each bump

### `core = 2.0.0`
`trust-delta/tmai-core` Cargo.toml sits at 2.0.0. The `core-v2.0.0` tag is the first real release tag under the monorepo re-consolidation contract (no `core-v*` existed before). Without this pin, `release.yml`'s `read_version` guard rejects any `v*` tag push here.

### `api_spec = 2.0.0`
`api-spec/openapi.json` was regenerated to `info.version = "2.0.0"` after the tmai-core 2.0.0 wire surface (DispatchId / DispatchRefs / CoreEvent payload expansion). Bot PR #510 carried the artifact; this just moves the version pin to match.

## Test plan
- [ ] `validate-spec.yml` passes on this PR
- [ ] Once merged, `release.yml` `workflow_dispatch` (version=2.0.0) completes `fetch-core`, `build-webui`, `build-ratatui`, `bundle` without `publish` (publish is gated by `github.event_name == 'push'`)

## Non-goals
- No `v*` tag push yet — this PR only unblocks the dry-run gate.
- `install.sh` (Phase 4 step C1) is a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **アップデート**
  * コアのバージョンを 2.0.0 に更新しました。
  * API スペックのバージョンを 2.0.0 に更新しました。
  * 関連するドキュメント記述を調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->