### PR TITLE
fix(react): #174 — stop preemptive ticket refresh; reset xterm on reconnect

### DIFF
--- a/clients/react/src/hooks/useAgentTerminalStream.ts
+++ b/clients/react/src/hooks/useAgentTerminalStream.ts
@@ -6,9 +6,18 @@
 // - `?mode=stream` — receives ANSI byte chunks pushed by the PTY-server.
 // - `?mode=keys`   — sends raw key bytes to the agent's stdin.
 //
-// The hook re-subscribes automatically before the ticket expires and
-// reconnects on transport-level close. Both WebSockets close on unmount
-// or `agentId` change.
+// Tickets are one-shot bearer credentials checked at WS upgrade only;
+// once both sockets are open the ticket TTL no longer matters. The hook
+// therefore does NOT preemptively reconnect when the ticket nears its
+// expiry — doing so would tear down a perfectly healthy WS pair just to
+// open a fresh one, and each fresh stream forces the supervisor to
+// re-flush its per-agent scrollback (tmai-core PR #227). With this
+// idle preview accumulated stacked redraws every TICKET_REFRESH_LEAD_MS
+// because each scrollback replay landed on top of whatever xterm had
+// already rendered. We only reconnect when the transport actually
+// closes (proxy idle, network blip, agent died). On reconnect the
+// consumer is signalled via `onStatus("connecting")` so it can reset
+// the rendering surface before the new scrollback flush arrives.
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api";
@@ -40,10 +49,6 @@ interface UseAgentTerminalStreamResult {
 }
 
 const RECONNECT_DELAY_MS = 3_000;
-// Re-subscribe this far ahead of the ticket's expiry — must exceed the
-// expected round-trip + WS open time so a fresh stream is ready before
-// the old token is rejected.
-const TICKET_REFRESH_LEAD_MS = 30_000;
 
 function buildWsUrl(
   agentId: string,
@@ -65,7 +70,6 @@ export function useAgentTerminalStream({
   const [status, setStatus] = useState<TerminalStreamStatus>("idle");
   const streamWsRef = useRef<WebSocket | null>(null);
   const keysWsRef = useRef<WebSocket | null>(null);
-  const refreshTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   // Set to `true` on unmount or agentId change. Async tasks check this
   // before touching state or refs to avoid clobbering a stale agent.
@@ -93,10 +97,6 @@ export function useAgentTerminalStream({
     abortedRef.current = false;
 
     const clearTimers = (): void => {
-      if (refreshTimerRef.current) {
-        clearTimeout(refreshTimerRef.current);
-        refreshTimerRef.current = null;
-      }
       if (reconnectTimerRef.current) {
         clearTimeout(reconnectTimerRef.current);
         reconnectTimerRef.current = null;
@@ -112,24 +112,6 @@ export function useAgentTerminalStream({
         keysWsRef.current.close(1000);
         keysWsRef.current = null;
       }
-    };
-
-    const scheduleRefresh = (expiresAt: string): void => {
-      const expiresMs = Date.parse(expiresAt);
-      // Wall-clock parse can fail or yield NaN — guard with a sane floor
-      // so we still refresh after a few minutes rather than never.
-      const rawDelay = Number.isFinite(expiresMs)
-        ? Math.max(1_000, expiresMs - Date.now() - TICKET_REFRESH_LEAD_MS)
-        : 60_000;
-      // setTimeout clamps to a 32-bit signed int internally; values past
-      // ~24.8 days (2_147_483_647 ms) get coerced to 1 ms and fire
-      // immediately. Cap at 1 hour — a far-future expires_at is fine, we
-      // just want to wake up periodically and re-evaluate.
-      const safeDelay = Math.min(rawDelay, 60 * 60 * 1_000);
-      refreshTimerRef.current = setTimeout(() => {
-        if (abortedRef.current) return;
-        void connect();
-      }, safeDelay);
     };
 
     const connect = async (): Promise<void> => {
@@ -180,8 +162,6 @@ export function useAgentTerminalStream({
         // onerror is best-effort: onclose follows reliably and drives
         // the reconnect path.
         stream.onerror = (): void => {};
-
-        scheduleRefresh(subscription.expires_at);
       } catch {
         if (abortedRef.current) return;
         setStatusBoth("error");

--- a/clients/react/src/hooks/useTerminal.ts
+++ b/clients/react/src/hooks/useTerminal.ts
@@ -8,6 +8,14 @@
 // `/api/agents/{id}/terminal` WS using a `pty_session_id` selector) to
 // `useAgentTerminalStream({ agentId })` (rev3 ticket-authorized
 // stream/keys pair scoped on the canonical agent_id).
+//
+// Note: an earlier revision kept a module-level `AGENT_REPLAY_BUFFERS`
+// map that replayed prior bytes when the user switched back to an
+// agent. tmai-core PR #227 made the PTY-server flush its own
+// per-agent scrollback as the first frames of every Stream attach,
+// so the React-side buffer became redundant — and worse, double-
+// rendered every reattach (PTY flush bytes were re-appended to the
+// React buffer via `onData`, so each switch grew the next replay).
 
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "@xterm/xterm";
@@ -18,42 +26,6 @@ interface UseTerminalOptions {
   agentId: string | null;
   containerRef: React.RefObject<HTMLDivElement | null>;
   autoScroll?: boolean;
-}
-
-// Per-agent ANSI replay buffer.
-//
-// The rev3 PTY-server's ANSI broadcast is push-only — there is no
-// catch-up replay for late subscribers (scrollback lands with #175).
-// When the user switches agents, the xterm instance is disposed and
-// recreated, so without our own buffer the new pane is blank until
-// the agent next emits anything (which idle agents may not do for a
-// long time). We keep a bounded chunk log per agent and replay it on
-// re-mount so switching back to a previously-seen agent restores the
-// last screen state immediately.
-const AGENT_REPLAY_BUFFERS = new Map<string, Uint8Array[]>();
-const AGENT_REPLAY_BYTE_CAP = 256_000;
-
-function appendReplay(agentId: string, bytes: Uint8Array): void {
-  const list = AGENT_REPLAY_BUFFERS.get(agentId) ?? [];
-  list.push(bytes);
-  // Drop oldest chunks until total bytes is under the cap. This trims at
-  // chunk granularity rather than byte-exact slicing, which keeps ANSI
-  // escape sequences whole.
-  let total = 0;
-  for (const b of list) total += b.byteLength;
-  while (total > AGENT_REPLAY_BYTE_CAP && list.length > 1) {
-    const dropped = list.shift();
-    if (dropped) total -= dropped.byteLength;
-  }
-  AGENT_REPLAY_BUFFERS.set(agentId, list);
-}
-
-function replayInto(term: Terminal, agentId: string): void {
-  const list = AGENT_REPLAY_BUFFERS.get(agentId);
-  if (!list) return;
-  for (const chunk of list) {
-    term.write(chunk);
-  }
 }
 
 export function useTerminal({ agentId, containerRef, autoScroll = true }: UseTerminalOptions) {
@@ -68,19 +40,12 @@ export function useTerminal({ agentId, containerRef, autoScroll = true }: UseTer
   }, []);
 
   // Stream incoming ANSI bytes into the terminal — `term.write` accepts
-  // `Uint8Array` directly. Also append to the per-agent replay buffer
-  // so a future re-mount of this hook can restore the screen.
-  const onData = useCallback(
-    (bytes: Uint8Array): void => {
-      termRef.current?.write(bytes);
-      if (agentId) {
-        // Copy because the underlying ArrayBuffer may be reused by the
-        // WebSocket layer for the next frame.
-        appendReplay(agentId, new Uint8Array(bytes));
-      }
-    },
-    [agentId],
-  );
+  // `Uint8Array` directly. Re-attach replay is owned by the PTY-server
+  // (it flushes its scrollback ring before live ANSI on every Stream
+  // attach), so this hook does not need a local buffer.
+  const onData = useCallback((bytes: Uint8Array): void => {
+    termRef.current?.write(bytes);
+  }, []);
 
   const { sendKeys } = useAgentTerminalStream({ agentId, onData });
 
@@ -109,10 +74,10 @@ export function useTerminal({ agentId, containerRef, autoScroll = true }: UseTer
     termRef.current = term;
     fitAddonRef.current = fitAddon;
 
-    // Restore the previous screen for this agent before live bytes
-    // start arriving on the freshly-opened WebSocket. Without this the
-    // pane is blank for any agent that is currently idle.
-    replayInto(term, agentId);
+    // Re-attach replay is handled by the PTY-server: the first frames
+    // delivered by `useAgentTerminalStream` are the agent's scrollback
+    // (tmai-core PR #227) and xterm renders them as soon as they
+    // arrive — no client-side warmup write needed.
 
     // Forward xterm input → keys-mode WS.
     const inputDisposable = term.onData((data: string): void => {

--- a/clients/react/src/hooks/useTerminal.ts
+++ b/clients/react/src/hooks/useTerminal.ts
@@ -20,7 +20,7 @@
 import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "@xterm/xterm";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { useAgentTerminalStream } from "./useAgentTerminalStream";
+import { type TerminalStreamStatus, useAgentTerminalStream } from "./useAgentTerminalStream";
 
 interface UseTerminalOptions {
   agentId: string | null;
@@ -47,7 +47,21 @@ export function useTerminal({ agentId, containerRef, autoScroll = true }: UseTer
     termRef.current?.write(bytes);
   }, []);
 
-  const { sendKeys } = useAgentTerminalStream({ agentId, onData });
+  // Reset xterm whenever the stream is about to (re)connect. Each
+  // connect triggers a fresh PTY-server scrollback flush; without
+  // wiping the canvas first, those bytes would render on top of
+  // whatever was already on screen and the preview would stack.
+  // The very first connect runs against an empty xterm, so this is
+  // a no-op there. (`status === "connecting"` fires synchronously
+  // before the WebSocket opens, so the reset always lands before
+  // the first byte of the new stream arrives.)
+  const onStatus = useCallback((next: TerminalStreamStatus): void => {
+    if (next === "connecting") {
+      termRef.current?.reset();
+    }
+  }, []);
+
+  const { sendKeys } = useAgentTerminalStream({ agentId, onData, onStatus });
 
   useEffect(() => {
     if (!agentId || !containerRef.current) return;


### PR DESCRIPTION
## Summary

Idle preview was stacking the same screen every ~30 seconds because `useAgentTerminalStream.scheduleRefresh` tore down a perfectly healthy WebSocket pair ahead of every ticket expiry and opened a fresh one. Tickets are one-shot credentials — checked only at WS upgrade — so once the WS is open the TTL is irrelevant. Each fresh stream caused the supervisor (tmai-core PR #227) to re-flush its scrollback, which landed on top of whatever was already rendered, and after a few cycles the user saw the screen stacked 3×, 4×, … .

## Changes

1. **Drop `scheduleRefresh` / `TICKET_REFRESH_LEAD_MS`** in `useAgentTerminalStream.ts`. The WS lives until the transport actually closes (proxy idle, network blip, agent died). The existing `onclose` handler still runs `connect()` to mint a fresh ticket and reattach, so genuine disconnects continue to recover.
2. **`useTerminal` resets xterm on every transition into `connecting`** (via the existing `onStatus` callback). Even when a legitimate reconnect happens, the next scrollback flush lands on a clean canvas instead of compounding. The first connect runs against an empty xterm, so this is a no-op there.

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm exec biome check` — no new findings
- [x] `pnpm vitest run` — 241 passed / 2 skipped (existing `useAgentTerminalStream` tests still cover the connect / reconnect flow; the fixed-future `expires_at` they used was just so the now-removed refresh timer wouldn't fire mid-test)
- [x] `pnpm build` — succeeds
- Manual: leave the preview pane open with no input. The screen should stay at one stable copy of the agent's output instead of accumulating duplicates over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)