### PR TITLE
feat(install): add install.sh and point READMEs at it

### DIFF
--- a/README.ja.md
+++ b/README.ja.md
@@ -24,14 +24,27 @@
 
 ## インストール
 
-対応プラットフォームのバイナリリリースは本 repo の [Releases ページ](https://github.com/trust-delta/tmai/releases) に添付されます (linux x86_64 / linux aarch64 / macOS aarch64 — 配布時期は [`tmai-core#17`](https://github.com/trust-delta/tmai-core/issues/17) の後継タスクで管理)。
+対応プラットフォームのバンドル tarball は本 repo の [Releases](https://github.com/trust-delta/tmai/releases) に添付されます。install スクリプトがプラットフォームを自動判定し、SHA-256 を検証してから prefix 以下に展開します:
 
 ```bash
-# クイックインストール (Releases 公開後):
-curl -L https://github.com/trust-delta/tmai/releases/latest/download/tmai-$(uname -s | tr A-Z a-z)-$(uname -m).tar.gz | tar xz -C ~/.local/bin
+# 最新リリースを $HOME/.local (デフォルト prefix) に:
+curl -fsSL https://raw.githubusercontent.com/trust-delta/tmai/main/install.sh | bash
+
+# バージョンと prefix を指定:
+curl -fsSL https://raw.githubusercontent.com/trust-delta/tmai/main/install.sh \
+  | bash -s -- --version 2.0.0 --prefix /usr/local
 ```
 
-それまではソースビルドを利用してください — [`tmai-core` の getting-started](https://github.com/trust-delta/tmai-core/blob/main/doc/getting-started.md) 参照 (リポジトリ権限が必要)。
+展開先:
+
+```
+$PREFIX/bin/tmai
+$PREFIX/bin/tmai-ratatui
+$PREFIX/share/tmai/webui/       # tmai が binary 相対 fallback で自動配信
+$PREFIX/share/tmai/api-spec/    # OpenAPI + CoreEvent JSON Schema リファレンス
+```
+
+対応プラットフォーム: Linux x86_64、Linux aarch64、macOS arm64。他のプラットフォームは [`tmai-core`](https://github.com/trust-delta/tmai-core) でのソースビルド (リポジトリ権限が必要)。
 
 ## クイックスタート
 

--- a/README.md
+++ b/README.md
@@ -22,14 +22,27 @@
 
 ## Install
 
-Binary releases for supported platforms are attached to this repo's [Releases page](https://github.com/trust-delta/tmai/releases) (linux x86_64 / linux aarch64 / macOS aarch64 — ETA tracked in [`tmai-core#17`](https://github.com/trust-delta/tmai-core/issues/17) successor tasks).
+Prebuilt bundle tarballs are attached to this repo's [Releases](https://github.com/trust-delta/tmai/releases). The install script picks the right artefact for your platform, verifies the SHA-256, and lays the tree out under a prefix:
 
 ```bash
-# Quick install (planned — once Releases land):
-curl -L https://github.com/trust-delta/tmai/releases/latest/download/tmai-$(uname -s | tr A-Z a-z)-$(uname -m).tar.gz | tar xz -C ~/.local/bin
+# Latest release into $HOME/.local (default prefix):
+curl -fsSL https://raw.githubusercontent.com/trust-delta/tmai/main/install.sh | bash
+
+# Pinned version + custom prefix:
+curl -fsSL https://raw.githubusercontent.com/trust-delta/tmai/main/install.sh \
+  | bash -s -- --version 2.0.0 --prefix /usr/local
 ```
 
-Until then, build from source — see [`tmai-core`'s getting started guide](https://github.com/trust-delta/tmai-core/blob/main/doc/getting-started.md) (requires repository access).
+This installs:
+
+```
+$PREFIX/bin/tmai
+$PREFIX/bin/tmai-ratatui
+$PREFIX/share/tmai/webui/       # served automatically by tmai (binary-relative fallback)
+$PREFIX/share/tmai/api-spec/    # OpenAPI + CoreEvent JSON Schema reference
+```
+
+Supported platforms: Linux x86_64, Linux aarch64, macOS arm64. For other platforms, build from source in [`tmai-core`](https://github.com/trust-delta/tmai-core) (requires repository access).
 
 ## Quick start
 

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+# tmai installer
+#
+# Downloads the per-platform tmai bundle tarball from a GitHub Release,
+# verifies sha256, and installs under --prefix (default: $HOME/.local):
+#
+#   $PREFIX/bin/tmai
+#   $PREFIX/bin/tmai-ratatui
+#   $PREFIX/share/tmai/webui/
+#   $PREFIX/share/tmai/api-spec/
+#
+# tmai resolves the WebUI via the binary-relative fallback
+# <exe>/../share/tmai/webui/, so the layout above works without extra env.
+#
+# Usage:
+#   curl -fsSL https://raw.githubusercontent.com/trust-delta/tmai/main/install.sh | bash
+#   curl -fsSL https://raw.githubusercontent.com/trust-delta/tmai/main/install.sh | bash -s -- --version 2.0.0
+#   curl -fsSL https://raw.githubusercontent.com/trust-delta/tmai/main/install.sh | bash -s -- --prefix ~/.local
+
+set -euo pipefail
+
+REPO="trust-delta/tmai"
+PREFIX="${HOME}/.local"
+VERSION=""
+
+print_help() {
+  cat <<'HELP'
+tmai installer
+
+Usage:
+  curl -fsSL https://raw.githubusercontent.com/trust-delta/tmai/main/install.sh | bash
+  curl -fsSL https://raw.githubusercontent.com/trust-delta/tmai/main/install.sh | bash -s -- [OPTIONS]
+
+Options:
+  --version X.Y.Z   Install a specific version (default: latest release).
+  --prefix DIR      Install prefix (default: $HOME/.local).
+                    Places bin/tmai, bin/tmai-ratatui, and
+                    share/tmai/{webui,api-spec}/ under DIR.
+  --help, -h        Show this message.
+
+Supported platforms:
+  Linux  x86_64  (x86_64-unknown-linux-gnu)
+  Linux  aarch64 (aarch64-unknown-linux-gnu)
+  macOS  arm64   (aarch64-apple-darwin)
+HELP
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      [[ $# -ge 2 ]] || { echo "--version needs a value" >&2; exit 2; }
+      VERSION="$2"
+      shift 2
+      ;;
+    --prefix)
+      [[ $# -ge 2 ]] || { echo "--prefix needs a value" >&2; exit 2; }
+      PREFIX="$2"
+      shift 2
+      ;;
+    --help|-h)
+      print_help
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      echo "Run with --help for usage." >&2
+      exit 2
+      ;;
+  esac
+done
+
+need() {
+  command -v "$1" >/dev/null 2>&1 || { echo "Required command not found: $1" >&2; exit 1; }
+}
+need curl
+need tar
+need shasum
+
+uname_s=$(uname -s)
+uname_m=$(uname -m)
+case "${uname_s}:${uname_m}" in
+  Linux:x86_64)              target="x86_64-unknown-linux-gnu" ;;
+  Linux:aarch64|Linux:arm64) target="aarch64-unknown-linux-gnu" ;;
+  Darwin:arm64)              target="aarch64-apple-darwin" ;;
+  *)
+    echo "Unsupported platform: ${uname_s} ${uname_m}" >&2
+    echo "Supported: Linux x86_64, Linux aarch64, macOS arm64." >&2
+    exit 1
+    ;;
+esac
+
+if [[ -z "${VERSION}" ]]; then
+  echo "Resolving latest release tag..."
+  VERSION=$(
+    curl -fsSL "https://api.github.com/repos/${REPO}/releases/latest" \
+      | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v\{0,1\}\([^"]*\)".*/\1/p' \
+      | head -n1
+  )
+  if [[ -z "${VERSION}" ]]; then
+    echo "Failed to resolve latest release tag from ${REPO}." >&2
+    exit 1
+  fi
+fi
+
+archive="tmai-v${VERSION}-${target}.tar.gz"
+base="https://github.com/${REPO}/releases/download/v${VERSION}"
+
+tmp=$(mktemp -d)
+trap 'rm -rf "${tmp}"' EXIT
+
+echo "Downloading ${archive}..."
+curl -fsSL "${base}/${archive}"        -o "${tmp}/${archive}"
+curl -fsSL "${base}/${archive}.sha256" -o "${tmp}/${archive}.sha256"
+
+echo "Verifying sha256..."
+( cd "${tmp}" && shasum -c "${archive}.sha256" )
+
+echo "Extracting..."
+tar -xzf "${tmp}/${archive}" -C "${tmp}"
+staging="${tmp}/tmai-v${VERSION}"
+
+mkdir -p "${PREFIX}/bin" "${PREFIX}/share/tmai"
+cp -f "${staging}/bin/tmai"          "${PREFIX}/bin/tmai"
+cp -f "${staging}/bin/tmai-ratatui"  "${PREFIX}/bin/tmai-ratatui"
+chmod +x "${PREFIX}/bin/tmai" "${PREFIX}/bin/tmai-ratatui"
+
+rm -rf "${PREFIX}/share/tmai/webui" "${PREFIX}/share/tmai/api-spec"
+cp -R "${staging}/share/tmai/webui"     "${PREFIX}/share/tmai/webui"
+cp -R "${staging}/share/tmai/api-spec"  "${PREFIX}/share/tmai/api-spec"
+
+echo
+echo "tmai ${VERSION} installed at ${PREFIX}:"
+echo "  bin/tmai"
+echo "  bin/tmai-ratatui"
+echo "  share/tmai/webui/"
+echo "  share/tmai/api-spec/"
+echo
+case ":${PATH}:" in
+  *":${PREFIX}/bin:"*) ;;
+  *)
+    echo "Reminder: add ${PREFIX}/bin to your PATH, e.g."
+    echo "  echo 'export PATH=\"${PREFIX}/bin:\$PATH\"' >> ~/.bashrc"
+    ;;
+esac


### PR DESCRIPTION
## Summary
Phase 4 step C1 — land the `install.sh` that the READMEs are about to point at, so the v2.0.0 tag push can cut a consumable public release.

## Changes
- `install.sh`: curl-pipeable bash installer. Detects platform (Linux x86_64, Linux aarch64, macOS arm64), resolves the latest (or `--version`-pinned) GitHub Release tag on this repo, downloads the matching `tmai-v<version>-<target>.tar.gz` + `.sha256`, verifies integrity, extracts under `$PREFIX` (default `$HOME/.local`).
- `README.md` / `README.ja.md`: replace the placeholder "planned" install block with the real `curl … | bash` one-liner and document the resulting layout.

## Resulting layout
```
$PREFIX/bin/tmai
$PREFIX/bin/tmai-ratatui
$PREFIX/share/tmai/webui/       # served by tmai's binary-relative fallback
$PREFIX/share/tmai/api-spec/
```

This layout matches the tarball shape published by `.github/workflows/release.yml`, and lines up with tmai-core's `<exe>/../share/tmai/webui/` fallback (added in tmai-core#109 / Phase 3). No env or config edits needed post-install.

## Test plan
- [x] `bash -n install.sh` (syntax check)
- [x] `./install.sh --help` (prints usage)
- [ ] Manual after the v2.0.0 tag lands: `curl -fsSL .../install.sh | bash -s -- --prefix /tmp/tmai-test`, then `/tmp/tmai-test/bin/tmai --version` = `tmai-core 2.0.0`
- [ ] (optional) `--version` pinning path by re-running with an older tag once one exists

## Non-goals
- Updating the "Repositories" table in the READMEs to reflect the 2 repo / archive structure — separate PR to keep this one focused.
- Adding a `v2.0.0 — re-consolidation` section to `CHANGELOG.md` — separate PR.
- Homebrew tap / `cargo binstall` — tracked in the 2026-04-21 decision's open questions.

## Sequence
Merge this → push `v2.0.0` tag → release workflow publishes tarballs → `install.sh` becomes consumable via `raw.githubusercontent.com/.../main/install.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 新しいインストーラースクリプトを追加。プラットフォーム自動検出、SHA-256検証、カスタマイズ可能な設定先に対応しています。

* **ドキュメント**
  * インストール手順を更新。英語版・日本語版のREADMEを改善し、新インストーラーの使用方法と対応プラットフォーム（Linux x86_64、Linux aarch64、macOS arm64）を明記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->