### PR TITLE
feat(react): add deep-link route /agents/:scheme/:id (#157)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { AgentActions } from "@/components/agent/AgentActions";
 import { AgentList } from "@/components/agent/AgentList";
+import { AgentNotFound } from "@/components/agent/AgentNotFound";
 import { PreviewPanel } from "@/components/agent/PreviewPanel";
 import { HelpOverlay } from "@/components/layout/HelpOverlay";
 import { SplitPaneLayout } from "@/components/layout/SplitPaneLayout";
@@ -15,6 +16,7 @@ import { UsagePanel } from "@/components/usage/UsagePanel";
 import { BranchGraph } from "@/components/worktree/BranchGraph";
 import { WorktreePanel } from "@/components/worktree/WorktreePanel";
 import { useAgents } from "@/hooks/useAgents";
+import { useDeepLink } from "@/hooks/useDeepLink";
 import { useIdleNotification } from "@/hooks/useIdleNotification";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
@@ -26,6 +28,7 @@ import { useSSE } from "@/lib/sse-provider";
 export function App() {
   const { agents, attentionCount, loading, refresh } = useAgents();
   const { worktrees, refresh: refreshWorktrees } = useWorktrees();
+  const deepLink = useDeepLink();
   const toast = useToast();
   const { success: toastSuccess, error: toastError, info: toastInfo } = toast;
   const [notifyConfig, setNotifyConfig] = useState({ enabled: true, thresholdSecs: 10 });
@@ -61,6 +64,16 @@ export function App() {
     },
   });
   const [selection, setSelection] = useState<Selection | null>(null);
+  // null: not a deep-link URL
+  // "pending": deep-link detected, waiting for agent list to load
+  // "resolved": agent found and selected
+  // "not_found": agent not in the list → show 404
+  const [deepLinkStatus, setDeepLinkStatus] = useState<"pending" | "resolved" | "not_found" | null>(
+    () => {
+      if (deepLink === null) return null;
+      return deepLink.knownScheme ? "pending" : "not_found";
+    },
+  );
   const [registeredProjects, setRegisteredProjects] = useState<string[]>([]);
   const [currentProject, setCurrentProject] = useState<string | null>(null);
   const [currentProjectIndex, setCurrentProjectIndex] = useState(0);
@@ -155,6 +168,20 @@ export function App() {
     },
     [closeMobileDrawer],
   );
+
+  // Resolve deep-link once the agent list has loaded.
+  // Runs whenever agents or loading changes; guards on deepLinkStatus so it
+  // fires exactly once (subsequent state changes flip status off "pending").
+  useEffect(() => {
+    if (deepLinkStatus !== "pending" || loading) return;
+    const agent = agents.find((a) => a.id === deepLink?.canonicalId);
+    if (agent) {
+      setSelection({ type: "agent", id: agent.target });
+      setDeepLinkStatus("resolved");
+    } else {
+      setDeepLinkStatus("not_found");
+    }
+  }, [deepLinkStatus, loading, agents, deepLink]);
 
   // Derive selectedTarget string for components that need it
   const selectedTarget = selection?.type === "agent" ? selection.id : null;
@@ -582,6 +609,8 @@ export function App() {
               >
                 <PreviewPanel agentId={selectedAgent.id} />
               </div>
+            ) : deepLinkStatus === "not_found" && deepLink ? (
+              <AgentNotFound scheme={deepLink.scheme} id={deepLink.id} />
             ) : (
               <div className="flex flex-1 items-center justify-center animate-fade-in">
                 <div className="glass-light rounded-2xl px-8 py-8 text-center transition-subtle hover:glass mx-4">

--- a/clients/react/src/components/agent/AgentNotFound.tsx
+++ b/clients/react/src/components/agent/AgentNotFound.tsx
@@ -1,0 +1,21 @@
+interface Props {
+  scheme: string;
+  id: string;
+}
+
+export function AgentNotFound({ scheme, id }: Props) {
+  const canonicalId = `${scheme}:${id}`;
+  return (
+    <div className="flex flex-1 items-center justify-center animate-fade-in">
+      <div className="glass-light rounded-2xl px-8 py-8 text-center mx-4 max-w-md">
+        <div className="text-4xl font-bold text-zinc-600 mb-3">404</div>
+        <h2 className="text-base font-semibold text-zinc-300 mb-2">Agent not found</h2>
+        <p className="text-xs font-mono text-zinc-500 break-all">{canonicalId}</p>
+        <p className="mt-3 text-xs text-zinc-600">
+          The agent may have ended or the id is no longer valid. Select an agent from the sidebar to
+          continue.
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/clients/react/src/hooks/__tests__/useDeepLink.test.ts
+++ b/clients/react/src/hooks/__tests__/useDeepLink.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { parseDeepLink } from "../useDeepLink";
+
+describe("parseDeepLink", () => {
+  it("parses a valid claude deep-link", () => {
+    const result = parseDeepLink("/agents/claude/ea760770-c137-46f6-8fd8-a00d9691c1fb");
+    expect(result).toEqual({
+      scheme: "claude",
+      id: "ea760770-c137-46f6-8fd8-a00d9691c1fb",
+      knownScheme: true,
+      canonicalId: "claude:ea760770-c137-46f6-8fd8-a00d9691c1fb",
+    });
+  });
+
+  it("parses codex, gemini, opencode schemes as known", () => {
+    for (const scheme of ["codex", "gemini", "opencode"]) {
+      const result = parseDeepLink(`/agents/${scheme}/some-id-value`);
+      expect(result?.knownScheme).toBe(true);
+      expect(result?.scheme).toBe(scheme);
+    }
+  });
+
+  it("marks provisional scheme as unknown", () => {
+    const result = parseDeepLink("/agents/provisional/ea760770-c137-46f6-8fd8-a00d9691c1fb");
+    expect(result).not.toBeNull();
+    expect(result?.knownScheme).toBe(false);
+  });
+
+  it("marks an arbitrary unknown scheme as unknown", () => {
+    const result = parseDeepLink("/agents/mystery/some-id");
+    expect(result?.knownScheme).toBe(false);
+  });
+
+  it("returns null for the root path", () => {
+    expect(parseDeepLink("/")).toBeNull();
+  });
+
+  it("returns null for /agents with no scheme or id", () => {
+    expect(parseDeepLink("/agents")).toBeNull();
+    expect(parseDeepLink("/agents/")).toBeNull();
+  });
+
+  it("returns null when id segment is missing", () => {
+    expect(parseDeepLink("/agents/claude")).toBeNull();
+    expect(parseDeepLink("/agents/claude/")).toBeNull();
+  });
+
+  it("returns null for unrelated paths", () => {
+    expect(parseDeepLink("/settings")).toBeNull();
+    expect(parseDeepLink("/agents/claude/uuid/extra")).toBeNull();
+  });
+
+  it("builds canonicalId correctly", () => {
+    const result = parseDeepLink("/agents/gemini/opaque-session-abc123");
+    expect(result?.canonicalId).toBe("gemini:opaque-session-abc123");
+  });
+});

--- a/clients/react/src/hooks/useDeepLink.ts
+++ b/clients/react/src/hooks/useDeepLink.ts
@@ -1,0 +1,40 @@
+// Deep-link URL parser for /agents/:scheme/:id routes.
+//
+// Canonical AgentId wire form is "<scheme>:<id>" (e.g. "claude:ea760770-...").
+// The URL path replaces the colon with a slash to avoid encoder-mangling:
+//   /agents/claude/ea760770-c137-46f6-8fd8-a00d9691c1fb
+//
+// Provisional agents are excluded from the known-scheme set because they are
+// not exposed on the wire (AgentId spec §96 PR4).
+
+const KNOWN_SCHEMES = new Set(["claude", "codex", "gemini", "opencode"]);
+const DEEP_LINK_RE = /^\/agents\/([^/]+)\/([^/]+)\/?$/;
+
+export interface DeepLinkParams {
+  scheme: string;
+  id: string;
+  /** True when the scheme is in the known set. False → render 404 immediately. */
+  knownScheme: boolean;
+  /** The canonical AgentId wire form: "<scheme>:<id>" */
+  canonicalId: string;
+}
+
+/** Parse a pathname, returning deep-link params or null if it doesn't match. */
+export function parseDeepLink(pathname: string): DeepLinkParams | null {
+  const match = DEEP_LINK_RE.exec(pathname);
+  if (!match) return null;
+  const [, scheme, id] = match;
+  return {
+    scheme,
+    id,
+    knownScheme: KNOWN_SCHEMES.has(scheme),
+    canonicalId: `${scheme}:${id}`,
+  };
+}
+
+/** Returns deep-link params when the current URL matches /agents/:scheme/:id, otherwise null. */
+export function useDeepLink(): DeepLinkParams | null {
+  // Evaluated once at render time. window.location.pathname is stable for the
+  // lifetime of a page load — no state or effect needed.
+  return parseDeepLink(window.location.pathname);
+}


### PR DESCRIPTION
## Summary

- Adds `useDeepLink` hook that parses `/agents/:scheme/:id` from the current URL pathname
- Adds `AgentNotFound` component for graceful 404 display
- Wires deep-link resolution into `App.tsx`: on agent list load, finds the matching agent by canonical id (`<scheme>:<id>`) and selects it; shows 404 if not found or scheme is unknown
- Adds unit tests for `parseDeepLink` covering all schemes, unknown schemes, and invalid paths

No server-side changes required — the Axum server already serves `index.html` as SPA fallback for all unrecognised paths.

Closes trust-delta/tmai-core#157.

## Test plan

- [ ] `pnpm test` passes (212 tests)
- [ ] `pnpm run lint` clean (no new warnings)
- [ ] `pnpm run build` succeeds
- [ ] Navigate to `/agents/claude/<uuid>?token=…` while the matching agent is running → agent panel opens
- [ ] Navigate to `/agents/claude/<nonexistent-uuid>?token=…` → "404 Agent not found" view in main content; sidebar still usable
- [ ] Navigate to `/agents/provisional/<uuid>?token=…` (unknown scheme) → immediate 404 view
- [ ] Click an agent in the sidebar after seeing 404 → agent panel replaces 404 view normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ディープリンク機能を追加し、URLから直接エージェントを選択できるようにしました。エージェントが見つからない場合は、404スタイルのメッセージを表示します。

* **Tests**
  * ディープリンク解析機能のテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->