### PR TITLE
Phase 2 (React): drop derived calculations and consume new Snapshot types (#521)

### DIFF
--- a/clients/react/src/components/agent/AgentCard.tsx
+++ b/clients/react/src/components/agent/AgentCard.tsx
@@ -5,7 +5,6 @@ import {
   type ConnectionChannels,
   type DetectionSource,
   isAiAgent,
-  needsAttention,
   type SendCapability,
   statusName,
 } from "@/lib/api";
@@ -120,7 +119,7 @@ interface AgentCardProps {
 // Card displaying a single agent's status and info
 export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
   const name = statusName(agent.status);
-  const attention = needsAttention(agent.status);
+  const attention = agent.needs_attention ?? false;
   const typeInfo = agentTypeLabel(agent.agent_type);
   const isAi = isAiAgent(agent.agent_type);
   // Auto-approve state

--- a/clients/react/src/hooks/useAgents.ts
+++ b/clients/react/src/hooks/useAgents.ts
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useState } from "react";
-import { type AgentSnapshot, api, needsAttention } from "@/lib/api";
+import { type AgentSnapshot, api } from "@/lib/api";
 import { useSSE } from "@/lib/sse-provider";
 import { type CoreEvent, useTauriEvents } from "./useTauriEvents";
 
@@ -14,7 +14,7 @@ export function useAgents() {
     try {
       const agentList = await api.listAgents();
       setAgents(agentList);
-      setAttentionCount(agentList.filter((a) => needsAttention(a.status)).length);
+      setAttentionCount(agentList.filter((a) => a.needs_attention ?? false).length);
     } catch (_e) {
       // Server may not be ready yet during startup
     } finally {
@@ -48,7 +48,7 @@ export function useAgents() {
   useSSE({
     onAgents: (agentList) => {
       setAgents(agentList);
-      setAttentionCount(agentList.filter((a) => needsAttention(a.status)).length);
+      setAttentionCount(agentList.filter((a) => a.needs_attention ?? false).length);
       setLoading(false);
     },
   });

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -79,10 +79,6 @@ export function statusName(status: AgentStatus): string {
   return "Unknown";
 }
 
-export function needsAttention(status: AgentStatus): boolean {
-  const name = statusName(status);
-  return name === "AwaitingApproval" || name === "Error";
-}
 
 export type DetectionSource = "CapturePane" | "IpcSocket" | "HttpHook" | "WebSocket";
 export type SendCapability = "Ipc" | "Tmux" | "PtyInject" | "None";
@@ -168,6 +164,14 @@ export interface AgentSnapshot {
   model_id?: string | null;
   model_display_name?: string | null;
   is_orchestrator?: boolean;
+  // Derived fields computed by tmai-core (tmai-core@c40e8b8aa5, Phase 1)
+  needs_attention?: boolean;
+  display_label?: string;
+  has_queued_prompt?: boolean;
+  queued_prompt_count?: number;
+  has_pending_approval?: boolean;
+  primary_worktree_path?: string | null;
+  current_dispatch_id?: string | null;
 }
 
 // ── Prompt Queue ──
@@ -348,7 +352,7 @@ export function groupByProject(
       });
     }
 
-    const attentionCount = groupAgents.filter((a) => needsAttention(a.status)).length;
+    const attentionCount = groupAgents.filter((a) => a.needs_attention ?? false).length;
 
     const normRegistered = new Set(registeredProjects.map((p) => normalizeGitDir(p)));
 
@@ -846,7 +850,7 @@ export const api = {
   listAgents: () => apiFetch<AgentSnapshot[]>("/agents"),
   attentionCount: async () => {
     const agents = await apiFetch<AgentSnapshot[]>("/agents");
-    return agents.filter((a) => needsAttention(a.status)).length;
+    return agents.filter((a) => a.needs_attention ?? false).length;
   },
 
   // Agent actions

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -79,7 +79,6 @@ export function statusName(status: AgentStatus): string {
   return "Unknown";
 }
 
-
 export type DetectionSource = "CapturePane" | "IpcSocket" | "HttpHook" | "WebSocket";
 export type SendCapability = "Ipc" | "Tmux" | "PtyInject" | "None";
 

--- a/clients/react/src/types/index.ts
+++ b/clients/react/src/types/index.ts
@@ -5,8 +5,18 @@
 // them by hand — update tmai-api-spec and re-sync. See ./README.md.
 
 export type { ActionOrigin } from "./generated/ActionOrigin";
+export type { ApprovalSnapshot } from "./generated/ApprovalSnapshot";
+export type { BootstrapRequiredEvent } from "./generated/BootstrapRequiredEvent";
 export type { CoreEvent } from "./generated/CoreEvent";
+export type { DispatchSnapshot } from "./generated/DispatchSnapshot";
+export type { EntityChange } from "./generated/EntityChange";
+export type { EntityUpdateEnvelope } from "./generated/EntityUpdateEnvelope";
 export type { GuardrailKind } from "./generated/GuardrailKind";
 export type { Milestone } from "./generated/Milestone";
+export type { QueueSnapshot } from "./generated/QueueSnapshot";
+export type { RuntimeSnapshot } from "./generated/RuntimeSnapshot";
 export type { TaskMetaSnapshot } from "./generated/TaskMetaSnapshot";
+export type { TeamSnapshot } from "./generated/TeamSnapshot";
+export type { WorkflowSnapshot } from "./generated/WorkflowSnapshot";
 export type { WorktreeInfo } from "./generated/WorktreeInfo";
+export type { WorktreeSnapshot } from "./generated/WorktreeSnapshot";

--- a/clients/react/src/types/sse-event.ts
+++ b/clients/react/src/types/sse-event.ts
@@ -9,11 +9,37 @@
 // PascalCase variant name; the payload on the wire is the variant's fields
 // (flat, thanks to `#[serde(tag = "type")]`). We reconstruct the tagged
 // shape here to match `CoreEvent`.
+//
+// Phase 1 transition: the new Entity-Update variants (AgentUpdate,
+// DispatchUpdate, TeamUpdate, WorktreeUpdate, QueueUpdate, RuntimeUpdate)
+// coexist with legacy signal variants (AgentStatusChanged, AgentsUpdated,
+// etc.) — both shapes are in CoreEvent and accepted by asCoreEvent().
 
 import type { CoreEvent } from "./generated/CoreEvent";
 
 // All PascalCase discriminant values from CoreEvent.
 type CoreEventTag = CoreEvent extends { type: infer T } ? T : never;
+
+// Entity-Update variants introduced in Phase 1 (tmai-core@c40e8b8aa5).
+// These carry a full snapshot payload and replace the legacy signal events
+// for reactive state management. The sibling SSE/Bootstrap wiring sub-issue
+// wires up the actual snapshot consumption.
+const ENTITY_UPDATE_TAGS = [
+  "AgentUpdate",
+  "DispatchUpdate",
+  "TeamUpdate",
+  "WorktreeUpdate",
+  "QueueUpdate",
+  "RuntimeUpdate",
+] as const;
+
+type EntityUpdateTag = (typeof ENTITY_UPDATE_TAGS)[number];
+
+export type EntityUpdateEvent = Extract<CoreEvent, { type: EntityUpdateTag }>;
+
+export function isEntityUpdateEvent(event: CoreEvent): event is EntityUpdateEvent {
+  return (ENTITY_UPDATE_TAGS as readonly string[]).includes(event.type);
+}
 
 export function asCoreEvent(eventName: string, data: unknown): CoreEvent | null {
   if (data === null || typeof data !== "object") {


### PR DESCRIPTION
## Summary

Resolves #521. Phase 2 step 1: remove derived state calculations from React and consume the new Snapshot types generated by tmai-core@c40e8b8aa5.

- **Remove `needsAttention(status)` helper** — replaced at all three call sites (`groupByProject`, `api.attentionCount`, `useAgents`) with `agent.needs_attention ?? false` (field read). `AgentCard` updated likewise.
- **Add derived fields to `AgentSnapshot`** — `needs_attention`, `display_label`, `has_queued_prompt`, `queued_prompt_count`, `has_pending_approval`, `primary_worktree_path`, `current_dispatch_id` (all optional for backward compatibility during Phase 1 parallel emission).
- **Expand `types/index.ts` barrel** — surfaces the full new Snapshot type set: `ApprovalSnapshot`, `BootstrapRequiredEvent`, `DispatchSnapshot`, `EntityChange`, `EntityUpdateEnvelope`, `QueueSnapshot`, `RuntimeSnapshot`, `TeamSnapshot`, `WorkflowSnapshot`, `WorktreeSnapshot`.
- **`sse-event.ts` discriminator** — adds `EntityUpdateEvent` type alias and `isEntityUpdateEvent()` predicate for the six Entity-Update variants; `asCoreEvent()` unchanged (already accepts both new and legacy shapes via the updated `CoreEvent` union).

## Test plan

- [x] `pnpm tsc -b --noEmit` passes (0 errors)
- [x] `pnpm build` (`tsc -b && vite build`) succeeds
- [x] `pnpm test --run` — 193 tests pass across 24 test files

## Out of scope (separate sub-issues)

- SSE Entity-Update subscription / Bootstrap-based initial load / Resync protocol
- Polling removal in `useQueuedPrompts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)