### PR TITLE
chore(gen): sync generated spec + types from tmai-core@d0ac438a37

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -41,7 +41,7 @@
               ]
             },
             "id": {
-              "description": "Agent target ID (e.g., \"main:0.0\")",
+              "description": "Canonical AgentId in `<scheme>:<id>` form (e.g. `\"claude:ea760770-c137-...\"`),\nmatching `AgentSnapshot.id`.",
               "type": "string"
             },
             "is_orchestrator": {
@@ -2900,7 +2900,7 @@
           "description": "Whether the agent was upserted or removed."
         },
         "id": {
-          "description": "Stable agent identifier (UUID short hash).",
+          "description": "Canonical AgentId (`<scheme>:<id>` form, matches `AgentSnapshot.id`).\nStable across tmux pane renumber, `claude --resume`, tmai restart, and\nprocess restart. Provisional ids (`provisional:<uuid>`) are normally\nhidden but become wire-visible when the agent has a `pty_session_id`\n(PTY-server backed spawn).",
           "type": "string"
         },
         "origin": {

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -127,7 +127,7 @@
               },
               "id": {
                 "type": "string",
-                "description": "Agent target ID (e.g., \"main:0.0\")"
+                "description": "Canonical AgentId in `<scheme>:<id>` form (e.g. `\"claude:ea760770-c137-...\"`),\nmatching `AgentSnapshot.id`."
               },
               "is_orchestrator": {
                 "type": "boolean",
@@ -1371,7 +1371,7 @@
               },
               "id": {
                 "type": "string",
-                "description": "Stable agent identifier (UUID short hash)."
+                "description": "Canonical AgentId (`<scheme>:<id>` form, matches `AgentSnapshot.id`).\nStable across tmux pane renumber, `claude --resume`, tmai restart, and\nprocess restart. Provisional ids (`provisional:<uuid>`) are normally\nhidden but become wire-visible when the agent has a `pty_session_id`\n(PTY-server backed spawn)."
               },
               "origin": {
                 "oneOf": [

--- a/clients/react/src/types/generated/ActionOrigin.ts
+++ b/clients/react/src/types/generated/ActionOrigin.ts
@@ -20,7 +20,8 @@ interface: string,
  */
 cwd?: string | null, } | { "kind": "Agent", 
 /**
- * Agent target ID (e.g., "main:0.0")
+ * Canonical AgentId in `<scheme>:<id>` form (e.g. `"claude:ea760770-c137-..."`),
+ * matching `AgentSnapshot.id`.
  */
 id: string, 
 /**

--- a/clients/react/src/types/generated/CoreEvent.ts
+++ b/clients/react/src/types/generated/CoreEvent.ts
@@ -377,7 +377,11 @@ reason: string, } | { "type": "AgentUpdate",
  */
 change: EntityChange, 
 /**
- * Stable agent identifier (UUID short hash).
+ * Canonical AgentId (`<scheme>:<id>` form, matches `AgentSnapshot.id`).
+ * Stable across tmux pane renumber, `claude --resume`, tmai restart, and
+ * process restart. Provisional ids (`provisional:<uuid>`) are normally
+ * hidden but become wire-visible when the agent has a `pty_session_id`
+ * (PTY-server backed spawn).
  */
 id: string, 
 /**

--- a/clients/react/src/types/generated/EntityUpdateEnvelope.ts
+++ b/clients/react/src/types/generated/EntityUpdateEnvelope.ts
@@ -30,7 +30,10 @@ change: EntityChange,
  */
 entity: string, 
 /**
- * Stable entity identifier within the domain.
+ * Stable entity identifier within the domain. For `entity == "Agent"`
+ * this is the canonical AgentId (`<scheme>:<id>` form, matches
+ * `AgentSnapshot.id`); for other entities (Dispatch, Worktree, Queue,
+ * ...) it is the corresponding domain-native id.
  */
 id: string, 
 /**


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@d0ac438a37700be6295ad0b40a6f37c552721795

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/corevents.schema.json                            | 4 ++--
 api-spec/openapi.json                                     | 4 ++--
 clients/react/src/types/generated/ActionOrigin.ts         | 3 ++-
 clients/react/src/types/generated/CoreEvent.ts            | 6 +++++-
 clients/react/src/types/generated/EntityUpdateEnvelope.ts | 5 ++++-
 5 files changed, 15 insertions(+), 7 deletions(-)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## ドキュメント
* APIドキュメントを更新し、エージェント識別子の形式と動作をより詳しく説明しました。エージェントIDが`<scheme>:<id>`形式で表現され、再起動やセッション再開時に安定していることを明確化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->