### PR TITLE
feat(react): #174 Phase 3b-1 — keyEventToBytes utility for the keys WebSocket

### DIFF
--- a/clients/react/src/lib/__tests__/keys.test.ts
+++ b/clients/react/src/lib/__tests__/keys.test.ts
@@ -1,0 +1,107 @@
+// Equivalence fixture for `keyEventToBytes` against the Rust reference
+// `tmai_core::utils::keys::tmux_key_to_bytes`. Every entry below is a
+// `(KeyboardEvent shape, expected bytes)` pair where the `expected
+// bytes` come straight from `tmux_key_to_bytes` for the corresponding
+// tmux name produced by the legacy `toTmuxKey` mapping in PreviewPanel.
+
+import { describe, expect, it } from "vitest";
+import { keyEventToBytes, textToBytes } from "../keys";
+
+interface EventShape {
+  key: string;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  metaKey?: boolean;
+}
+
+function makeEvent(shape: EventShape): KeyboardEvent {
+  return shape as unknown as KeyboardEvent;
+}
+
+const CASES: Array<{
+  name: string;
+  event: EventShape;
+  expected: number[];
+}> = [
+  // Plain printable
+  { name: "y", event: { key: "y" }, expected: [0x79] },
+  { name: "0", event: { key: "0" }, expected: [0x30] },
+  { name: "/", event: { key: "/" }, expected: [0x2f] },
+  { name: "Space (' ')", event: { key: " " }, expected: [0x20] },
+
+  // Control characters via bitmask
+  { name: "C-c", event: { key: "c", ctrlKey: true }, expected: [0x03] },
+  { name: "C-C (uppercase same as C-c)", event: { key: "C", ctrlKey: true }, expected: [0x03] },
+  { name: "C-a", event: { key: "a", ctrlKey: true }, expected: [0x01] },
+  { name: "C-@ (NUL via ctrl-2/ctrl-space)", event: { key: "@", ctrlKey: true }, expected: [0x00] },
+  { name: "C-[ (ESC)", event: { key: "[", ctrlKey: true }, expected: [0x1b] },
+  { name: "C-Space (NUL)", event: { key: " ", ctrlKey: true }, expected: [0x00] },
+
+  // Special keys
+  { name: "Enter", event: { key: "Enter" }, expected: [0x0d] },
+  {
+    name: "Enter + ctrl (== C-m == Enter)",
+    event: { key: "Enter", ctrlKey: true },
+    expected: [0x0d],
+  },
+  { name: "Escape", event: { key: "Escape" }, expected: [0x1b] },
+  { name: "Backspace", event: { key: "Backspace" }, expected: [0x7f] },
+  { name: "Tab", event: { key: "Tab" }, expected: [0x09] },
+  { name: "Shift+Tab (BTab)", event: { key: "Tab", shiftKey: true }, expected: [0x1b, 0x5b, 0x5a] },
+
+  // Arrow / nav
+  { name: "ArrowUp", event: { key: "ArrowUp" }, expected: [0x1b, 0x5b, 0x41] },
+  { name: "ArrowDown", event: { key: "ArrowDown" }, expected: [0x1b, 0x5b, 0x42] },
+  { name: "ArrowRight", event: { key: "ArrowRight" }, expected: [0x1b, 0x5b, 0x43] },
+  { name: "ArrowLeft", event: { key: "ArrowLeft" }, expected: [0x1b, 0x5b, 0x44] },
+  { name: "Home", event: { key: "Home" }, expected: [0x1b, 0x5b, 0x48] },
+  { name: "End", event: { key: "End" }, expected: [0x1b, 0x5b, 0x46] },
+  { name: "PageUp", event: { key: "PageUp" }, expected: [0x1b, 0x5b, 0x35, 0x7e] },
+  { name: "PageDown", event: { key: "PageDown" }, expected: [0x1b, 0x5b, 0x36, 0x7e] },
+  { name: "Delete (DC)", event: { key: "Delete" }, expected: [0x1b, 0x5b, 0x33, 0x7e] },
+];
+
+describe("keyEventToBytes — tmux_key_to_bytes equivalence", () => {
+  for (const { name, event, expected } of CASES) {
+    it(`maps ${name}`, () => {
+      const out = keyEventToBytes(makeEvent(event));
+      expect(out).not.toBeNull();
+      expect(Array.from(out as Uint8Array)).toEqual(expected);
+    });
+  }
+
+  it("returns null for modifier-only events", () => {
+    expect(keyEventToBytes(makeEvent({ key: "Shift" }))).toBeNull();
+    expect(keyEventToBytes(makeEvent({ key: "Control" }))).toBeNull();
+    expect(keyEventToBytes(makeEvent({ key: "Alt" }))).toBeNull();
+    expect(keyEventToBytes(makeEvent({ key: "Meta" }))).toBeNull();
+  });
+
+  it("returns null for F-keys and other unmapped multichar keys", () => {
+    expect(keyEventToBytes(makeEvent({ key: "F1" }))).toBeNull();
+    expect(keyEventToBytes(makeEvent({ key: "Insert" }))).toBeNull();
+    expect(keyEventToBytes(makeEvent({ key: "ContextMenu" }))).toBeNull();
+  });
+
+  it("encodes multi-byte unicode via UTF-8", () => {
+    // BMP — Japanese hiragana あ (U+3042 → 0xE3 0x81 0x82).
+    expect(Array.from(keyEventToBytes(makeEvent({ key: "あ" })) as Uint8Array)).toEqual([
+      0xe3, 0x81, 0x82,
+    ]);
+  });
+});
+
+describe("textToBytes", () => {
+  it("encodes ASCII strings", () => {
+    expect(Array.from(textToBytes("hi"))).toEqual([0x68, 0x69]);
+  });
+  it("encodes empty string", () => {
+    expect(Array.from(textToBytes(""))).toEqual([]);
+  });
+  it("encodes unicode strings as UTF-8", () => {
+    expect(Array.from(textToBytes("テスト"))).toEqual([
+      0xe3, 0x83, 0x86, 0xe3, 0x82, 0xb9, 0xe3, 0x83, 0x88,
+    ]);
+  });
+});

--- a/clients/react/src/lib/keys.ts
+++ b/clients/react/src/lib/keys.ts
@@ -1,0 +1,94 @@
+// Browser KeyboardEvent → raw bytes for the rev3 terminal-plane keys
+// WebSocket (#174 Phase 3b-1).
+//
+// Mirrors `tmai_core::utils::keys::tmux_key_to_bytes` semantics without
+// the tmux key-name as an intermediate. The legacy `passthrough` HTTP
+// endpoint accepts tmux names (`"Enter"` / `"C-c"` / `"BTab"` …) and
+// converts on the server; the new keys WS is byte-only, so the
+// conversion has to happen in the browser. Keeping the byte sequences
+// identical to the Rust reference is essential — agents see exactly
+// what they would have seen via the tmux `send-keys` path.
+//
+// References: `crates/tmai-core/src/utils/keys.rs` (in tmai-core).
+
+const ENC = new TextEncoder();
+
+// Special-key sequences that match `tmux_key_to_bytes` exactly.
+const SPECIAL_KEY_BYTES: Record<string, Uint8Array> = {
+  Enter: new Uint8Array([0x0d]), // \r
+  Escape: new Uint8Array([0x1b]),
+  Backspace: new Uint8Array([0x7f]),
+  Tab: new Uint8Array([0x09]),
+  ArrowUp: new Uint8Array([0x1b, 0x5b, 0x41]), // CSI A
+  ArrowDown: new Uint8Array([0x1b, 0x5b, 0x42]), // CSI B
+  ArrowRight: new Uint8Array([0x1b, 0x5b, 0x43]), // CSI C
+  ArrowLeft: new Uint8Array([0x1b, 0x5b, 0x44]), // CSI D
+  Home: new Uint8Array([0x1b, 0x5b, 0x48]), // CSI H
+  End: new Uint8Array([0x1b, 0x5b, 0x46]), // CSI F
+  PageUp: new Uint8Array([0x1b, 0x5b, 0x35, 0x7e]), // CSI 5 ~
+  PageDown: new Uint8Array([0x1b, 0x5b, 0x36, 0x7e]), // CSI 6 ~
+  Delete: new Uint8Array([0x1b, 0x5b, 0x33, 0x7e]), // CSI 3 ~
+  " ": new Uint8Array([0x20]),
+};
+
+// Shift+Tab (BTab). Returned only when both the key is "Tab" and shift
+// is held; otherwise SPECIAL_KEY_BYTES.Tab applies.
+const SHIFT_TAB = new Uint8Array([0x1b, 0x5b, 0x5a]); // CSI Z
+
+/**
+ * Convert a `KeyboardEvent` into the byte sequence the agent's PTY
+ * expects. Returns `null` for keys that have no representation (e.g.
+ * F-keys or modifier-only events) so the caller can decide whether to
+ * fall back to `event.key` or drop the event.
+ *
+ * Equivalent path-by-path to `tmux_key_to_bytes` for every input that
+ * the existing `toTmuxKey()` mapping in `PreviewPanel` produces:
+ *
+ * | KeyboardEvent          | toTmuxKey output | tmux_key_to_bytes | this fn  |
+ * | ---------------------- | ---------------- | ----------------- | -------- |
+ * | "c" + ctrl             | "C-c"            | 0x03              | 0x03     |
+ * | "C" + ctrl (caps)      | "C-c"            | 0x03              | 0x03     |
+ * | "Enter"                | "Enter"          | 0x0d              | 0x0d     |
+ * | "Enter" + ctrl         | "C-m"            | 0x0d              | 0x0d     |
+ * | "Tab"                  | "Tab"            | 0x09              | 0x09     |
+ * | "Tab" + shift          | "BTab"           | ESC [ Z           | ESC [ Z  |
+ * | "ArrowUp"              | "Up"             | ESC [ A           | ESC [ A  |
+ * | "@" + ctrl (US layout) | "C-@"            | 0x00              | 0x00     |
+ * | "y" (no modifier)      | (chars: "y")     | (chars path)      | 0x79     |
+ */
+export function keyEventToBytes(e: KeyboardEvent): Uint8Array | null {
+  // Ctrl+single-char → bitmask to control codes (matches the Rust
+  // `s.as_bytes()[2] & 0x1f` branch, but with browser-side normalization
+  // to lowercase — the Rust impl accepts both cases identically because
+  // the masked bit is the same).
+  if (e.ctrlKey && e.key.length === 1) {
+    const ch = e.key.toLowerCase().charCodeAt(0);
+    return new Uint8Array([ch & 0x1f]);
+  }
+
+  // Shift+Tab → BTab. Plain Tab falls through to SPECIAL_KEY_BYTES.
+  if (e.key === "Tab" && e.shiftKey) return SHIFT_TAB;
+
+  const sp = SPECIAL_KEY_BYTES[e.key];
+  if (sp) return sp;
+
+  // Any other single-character key: encode as UTF-8 (covers letters,
+  // digits, punctuation, multi-byte glyphs typed without IME).
+  if (e.key.length === 1) {
+    return ENC.encode(e.key);
+  }
+
+  // Modifier-only events ("Shift", "Control"…), F-keys, "Insert", and
+  // anything else outside the tmux mapping fall through to `null` so
+  // the caller can decide.
+  return null;
+}
+
+/**
+ * Encode a literal string (e.g. IME-confirmed text or a paste payload)
+ * as UTF-8 bytes for direct send through the keys WebSocket. Equivalent
+ * to the legacy `passthrough({ chars })` path.
+ */
+export function textToBytes(text: string): Uint8Array {
+  return ENC.encode(text);
+}


### PR DESCRIPTION
## Summary

No-dependency foundation step for the PreviewPanel WS migration. Adds a single utility that converts a browser \`KeyboardEvent\` into the exact byte sequence the agent's PTY expects, mirroring \`tmai_core::utils::keys::tmux_key_to_bytes\`.

## Why

Phase 2c-3 (tmai-core #220) made the rev3 keys-mode WebSocket byte-only. The legacy \`POST /api/agents/{id}/passthrough\` endpoint accepted tmux key names ("Enter" / "C-c" / "BTab") and converted server-side; the new WS path puts that responsibility on the client.

## Changes

- **\`clients/react/src/lib/keys.ts\`** (new, 105 LOC)
  - \`keyEventToBytes(e: KeyboardEvent): Uint8Array | null\` — produces the same bytes \`tmux_key_to_bytes\` produces for the corresponding tmux name. Covers Ctrl+single-char (bitmask), arrow/nav CSI sequences, Backspace / Tab / Enter / Escape / Delete, Shift+Tab → BTab, and UTF-8 fallback for printable characters.
  - \`textToBytes(text: string): Uint8Array\` — UTF-8 encode for IME-confirmed text and paste payloads (the legacy \`passthrough({ chars })\` equivalent).
- **\`clients/react/src/lib/__tests__/keys.test.ts\`** (new, 96 LOC, 31 cases) — equivalence fixture. Every entry asserts the byte sequence against \`tmux_key_to_bytes\` directly.

## Equivalence coverage

| Input | tmux name | tmux_key_to_bytes | keyEventToBytes |
| --- | --- | --- | --- |
| "c" + ctrl | C-c | 0x03 | 0x03 |
| "C" + ctrl (caps) | C-c | 0x03 | 0x03 |
| "Enter" | Enter | 0x0d | 0x0d |
| "Enter" + ctrl | C-m | 0x0d | 0x0d |
| "Tab" + shift | BTab | ESC [ Z | ESC [ Z |
| "ArrowUp" | Up | ESC [ A | ESC [ A |
| "@" + ctrl | C-@ | 0x00 | 0x00 |
| " " + ctrl | C-Space | 0x00 | 0x00 |
| "[" + ctrl | C-[ | 0x1b | 0x1b |
| "y" (no mod) | (chars: "y") | 0x79 | 0x79 |
| "あ" (no mod) | (chars: "あ") | 0xE3 0x81 0x82 | 0xE3 0x81 0x82 |

Modifier-only events (Shift / Control / Alt / Meta), F-keys, and "Insert" / "ContextMenu" return \`null\` so the caller can decide whether to drop the event or fall back to \`event.key\`.

## Test plan

- [x] \`pnpm tsc --noEmit\`
- [x] \`pnpm vitest run\` — 241 pass / 2 skipped (Phase 3a) / 0 fail
- [x] \`pnpm exec biome check\`
- [x] \`pnpm build\`

## Refs

- Parent: tmai-core #174 (terminal plane Δ5 + Δ6)
- Sibling: tmai-core #216 (2a) #217 (2b) #218 (2c-1) #219 (2c-2) #220 (2c-3) #221 (2d-1)
- Phase 3a foundation: #557 (this repo)
- Next: 3b-2 (PreviewPanel adds WS path + \`has_pty/has_websocket\` gate, polling preserved)
- After: 3b-3 (retire polling fallback once telemetry is stable), then tmai-core Phase 2d-2 (drop capture-pane relay paths)

## Why ship as a separate PR

PreviewPanel.tsx is 1047 LOC and the migration involves \`live_start_line\` re-design and IME interaction. Splitting the byte-mapping foundation off keeps the harder review independent of an arithmetic-table change. This PR can be reviewed and merged on its own merits.