### PR TITLE
revert(sse): drop Agent envelope-id defensive after #96 wire unification

### DIFF
--- a/clients/react/src/lib/sse-provider.tsx
+++ b/clients/react/src/lib/sse-provider.tsx
@@ -144,24 +144,10 @@ export function SSEProvider({ children }: { children: ReactNode }) {
           }
 
           if (entity === "Agent") {
-            // tmai-core #96: AgentUpdate envelope.id is the pane target
-            // (e.g. "session-1:2.1") while bootstrap seeds the cache with
-            // snapshot.id (e.g. "add98d12"). Without normalization we end
-            // up with two entries per agent — one per identifier scheme —
-            // which surfaces as duplicate cards whose status drifts apart.
-            // Always pin the cache key to the snapshot.id and drop any
-            // stray entry that the envelope id may have created.
             if (change === "Removed") {
               agentMapRef.current.delete(id);
-              if (snapshot != null) {
-                agentMapRef.current.delete((snapshot as AgentSnapshot).id);
-              }
             } else if (snapshot != null) {
-              const snap = snapshot as AgentSnapshot;
-              if (snap.id !== id) {
-                agentMapRef.current.delete(id);
-              }
-              agentMapRef.current.set(snap.id, snap);
+              agentMapRef.current.set(id, snapshot as AgentSnapshot);
             }
             setAgents([...agentMapRef.current.values()]);
           } else if (entity === "Worktree") {


### PR DESCRIPTION
## Summary

Drop the client-side defensive that pinned the agent cache key to \`snapshot.id\` and discarded the entry the AgentUpdate envelope's pane-target id had separately created. tmai-core's #96 Phase 1 (PR #155 + regression hot-fix #159) makes the canonical AgentId form (\`<scheme>:<id>\`, e.g. \`claude:<uuid>\`) flow through both \`snapshot.id\` and the envelope's outer \`id\`, with **\`envelope.id == snapshot.id\` as an invariant** on the wire. The defensive is no longer needed and the Agent branch can match Worktree / Queue again.

## Verified locally against the post-#155 + #159 engine

```
GET /api/agents → [{ id: 'claude:acdc1274-...', pane: 'session-1:2.1', ... }]

SSE event: AgentUpdate
  envelope.id  = 'claude:acdc1274-1d98-4993-b493-2fee7246ca13'
  snapshot.id  = 'claude:acdc1274-1d98-4993-b493-2fee7246ca13'
  match        = True
```

Identifiers are now the canonical AgentId Display form.

## Diff

\`\`\`ts
// Before (defensive, PR #541 commit 28c369d):
if (entity === "Agent") {
  if (change === "Removed") {
    agentMapRef.current.delete(id);
    if (snapshot != null) agentMapRef.current.delete((snapshot as AgentSnapshot).id);
  } else if (snapshot != null) {
    const snap = snapshot as AgentSnapshot;
    if (snap.id !== id) agentMapRef.current.delete(id);
    agentMapRef.current.set(snap.id, snap);
  }
  setAgents([...agentMapRef.current.values()]);
}

// After (matches Worktree / Queue branches):
if (entity === "Agent") {
  if (change === "Removed") {
    agentMapRef.current.delete(id);
  } else if (snapshot != null) {
    agentMapRef.current.set(id, snapshot as AgentSnapshot);
  }
  setAgents([...agentMapRef.current.values()]);
}
\`\`\`

Closes trust-delta/tmai-core#151.

## Test plan

- [x] \`pnpm tsc --noEmit\`
- [x] \`pnpm test\` (203 passing)
- [x] Manual: post-#155 + #159 engine returns canonical id; verified SSE invariant; agent rendered without duplicate cards

## Notes

- Worktree / Queue branches are intentionally unchanged: the same \`envelope.id == snapshot.id\` invariant should now hold there as well per Phase 1 PR4 description, but they did not have client-side defensives to revert.
- If a future user runs an older engine binary (pre-#155), this branch will surface the original duplicate-cards behaviour. Prefer running matched engine + WebUI versions; the defensive is intentionally not preserved as a permanent compat shim.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * エージェント情報のキャッシュ処理を簡潔化し、重複キャッシュエントリの生成を防止しました

* **パフォーマンス改善**
  * リアルタイムストリーミング更新時のエージェント同期メカニズムを最適化し、キャッシュの一貫性を向上

<!-- end of auto-generated comment: release notes by coderabbit.ai -->