### PR TITLE
Phase 2 (CI): contract consistency + generated drift safety net (#524)

### DIFF
--- a/.github/workflows/types-drift.yml
+++ b/.github/workflows/types-drift.yml
@@ -1,20 +1,56 @@
 name: Types Drift Check
 
-# Ensures that generated TypeScript types under clients/react/src/types/generated/
-# and the hand-written WebUI code stay in sync. Any PR touching either the
-# generated types or the api-spec is gated on a successful type check.
+# Ensures generated files under clients/*/src/types/generated/ and api-spec/
+# are never hand-edited, and that consuming code still compiles after any
+# generated update pushed by the sync bot.
 
 on:
   pull_request:
     paths:
       - "api-spec/**"
       - "clients/react/src/types/generated/**"
+      - "clients/ratatui/src/types/generated/**"
 
 permissions:
   contents: read
 
 jobs:
-  drift:
+  # Fail any human-authored PR that touches bot-managed generated paths.
+  # Bot-created PRs (user.login ends in "[bot]") are exempted so that the
+  # recovery flow — humans pushing consuming-code fixes onto a bot branch —
+  # can proceed without triggering this gate.
+  no-hand-edits:
+    runs-on: ubuntu-latest
+    if: "!contains(github.event.pull_request.user.login, '[bot]')"
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Detect hand edits in bot-managed paths
+        run: |
+          CHANGED=$(git diff --name-only "origin/${{ github.base_ref }}...HEAD")
+          VIOLATIONS=""
+          while IFS= read -r file; do
+            case "$file" in
+              clients/react/src/types/generated/*|\
+              clients/ratatui/src/types/generated/*|\
+              api-spec/*)
+                VIOLATIONS="${VIOLATIONS}  ${file}"$'\n'
+                ;;
+            esac
+          done <<< "$CHANGED"
+
+          if [ -n "$VIOLATIONS" ]; then
+            echo "::error::Hand edits detected in bot-managed paths."
+            echo "Affected files:"
+            echo "$VIOLATIONS"
+            echo "These paths are owned by the tmai-core sync bot."
+            echo "See CONTRIBUTING.md 'Bot-managed generated files' for the recovery flow."
+            exit 1
+          fi
+
+  ts-drift:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,3 +72,18 @@ jobs:
       - name: Type check (fails if generated types break the build)
         working-directory: clients/react
         run: pnpm tsc --noEmit
+
+  rust-drift:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: clients/ratatui
+
+      - name: Cargo check (fails if generated Rust types break the build)
+        working-directory: clients/ratatui
+        run: cargo check --all-targets

--- a/.github/workflows/types-drift.yml
+++ b/.github/workflows/types-drift.yml
@@ -51,6 +51,10 @@ jobs:
           fi
 
   ts-drift:
+    needs: no-hand-edits
+    # always() lets this run even when no-hand-edits was skipped (bot PRs);
+    # != 'failure' short-circuits when the hand-edit gate already failed.
+    if: always() && needs.no-hand-edits.result != 'failure'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -74,6 +78,8 @@ jobs:
         run: pnpm tsc --noEmit
 
   rust-drift:
+    needs: no-hand-edits
+    if: always() && needs.no-hand-edits.result != 'failure'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/CONTRIBUTING.ja.md
+++ b/CONTRIBUTING.ja.md
@@ -27,6 +27,63 @@
 - `versions.toml` — `release.yml` が読む bundle バージョン pin
 - `README.md` / `README.ja.md` / `CHANGELOG.md` / `LICENSE` / `assets/` — ランディング / ドキュメント / メディア
 
+## Bot 管理の生成ファイル
+
+以下のパスは `tmai-core` 同期 bot が書き込む専用領域です。**手編集は禁止**です：
+
+| パス | 内容 |
+|------|------|
+| `clients/react/src/types/generated/` | `tmai-core` の Rust ソースから生成した TypeScript 型 |
+| `clients/ratatui/src/types/generated/` | `tmai-core` からミラーされた Rust 型 |
+| `api-spec/` | OpenAPI spec / JSON Schema / MCP snapshot — すべて生成物 |
+
+CI はこれらのパスを人間の著者が変更した PR を reject します。
+PR で `Hand edits detected in bot-managed paths` エラーが出た場合は、
+該当ファイルの変更を取り除き、代わりに `tmai-core` 側に issue を立ててください。
+
+### Bot PR リカバリーフロー
+
+同期 bot PR が、生成物でリネーム・削除されたシンボルを参照している消費コードのせいで失敗した場合は、**消費コードだけを最小限修正**してください。生成ファイル自体は絶対に編集しないでください。
+
+**手順**
+
+1. bot ブランチをローカルに checkout する：
+   ```sh
+   git fetch origin
+   git checkout <bot-branch-name>
+   ```
+2. 壊れたシンボルを参照している消費ファイルだけを開いて参照を更新する。
+   `generated/` や `api-spec/` 以下は **一切触らない**。
+3. 同じ bot ブランチにコミット・プッシュする：
+   ```sh
+   git add <変更ファイル>
+   git commit -m "fix: update consuming code for <symbol rename>"
+   git push origin <bot-branch-name>
+   ```
+4. CI が自動で再実行されます。全ジョブが green になったらマージしてください。
+
+**実例 — PR #520 (`TaskMetaSnapshot` リネーム)**
+
+`tmai-core` が `TaskMetaEntry` → `TaskMetaSnapshot` にリネームしました。
+sync bot PR は生成ファイルを正しく更新しましたが、`src/types/index.ts` が
+旧名のまま再エクスポートしていたため TypeScript ビルドが壊れました。
+
+コミット `0a1443f` で適用した修正：
+```diff
+// clients/react/src/types/index.ts
+-export type { TaskMetaEntry } from "./generated/TaskMetaSnapshot";
++export type { TaskMetaSnapshot } from "./generated/TaskMetaSnapshot";
+```
+
+変更したのは `src/types/index.ts`（消費コード）のみで、生成ファイルには一切手を加えていません。
+
+### Phase 1 移行中の注意
+
+スナップショット契約移行の Phase 1 期間中は、React クライアントは
+**従来の `diff` スタイル CoreEvent** と **新しい `EntityUpdateEnvelope` ラッパー**
+の両方を受け取れるようにしておく必要があります。
+Phase 3 でレガシーパスを廃止する予定です。それまでは SSE イベントハンドラーで両方の分岐を維持してください。
+
 ## Issue
 
 上記リストの領域は本リポジトリに issue を提出してください。エンジン側のバグでも、まず本リポジトリに issue を立てていただければ再現・triage し、必要に応じてエンジン側へ引き継ぎます。

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,6 +27,66 @@ The previous sub-repos (`tmai-api-spec`, `tmai-react`, `tmai-ratatui`) were arch
 - `versions.toml` — bundle version pin read by `release.yml`
 - `README.md` / `README.ja.md` / `CHANGELOG.md` / `LICENSE` / `assets/` — landing / docs / media
 
+## Bot-managed generated files
+
+The following paths are written exclusively by the `tmai-core` sync bot and **must not be hand-edited**:
+
+| Path | Contents |
+|------|----------|
+| `clients/react/src/types/generated/` | TypeScript types generated from the Rust source in `tmai-core` |
+| `clients/ratatui/src/types/generated/` | Rust types mirrored from `tmai-core` |
+| `api-spec/` | OpenAPI spec, JSON Schema, MCP snapshot — all generated |
+
+CI rejects any PR where a human author touches these paths.  If you see a
+`Hand edits detected in bot-managed paths` failure on your PR, remove those
+file changes and open the issue in `tmai-core` instead.
+
+### Bot PR recovery flow
+
+When a sync bot PR fails because consuming code references a renamed or removed
+generated symbol, apply a **minimal fix to the consuming code** — never edit the
+generated files themselves.
+
+**Steps**
+
+1. Check out the bot branch locally:
+   ```sh
+   git fetch origin
+   git checkout <bot-branch-name>
+   ```
+2. Open only the consuming files that reference the broken symbol and update
+   the references.  Do **not** touch anything under `generated/` or `api-spec/`.
+3. Commit and push back to the same bot branch:
+   ```sh
+   git add <changed files>
+   git commit -m "fix: update consuming code for <symbol rename>"
+   git push origin <bot-branch-name>
+   ```
+4. CI re-runs automatically.  Merge once all jobs are green.
+
+**Worked example — PR #520 (`TaskMetaSnapshot` rename)**
+
+`tmai-core` renamed `TaskMetaEntry` → `TaskMetaSnapshot`.  The sync bot PR
+updated all generated files correctly, but `src/types/index.ts` still
+re-exported the old name and broke the TypeScript build.
+
+Fix applied in commit `0a1443f`:
+```diff
+// clients/react/src/types/index.ts
+-export type { TaskMetaEntry } from "./generated/TaskMetaSnapshot";
++export type { TaskMetaSnapshot } from "./generated/TaskMetaSnapshot";
+```
+
+Only `src/types/index.ts` (consuming code) was touched; the generated files
+were left untouched.
+
+### Phase 1 transition note
+
+During Phase 1 of the snapshot-contract migration the React client must accept
+**both** legacy `diff`-style CoreEvents **and** the new `EntityUpdateEnvelope`
+wrapper emitted by tmai-core ≥ the contract boundary.  Phase 3 will retire the
+legacy path; until then, keep both branches in SSE event handlers.
+
 ## Issues
 
 File issues here for anything in the list above. For engine-side bugs, still open the issue here — we'll reproduce / triage and hand it over to the engine side if needed.


### PR DESCRIPTION
## Summary

- **`no-hand-edits` CI job**: rejects any PR where a human author touches `clients/*/src/types/generated/` or `api-spec/`; bot-created PRs (`user.login` contains `[bot]`) are exempted so the recovery flow (humans pushing consuming-code fixes onto a bot branch) is not blocked
- **`rust-drift` CI job**: runs `cargo check --all-targets` on `clients/ratatui` when ratatui generated types or `api-spec` change — extends the existing TS drift check to Rust
- **Workflow trigger**: added `clients/ratatui/src/types/generated/**` to `on.pull_request.paths`
- **CONTRIBUTING.md / CONTRIBUTING.ja.md**: new "Bot-managed generated files" section with no-hand-edit rule, step-by-step recovery flow, worked example from PR #520 (`TaskMetaSnapshot` rename), and Phase 1 dual-path transition note

## Test plan

- [ ] Verify `no-hand-edits` job logic: a PR touching any file under `clients/react/src/types/generated/`, `clients/ratatui/src/types/generated/`, or `api-spec/` from a non-bot user should fail with a clear error message
- [ ] Verify bot-authored PRs (`user.login` ending in `[bot]`) skip `no-hand-edits`
- [ ] Verify `rust-drift` job runs `cargo check --all-targets` on `clients/ratatui`
- [ ] Verify `ts-drift` job still runs `pnpm tsc --noEmit` on `clients/react`
- [ ] Check CONTRIBUTING.md renders correctly with the new section

Closes #524

🤖 Generated with [Claude Code](https://claude.com/claude-code)