### PR TITLE
chore(gen): sync generated spec + types from tmai-core@5b42cb9315

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -95,7 +95,7 @@
       "description": "Snapshot of the auto-approve state for a single agent.",
       "properties": {
         "agent_id": {
-          "description": "Stable agent identifier (UUID short hash)",
+          "description": "Canonical agent identifier (`<scheme>:<id>`)",
           "type": "string"
         },
         "agent_stable_id": {
@@ -642,13 +642,6 @@
     "DispatchSnapshot": {
       "description": "UI-facing snapshot of a dispatched unit of work.",
       "properties": {
-        "agent_stable_id": {
-          "description": "Stable agent id (8-char hex), if the agent has been attached.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
         "agent_target": {
           "description": "Live agent tmux target (e.g. \"main:0.1\"), if the agent has been attached.",
           "type": [
@@ -1096,7 +1089,7 @@
           "type": "string"
         },
         "agent_id": {
-          "description": "Stable agent identifier (UUID short hash, matches `AgentSnapshot.id`)",
+          "description": "Canonical agent identifier (`<scheme>:<id>`, matches `AgentSnapshot.id`)",
           "type": "string"
         },
         "agent_stable_id": {

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -145,7 +145,7 @@
         "properties": {
           "agent_id": {
             "type": "string",
-            "description": "Stable agent identifier (UUID short hash)"
+            "description": "Canonical agent identifier (`<scheme>:<id>`)"
           },
           "agent_stable_id": {
             "type": "string",
@@ -1839,13 +1839,6 @@
           "is_terminal"
         ],
         "properties": {
-          "agent_stable_id": {
-            "type": [
-              "string",
-              "null"
-            ],
-            "description": "Stable agent id (8-char hex), if the agent has been attached."
-          },
           "agent_target": {
             "type": [
               "string",
@@ -2289,7 +2282,7 @@
           },
           "agent_id": {
             "type": "string",
-            "description": "Stable agent identifier (UUID short hash, matches `AgentSnapshot.id`)"
+            "description": "Canonical agent identifier (`<scheme>:<id>`, matches `AgentSnapshot.id`)"
           },
           "agent_stable_id": {
             "type": "string",

--- a/clients/ratatui/src/types/generated/dispatch_snapshot.rs
+++ b/clients/ratatui/src/types/generated/dispatch_snapshot.rs
@@ -11,8 +11,6 @@ use std::collections::HashMap;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub struct DispatchSnapshot {
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub agent_stable_id: Option<Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub agent_target: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub bundle_id: Option<BundleId>,

--- a/clients/react/src/types/generated/ApprovalSnapshot.ts
+++ b/clients/react/src/types/generated/ApprovalSnapshot.ts
@@ -9,7 +9,7 @@ import type { RecentDecision } from "./RecentDecision";
  */
 export type ApprovalSnapshot = { 
 /**
- * Stable agent identifier (UUID short hash)
+ * Canonical agent identifier (`<scheme>:<id>`)
  */
 agent_id: string, 
 /**

--- a/clients/react/src/types/generated/DispatchSnapshot.ts
+++ b/clients/react/src/types/generated/DispatchSnapshot.ts
@@ -48,10 +48,6 @@ finished_at?: string,
  */
 agent_target?: string, 
 /**
- * Stable agent id (8-char hex), if the agent has been attached.
- */
-agent_stable_id?: string, 
-/**
  * PTY session id, if the agent was spawned via the PTY layer.
  */
 pty_session_id?: string, 

--- a/clients/react/src/types/generated/QueueAgentEntry.ts
+++ b/clients/react/src/types/generated/QueueAgentEntry.ts
@@ -6,7 +6,7 @@ import type { QueuedPrompt } from "./QueuedPrompt";
  */
 export type QueueAgentEntry = { 
 /**
- * Stable agent identifier (UUID short hash, matches `AgentSnapshot.id`)
+ * Canonical agent identifier (`<scheme>:<id>`, matches `AgentSnapshot.id`)
  */
 agent_id: string, 
 /**


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@5b42cb9315d4063df614496e7286acd1c39aaef0

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/corevents.schema.json                           | 11 ++---------
 api-spec/openapi.json                                    | 11 ++---------
 clients/ratatui/src/types/generated/dispatch_snapshot.rs |  2 --
 clients/react/src/types/generated/ApprovalSnapshot.ts    |  2 +-
 clients/react/src/types/generated/DispatchSnapshot.ts    |  4 ----
 clients/react/src/types/generated/QueueAgentEntry.ts     |  2 +-
 6 files changed, 6 insertions(+), 26 deletions(-)
```

</details>