### PR TITLE
fix(terminal): #174 Phase 3a follow-up — replay per-agent ANSI buffer on agent switch

### DIFF
--- a/clients/react/src/hooks/useTerminal.ts
+++ b/clients/react/src/hooks/useTerminal.ts
@@ -20,6 +20,42 @@ interface UseTerminalOptions {
   autoScroll?: boolean;
 }
 
+// Per-agent ANSI replay buffer.
+//
+// The rev3 PTY-server's ANSI broadcast is push-only — there is no
+// catch-up replay for late subscribers (scrollback lands with #175).
+// When the user switches agents, the xterm instance is disposed and
+// recreated, so without our own buffer the new pane is blank until
+// the agent next emits anything (which idle agents may not do for a
+// long time). We keep a bounded chunk log per agent and replay it on
+// re-mount so switching back to a previously-seen agent restores the
+// last screen state immediately.
+const AGENT_REPLAY_BUFFERS = new Map<string, Uint8Array[]>();
+const AGENT_REPLAY_BYTE_CAP = 256_000;
+
+function appendReplay(agentId: string, bytes: Uint8Array): void {
+  const list = AGENT_REPLAY_BUFFERS.get(agentId) ?? [];
+  list.push(bytes);
+  // Drop oldest chunks until total bytes is under the cap. This trims at
+  // chunk granularity rather than byte-exact slicing, which keeps ANSI
+  // escape sequences whole.
+  let total = 0;
+  for (const b of list) total += b.byteLength;
+  while (total > AGENT_REPLAY_BYTE_CAP && list.length > 1) {
+    const dropped = list.shift();
+    if (dropped) total -= dropped.byteLength;
+  }
+  AGENT_REPLAY_BUFFERS.set(agentId, list);
+}
+
+function replayInto(term: Terminal, agentId: string): void {
+  const list = AGENT_REPLAY_BUFFERS.get(agentId);
+  if (!list) return;
+  for (const chunk of list) {
+    term.write(chunk);
+  }
+}
+
 export function useTerminal({ agentId, containerRef, autoScroll = true }: UseTerminalOptions) {
   const termRef = useRef<Terminal | null>(null);
   const fitAddonRef = useRef<FitAddon | null>(null);
@@ -32,10 +68,19 @@ export function useTerminal({ agentId, containerRef, autoScroll = true }: UseTer
   }, []);
 
   // Stream incoming ANSI bytes into the terminal — `term.write` accepts
-  // `Uint8Array` directly.
-  const onData = useCallback((bytes: Uint8Array): void => {
-    termRef.current?.write(bytes);
-  }, []);
+  // `Uint8Array` directly. Also append to the per-agent replay buffer
+  // so a future re-mount of this hook can restore the screen.
+  const onData = useCallback(
+    (bytes: Uint8Array): void => {
+      termRef.current?.write(bytes);
+      if (agentId) {
+        // Copy because the underlying ArrayBuffer may be reused by the
+        // WebSocket layer for the next frame.
+        appendReplay(agentId, new Uint8Array(bytes));
+      }
+    },
+    [agentId],
+  );
 
   const { sendKeys } = useAgentTerminalStream({ agentId, onData });
 
@@ -63,6 +108,11 @@ export function useTerminal({ agentId, containerRef, autoScroll = true }: UseTer
 
     termRef.current = term;
     fitAddonRef.current = fitAddon;
+
+    // Restore the previous screen for this agent before live bytes
+    // start arriving on the freshly-opened WebSocket. Without this the
+    // pane is blank for any agent that is currently idle.
+    replayInto(term, agentId);
 
     // Forward xterm input → keys-mode WS.
     const inputDisposable = term.onData((data: string): void => {


### PR DESCRIPTION
## Summary

After PRs #557 / #558 / #559 / tmai-core #221-#224 the terminal-plane WS path works end-to-end, but switching between spawned agents shows a blank pane until the new agent next emits — for idle agents, that may be indefinite.

## Root cause

The rev3 PTY-server's ANSI broadcast is push-only; subscribing late returns nothing for past output. Each agent switch disposes the xterm instance and recreates it, and the new instance has no scrollback. PTY-server scrollback (#175) is the eventual durable fix; in the meantime the React side needs to keep its own replay buffer.

## Fix

- Module-level \`Map<agentId, Uint8Array[]>\` chunk log in \`useTerminal.ts\`.
- \`onData\` appends each WS frame (copying the \`Uint8Array\`, since the underlying \`ArrayBuffer\` may be reused by the WebSocket layer).
- Chunk granularity trim to ~256 KB so ANSI escape sequences are kept whole. Same cap as \`PreviewPanel\`'s \`liveBufferRef\` in Phase 3b-2.
- The xterm \`useEffect\` calls \`replayInto(term, agentId)\` immediately after \`term.open(...)\`, so a re-mount restores the previous screen before the freshly-opened WebSocket starts pushing live bytes.

## Caveat

Replaying raw ANSI rebuilds attribute / cursor state from sequences alone, which is what xterm is designed to handle. Anything that depended on a missed clear-screen at the boundary will look slightly different until the agent next repaints — acceptable until #175 (PTY-server scrollback) lands.

## Test plan

- [x] \`pnpm tsc --noEmit\`
- [x] \`pnpm vitest run\` — 241 / 2 skipped / 0 failed
- [x] \`pnpm exec biome check\`
- [x] \`pnpm build\`
- [x] Manual verify in tmux: switching between two spawned agents now restores each agent's screen instantly instead of going blank.

## Refs

- Parent: tmai-core #174 (terminal plane Δ5 + Δ6)
- Phase 3a foundation: #557; Phase 3b-1/3b-2: #558 / #559
- Caveat-resolver: tmai-core #175 (scrollback)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* エージェント切り替え時のターミナル出力が空白になる問題を修正しました。ターミナルの出力履歴がキャッシュされるようになり、エージェント切り替え時に以前の出力が復元されます。これにより、アイドル状態のエージェントでも適切に出力が表示されるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->