### PR TITLE
Phase 2 (React): subscribe Entity-Update envelope + Bootstrap-based load (drop polling) (#522)

### DIFF
--- a/clients/react/src/components/agent/__tests__/PreviewPanel-interaction.test.tsx
+++ b/clients/react/src/components/agent/__tests__/PreviewPanel-interaction.test.tsx
@@ -10,6 +10,11 @@ global.ResizeObserver = class ResizeObserver {
 };
 Element.prototype.scrollIntoView = vi.fn();
 
+// ── mock @/lib/sse-provider — useSSE is a no-op in these unit tests ──
+vi.mock("@/lib/sse-provider", () => ({
+  useSSE: vi.fn(),
+}));
+
 vi.mock("@/lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/api")>();
   const hang = new Promise<never>(() => {});

--- a/clients/react/src/components/agent/__tests__/PreviewPanel-queue.test.tsx
+++ b/clients/react/src/components/agent/__tests__/PreviewPanel-queue.test.tsx
@@ -11,6 +11,11 @@ global.ResizeObserver = class ResizeObserver {
 };
 Element.prototype.scrollIntoView = vi.fn();
 
+// ── mock @/lib/sse-provider — useSSE is a no-op in these unit tests ──
+vi.mock("@/lib/sse-provider", () => ({
+  useSSE: vi.fn(),
+}));
+
 // ── mock @/lib/api ──
 vi.mock("@/lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/api")>();

--- a/clients/react/src/components/worktree/__tests__/sse-named-events.test.ts
+++ b/clients/react/src/components/worktree/__tests__/sse-named-events.test.ts
@@ -49,6 +49,11 @@ describe("subscribeSSE named-event registration (#470)", () => {
       // pass vacuously from a rewrite that dropped every listener.
       expect(events).toContain("pr_created");
       expect(events).toContain("agents");
+      // Phase 2: entity-update envelope events must be registered (#522)
+      expect(events).toContain("AgentUpdate");
+      expect(events).toContain("WorktreeUpdate");
+      expect(events).toContain("QueueUpdate");
+      expect(events).toContain("BootstrapRequired");
       sub.unlisten();
     } finally {
       vi.stubGlobal("EventSource", originalEventSource);

--- a/clients/react/src/hooks/__tests__/useQueuedPrompts.test.ts
+++ b/clients/react/src/hooks/__tests__/useQueuedPrompts.test.ts
@@ -10,6 +10,15 @@ vi.mock("@/lib/api", () => ({
   },
 }));
 
+// Mock sse-provider so useSSE is a no-op in unit tests.
+// The onEntityUpdate subscription is exercised in the integration test block below.
+let capturedSSEHandlers: Parameters<typeof import("@/lib/sse-provider").useSSE>[0] | null = null;
+vi.mock("@/lib/sse-provider", () => ({
+  useSSE: (handlers: unknown) => {
+    capturedSSEHandlers = handlers as Parameters<typeof import("@/lib/sse-provider").useSSE>[0];
+  },
+}));
+
 import type { QueuedPrompt } from "@/lib/api";
 import { api } from "@/lib/api";
 import { useQueuedPrompts } from "../useQueuedPrompts";
@@ -21,6 +30,7 @@ const ITEMS: QueuedPrompt[] = [
 
 describe("useQueuedPrompts", () => {
   beforeEach(() => {
+    capturedSSEHandlers = null;
     vi.mocked(api.getPromptQueue).mockResolvedValue(ITEMS);
     vi.mocked(api.cancelQueuedPrompt).mockResolvedValue({ status: "cancelled" });
   });
@@ -91,13 +101,20 @@ describe("useQueuedPrompts", () => {
     );
   });
 
-  it("registers a 3 s polling interval on mount", () => {
+  // Phase 2: polling replaced by SSE subscription
+  it("does NOT start a polling interval on mount (SSE-driven)", () => {
     const spy = vi.spyOn(global, "setInterval");
     const { unmount } = renderHook(() => useQueuedPrompts("agent-1"));
-    const intervals = spy.mock.calls.filter(([, ms]) => ms === 3000);
-    expect(intervals).toHaveLength(1);
+    const pollingIntervals = spy.mock.calls.filter(([, ms]) => ms === 3000);
+    expect(pollingIntervals).toHaveLength(0);
     unmount();
     spy.mockRestore();
+  });
+
+  it("registers an onEntityUpdate handler via useSSE", () => {
+    renderHook(() => useQueuedPrompts("agent-1"));
+    expect(capturedSSEHandlers).not.toBeNull();
+    expect(typeof capturedSSEHandlers?.onEntityUpdate).toBe("function");
   });
 
   // #9 — notifications must be surfaced separately from the conversation input
@@ -109,24 +126,21 @@ describe("useQueuedPrompts", () => {
       const { result } = renderHook(() => useQueuedPrompts("agent-1", onNewItem));
       await waitFor(() => expect(result.current.items).toHaveLength(1));
 
-      // First poll: both items are new
+      // First fetch: item is new
       expect(onNewItem).toHaveBeenCalledTimes(1);
       expect(onNewItem).toHaveBeenCalledWith(ITEMS[0]);
     });
 
-    it("does NOT fire again for items already seen on a subsequent poll", async () => {
+    it("does NOT fire again for items already seen on a subsequent refresh", async () => {
       const onNewItem = vi.fn();
-      // First poll returns item 1
       vi.mocked(api.getPromptQueue)
         .mockResolvedValueOnce([ITEMS[0]])
-        // Second poll returns same item 1
         .mockResolvedValue([ITEMS[0]]);
 
       const { result } = renderHook(() => useQueuedPrompts("agent-1", onNewItem));
       await waitFor(() => expect(result.current.items).toHaveLength(1));
       expect(onNewItem).toHaveBeenCalledTimes(1);
 
-      // Trigger a manual refresh (simulates the 3-second interval)
       await act(async () => {
         await result.current.refresh();
       });
@@ -136,10 +150,8 @@ describe("useQueuedPrompts", () => {
 
     it("fires for each genuinely new item when the queue grows", async () => {
       const onNewItem = vi.fn();
-      // First poll: empty queue
       vi.mocked(api.getPromptQueue)
         .mockResolvedValueOnce([])
-        // Second poll: two new items
         .mockResolvedValue(ITEMS);
 
       const { result } = renderHook(() => useQueuedPrompts("agent-1", onNewItem));
@@ -154,8 +166,6 @@ describe("useQueuedPrompts", () => {
       expect(onNewItem).toHaveBeenCalledWith(ITEMS[1]);
     });
 
-    // Guards against UUID collisions across agents and preserves the
-    // "fire for genuinely new arrivals" contract as a per-agent invariant.
     it("resets seen IDs when agentId changes so onNewItem fires for the new agent's queue", async () => {
       const onNewItem = vi.fn();
       vi.mocked(api.getPromptQueue).mockResolvedValue([ITEMS[0]]);
@@ -174,6 +184,93 @@ describe("useQueuedPrompts", () => {
       // Even though ITEMS[0].id is the same string, the agent switched —
       // onNewItem must fire again because state is per-agent.
       expect(onNewItem).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe("QueueUpdate entity event handling", () => {
+    it("updates items when QueueUpdate Upserted event arrives for this agent", async () => {
+      vi.mocked(api.getPromptQueue).mockResolvedValue([]);
+      const { result } = renderHook(() => useQueuedPrompts("agent-1"));
+      await waitFor(() => expect(result.current.items).toHaveLength(0));
+
+      // Simulate a QueueUpdate SSE event arriving
+      act(() => {
+        capturedSSEHandlers?.onEntityUpdate?.({
+          v: 1,
+          event: "QueueUpdate",
+          change: "Upserted",
+          entity: "Queue",
+          id: "agent-1",
+          snapshot: { agent_id: "agent-1", agent_stable_id: "a1", agent_display_label: "A1", queue: ITEMS, total_count: 2, oldest_queued_at: ITEMS[0].queued_at },
+          seq: 1 as unknown as bigint,
+          ts: new Date().toISOString(),
+        });
+      });
+
+      await waitFor(() => expect(result.current.items).toHaveLength(2));
+      expect(result.current.items[0].id).toBe("1");
+    });
+
+    it("clears items when QueueUpdate Removed event arrives", async () => {
+      const { result } = renderHook(() => useQueuedPrompts("agent-1"));
+      await waitFor(() => expect(result.current.items).toHaveLength(2));
+
+      act(() => {
+        capturedSSEHandlers?.onEntityUpdate?.({
+          v: 1,
+          event: "QueueUpdate",
+          change: "Removed",
+          entity: "Queue",
+          id: "agent-1",
+          seq: 2 as unknown as bigint,
+          ts: new Date().toISOString(),
+        });
+      });
+
+      expect(result.current.items).toHaveLength(0);
+    });
+
+    it("ignores QueueUpdate events for other agents", async () => {
+      const { result } = renderHook(() => useQueuedPrompts("agent-1"));
+      await waitFor(() => expect(result.current.items).toHaveLength(2));
+
+      act(() => {
+        capturedSSEHandlers?.onEntityUpdate?.({
+          v: 1,
+          event: "QueueUpdate",
+          change: "Removed",
+          entity: "Queue",
+          id: "agent-2", // different agent
+          seq: 3 as unknown as bigint,
+          ts: new Date().toISOString(),
+        });
+      });
+
+      // agent-1's items unchanged
+      expect(result.current.items).toHaveLength(2);
+    });
+
+    it("fires onNewItem for items arriving via SSE", async () => {
+      const onNewItem = vi.fn();
+      vi.mocked(api.getPromptQueue).mockResolvedValue([]);
+      const { result } = renderHook(() => useQueuedPrompts("agent-1", onNewItem));
+      await waitFor(() => expect(result.current.items).toHaveLength(0));
+
+      act(() => {
+        capturedSSEHandlers?.onEntityUpdate?.({
+          v: 1,
+          event: "QueueUpdate",
+          change: "Upserted",
+          entity: "Queue",
+          id: "agent-1",
+          snapshot: { agent_id: "agent-1", agent_stable_id: "a1", agent_display_label: "A1", queue: [ITEMS[0]], total_count: 1, oldest_queued_at: ITEMS[0].queued_at },
+          seq: 4 as unknown as bigint,
+          ts: new Date().toISOString(),
+        });
+      });
+
+      await waitFor(() => expect(onNewItem).toHaveBeenCalledTimes(1));
+      expect(onNewItem).toHaveBeenCalledWith(ITEMS[0]);
     });
   });
 });

--- a/clients/react/src/hooks/__tests__/useQueuedPrompts.test.ts
+++ b/clients/react/src/hooks/__tests__/useQueuedPrompts.test.ts
@@ -133,9 +133,7 @@ describe("useQueuedPrompts", () => {
 
     it("does NOT fire again for items already seen on a subsequent refresh", async () => {
       const onNewItem = vi.fn();
-      vi.mocked(api.getPromptQueue)
-        .mockResolvedValueOnce([ITEMS[0]])
-        .mockResolvedValue([ITEMS[0]]);
+      vi.mocked(api.getPromptQueue).mockResolvedValueOnce([ITEMS[0]]).mockResolvedValue([ITEMS[0]]);
 
       const { result } = renderHook(() => useQueuedPrompts("agent-1", onNewItem));
       await waitFor(() => expect(result.current.items).toHaveLength(1));
@@ -150,9 +148,7 @@ describe("useQueuedPrompts", () => {
 
     it("fires for each genuinely new item when the queue grows", async () => {
       const onNewItem = vi.fn();
-      vi.mocked(api.getPromptQueue)
-        .mockResolvedValueOnce([])
-        .mockResolvedValue(ITEMS);
+      vi.mocked(api.getPromptQueue).mockResolvedValueOnce([]).mockResolvedValue(ITEMS);
 
       const { result } = renderHook(() => useQueuedPrompts("agent-1", onNewItem));
       await waitFor(() => expect(result.current.items).toHaveLength(0));
@@ -201,7 +197,14 @@ describe("useQueuedPrompts", () => {
           change: "Upserted",
           entity: "Queue",
           id: "agent-1",
-          snapshot: { agent_id: "agent-1", agent_stable_id: "a1", agent_display_label: "A1", queue: ITEMS, total_count: 2, oldest_queued_at: ITEMS[0].queued_at },
+          snapshot: {
+            agent_id: "agent-1",
+            agent_stable_id: "a1",
+            agent_display_label: "A1",
+            queue: ITEMS,
+            total_count: 2,
+            oldest_queued_at: ITEMS[0].queued_at,
+          },
           seq: 1 as unknown as bigint,
           ts: new Date().toISOString(),
         });
@@ -263,7 +266,14 @@ describe("useQueuedPrompts", () => {
           change: "Upserted",
           entity: "Queue",
           id: "agent-1",
-          snapshot: { agent_id: "agent-1", agent_stable_id: "a1", agent_display_label: "A1", queue: [ITEMS[0]], total_count: 1, oldest_queued_at: ITEMS[0].queued_at },
+          snapshot: {
+            agent_id: "agent-1",
+            agent_stable_id: "a1",
+            agent_display_label: "A1",
+            queue: [ITEMS[0]],
+            total_count: 1,
+            oldest_queued_at: ITEMS[0].queued_at,
+          },
           seq: 4 as unknown as bigint,
           ts: new Date().toISOString(),
         });

--- a/clients/react/src/hooks/useAgents.ts
+++ b/clients/react/src/hooks/useAgents.ts
@@ -1,57 +1,37 @@
-import { useCallback, useEffect, useState } from "react";
-import { type AgentSnapshot, api } from "@/lib/api";
-import { useSSE } from "@/lib/sse-provider";
+import { useCallback } from "react";
+import type { AgentSnapshot } from "@/lib/api";
+import { useSSEContext } from "@/lib/sse-provider";
 import { type CoreEvent, useTauriEvents } from "./useTauriEvents";
 
-// Hook to fetch and reactively update agent list via Tauri events + HTTP fallback
+// Hook to access the reactive agent list from the shared SSE entity cache.
+//
+// Phase 2: removed per-hook api.listAgents() initial fetch + retry loop.
+// Agents are seeded via api.bootstrap() in SSEProvider on mount and kept live
+// by AgentUpdate entity events. useAgents now just reads from the shared cache.
 export function useAgents() {
-  const [agents, setAgents] = useState<AgentSnapshot[]>([]);
-  const [attentionCount, setAttentionCount] = useState(0);
-  const [loading, setLoading] = useState(true);
+  const { cache, refreshCache } = useSSEContext();
+  const { agents, loading } = cache;
+  // needs_attention is a derived field computed by tmai-core (#521)
+  const attentionCount = agents.filter((a) => a.needs_attention ?? false).length;
 
-  // Fallback: fetch via HTTP API (used for initial load)
-  const refresh = useCallback(async () => {
-    try {
-      const agentList = await api.listAgents();
-      setAgents(agentList);
-      setAttentionCount(agentList.filter((a) => a.needs_attention ?? false).length);
-    } catch (_e) {
-      // Server may not be ready yet during startup
-    } finally {
-      setLoading(false);
-    }
-  }, []);
+  // refreshCache triggers a full re-bootstrap; used by the Tauri event path
+  // to pull a fresh snapshot when the desktop app signals an agent change.
+  const refresh = useCallback(() => {
+    void refreshCache();
+  }, [refreshCache]);
 
-  // Handle Tauri core-event emissions
   const handleTauriEvent = useCallback(
     (event: CoreEvent) => {
       if (event.type === "agents-updated") {
-        // Refresh agent list when AgentsUpdated event is received
         refresh();
       }
     },
     [refresh],
   );
 
-  // Subscribe to Tauri events
   useTauriEvents(handleTauriEvent);
-
-  useEffect(() => {
-    // Initial fetch (retry until server/API is ready)
-    const retryInterval = setInterval(() => {
-      refresh().then(() => clearInterval(retryInterval));
-    }, 500);
-    return () => clearInterval(retryInterval);
-  }, [refresh]);
-
-  // Shared SSE subscription (previously opened its own EventSource)
-  useSSE({
-    onAgents: (agentList) => {
-      setAgents(agentList);
-      setAttentionCount(agentList.filter((a) => a.needs_attention ?? false).length);
-      setLoading(false);
-    },
-  });
 
   return { agents, attentionCount, loading, refresh };
 }
+
+export type { AgentSnapshot };

--- a/clients/react/src/hooks/useQueuedPrompts.ts
+++ b/clients/react/src/hooks/useQueuedPrompts.ts
@@ -1,37 +1,42 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { QueuedPrompt } from "@/lib/api";
 import { api } from "@/lib/api";
+import { useSSE } from "@/lib/sse-provider";
+import type { QueueAgentEntry } from "@/types/generated/QueueAgentEntry";
 
-// Polls the pending send_prompt queue for an agent every 3 s.
+// Subscribes to the pending send_prompt queue for an agent via QueueUpdate
+// SSE entity events (Phase 2 — no polling).
+//
 // Optimistically removes cancelled items; re-syncs on cancel failure
 // (race: agent became idle and flushed the queue simultaneously).
 //
 // onNewItem fires for each queue item that was not present in the previous
-// poll. Callers use this to surface incoming notifications in a UI surface
+// snapshot. Callers use this to surface incoming notifications in a UI surface
 // that is isolated from the conversation input (fixes #9).
 export function useQueuedPrompts(agentId: string, onNewItem?: (item: QueuedPrompt) => void) {
   const [items, setItems] = useState<QueuedPrompt[]>([]);
-  // Track known IDs so we can fire onNewItem only for genuinely new arrivals.
   const knownIdsRef = useRef(new Set<string>());
-  // Keep callback in a ref so refresh() doesn't need to re-register on every render.
   const onNewItemRef = useRef(onNewItem);
   onNewItemRef.current = onNewItem;
+
+  const applyQueue = useCallback((newQueue: QueuedPrompt[]) => {
+    for (const item of newQueue) {
+      if (!knownIdsRef.current.has(item.id)) {
+        onNewItemRef.current?.(item);
+      }
+    }
+    knownIdsRef.current = new Set(newQueue.map((q) => q.id));
+    setItems(newQueue);
+  }, []);
 
   const refresh = useCallback(async () => {
     try {
       const queue = await api.getPromptQueue(agentId);
-      // Notify caller about items that arrived since the last poll.
-      for (const item of queue) {
-        if (!knownIdsRef.current.has(item.id)) {
-          onNewItemRef.current?.(item);
-        }
-      }
-      knownIdsRef.current = new Set(queue.map((q) => q.id));
-      setItems(queue);
+      applyQueue(queue);
     } catch {
       // Endpoint not yet reachable (backend may be starting up); treat as empty.
     }
-  }, [agentId]);
+  }, [agentId, applyQueue]);
 
   const cancel = useCallback(
     async (promptId: string) => {
@@ -42,7 +47,7 @@ export function useQueuedPrompts(agentId: string, onNewItem?: (item: QueuedPromp
         // the optimistic remove already matches reality; no re-sync needed.
       } catch {
         // Actual failure (network, 404 on unknown agent, etc.) — re-sync.
-        refresh();
+        void refresh();
       }
     },
     [agentId, refresh],
@@ -55,11 +60,26 @@ export function useQueuedPrompts(agentId: string, onNewItem?: (item: QueuedPromp
     knownIdsRef.current = new Set();
   }, [agentId]);
 
+  // Initial fetch (once, no polling) — provides data before the first QueueUpdate event.
   useEffect(() => {
-    refresh();
-    const interval = setInterval(refresh, 3000);
-    return () => clearInterval(interval);
+    void refresh();
   }, [refresh]);
+
+  // Live updates via QueueUpdate entity events — replaces the 3 s polling interval.
+  useSSE({
+    onEntityUpdate: (envelope) => {
+      if (envelope.entity !== "Queue" || envelope.id !== agentId) return;
+      if (envelope.change === "Removed") {
+        knownIdsRef.current = new Set();
+        setItems([]);
+      } else if (envelope.snapshot != null) {
+        const entry = envelope.snapshot as QueueAgentEntry;
+        // Generated QueuedPrompt uses `origin: ActionOrigin | null`; api-http uses `origin?: ActionOrigin`.
+        // Both shapes are structurally identical at runtime; cast to satisfy the api-http type.
+        applyQueue(entry.queue as QueuedPrompt[]);
+      }
+    },
+  });
 
   return { items, cancel, refresh };
 }

--- a/clients/react/src/hooks/useWorktrees.ts
+++ b/clients/react/src/hooks/useWorktrees.ts
@@ -1,41 +1,30 @@
-import { useCallback, useEffect, useState } from "react";
-import { api, type WorktreeSnapshot } from "@/lib/api";
-import { useSSE } from "@/lib/sse-provider";
+import { useCallback } from "react";
+import type { WorktreeSnapshot } from "@/lib/api";
+import { useSSE, useSSEContext } from "@/lib/sse-provider";
 
-// Hook to fetch and reactively update worktree list via SSE events.
+// Hook to access the reactive worktree list from the shared SSE entity cache.
 //
-// Worktree state is produced exclusively by the Poller and exposed through
-// `worktree_created` / `worktree_removed` events (#425). Refetch triggers are:
-//   - worktree_* named events (immediate, post-action)
-//   - SSE reconnect (EventSource doesn't replay missed named events — any
-//     offline window would otherwise leave the UI on stale data)
-// The previous `onAgents`-debounced refresh is gone: it was a catch-all that
-// fired per agent tick and caused transient stale renders right after
-// delete/create, which is exactly the problem #425 resolves.
+// Phase 2: removed per-hook api.listWorktrees() initial fetch.
+// Worktrees are seeded via api.bootstrap() in SSEProvider and kept live by
+// WorktreeUpdate entity events.
+//
+// Legacy worktree_created / worktree_removed named events are still registered
+// here as a compatibility shim (Phase 1 backend still emits them in parallel);
+// they trigger refreshCache to stay consistent during the Phase 3 transition.
 export function useWorktrees(): {
   worktrees: WorktreeSnapshot[];
   loading: boolean;
   refresh: () => void;
 } {
-  const [worktrees, setWorktrees] = useState<WorktreeSnapshot[]>([]);
-  const [loading, setLoading] = useState(true);
+  const { cache, refreshCache } = useSSEContext();
+  const { worktrees, loading } = cache;
 
-  const refresh = useCallback(async () => {
-    try {
-      const list = await api.listWorktrees();
-      setWorktrees(list);
-    } catch {
-      // Server may not be ready yet
-    } finally {
-      setLoading(false);
-    }
-  }, []);
-
-  useEffect(() => {
-    refresh();
-  }, [refresh]);
+  const refresh = useCallback(() => {
+    void refreshCache();
+  }, [refreshCache]);
 
   useSSE({
+    // Legacy named events still fire during Phase 1/2; use as supplemental trigger.
     onEvent: (eventName) => {
       if (eventName === "worktree_created" || eventName === "worktree_removed") {
         refresh();

--- a/clients/react/src/lib/__tests__/sse-reconnect.test.ts
+++ b/clients/react/src/lib/__tests__/sse-reconnect.test.ts
@@ -1,0 +1,171 @@
+// Integration test: subscribeSSE reconnect behaviour (#522)
+//
+// Verifies that:
+//   1. After an SSE error, the connection reopens with ?since=<lastSeq>
+//   2. BootstrapRequired triggers the consumer's handler
+//   3. Entity-Update events update lastSeq tracked inside subscribeSSE
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// ── Fake EventSource ─────────────────────────────────────────────────────────
+
+type ESListener = (e: { data: string }) => void;
+
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  url: string;
+  listeners: Record<string, ESListener[]> = {};
+  onerror: ((e: unknown) => void) | null = null;
+
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+  addEventListener(type: string, cb: ESListener): void {
+    this.listeners[type] ??= [];
+    this.listeners[type].push(cb);
+  }
+  close(): void {}
+
+  // Test helper: fire a named event (BigInt → string so JSON.stringify works)
+  emit(type: string, data: unknown): void {
+    const replacer = (_: string, v: unknown) => (typeof v === "bigint" ? v.toString() : v);
+    for (const cb of this.listeners[type] ?? []) {
+      cb({ data: JSON.stringify(data, replacer) });
+    }
+  }
+  // Test helper: simulate connection error
+  triggerError(): void {
+    this.onerror?.(new Event("error"));
+  }
+}
+
+// ── Setup ────────────────────────────────────────────────────────────────────
+
+let originalEventSource: typeof globalThis.EventSource;
+let originalWindow: unknown;
+
+beforeEach(() => {
+  FakeEventSource.instances = [];
+  originalEventSource = globalThis.EventSource;
+  originalWindow = (globalThis as unknown as Record<string, unknown>).window;
+
+  vi.stubGlobal("EventSource", FakeEventSource);
+  vi.stubGlobal("window", {
+    location: { origin: "http://localhost", search: "?token=t" },
+  } as unknown as Window);
+  // Use fake timers so setTimeout in the reconnect path is controlled
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.stubGlobal("EventSource", originalEventSource);
+  vi.stubGlobal("window", originalWindow);
+  vi.useRealTimers();
+  vi.resetModules();
+});
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("subscribeSSE reconnect with ?since= (#522)", () => {
+  it("initial connection has no ?since= parameter", async () => {
+    const mod = await import("@/lib/api-http");
+    const sub = mod.subscribeSSE({});
+    const es = FakeEventSource.instances[FakeEventSource.instances.length - 1];
+    expect(es).toBeDefined();
+    expect(es.url).not.toContain("since=");
+    sub.unlisten();
+  });
+
+  it("reconnects with ?since=<lastSeq> after SSE error", async () => {
+    const mod = await import("@/lib/api-http");
+    const sub = mod.subscribeSSE({});
+
+    const firstEs = FakeEventSource.instances[FakeEventSource.instances.length - 1];
+    expect(firstEs.url).not.toContain("since=");
+
+    // Fire an AgentUpdate event to establish lastSeq = 42 (number after JSON round-trip)
+    firstEs.emit("AgentUpdate", {
+      v: 1,
+      event: "AgentUpdate",
+      change: "Upserted",
+      entity: "Agent",
+      id: "abc",
+      snapshot: {},
+      seq: 42,
+      ts: new Date().toISOString(),
+    });
+
+    // Simulate connection error → subscribeSSE schedules a reconnect
+    firstEs.triggerError();
+
+    // Advance fake timers past the 3 s backoff
+    vi.advanceTimersByTime(3100);
+
+    const secondEs = FakeEventSource.instances[FakeEventSource.instances.length - 1];
+    expect(secondEs).not.toBe(firstEs);
+    expect(secondEs.url).toContain("since=42");
+
+    sub.unlisten();
+  });
+
+  it("does not reconnect after unlisten()", async () => {
+    const mod = await import("@/lib/api-http");
+    const sub = mod.subscribeSSE({});
+
+    const firstEs = FakeEventSource.instances[FakeEventSource.instances.length - 1];
+    sub.unlisten(); // stop before the error
+
+    firstEs.triggerError();
+    vi.advanceTimersByTime(3100);
+
+    // No new EventSource should have been created
+    expect(FakeEventSource.instances[FakeEventSource.instances.length - 1]).toBe(firstEs);
+  });
+
+  it("calls onBootstrapRequired with the parsed event", async () => {
+    const onBootstrapRequired = vi.fn();
+    const mod = await import("@/lib/api-http");
+    const sub = mod.subscribeSSE({ onBootstrapRequired });
+
+    const es = FakeEventSource.instances[FakeEventSource.instances.length - 1];
+    // seq comes back as number after JSON round-trip (JSON doesn't support BigInt)
+    es.emit("BootstrapRequired", { event: "BootstrapRequired", seq: 99 });
+
+    expect(onBootstrapRequired).toHaveBeenCalledOnce();
+    expect(onBootstrapRequired.mock.calls[0][0].seq).toBe(99);
+
+    sub.unlisten();
+  });
+
+  it("calls onEntityUpdate for AgentUpdate events and tracks seq", async () => {
+    const onEntityUpdate = vi.fn();
+    const mod = await import("@/lib/api-http");
+    const sub = mod.subscribeSSE({ onEntityUpdate });
+
+    const es = FakeEventSource.instances[FakeEventSource.instances.length - 1];
+    // seq is number after JSON round-trip
+    const envelope = {
+      v: 1,
+      event: "AgentUpdate",
+      change: "Upserted",
+      entity: "Agent",
+      id: "abc",
+      snapshot: { id: "abc" },
+      seq: 7,
+      ts: new Date().toISOString(),
+    };
+    es.emit("AgentUpdate", envelope);
+
+    expect(onEntityUpdate).toHaveBeenCalledOnce();
+    expect(onEntityUpdate.mock.calls[0][0].seq).toBe(7);
+
+    // After error, reconnect uses ?since=7
+    es.triggerError();
+    vi.advanceTimersByTime(3100);
+    const secondEs = FakeEventSource.instances[FakeEventSource.instances.length - 1];
+    expect(secondEs.url).toContain("since=7");
+
+    sub.unlisten();
+  });
+});

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -1,6 +1,18 @@
 // HTTP/SSE/WebSocket API layer for tmai axum backend.
 // Replaces Tauri IPC — all communication goes through the existing web API.
 
+import type { ApprovalSnapshot } from "@/types/generated/ApprovalSnapshot";
+import type { BootstrapRequiredEvent } from "@/types/generated/BootstrapRequiredEvent";
+import type { DispatchSnapshot } from "@/types/generated/DispatchSnapshot";
+import type { EntityUpdateEnvelope } from "@/types/generated/EntityUpdateEnvelope";
+import type { QueueAgentEntry } from "@/types/generated/QueueAgentEntry";
+import type { QueueSnapshot } from "@/types/generated/QueueSnapshot";
+import type { RuntimeSnapshot } from "@/types/generated/RuntimeSnapshot";
+import type { TeamSnapshot } from "@/types/generated/TeamSnapshot";
+import type { WorkflowSnapshot } from "@/types/generated/WorkflowSnapshot";
+
+export type { BootstrapRequiredEvent, EntityUpdateEnvelope, QueueAgentEntry, QueueSnapshot };
+
 // ── Connection config ──
 
 // Extract token from URL query params. Base URL is same origin (served by axum).
@@ -171,6 +183,19 @@ export interface AgentSnapshot {
   has_pending_approval?: boolean;
   primary_worktree_path?: string | null;
   current_dispatch_id?: string | null;
+}
+
+// ── Bootstrap payload (all 9 domain snapshots in one shot) ──
+
+export interface BootstrapPayload {
+  agents: AgentSnapshot[];
+  worktrees: WorktreeSnapshot[];
+  teams: TeamSnapshot[];
+  queue: QueueSnapshot;
+  dispatches: DispatchSnapshot[];
+  workflow: WorkflowSnapshot;
+  runtime: RuntimeSnapshot;
+  approvals: ApprovalSnapshot[];
 }
 
 // ── Prompt Queue ──
@@ -845,6 +870,9 @@ export interface DirEntry {
 // ── API wrappers ──
 
 export const api = {
+  // Bootstrap — all 9 domain snapshots in one request (Phase 2)
+  bootstrap: () => apiFetch<BootstrapPayload>("/bootstrap"),
+
   // Agent queries
   listAgents: () => apiFetch<AgentSnapshot[]>("/agents"),
   attentionCount: async () => {
@@ -1249,87 +1277,154 @@ export const api = {
 
 // ── SSE event subscription ──
 
+// SSE event names that carry EntityUpdateEnvelope payloads (Phase 2).
+const ENTITY_UPDATE_EVENTS = [
+  "AgentUpdate",
+  "WorktreeUpdate",
+  "QueueUpdate",
+  "TeamUpdate",
+  "DispatchUpdate",
+  "WorkflowUpdate",
+  "RuntimeUpdate",
+  "ApprovalUpdate",
+] as const;
+
 /// Subscribe to SSE named events from /api/events.
 ///
-/// The axum backend sends named SSE events:
-///   - "agents" — full AgentSnapshot[] payload
-///   - "teams"  — full team info payload
-///   - other named events (teammate_idle, task_completed, etc.)
+/// Phase 2 additions:
+///   - `since` — reconnect with `?since=<seq>` to replay missed entity updates
+///   - `onEntityUpdate` — called for each EntityUpdateEnvelope (AgentUpdate, etc.)
+///   - `onBootstrapRequired` — called when the server's event buffer overflowed;
+///     consumer should re-bootstrap and reconnect
 ///
-/// EventSource.onmessage only fires for unnamed events, so we use
-/// addEventListener for each named event type.
-export function subscribeSSE(handlers: {
-  onAgents?: (agents: AgentSnapshot[]) => void;
-  onEvent?: (eventName: string, data: unknown) => void;
-  /// Fires on every SSE connection *after* the first successful open.
-  /// Subscribers use this to refetch domain data they missed while the
-  /// socket was disconnected (EventSource doesn't replay named events
-  /// across auto-reconnect).
-  onReconnect?: () => void;
-}): { unlisten: () => void } {
-  const url = `${config.baseUrl}/api/events?token=${config.token}`;
-  const es = new EventSource(url);
+/// Legacy events (agents, teams, git_state_changed, …) are still forwarded via
+/// `onAgents` / `onEvent` for parallel Phase 1 compatibility; Phase 3 removes them.
+///
+/// Implements controlled reconnect: on SSE error the connection is closed and
+/// reopened after a 3 s backoff with the current `?since=<seq>`, so the server
+/// replays any events missed during the gap.
+export function subscribeSSE(
+  handlers: {
+    onAgents?: (agents: AgentSnapshot[]) => void;
+    onEvent?: (eventName: string, data: unknown) => void;
+    onEntityUpdate?: (envelope: EntityUpdateEnvelope) => void;
+    onBootstrapRequired?: (event: BootstrapRequiredEvent) => void;
+    /// Fires on every SSE connection *after* the first successful open.
+    onReconnect?: () => void;
+  },
+  since?: bigint,
+): { unlisten: () => void } {
+  let stopped = false;
+  let lastSeq: bigint | undefined = since;
+  const esHolder: { current: EventSource | null } = { current: null };
 
-  // Track first-vs-subsequent opens so onReconnect only fires on reopen.
-  // Without this, initial mount would trigger a redundant refetch on top
-  // of the component's own first-fetch.
-  let firstOpen = true;
-  es.addEventListener("open", () => {
-    if (firstOpen) {
-      firstOpen = false;
-      return;
+  function connect(): void {
+    if (stopped) return;
+    const sinceParam = lastSeq != null ? `&since=${lastSeq}` : "";
+    const url = `${config.baseUrl}/api/events?token=${config.token}${sinceParam}`;
+    const es = new EventSource(url);
+    esHolder.current = es;
+
+    // Track first-vs-subsequent opens so onReconnect only fires on reopen.
+    let firstOpen = true;
+    es.addEventListener("open", () => {
+      if (firstOpen) {
+        firstOpen = false;
+        return;
+      }
+      handlers.onReconnect?.();
+    });
+
+    // Entity-Update envelopes (Phase 2) — track lastSeq for reconnect
+    for (const name of ENTITY_UPDATE_EVENTS) {
+      es.addEventListener(name, (e) => {
+        try {
+          const envelope = JSON.parse(e.data) as EntityUpdateEnvelope;
+          if (lastSeq === undefined || envelope.seq > lastSeq) {
+            lastSeq = envelope.seq;
+          }
+          handlers.onEntityUpdate?.(envelope);
+        } catch {
+          // Ignore parse errors
+        }
+      });
     }
-    handlers.onReconnect?.();
-  });
 
-  // "agents" named event — full agent list
-  es.addEventListener("agents", (e) => {
-    try {
-      const agents = JSON.parse(e.data) as AgentSnapshot[];
-      handlers.onAgents?.(agents);
-    } catch {
-      // Ignore parse errors
-    }
-  });
-
-  // Other named events — forward to generic handler
-  const namedEvents = [
-    "teams",
-    "teammate_idle",
-    "task_completed",
-    "context_compacting",
-    "usage",
-    "worktree_created",
-    "worktree_removed",
-    "agent_stopped",
-    // PR monitor events — drive WebUI lockstep with PR Monitor's poll tick (#422)
-    "pr_created",
-    "pr_ci_passed",
-    "pr_ci_failed",
-    "pr_review_feedback",
-    "pr_closed",
-    // Git monitor transition event — BranchGraph refetches branches + graph
-    // in response (#423). Without this registration, EventSource silently
-    // drops every `git_state_changed` payload and the panel never learns
-    // about backend git transitions.
-    "git_state_changed",
-  ];
-  for (const name of namedEvents) {
-    es.addEventListener(name, (e) => {
+    // BootstrapRequired — server buffer overflowed; consumer must re-bootstrap
+    es.addEventListener("BootstrapRequired", (e) => {
       try {
-        const data = JSON.parse(e.data);
-        handlers.onEvent?.(name, data);
+        const event = JSON.parse(e.data) as BootstrapRequiredEvent;
+        handlers.onBootstrapRequired?.(event);
       } catch {
-        // Ignore
+        // Ignore parse errors
       }
     });
+
+    // "agents" named event — full agent list (legacy, still emitted in Phase 1/2)
+    es.addEventListener("agents", (e) => {
+      try {
+        const agents = JSON.parse(e.data) as AgentSnapshot[];
+        handlers.onAgents?.(agents);
+      } catch {
+        // Ignore parse errors
+      }
+    });
+
+    // Other named events — forward to generic handler
+    const namedEvents = [
+      "teams",
+      "teammate_idle",
+      "task_completed",
+      "context_compacting",
+      "usage",
+      "worktree_created",
+      "worktree_removed",
+      "agent_stopped",
+      // PR monitor events — drive WebUI lockstep with PR Monitor's poll tick (#422)
+      "pr_created",
+      "pr_ci_passed",
+      "pr_ci_failed",
+      "pr_review_feedback",
+      "pr_closed",
+      // Git monitor transition event — BranchGraph refetches branches + graph
+      // in response (#423). Without this registration, EventSource silently
+      // drops every `git_state_changed` payload and the panel never learns
+      // about backend git transitions.
+      "git_state_changed",
+    ];
+    for (const name of namedEvents) {
+      es.addEventListener(name, (e) => {
+        try {
+          const data = JSON.parse(e.data);
+          handlers.onEvent?.(name, data);
+        } catch {
+          // Ignore
+        }
+      });
+    }
+
+    // Controlled reconnect: close and reopen with ?since=lastSeq after backoff
+    // so the server replays events missed during the disconnect window.
+    es.onerror = () => {
+      if (esHolder.current === es) {
+        es.close();
+        esHolder.current = null;
+        if (!stopped) {
+          setTimeout(() => connect(), 3000);
+        }
+      }
+    };
   }
 
-  es.onerror = () => {
-    // EventSource auto-reconnects
-  };
+  connect();
 
-  return { unlisten: () => es.close() };
+  return {
+    unlisten: () => {
+      stopped = true;
+      esHolder.current?.close();
+      esHolder.current = null;
+    },
+  };
 }
 
 // ── WebSocket terminal ──

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -48,6 +48,9 @@ async function isInTauri(): Promise<boolean> {
 
 // Create Tauri-aware API wrapper that overrides agent methods
 export const api = {
+  // Bootstrap — delegates to HTTP (no Tauri IPC equivalent)
+  bootstrap: () => httpApi.bootstrap(),
+
   // Agent queries - use Tauri IPC if available
   listAgents: async (): Promise<AgentSnapshot[]> => {
     try {

--- a/clients/react/src/lib/sse-provider.tsx
+++ b/clients/react/src/lib/sse-provider.tsx
@@ -1,50 +1,169 @@
-import { createContext, type ReactNode, useCallback, useContext, useEffect, useRef } from "react";
-import { type AgentSnapshot, subscribeSSE } from "./api";
+import {
+  createContext,
+  type ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import type { AgentSnapshot, BootstrapPayload, WorktreeSnapshot } from "./api";
+import { api, subscribeSSE } from "./api";
+import type { BootstrapRequiredEvent } from "@/types/generated/BootstrapRequiredEvent";
+import type { EntityUpdateEnvelope } from "@/types/generated/EntityUpdateEnvelope";
+import type { QueueAgentEntry } from "@/types/generated/QueueAgentEntry";
 
 // Handlers a subscriber can register with the shared SSE connection.
-interface SSEHandlers {
+export interface SSEHandlers {
   onAgents?: (agents: AgentSnapshot[]) => void;
   onEvent?: (eventName: string, data: unknown) => void;
+  onEntityUpdate?: (envelope: EntityUpdateEnvelope) => void;
   /// Fires after SSE reconnects (not on the first open). Subscribers
   /// that rely on event-driven state should refetch their snapshot
   /// here, since EventSource doesn't replay missed named events.
   onReconnect?: () => void;
 }
 
+// Normalized entity cache — seeded by bootstrap, kept live via EntityUpdate events.
+export interface EntityCache {
+  agents: AgentSnapshot[];
+  worktrees: WorktreeSnapshot[];
+  // Per-agent queue entries (one entry per agent that has queued prompts)
+  queueEntries: QueueAgentEntry[];
+  loading: boolean;
+}
+
 interface SSEContextValue {
   subscribe: (handlers: SSEHandlers) => () => void;
+  cache: EntityCache;
+  // Trigger a full re-bootstrap (e.g., on Tauri agent-updated events)
+  refreshCache: () => Promise<void>;
 }
 
 const SSEContext = createContext<SSEContextValue | null>(null);
 
-// Provider that opens a single EventSource connection and fans out events
-// to every registered subscriber. Replaces the pattern where each hook/
-// component called subscribeSSE directly, which created N parallel SSE
-// connections and caused N× fetch/render amplification (observed in the
-// 2026-04-12 cold-start flood investigation).
+// Provider that owns a single EventSource connection, fans out events to
+// subscribers, and maintains a normalized entity cache seeded by bootstrap.
+//
+// Replaces the pattern where each hook/component called subscribeSSE directly,
+// which created N parallel SSE connections (observed in the 2026-04-12 cold-start
+// flood investigation). Also eliminates per-hook polling by maintaining a shared
+// cache that hooks read reactively.
 export function SSEProvider({ children }: { children: ReactNode }) {
   const subscribersRef = useRef(new Set<SSEHandlers>());
 
-  useEffect(() => {
-    const { unlisten } = subscribeSSE({
-      onAgents: (agents) => {
-        for (const sub of subscribersRef.current) {
-          sub.onAgents?.(agents);
-        }
-      },
-      onEvent: (eventName, data) => {
-        for (const sub of subscribersRef.current) {
-          sub.onEvent?.(eventName, data);
-        }
-      },
-      onReconnect: () => {
-        for (const sub of subscribersRef.current) {
-          sub.onReconnect?.();
-        }
-      },
-    });
-    return unlisten;
+  // Entity maps — O(1) upsert/remove, id is the stable entity key
+  const agentMapRef = useRef<Map<string, AgentSnapshot>>(new Map());
+  const worktreeMapRef = useRef<Map<string, WorktreeSnapshot>>(new Map());
+  // Queue map: keyed by agent_id (entity id == QueueAgentEntry.agent_id)
+  const queueMapRef = useRef<Map<string, QueueAgentEntry>>(new Map());
+
+  // Reactive state derived from the maps — triggers re-renders in consumers
+  const [agents, setAgents] = useState<AgentSnapshot[]>([]);
+  const [worktrees, setWorktrees] = useState<WorktreeSnapshot[]>([]);
+  const [queueEntries, setQueueEntries] = useState<QueueAgentEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  // lastSeq drives ?since=<seq> on SSE reconnect to replay missed entity events
+  const lastSeqRef = useRef<bigint | undefined>(undefined);
+  // Increment to force SSE effect re-run (e.g., after BootstrapRequired recovery)
+  const [reconnectKey, setReconnectKey] = useState(0);
+
+  const refreshCache = useCallback(async (): Promise<void> => {
+    try {
+      const payload: BootstrapPayload = await api.bootstrap();
+
+      agentMapRef.current = new Map(payload.agents.map((a) => [a.id, a]));
+      worktreeMapRef.current = new Map(payload.worktrees.map((w) => [w.name, w]));
+      const qMap = new Map<string, QueueAgentEntry>();
+      for (const entry of payload.queue.entries) {
+        qMap.set(entry.agent_id, entry);
+      }
+      queueMapRef.current = qMap;
+
+      setAgents([...agentMapRef.current.values()]);
+      setWorktrees([...worktreeMapRef.current.values()]);
+      setQueueEntries([...queueMapRef.current.values()]);
+      setLoading(false);
+    } catch {
+      // Server may not be ready yet during startup; loading stays true
+    }
   }, []);
+
+  // Seed cache on mount
+  useEffect(() => {
+    void refreshCache();
+  }, [refreshCache]);
+
+  useEffect(() => {
+    const { unlisten } = subscribeSSE(
+      {
+        onAgents: (agentList) => {
+          // Legacy "agents" full-list event — update map and state
+          agentMapRef.current = new Map(agentList.map((a) => [a.id, a]));
+          setAgents([...agentMapRef.current.values()]);
+          setLoading(false);
+          for (const sub of subscribersRef.current) {
+            sub.onAgents?.(agentList);
+          }
+        },
+        onEvent: (eventName, data) => {
+          for (const sub of subscribersRef.current) {
+            sub.onEvent?.(eventName, data);
+          }
+        },
+        onEntityUpdate: (envelope) => {
+          const { entity, id, change, snapshot } = envelope;
+
+          // Track the latest seq for ?since= reconnect
+          if (lastSeqRef.current === undefined || envelope.seq > lastSeqRef.current) {
+            lastSeqRef.current = envelope.seq;
+          }
+
+          if (entity === "Agent") {
+            if (change === "Removed") {
+              agentMapRef.current.delete(id);
+            } else if (snapshot != null) {
+              agentMapRef.current.set(id, snapshot as AgentSnapshot);
+            }
+            setAgents([...agentMapRef.current.values()]);
+          } else if (entity === "Worktree") {
+            if (change === "Removed") {
+              worktreeMapRef.current.delete(id);
+            } else if (snapshot != null) {
+              worktreeMapRef.current.set(id, snapshot as WorktreeSnapshot);
+            }
+            setWorktrees([...worktreeMapRef.current.values()]);
+          } else if (entity === "Queue") {
+            if (change === "Removed") {
+              queueMapRef.current.delete(id);
+            } else if (snapshot != null) {
+              queueMapRef.current.set(id, snapshot as QueueAgentEntry);
+            }
+            setQueueEntries([...queueMapRef.current.values()]);
+          }
+
+          for (const sub of subscribersRef.current) {
+            sub.onEntityUpdate?.(envelope);
+          }
+        },
+        onBootstrapRequired: (_event: BootstrapRequiredEvent) => {
+          // Buffer overflowed: re-seed from REST then reconnect SSE without ?since=
+          // so the server sends a fresh stream from the current position.
+          lastSeqRef.current = undefined;
+          void refreshCache().then(() => setReconnectKey((k) => k + 1));
+        },
+        onReconnect: () => {
+          for (const sub of subscribersRef.current) {
+            sub.onReconnect?.();
+          }
+        },
+      },
+      lastSeqRef.current,
+    );
+    return unlisten;
+    // reconnectKey triggers effect re-run → new SSE connection with updated ?since=
+  }, [refreshCache, reconnectKey]);
 
   const subscribe = useCallback((handlers: SSEHandlers) => {
     subscribersRef.current.add(handlers);
@@ -53,7 +172,13 @@ export function SSEProvider({ children }: { children: ReactNode }) {
     };
   }, []);
 
-  return <SSEContext.Provider value={{ subscribe }}>{children}</SSEContext.Provider>;
+  const cache: EntityCache = { agents, worktrees, queueEntries, loading };
+
+  return (
+    <SSEContext.Provider value={{ subscribe, cache, refreshCache }}>
+      {children}
+    </SSEContext.Provider>
+  );
 }
 
 // Subscribe to the shared SSE connection. Handlers are held via ref so
@@ -71,8 +196,19 @@ export function useSSE(handlers: SSEHandlers): void {
     const stable: SSEHandlers = {
       onAgents: (agents) => handlersRef.current.onAgents?.(agents),
       onEvent: (eventName, data) => handlersRef.current.onEvent?.(eventName, data),
+      onEntityUpdate: (envelope) => handlersRef.current.onEntityUpdate?.(envelope),
       onReconnect: () => handlersRef.current.onReconnect?.(),
     };
     return ctx.subscribe(stable);
   }, [ctx]);
+}
+
+// Access the full SSE context (cache + refreshCache + subscribe).
+// Use this when a hook needs to read from the normalized entity cache.
+export function useSSEContext(): SSEContextValue {
+  const ctx = useContext(SSEContext);
+  if (!ctx) {
+    throw new Error("useSSEContext must be used inside <SSEProvider>");
+  }
+  return ctx;
 }

--- a/clients/react/src/lib/sse-provider.tsx
+++ b/clients/react/src/lib/sse-provider.tsx
@@ -195,8 +195,15 @@ export function SSEProvider({ children }: { children: ReactNode }) {
 
   const cache: EntityCache = { agents, worktrees, queueEntries, loading };
 
+  // Expose as () => Promise<void> to match SSEContextValue; callers don't need the boolean.
+  const refreshCacheVoid = useCallback(async (): Promise<void> => {
+    await refreshCache();
+  }, [refreshCache]);
+
   return (
-    <SSEContext.Provider value={{ subscribe, cache, refreshCache }}>{children}</SSEContext.Provider>
+    <SSEContext.Provider value={{ subscribe, cache, refreshCache: refreshCacheVoid }}>
+      {children}
+    </SSEContext.Provider>
   );
 }
 

--- a/clients/react/src/lib/sse-provider.tsx
+++ b/clients/react/src/lib/sse-provider.tsx
@@ -7,11 +7,11 @@ import {
   useRef,
   useState,
 } from "react";
-import type { AgentSnapshot, BootstrapPayload, WorktreeSnapshot } from "./api";
-import { api, subscribeSSE } from "./api";
 import type { BootstrapRequiredEvent } from "@/types/generated/BootstrapRequiredEvent";
 import type { EntityUpdateEnvelope } from "@/types/generated/EntityUpdateEnvelope";
 import type { QueueAgentEntry } from "@/types/generated/QueueAgentEntry";
+import type { AgentSnapshot, BootstrapPayload, WorktreeSnapshot } from "./api";
+import { api, subscribeSSE } from "./api";
 
 // Handlers a subscriber can register with the shared SSE connection.
 export interface SSEHandlers {
@@ -95,6 +95,7 @@ export function SSEProvider({ children }: { children: ReactNode }) {
     void refreshCache();
   }, [refreshCache]);
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: reconnectKey is intentional — incrementing it forces a new SSE connection after BootstrapRequired recovery
   useEffect(() => {
     const { unlisten } = subscribeSSE(
       {
@@ -162,7 +163,6 @@ export function SSEProvider({ children }: { children: ReactNode }) {
       lastSeqRef.current,
     );
     return unlisten;
-    // reconnectKey triggers effect re-run → new SSE connection with updated ?since=
   }, [refreshCache, reconnectKey]);
 
   const subscribe = useCallback((handlers: SSEHandlers) => {
@@ -175,9 +175,7 @@ export function SSEProvider({ children }: { children: ReactNode }) {
   const cache: EntityCache = { agents, worktrees, queueEntries, loading };
 
   return (
-    <SSEContext.Provider value={{ subscribe, cache, refreshCache }}>
-      {children}
-    </SSEContext.Provider>
+    <SSEContext.Provider value={{ subscribe, cache, refreshCache }}>{children}</SSEContext.Provider>
   );
 }
 

--- a/clients/react/src/lib/sse-provider.tsx
+++ b/clients/react/src/lib/sse-provider.tsx
@@ -69,12 +69,14 @@ export function SSEProvider({ children }: { children: ReactNode }) {
   // Increment to force SSE effect re-run (e.g., after BootstrapRequired recovery)
   const [reconnectKey, setReconnectKey] = useState(0);
 
-  const refreshCache = useCallback(async (): Promise<void> => {
+  const refreshCache = useCallback(async (): Promise<boolean> => {
     try {
       const payload: BootstrapPayload = await api.bootstrap();
 
       agentMapRef.current = new Map(payload.agents.map((a) => [a.id, a]));
-      worktreeMapRef.current = new Map(payload.worktrees.map((w) => [w.name, w]));
+      // WorktreeUpdate envelope.id = WorktreeSnapshot.path (per corevents.schema.json
+      // "Worktree path (unique per repo)"), so key by path to match EntityUpdate upsert/remove.
+      worktreeMapRef.current = new Map(payload.worktrees.map((w) => [w.path, w]));
       const qMap = new Map<string, QueueAgentEntry>();
       for (const entry of payload.queue.entries) {
         qMap.set(entry.agent_id, entry);
@@ -85,14 +87,31 @@ export function SSEProvider({ children }: { children: ReactNode }) {
       setWorktrees([...worktreeMapRef.current.values()]);
       setQueueEntries([...queueMapRef.current.values()]);
       setLoading(false);
+      return true;
     } catch {
-      // Server may not be ready yet during startup; loading stays true
+      return false;
     }
   }, []);
 
-  // Seed cache on mount
+  // Seed cache on mount with exponential backoff retry (server may be starting up).
   useEffect(() => {
-    void refreshCache();
+    let cancelled = false;
+    let retryHandle: ReturnType<typeof setTimeout> | null = null;
+    let delay = 1_000;
+
+    async function attempt() {
+      const ok = await refreshCache();
+      if (!ok && !cancelled) {
+        delay = Math.min(delay * 2, 30_000);
+        retryHandle = setTimeout(() => void attempt(), delay);
+      }
+    }
+
+    void attempt();
+    return () => {
+      cancelled = true;
+      if (retryHandle !== null) clearTimeout(retryHandle);
+    };
   }, [refreshCache]);
 
   // biome-ignore lint/correctness/useExhaustiveDependencies: reconnectKey is intentional — incrementing it forces a new SSE connection after BootstrapRequired recovery
@@ -152,7 +171,9 @@ export function SSEProvider({ children }: { children: ReactNode }) {
           // Buffer overflowed: re-seed from REST then reconnect SSE without ?since=
           // so the server sends a fresh stream from the current position.
           lastSeqRef.current = undefined;
-          void refreshCache().then(() => setReconnectKey((k) => k + 1));
+          void refreshCache().then((ok) => {
+            if (ok) setReconnectKey((k) => k + 1);
+          });
         },
         onReconnect: () => {
           for (const sub of subscribersRef.current) {


### PR DESCRIPTION
## Summary

- **Bootstrap-based initial load**: `SSEProvider` calls `GET /api/bootstrap` on mount to seed per-domain entity caches (`agents`, `worktrees`, `queueEntries`) in one shot. `useAgents` and `useWorktrees` now read from the shared `EntityCache` via context — their per-hook `api.listAgents()` / `api.listWorktrees()` initial fetches and retry loops are removed.

- **Entity-Update envelope dispatcher**: `sse-provider.tsx` registers `AgentUpdate`, `WorktreeUpdate`, `QueueUpdate` (and 5 other domain) SSE events and maintains normalized `Map<id, Snapshot>` caches. `BootstrapRequired` triggers a full re-seed + SSE reconnect.

- **Drop polling in `useQueuedPrompts`**: 3 s `setInterval` removed. Hook does a single initial fetch then subscribes to `QueueUpdate` entity events via `useSSE` for live updates. Optimistic cancel + re-sync on failure preserved.

- **`?since=<seq>` reconnect**: `subscribeSSE` now accepts `since?: bigint`, tracks `lastSeq` from each entity envelope, and on SSE error closes + reopens the connection with `?since=<lastSeq>` after a 3 s backoff — replaying any events missed during the disconnect window.

## Test plan

- [x] `pnpm build` passes (TypeScript + Vite)
- [x] `pnpm test` passes: 25 test files, 203 tests
- [x] `sse-named-events.test.ts` asserts `AgentUpdate`, `WorktreeUpdate`, `QueueUpdate`, `BootstrapRequired` are registered on the EventSource
- [x] `sse-reconnect.test.ts` simulates disconnect/reconnect and verifies `?since=<seq>` is used on the new connection
- [x] `useQueuedPrompts.test.ts`: polling interval test removed; QueueUpdate SSE event tests added

Closes #522

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * サーバー・センント・イベント（SSE）による リアルタイムエンティティ更新機能を追加しました。エージェント、キュー、ワークツリーの変更がポーリングではなく即座に反映されるようになります。

* **テスト**
  * SSE統合、キャッシング機構、エンティティ更新イベントの登録検証テストを充実させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->