### PR TITLE
fix(preview): keep auto-scroll honest across agent switches

### DIFF
--- a/clients/react/src/components/agent/PreviewPanel.tsx
+++ b/clients/react/src/components/agent/PreviewPanel.tsx
@@ -448,6 +448,11 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
     // Drop any in-flight guard from the previous agent so the first
     // fetch for the new agent isn't itself skipped.
     fetchInFlightRef.current = false;
+    // Suppress the synthetic onScroll the browser fires when the
+    // history block re-rendering after the switch changes scrollHeight
+    // — without this, autoScroll would flip off without any user
+    // gesture, exactly like the tab-switch case.
+    skipNextScrollEventRef.current = true;
     void fetchPreview();
   }, [agentId, fetchPreview]);
 
@@ -768,6 +773,20 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
       height: `${lineH}px`,
     });
   }, [liveHtml, autoScroll, liveCursor]);
+
+  // Pin to bottom when the History HTML lands too — for an idle agent
+  // the Live region barely changes, so the liveHtml-keyed scroll above
+  // would never fire and the panel would open scrolled to the top of a
+  // long scrollback. requestAnimationFrame defers until after the
+  // history innerHTML has been written and the layout is settled.
+  useEffect(() => {
+    if (!autoScroll) return;
+    if (window.getSelection()?.toString().length) return;
+    const id = requestAnimationFrame(() => {
+      bottomRef.current?.scrollIntoView({ behavior: "instant" });
+    });
+    return () => cancelAnimationFrame(id);
+  }, [historyHtml, autoScroll]);
 
   return (
     <div


### PR DESCRIPTION
## Summary

Follow-up to #541. Two related auto-scroll symptoms after the preview rewrite:

1. **Idle agent opens scrolled to the top.** Auto-scroll was only re-pinning on \`liveHtml\` updates — but an idle agent's Live region barely changes; only History fills in after the switch. The panel ended up showing the *top* of a long scrollback even with autoScroll on. Add a second re-pin keyed on \`historyHtml\`.
2. **Synthetic onScroll flipped autoScroll off without a gesture.** The agent-switch reset effect didn't arm \`skipNextScrollEventRef\`, so when the new content's scrollHeight changed the browser fired onScroll, \`handleScroll\` ran, and autoScroll silently turned off. The same flag already covers the tab-switch case; set it on agent switch too.

Both pins use \`requestAnimationFrame\` so the scroll lands after the relevant innerHTML write has flushed.

## Test plan

- [x] \`pnpm tsc --noEmit\`
- [x] \`pnpm test\` (203 passed)
- [ ] Manual: switch to an idle agent (no live output) — panel should land at bottom of history
- [ ] Manual: switch to a busy agent — autoScroll stays on, content keeps following

🤖 Generated with [Claude Code](https://claude.com/claude-code)