### PR TITLE
chore(gen): sync generated spec + types from tmai-core@339cf9a6f7

### DIFF
--- a/clients/react/src/types/generated/ActionOrigin.ts
+++ b/clients/react/src/types/generated/ActionOrigin.ts
@@ -18,7 +18,7 @@ interface: string,
  * `OrchestratorNotifier::source_project_scope` can scope notifications
  * without needing the caller to be tracked in `state.agents`.
  */
-cwd: string | null, } | { "kind": "Agent", 
+cwd?: string | null, } | { "kind": "Agent", 
 /**
  * Agent target ID (e.g., "main:0.0")
  */
@@ -34,7 +34,7 @@ is_orchestrator: boolean,
  * `OrchestratorNotifier::source_project_scope` can resolve the project
  * root when the MCP agent ID is not tracked in `state.agents` (#75).
  */
-cwd: string | null, } | { "kind": "System", 
+cwd?: string | null, } | { "kind": "System", 
 /**
  * Subsystem name (e.g., "auto_cleanup", "pr_monitor")
  */
@@ -43,4 +43,4 @@ subsystem: string,
  * Working directory of the originating subsystem process, used for
  * project-scope routing (#89).
  */
-cwd: string | null, };
+cwd?: string | null, };

--- a/clients/react/src/types/generated/CoreEvent.ts
+++ b/clients/react/src/types/generated/CoreEvent.ts
@@ -346,7 +346,7 @@ code: ErrorCode,
  * raw prompts). Defaults to `null` when the emitter has nothing
  * to attach.
  */
-context: unknown, } | { "type": "DispatchBypassUsed", 
+context?: unknown, } | { "type": "DispatchBypassUsed", 
 /**
  * Origin of the bypassing call.
  */

--- a/clients/react/src/types/generated/TmaiError.ts
+++ b/clients/react/src/types/generated/TmaiError.ts
@@ -31,7 +31,7 @@ retry_hint?: RetryHint,
  * `unknown`, which already accepts `undefined` at the call site — no
  * `ts(optional)` because that attribute rejects non-`Option<T>` fields.
  */
-context: unknown, 
+context?: unknown, 
 /**
  * Request/span identifier for correlating this error across MCP, WebUI,
  * and internal tracing spans.


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@339cf9a6f7fac564a160bdc6c89c29e202b1b38f

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 clients/react/src/types/generated/ActionOrigin.ts | 6 +++---
 clients/react/src/types/generated/CoreEvent.ts    | 2 +-
 clients/react/src/types/generated/TmaiError.ts    | 2 +-
 3 files changed, 5 insertions(+), 5 deletions(-)
```

</details>