### PR TITLE
fix(preview): use active-input poll cadence while user is typing

### DIFF
--- a/clients/react/src/components/agent/PreviewPanel.tsx
+++ b/clients/react/src/components/agent/PreviewPanel.tsx
@@ -302,14 +302,25 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
   // Polling interval: short (active_input_ms) for a window after every
   // keystroke, then focused (default 500ms), otherwise unfocused (2s).
   // The keystroke-triggered 50ms/200ms fetches alone don't cover the
-  // visible lag that shows up when the backend rewrites the preview a
-  // bit later (tmux repaint after send-keys); the active-input window
-  // keeps the preview caught up while the user is actively typing.
-  // Preview polling cadence: focused vs unfocused only. Keystroke-driven
-  // post-passthrough fetches (50ms + 200ms) complement the steady poll.
+  // Preview polling cadence:
+  //   - unfocused: slow (preview_poll_unfocused_ms, default 2000ms).
+  //   - focused, no recent input: medium (preview_poll_focused_ms, 200ms).
+  //   - focused, key pressed within the active-input window:
+  //     fast (preview_poll_active_input_ms, 50ms) so backend repaint after
+  //     send-keys feels near-realtime instead of lagging by a tick.
+  // The post-passthrough setTimeout(fetchPreview, 50/200) burst already
+  // catches one repaint per keystroke, but it does not cover the steady
+  // tmux/agent state changes that happen between keys (cursor blink,
+  // multi-character paste, IME confirms, etc.). lastInputTime is updated
+  // on every passthrough so this window slides forward with each key.
+  const ACTIVE_INPUT_WINDOW_MS = 500;
   const getPollInterval = useCallback(() => {
     const s = pollSettings.current;
-    return focused ? s.preview_poll_focused_ms : s.preview_poll_unfocused_ms;
+    if (!focused) return s.preview_poll_unfocused_ms;
+    if (Date.now() - lastInputTime.current < ACTIVE_INPUT_WINDOW_MS) {
+      return s.preview_poll_active_input_ms;
+    }
+    return s.preview_poll_focused_ms;
   }, [focused]);
 
   // Fetch preview content, shared between polling and post-keystroke refresh.


### PR DESCRIPTION
## Summary

\`preview_poll_active_input_ms\` (50ms / 20Hz) was defined in PreviewSettings but never consulted by the running poll loop — \`getPollInterval\` only returned focused / unfocused values (200ms / 2000ms). The post-passthrough \`setTimeout(fetchPreview, 50/200)\` burst caught the repaint right after each keystroke but did nothing for the steady tmux/agent state churn between keys (cursor blink, multi-character paste tail, IME confirms), so typing felt like it was lagging the preview by a 200ms tick.

## Change

Slide a **500ms active-input window** forward on each passthrough event (\`lastInputTime\` is already updated there). While inside the window the steady poll uses the fast cadence (50ms); otherwise it falls back to the existing focused cadence (200ms). Unfocused stays slow (2000ms).

```ts
const ACTIVE_INPUT_WINDOW_MS = 500;
const getPollInterval = useCallback(() => {
  const s = pollSettings.current;
  if (!focused) return s.preview_poll_unfocused_ms;
  if (Date.now() - lastInputTime.current < ACTIVE_INPUT_WINDOW_MS) {
    return s.preview_poll_active_input_ms;
  }
  return s.preview_poll_focused_ms;
}, [focused]);
```

## Followups (out of scope)

The eventual goal is engine-side push (SSE preview events or WebSocket terminal stream) so polling can go away entirely. This PR is the cheap-and-correct version that ships in 17 lines without touching the wire.

## Test plan

- [x] \`pnpm tsc --noEmit\`
- [x] \`pnpm test\` (203 passing)
- [ ] Manual: hold a key down in input mode and confirm the cursor / echoed character lands within ~50ms of input instead of ~200ms

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * プレビューパネルのポーリング間隔ロジックを調整。最近のユーザー入力に基づいて更新频度が動的に変更されるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->