### PR TITLE
chore(gen): sync generated spec + types from tmai-core@9cfdcb3ce1

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -2119,6 +2119,36 @@
       "type": "object"
     },
     {
+      "description": "An agent's `AgentId` was promoted from `Provisional` to a native\nsession id once the underlying CLI reported one (Phase 1 of #96).\n\nSubscribers that hold references to the previous id should rewrite\nthem to `to`. The wire form of `from` and `to` is `<scheme>:<id>`\n(e.g. `\"claude:ea760770-...\"`). `target` is the tmux pane id and\nremains the legacy lookup key during Phase 1.",
+      "properties": {
+        "from": {
+          "description": "Previous id, always a `provisional:<uuid>` in Phase 1",
+          "type": "string"
+        },
+        "target": {
+          "description": "Agent target ID (tmux pane string)",
+          "type": "string"
+        },
+        "to": {
+          "description": "New native id (`claude:<uuid>` / `codex:<uuid>` / etc.)",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "AgentIdPromoted"
+          ],
+          "type": "string"
+        }
+      },
+      "required": [
+        "target",
+        "from",
+        "to",
+        "type"
+      ],
+      "type": "object"
+    },
+    {
       "description": "Context compaction started (PreCompact hook event)",
       "properties": {
         "compaction_count": {

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -575,6 +575,36 @@
           },
           {
             "type": "object",
+            "description": "An agent's `AgentId` was promoted from `Provisional` to a native\nsession id once the underlying CLI reported one (Phase 1 of #96).\n\nSubscribers that hold references to the previous id should rewrite\nthem to `to`. The wire form of `from` and `to` is `<scheme>:<id>`\n(e.g. `\"claude:ea760770-...\"`). `target` is the tmux pane id and\nremains the legacy lookup key during Phase 1.",
+            "required": [
+              "target",
+              "from",
+              "to",
+              "type"
+            ],
+            "properties": {
+              "from": {
+                "type": "string",
+                "description": "Previous id, always a `provisional:<uuid>` in Phase 1"
+              },
+              "target": {
+                "type": "string",
+                "description": "Agent target ID (tmux pane string)"
+              },
+              "to": {
+                "type": "string",
+                "description": "New native id (`claude:<uuid>` / `codex:<uuid>` / etc.)"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "AgentIdPromoted"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
             "description": "Context compaction started (PreCompact hook event)",
             "required": [
               "target",

--- a/clients/ratatui/src/types/generated/core_event.rs
+++ b/clients/ratatui/src/types/generated/core_event.rs
@@ -40,6 +40,11 @@ pub enum CoreEvent {
         last_assistant_message: Option<Value>,
         target: String,
     },
+    AgentIdPromoted {
+        from: String,
+        target: String,
+        to: String,
+    },
     ContextCompacting {
         compaction_count: i32,
         target: String,

--- a/clients/react/src/types/generated/ActionOrigin.ts
+++ b/clients/react/src/types/generated/ActionOrigin.ts
@@ -18,7 +18,7 @@ interface: string,
  * `OrchestratorNotifier::source_project_scope` can scope notifications
  * without needing the caller to be tracked in `state.agents`.
  */
-cwd: string | null, } | { "kind": "Agent", 
+cwd?: string | null, } | { "kind": "Agent", 
 /**
  * Agent target ID (e.g., "main:0.0")
  */
@@ -34,7 +34,7 @@ is_orchestrator: boolean,
  * `OrchestratorNotifier::source_project_scope` can resolve the project
  * root when the MCP agent ID is not tracked in `state.agents` (#75).
  */
-cwd: string | null, } | { "kind": "System", 
+cwd?: string | null, } | { "kind": "System", 
 /**
  * Subsystem name (e.g., "auto_cleanup", "pr_monitor")
  */
@@ -43,4 +43,4 @@ subsystem: string,
  * Working directory of the originating subsystem process, used for
  * project-scope routing (#89).
  */
-cwd: string | null, };
+cwd?: string | null, };

--- a/clients/react/src/types/generated/CoreEvent.ts
+++ b/clients/react/src/types/generated/CoreEvent.ts
@@ -84,7 +84,19 @@ cwd: string,
 /**
  * Last assistant message (if available)
  */
-last_assistant_message: string | null, } | { "type": "ContextCompacting", 
+last_assistant_message: string | null, } | { "type": "AgentIdPromoted", 
+/**
+ * Agent target ID (tmux pane string)
+ */
+target: string, 
+/**
+ * Previous id, always a `provisional:<uuid>` in Phase 1
+ */
+from: string, 
+/**
+ * New native id (`claude:<uuid>` / `codex:<uuid>` / etc.)
+ */
+to: string, } | { "type": "ContextCompacting", 
 /**
  * Agent target ID
  */
@@ -346,7 +358,7 @@ code: ErrorCode,
  * raw prompts). Defaults to `null` when the emitter has nothing
  * to attach.
  */
-context: unknown, } | { "type": "DispatchBypassUsed", 
+context?: unknown, } | { "type": "DispatchBypassUsed", 
 /**
  * Origin of the bypassing call.
  */

--- a/clients/react/src/types/generated/TmaiError.ts
+++ b/clients/react/src/types/generated/TmaiError.ts
@@ -31,7 +31,7 @@ retry_hint?: RetryHint,
  * `unknown`, which already accepts `undefined` at the call site — no
  * `ts(optional)` because that attribute rejects non-`Option<T>` fields.
  */
-context: unknown, 
+context?: unknown, 
 /**
  * Request/span identifier for correlating this error across MCP, WebUI,
  * and internal tracing spans.


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@9cfdcb3ce18e3f8e44576d2dd89c73803c7da0a6

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/corevents.schema.json                    | 30 +++++++++++++++++++++++
 api-spec/openapi.json                             | 30 +++++++++++++++++++++++
 clients/ratatui/src/types/generated/core_event.rs |  5 ++++
 clients/react/src/types/generated/ActionOrigin.ts |  6 ++---
 clients/react/src/types/generated/CoreEvent.ts    | 16 ++++++++++--
 clients/react/src/types/generated/TmaiError.ts    |  2 +-
 6 files changed, 83 insertions(+), 6 deletions(-)
```

</details>