### PR TITLE
fix(react): adapt to wire envelope, dedupe agents, split preview into Live/Transcript tabs

### DIFF
--- a/clients/react/src/components/agent/PreviewPanel.tsx
+++ b/clients/react/src/components/agent/PreviewPanel.tsx
@@ -415,6 +415,21 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
     };
   }, [agentId]);
 
+  // Reset preview state on agent switch so the previous agent's
+  // capture-pane / transcript don't flash on screen until the first
+  // fetchPreview / fetchTranscript for the new agent comes back. The
+  // poll loop fires at timeout 0 on agent change, but the network
+  // round-trip still leaves a 200–500ms window of stale content
+  // otherwise.
+  useEffect(() => {
+    setHistory("");
+    setLive("");
+    setLiveStartLine(0);
+    setTranscriptRecords([]);
+    setCursorPos(null);
+    lastContentRef.current = null;
+  }, [agentId]);
+
   // Clear incoming-prompt indicator on agent switch and on unmount
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally clear on agent switch
   useEffect(() => {

--- a/clients/react/src/components/agent/PreviewPanel.tsx
+++ b/clients/react/src/components/agent/PreviewPanel.tsx
@@ -84,6 +84,21 @@ function originLabel(o: ActionOrigin): string {
 // Per-agent auto-scroll preference (persists across agent switches)
 const agentAutoScrollMap = new Map<string, boolean>();
 
+// Per-agent preview state cache. Lets us re-show the last-seen
+// capture-pane / transcript instantly on agent switch instead of
+// blanking out for the 200-500ms it takes the next fetchPreview to
+// return for the new agent. Polling continues to refresh these the
+// moment the new fetch lands.
+interface PreviewCache {
+  history: string;
+  live: string;
+  liveStartLine: number;
+  transcriptRecords: TranscriptRecord[];
+  cursorPos: CursorPos | null;
+  lastContent: string | null;
+}
+const previewCacheMap = new Map<string, PreviewCache>();
+
 const MONO_FONT_STACK =
   "'JetBrainsMono Nerd Font', 'JetBrainsMono NF', " +
   "'CaskaydiaCove Nerd Font', 'CaskaydiaCove NF', " +
@@ -415,19 +430,54 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
     };
   }, [agentId]);
 
-  // Reset preview state on agent switch so the previous agent's
-  // capture-pane / transcript don't flash on screen until the first
-  // fetchPreview / fetchTranscript for the new agent comes back. The
-  // poll loop fires at timeout 0 on agent change, but the network
-  // round-trip still leaves a 200–500ms window of stale content
-  // otherwise.
+  // Mirror the live preview state into a ref so the agent-switch
+  // cleanup below can capture the *most recent* values when it runs,
+  // not the closure values from when the effect last set itself up.
+  const stateForCacheRef = useRef<Omit<PreviewCache, "lastContent">>({
+    history,
+    live,
+    liveStartLine,
+    transcriptRecords,
+    cursorPos,
+  });
   useEffect(() => {
-    setHistory("");
-    setLive("");
-    setLiveStartLine(0);
-    setTranscriptRecords([]);
-    setCursorPos(null);
-    lastContentRef.current = null;
+    stateForCacheRef.current = {
+      history,
+      live,
+      liveStartLine,
+      transcriptRecords,
+      cursorPos,
+    };
+  }, [history, live, liveStartLine, transcriptRecords, cursorPos]);
+
+  // On agent switch: hydrate from previewCacheMap (if we've seen this
+  // agent before) so the panel updates instantly, then let the next
+  // fetchPreview/fetchTranscript tick refresh whatever changed. On
+  // cleanup (= the previous agentId's effect tearing down) save the
+  // most recent state so the next switch back can re-hydrate.
+  useEffect(() => {
+    const cached = previewCacheMap.get(agentId);
+    if (cached) {
+      setHistory(cached.history);
+      setLive(cached.live);
+      setLiveStartLine(cached.liveStartLine);
+      setTranscriptRecords(cached.transcriptRecords);
+      setCursorPos(cached.cursorPos);
+      lastContentRef.current = cached.lastContent;
+    } else {
+      setHistory("");
+      setLive("");
+      setLiveStartLine(0);
+      setTranscriptRecords([]);
+      setCursorPos(null);
+      lastContentRef.current = null;
+    }
+    return () => {
+      previewCacheMap.set(agentId, {
+        ...stateForCacheRef.current,
+        lastContent: lastContentRef.current,
+      });
+    };
   }, [agentId]);
 
   // Clear incoming-prompt indicator on agent switch and on unmount
@@ -570,10 +620,54 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
     () => capHistoryLines(deferredHistory, MAX_HISTORY_LINES),
     [deferredHistory],
   );
-  const historyHtml = useMemo(() => {
-    if (!historyCap.content) return "";
-    return ansi.ansi_to_html(shrinkContentToWidth(historyCap.content, cols));
-  }, [ansi, historyCap, cols]);
+
+  // History HTML conversion happens off the main thread via a Web Worker
+  // (lib/ansi-worker.ts). For a long-running agent the scrollback can
+  // reach hundreds of KB and the synchronous AnsiUp pass would block the
+  // tab for several seconds on every poll tick. The worker lets the Live
+  // region keep painting and input keep responding while the History
+  // pipeline catches up. Each request carries an incrementing id; a
+  // response whose id no longer matches the latest request is discarded
+  // so an in-flight conversion of stale content can't overwrite a newer
+  // one (e.g. on agent switch).
+  const [historyHtml, setHistoryHtml] = useState<string>("");
+  const ansiWorkerRef = useRef<Worker | null>(null);
+  const ansiRequestSeqRef = useRef(0);
+  const ansiLatestRequestIdRef = useRef(0);
+  useEffect(() => {
+    if (typeof Worker === "undefined") return; // jsdom / SSR fallback
+    const worker = new Worker(new URL("@/lib/ansi-worker.ts", import.meta.url), {
+      type: "module",
+    });
+    ansiWorkerRef.current = worker;
+    worker.onmessage = (e: MessageEvent<{ id: number; html: string }>) => {
+      if (e.data.id !== ansiLatestRequestIdRef.current) return;
+      setHistoryHtml(e.data.html);
+    };
+    return () => {
+      worker.terminate();
+      ansiWorkerRef.current = null;
+    };
+  }, []);
+  useEffect(() => {
+    if (!historyCap.content) {
+      ansiLatestRequestIdRef.current = ++ansiRequestSeqRef.current;
+      setHistoryHtml("");
+      return;
+    }
+    const content = shrinkContentToWidth(historyCap.content, cols);
+    const worker = ansiWorkerRef.current;
+    if (worker) {
+      const id = ++ansiRequestSeqRef.current;
+      ansiLatestRequestIdRef.current = id;
+      worker.postMessage({ id, content });
+    } else {
+      // Fallback when Web Worker is unavailable (jsdom in tests). Runs
+      // synchronously on the main thread; for production this branch
+      // should not be hit.
+      setHistoryHtml(ansi.ansi_to_html(content));
+    }
+  }, [historyCap, cols, ansi]);
 
   // Cursor row within the live region. The backend returns cursor_y as an
   // absolute row within the full capture output; since the tmux cursor is

--- a/clients/react/src/components/agent/PreviewPanel.tsx
+++ b/clients/react/src/components/agent/PreviewPanel.tsx
@@ -84,21 +84,6 @@ function originLabel(o: ActionOrigin): string {
 // Per-agent auto-scroll preference (persists across agent switches)
 const agentAutoScrollMap = new Map<string, boolean>();
 
-// Per-agent preview state cache. Lets us re-show the last-seen
-// capture-pane / transcript instantly on agent switch instead of
-// blanking out for the 200-500ms it takes the next fetchPreview to
-// return for the new agent. Polling continues to refresh these the
-// moment the new fetch lands.
-interface PreviewCache {
-  history: string;
-  live: string;
-  liveStartLine: number;
-  transcriptRecords: TranscriptRecord[];
-  cursorPos: CursorPos | null;
-  lastContent: string | null;
-}
-const previewCacheMap = new Map<string, PreviewCache>();
-
 const MONO_FONT_STACK =
   "'JetBrainsMono Nerd Font', 'JetBrainsMono NF', " +
   "'CaskaydiaCove Nerd Font', 'CaskaydiaCove NF', " +
@@ -430,54 +415,16 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
     };
   }, [agentId]);
 
-  // Mirror the live preview state into a ref so the agent-switch
-  // cleanup below can capture the *most recent* values when it runs,
-  // not the closure values from when the effect last set itself up.
-  const stateForCacheRef = useRef<Omit<PreviewCache, "lastContent">>({
-    history,
-    live,
-    liveStartLine,
-    transcriptRecords,
-    cursorPos,
-  });
+  // Reset preview state on agent switch so the previous agent's
+  // capture-pane / transcript don't flash on screen until the first
+  // fetchPreview / fetchTranscript for the new agent comes back.
   useEffect(() => {
-    stateForCacheRef.current = {
-      history,
-      live,
-      liveStartLine,
-      transcriptRecords,
-      cursorPos,
-    };
-  }, [history, live, liveStartLine, transcriptRecords, cursorPos]);
-
-  // On agent switch: hydrate from previewCacheMap (if we've seen this
-  // agent before) so the panel updates instantly, then let the next
-  // fetchPreview/fetchTranscript tick refresh whatever changed. On
-  // cleanup (= the previous agentId's effect tearing down) save the
-  // most recent state so the next switch back can re-hydrate.
-  useEffect(() => {
-    const cached = previewCacheMap.get(agentId);
-    if (cached) {
-      setHistory(cached.history);
-      setLive(cached.live);
-      setLiveStartLine(cached.liveStartLine);
-      setTranscriptRecords(cached.transcriptRecords);
-      setCursorPos(cached.cursorPos);
-      lastContentRef.current = cached.lastContent;
-    } else {
-      setHistory("");
-      setLive("");
-      setLiveStartLine(0);
-      setTranscriptRecords([]);
-      setCursorPos(null);
-      lastContentRef.current = null;
-    }
-    return () => {
-      previewCacheMap.set(agentId, {
-        ...stateForCacheRef.current,
-        lastContent: lastContentRef.current,
-      });
-    };
+    setHistory("");
+    setLive("");
+    setLiveStartLine(0);
+    setTranscriptRecords([]);
+    setCursorPos(null);
+    lastContentRef.current = null;
   }, [agentId]);
 
   // Clear incoming-prompt indicator on agent switch and on unmount

--- a/clients/react/src/components/agent/PreviewPanel.tsx
+++ b/clients/react/src/components/agent/PreviewPanel.tsx
@@ -317,8 +317,17 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
   // IME composition is in progress — re-rendering the preview during
   // composition disrupts the IME candidate window and causes visible
   // typing lag in CJK input methods.
+  // Guard against overlapping fetches. For agents with hundreds of KB of
+  // capture-pane scrollback, getPreview can take several seconds to
+  // arrive over a slow link; without this guard the 200ms poll cadence
+  // stacks up an arbitrary number of in-flight requests and the latest
+  // setHistory call ends up "behind" all the queued ones, which is what
+  // surfaces as "Waiting…" not progressing.
+  const fetchInFlightRef = useRef(false);
   const fetchPreview = useCallback(async () => {
     if (composingRef.current) return;
+    if (fetchInFlightRef.current) return;
+    fetchInFlightRef.current = true;
     try {
       const data = await api.getPreview(agentId);
       // Treat only null/undefined as "no payload" — an empty string is
@@ -352,6 +361,8 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
       }
     } catch {
       // Agent may not have content yet
+    } finally {
+      fetchInFlightRef.current = false;
     }
   }, [agentId]);
 
@@ -434,6 +445,9 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
     setTranscriptRecords([]);
     setCursorPos(null);
     lastContentRef.current = null;
+    // Drop any in-flight guard from the previous agent so the first
+    // fetch for the new agent isn't itself skipped.
+    fetchInFlightRef.current = false;
     void fetchPreview();
   }, [agentId, fetchPreview]);
 

--- a/clients/react/src/components/agent/PreviewPanel.tsx
+++ b/clients/react/src/components/agent/PreviewPanel.tsx
@@ -116,6 +116,11 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
   const [live, setLive] = useState<string>("");
   const [liveStartLine, setLiveStartLine] = useState<number>(0);
   const [transcriptRecords, setTranscriptRecords] = useState<TranscriptRecord[]>([]);
+  // "live" = capture-pane (cheap, default). "transcript" = JSONL records
+  // (heavy: per-record react-markdown). Splitting them into tabs keeps the
+  // common monitoring path light, and the transcript polling/render only
+  // runs when the user actively opens it.
+  const [activeTab, setActiveTab] = useState<"live" | "transcript">("live");
   const [cursorPos, setCursorPos] = useState<CursorPos | null>(null);
   const [showCursor, setShowCursor] = useState(true);
   const [focused, setFocused] = useState(true);
@@ -389,11 +394,16 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
     }
   }, [agentId]);
 
+  // Only fetch transcript while the Transcript tab is active. The Live tab
+  // never needs the JSONL records, so we avoid the 3s polling and the
+  // per-record react-markdown re-render entirely while the user is just
+  // monitoring the agent.
   useEffect(() => {
+    if (activeTab !== "transcript") return;
     fetchTranscript();
     const interval = setInterval(fetchTranscript, 3000);
     return () => clearInterval(interval);
-  }, [fetchTranscript]);
+  }, [fetchTranscript, activeTab]);
 
   // Pending passthrough refresh timers (cleared on agent switch / unmount)
   const passthroughTimers = useRef<ReturnType<typeof setTimeout>[]>([]);
@@ -434,12 +444,41 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
 
   // Auto-scroll to bottom (toggleable, default on)
   // Scroll up → auto OFF, scroll to bottom → auto ON
+  // skipNextScrollEventRef suppresses the synthetic onScroll the browser
+  // fires when a tab toggle changes scrollHeight (which would otherwise
+  // flip autoScroll off without any user gesture).
+  const skipNextScrollEventRef = useRef(false);
   const handleScroll = useCallback(() => {
+    if (skipNextScrollEventRef.current) {
+      skipNextScrollEventRef.current = false;
+      return;
+    }
     const el = scrollContainerRef.current;
     if (!el) return;
     const atBottom = el.scrollHeight - el.scrollTop - el.clientHeight < 24;
     setAutoScroll(atBottom);
   }, [setAutoScroll]);
+
+  // Mirror autoScroll into a ref so the tab-switch effect can read the
+  // current value without re-running every time autoScroll changes.
+  const autoScrollRef = useRef(autoScroll);
+  useEffect(() => {
+    autoScrollRef.current = autoScroll;
+  }, [autoScroll]);
+
+  // On switching back to the Live tab: suppress the tab-toggle's synthetic
+  // onScroll, and if autoScroll was on, re-pin to the bottom so resumption
+  // matches the user's intent ("auto" stays auto across tab switches).
+  useEffect(() => {
+    if (activeTab !== "live") return;
+    skipNextScrollEventRef.current = true;
+    if (!autoScrollRef.current) return;
+    const id = requestAnimationFrame(() => {
+      const el = scrollContainerRef.current;
+      if (el) el.scrollTop = el.scrollHeight;
+    });
+    return () => cancelAnimationFrame(id);
+  }, [activeTab]);
 
   // Handle special keys (non-IME) via the hidden input's keydown
   const handleKeyDown = useCallback(
@@ -703,41 +742,53 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
         >
           X
         </span>
-        {/* Transcript history (above live capture-pane) */}
-        {hasTranscript && (
-          <div className="select-text border-b border-white/10 pb-2 mb-2">
-            <TranscriptView records={transcriptRecords} />
-          </div>
-        )}
-        {/* Capture-pane output — split into scrollback history (rendered
-            once, cached) and live visible region (re-rendered each tick). */}
-        {hasContent ? (
-          <div
-            className="ansi-preview relative m-0 cursor-text select-text whitespace-pre-wrap break-words"
-            style={{
-              fontFamily: MONO_FONT_STACK,
-            }}
-          >
-            {historyCap.dropped > 0 && (
-              <div className="text-zinc-600 text-[10px] italic pb-1 select-none">
-                {`… ${historyCap.dropped.toLocaleString()} earlier line${
-                  historyCap.dropped === 1 ? "" : "s"
-                } hidden (showing last ${MAX_HISTORY_LINES.toLocaleString()})`}
-              </div>
-            )}
-            <div ref={historyRef} />
-            <div ref={liveRef} />
-            {cursorStyle && focused && hasDomFocus && showCursor && (
-              <div
-                className="pointer-events-none absolute animate-pulse bg-cyan-400/70"
-                style={cursorStyle}
-                aria-hidden="true"
-              />
-            )}
-          </div>
-        ) : (
-          <span className="text-zinc-600">Waiting for output...</span>
-        )}
+        {/* Transcript tab — JSONL records via per-record react-markdown.
+            Only mounted while activeTab === "transcript", so the Live tab
+            never pays the rendering cost in long conversations. */}
+        {activeTab === "transcript" &&
+          (hasTranscript ? (
+            <div className="select-text">
+              <TranscriptView records={transcriptRecords} />
+            </div>
+          ) : (
+            <div className="py-4 text-sm text-zinc-600">No transcript records yet</div>
+          ))}
+        {/* Live tab — always mounted so historyRef / liveRef survive tab
+            switches. Without this, switching to Transcript and back would
+            unmount the refs and the next innerHTML write only happens on
+            the next poll tick (visible delay). The display toggle is cheap
+            because the underlying DOM is preserved. */}
+        <div style={{ display: activeTab === "live" ? undefined : "none" }}>
+          {hasContent ? (
+            /* Capture-pane output split into scrollback history (rendered
+               once, cached) and live visible region (re-rendered each tick). */
+            <div
+              className="ansi-preview relative m-0 cursor-text select-text whitespace-pre-wrap break-words"
+              style={{
+                fontFamily: MONO_FONT_STACK,
+              }}
+            >
+              {historyCap.dropped > 0 && (
+                <div className="text-zinc-600 text-[10px] italic pb-1 select-none">
+                  {`… ${historyCap.dropped.toLocaleString()} earlier line${
+                    historyCap.dropped === 1 ? "" : "s"
+                  } hidden (showing last ${MAX_HISTORY_LINES.toLocaleString()})`}
+                </div>
+              )}
+              <div ref={historyRef} />
+              <div ref={liveRef} />
+              {cursorStyle && focused && hasDomFocus && showCursor && (
+                <div
+                  className="pointer-events-none absolute animate-pulse bg-cyan-400/70"
+                  style={cursorStyle}
+                  aria-hidden="true"
+                />
+              )}
+            </div>
+          ) : (
+            <span className="text-zinc-600">Waiting for output...</span>
+          )}
+        </div>
         <div ref={bottomRef} />
       </div>
 
@@ -780,6 +831,35 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
 
       {/* Footer status bar */}
       <div className="flex items-center gap-2 border-t border-white/5 px-3 py-1.5">
+        {/* View tabs — Live (capture-pane, light) / Transcript (JSONL, heavy) */}
+        <div className="inline-flex rounded bg-white/5 p-0.5">
+          <button
+            type="button"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => setActiveTab("live")}
+            className={`touch-target-sm rounded px-2 py-0.5 text-xs transition-colors ${
+              activeTab === "live"
+                ? "bg-cyan-500/20 text-cyan-400"
+                : "text-zinc-500 hover:text-zinc-300"
+            }`}
+            title="Live capture-pane (ANSI, lightweight)"
+          >
+            Live
+          </button>
+          <button
+            type="button"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => setActiveTab("transcript")}
+            className={`touch-target-sm rounded px-2 py-0.5 text-xs transition-colors ${
+              activeTab === "transcript"
+                ? "bg-cyan-500/20 text-cyan-400"
+                : "text-zinc-500 hover:text-zinc-300"
+            }`}
+            title="JSONL transcript (heavier; loaded on demand)"
+          >
+            Transcript
+          </button>
+        </div>
         <button
           type="button"
           onMouseDown={(e) => e.preventDefault()}

--- a/clients/react/src/components/agent/PreviewPanel.tsx
+++ b/clients/react/src/components/agent/PreviewPanel.tsx
@@ -321,7 +321,11 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
     if (composingRef.current) return;
     try {
       const data = await api.getPreview(agentId);
-      if (!data.content) return;
+      // Treat only null/undefined as "no payload" — an empty string is
+      // still a real preview state we should write through, otherwise
+      // an idle agent's quiet output keeps the UI pinned on
+      // "Waiting for output..." after an agent switch.
+      if (data.content == null) return;
       const sel = window.getSelection();
       if (sel && sel.toString().length > 0) return;
       // Split scrollback history from the live visible region so the history
@@ -418,6 +422,11 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
   // Reset preview state on agent switch so the previous agent's
   // capture-pane / transcript don't flash on screen until the first
   // fetchPreview / fetchTranscript for the new agent comes back.
+  // Also kick off an immediate fetch — the poll-loop useEffect will
+  // re-mount and fire `setTimeout(tick, 0)` too, but for an idle
+  // agent (no live output, content rarely changes) the difference
+  // between "fire immediately" and "wait for the next React tick +
+  // setTimeout schedule" was visible as a long-lived "Waiting…" state.
   useEffect(() => {
     setHistory("");
     setLive("");
@@ -425,7 +434,8 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
     setTranscriptRecords([]);
     setCursorPos(null);
     lastContentRef.current = null;
-  }, [agentId]);
+    void fetchPreview();
+  }, [agentId, fetchPreview]);
 
   // Clear incoming-prompt indicator on agent switch and on unmount
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentionally clear on agent switch

--- a/clients/react/src/lib/ansi-worker.ts
+++ b/clients/react/src/lib/ansi-worker.ts
@@ -1,0 +1,40 @@
+// Web Worker: ANSI escape sequences → HTML conversion off the main thread.
+//
+// Why: long-running agents accumulate hundreds of KB of capture-pane
+// scrollback. Running AnsiUp on that synchronously inside React's render
+// path freezes the tab (10s+ in extreme cases). Moving the conversion to
+// a worker keeps input handling, scrolling, and the Live tab responsive
+// while the heavy History HTML is being rebuilt.
+//
+// AnsiUp is stateful (it carries forward color/style state between calls
+// for streaming use), but for the History pipeline we always pass the full
+// capped scrollback in one message and don't need that streaming behaviour.
+// We construct a fresh AnsiUp per request so leftover state from a
+// previous request can never bleed into the next render.
+//
+// DOMPurify is intentionally NOT done here: porting it to a worker
+// requires a JSDOM polyfill which would balloon the worker bundle, and
+// DOMPurify itself is fast enough on the main thread to not be the
+// bottleneck. The worker returns raw HTML; the caller sanitizes.
+
+import { AnsiUp } from "ansi_up";
+
+interface ConvertRequest {
+  id: number;
+  content: string;
+}
+
+interface ConvertResponse {
+  id: number;
+  html: string;
+}
+
+self.onmessage = (e: MessageEvent<ConvertRequest>) => {
+  const { id, content } = e.data;
+  const ansi = new AnsiUp();
+  const html = ansi.ansi_to_html(content);
+  const response: ConvertResponse = { id, html };
+  self.postMessage(response);
+};
+
+export type { ConvertRequest, ConvertResponse };

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -186,8 +186,15 @@ export interface AgentSnapshot {
 }
 
 // ── Bootstrap payload (all 9 domain snapshots in one shot) ──
+//
+// tmai-core PR #150 (`fix(sse): centralize wire-event production`) wraps the
+// snapshot bundle in a `{ event, seq, snapshots }` envelope so the same shape
+// can flow over both the REST `/api/bootstrap` response and the SSE
+// "Bootstrap" frame. The flat `{ agents, worktrees, ... }` interface that
+// existed before that PR has been replaced; consumers read from
+// `payload.snapshots.<domain>`.
 
-export interface BootstrapPayload {
+export interface BootstrapSnapshots {
   agents: AgentSnapshot[];
   worktrees: WorktreeSnapshot[];
   teams: TeamSnapshot[];
@@ -196,6 +203,12 @@ export interface BootstrapPayload {
   workflow: WorkflowSnapshot;
   runtime: RuntimeSnapshot;
   approvals: ApprovalSnapshot[];
+}
+
+export interface BootstrapPayload {
+  event: "Bootstrap";
+  seq: number;
+  snapshots: BootstrapSnapshots;
 }
 
 // ── Prompt Queue ──

--- a/clients/react/src/lib/sse-provider.tsx
+++ b/clients/react/src/lib/sse-provider.tsx
@@ -72,13 +72,16 @@ export function SSEProvider({ children }: { children: ReactNode }) {
   const refreshCache = useCallback(async (): Promise<boolean> => {
     try {
       const payload: BootstrapPayload = await api.bootstrap();
+      // tmai-core PR #150 wraps the snapshot bundle in a `{ event, seq,
+      // snapshots }` envelope; read the per-domain arrays from `.snapshots`.
+      const { snapshots } = payload;
 
-      agentMapRef.current = new Map(payload.agents.map((a) => [a.id, a]));
+      agentMapRef.current = new Map(snapshots.agents.map((a) => [a.id, a]));
       // WorktreeUpdate envelope.id = WorktreeSnapshot.path (per corevents.schema.json
       // "Worktree path (unique per repo)"), so key by path to match EntityUpdate upsert/remove.
-      worktreeMapRef.current = new Map(payload.worktrees.map((w) => [w.path, w]));
+      worktreeMapRef.current = new Map(snapshots.worktrees.map((w) => [w.path, w]));
       const qMap = new Map<string, QueueAgentEntry>();
-      for (const entry of payload.queue.entries) {
+      for (const entry of snapshots.queue.entries) {
         qMap.set(entry.agent_id, entry);
       }
       queueMapRef.current = qMap;
@@ -141,10 +144,24 @@ export function SSEProvider({ children }: { children: ReactNode }) {
           }
 
           if (entity === "Agent") {
+            // tmai-core #96: AgentUpdate envelope.id is the pane target
+            // (e.g. "session-1:2.1") while bootstrap seeds the cache with
+            // snapshot.id (e.g. "add98d12"). Without normalization we end
+            // up with two entries per agent — one per identifier scheme —
+            // which surfaces as duplicate cards whose status drifts apart.
+            // Always pin the cache key to the snapshot.id and drop any
+            // stray entry that the envelope id may have created.
             if (change === "Removed") {
               agentMapRef.current.delete(id);
+              if (snapshot != null) {
+                agentMapRef.current.delete((snapshot as AgentSnapshot).id);
+              }
             } else if (snapshot != null) {
-              agentMapRef.current.set(id, snapshot as AgentSnapshot);
+              const snap = snapshot as AgentSnapshot;
+              if (snap.id !== id) {
+                agentMapRef.current.delete(id);
+              }
+              agentMapRef.current.set(snap.id, snap);
             }
             setAgents([...agentMapRef.current.values()]);
           } else if (entity === "Worktree") {


### PR DESCRIPTION
## Summary

Three related WebUI fixes that surfaced once tmai-core PR #150 (centralize wire-event production) landed and live agents started flowing through the new envelope path.

## Bootstrap envelope adoption (`api-http.ts`, `sse-provider.tsx`)

`GET /api/bootstrap` now returns `{ event, seq, snapshots }` instead of a flat `{ agents, worktrees, ... }` payload. The old `BootstrapPayload` shape made `payload.agents.map(...)` throw, the catch silently swallowed it, and the WebUI was stuck on **\"Initializing...\"** forever after re-running the engine. Add a `BootstrapSnapshots` type and read the per-domain arrays from `payload.snapshots`.

## Agent identity duplication workaround (`sse-provider.tsx`)

\`AgentUpdate\` envelopes carry \`envelope.id = pane_target\` (e.g. \`session-1:2.1\`) while bootstrap seeds the cache with \`snapshot.id = stable_id\` (e.g. \`add98d12\`). Without normalization the cache ends up with **two entries per agent** — one per identifier scheme — and the UI renders duplicate cards whose status drifts apart on every poll tick.

This PR pins the cache key to \`snapshot.id\` for the Agent entity and drops any stray entry the envelope id may have created. **This is a defensive client-side workaround** — the wire contract gap is tracked upstream as **trust-delta/tmai-core#151** (sister of the broader **#96** identity unification effort). The expectation is to revert this once the engine guarantees \`envelope.id == snapshot.id\`.

Note: the same wire pattern probably applies to the other entity-update entities (Worktree / Dispatch / Team / Queue / Workflow / Runtime / Approval). They are intentionally **not** touched here — we'd rather have the engine fix carry them all together.

## Preview Live/Transcript tabs (`PreviewPanel.tsx`)

Long claude conversations cause the WebUI to drag, and the prior Hybrid Scrollback Preview always rendered the JSONL transcript on top of the live capture-pane — paying the per-record react-markdown cost even while the user was just monitoring. Split the panel into two tabs:

- **Live**: capture-pane only (the cheap path), default on every open. Keeps mounting under \`display:none\` while Transcript is showing so the \`historyRef\` / \`liveRef\` survive tab switches.
- **Transcript**: JSONL records, lazy-mounted; the 3s \`getTranscript\` polling only runs while this tab is active.

A \`skipNextScrollEventRef\` guard prevents the synthetic \`onScroll\` the browser fires when the display flip changes \`scrollHeight\` from flipping \`autoScroll\` off without a real user gesture, and on returning to Live we re-pin to the bottom when \`autoScroll\` was on.

This is **Phase 1** of a larger preview-perf effort. If JSONL rendering proves to still be the dominant cost when the user actually opens the Transcript tab, Phase 2 candidates are progressive chunk loading or full virtual scroll inside the Transcript tab.

## Test plan

- [x] \`pnpm tsc --noEmit\` (clean)
- [x] \`pnpm test\` (203 passed, no regressions)
- [x] Manual: WebUI loads, both Live and Transcript tabs render, switching preserves state, autoScroll survives tab toggles
- [x] Manual: agent cards render once per agent (no duplicates) when bootstrap + first SSE tick race

## Linked

- Upstream wire issue: trust-delta/tmai-core#151
- Identity unification (broader): trust-delta/tmai-core#96
- Engine PR that exposed the envelope shift: trust-delta/tmai-core#150

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エージェント情報パネルにタブ（Live / Transcript）切替が追加されました。

* **改善**
  * トランスクリプト取得はTranscriptタブがアクティブなときのみ行われ、不要なポーリングを抑制します。
  * スクロール挙動が改善され、タブ切替時の不自然なスクロール発生を抑止し、オートスクロール復帰を安定化しました。
  * ANSI→HTML変換をメインスレッド外で処理し、表示パフォーマンスと応答性を向上しました。

* **バグ修正**
  * 重複・重なり得るプレビュー取得を防ぎ、切替時の古い表示や「待機中」の誤表示を解消しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->