### PR TITLE
feat(react): #569 spawn runtime radio selector — native enabled, tmux coming soon

### DIFF
--- a/clients/react/src/components/settings/SettingsPanel.tsx
+++ b/clients/react/src/components/settings/SettingsPanel.tsx
@@ -13,6 +13,7 @@ import {
 } from "@/lib/api";
 import { buildNotifyEventHelp } from "./notify-event-help";
 import { ScheduledKicksSection } from "./ScheduledKicksSection";
+import { SpawnRuntimeSelector } from "./SpawnRuntimeSelector";
 
 interface SettingsPanelProps {
   onClose: () => void;
@@ -112,16 +113,6 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
     } catch (_e) {}
   };
 
-  // Toggle spawn in tmux
-  const handleToggleSpawnInTmux = async () => {
-    if (!spawnSettings) return;
-    const newValue = !spawnSettings.use_tmux_window;
-    try {
-      await api.updateSpawnSettings({ use_tmux_window: newValue });
-      setSpawnSettings({ ...spawnSettings, use_tmux_window: newValue });
-    } catch (_e) {}
-  };
-
   // Update tmux window name
   const handleWindowNameChange = async (name: string) => {
     if (!spawnSettings) return;
@@ -135,7 +126,7 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
     if (!trimmed) return;
     try {
       await api.updateSpawnSettings({
-        use_tmux_window: spawnSettings.use_tmux_window,
+        runtime: spawnSettings.runtime,
         tmux_window_name: trimmed,
       });
     } catch (_e) {}
@@ -147,7 +138,7 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
     setSpawnSettings({ ...spawnSettings, worker_permission_mode: mode });
     try {
       await api.updateSpawnSettings({
-        use_tmux_window: spawnSettings.use_tmux_window,
+        runtime: spawnSettings.runtime,
         worker_permission_mode: mode,
       });
     } catch (_e) {}
@@ -566,43 +557,12 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
               How new agents are started from the Web UI.
             </p>
 
-            <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3">
-              <label className="flex items-center justify-between gap-3">
-                <div className="flex-1">
-                  <span className="text-sm text-zinc-300">Spawn in tmux window</span>
-                  <p className="mt-0.5 text-[11px] text-zinc-600">
-                    {spawnSettings.tmux_available
-                      ? `New agents will appear as tmux panes in the "${spawnSettings.tmux_window_name}" window, detected by the poller like regular sessions.`
-                      : "tmux is not available in this mode. Agents are spawned as internal PTY sessions."}
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={handleToggleSpawnInTmux}
-                  disabled={!spawnSettings.tmux_available}
-                  className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
-                    !spawnSettings.tmux_available
-                      ? "cursor-not-allowed bg-white/5"
-                      : spawnSettings.use_tmux_window
-                        ? "bg-cyan-500/40"
-                        : "bg-white/10"
-                  }`}
-                >
-                  <span
-                    className={`inline-block h-3.5 w-3.5 rounded-full transition-transform ${
-                      !spawnSettings.tmux_available
-                        ? "translate-x-0.5 bg-zinc-700"
-                        : spawnSettings.use_tmux_window
-                          ? "translate-x-[18px] bg-cyan-400"
-                          : "translate-x-0.5 bg-zinc-500"
-                    }`}
-                  />
-                </button>
-              </label>
+            <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-3">
+              <SpawnRuntimeSelector settings={spawnSettings} onSettingsChange={setSpawnSettings} />
 
-              {/* Window name field — shown when tmux is available and enabled */}
-              {spawnSettings.tmux_available && spawnSettings.use_tmux_window && (
-                <div className="mt-3 flex items-center gap-2">
+              {/* Window name field — shown when runtime is tmux */}
+              {spawnSettings.runtime === "tmux" && (
+                <div className="flex items-center gap-2">
                   <span className="shrink-0 text-xs text-zinc-500">Window name</span>
                   <input
                     type="text"
@@ -618,7 +578,7 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
               )}
 
               {/* Worker permission mode — applies to dispatched workers only */}
-              <div className="mt-4 border-t border-white/5 pt-3">
+              <div className="border-t border-white/5 pt-3">
                 <div className="flex items-center justify-between gap-3">
                   <div className="flex-1">
                     <span className="text-xs text-zinc-400">Worker permission mode</span>

--- a/clients/react/src/components/settings/SpawnRuntimeSelector.tsx
+++ b/clients/react/src/components/settings/SpawnRuntimeSelector.tsx
@@ -1,0 +1,87 @@
+import type { SpawnRuntime, SpawnSettings } from "@/lib/api";
+import { api } from "@/lib/api";
+
+interface SpawnRuntimeSelectorProps {
+  settings: SpawnSettings;
+  onSettingsChange: (updated: SpawnSettings) => void;
+}
+
+interface RuntimeOption {
+  value: SpawnRuntime;
+  label: string;
+  description: string;
+  disabled: boolean;
+}
+
+const RUNTIME_OPTIONS: RuntimeOption[] = [
+  {
+    value: "native",
+    label: "Native",
+    description:
+      "PTY-server backed. Agents run under tmai's supervisor. Required for browser preview, resize, programmatic input. (default)",
+    disabled: false,
+  },
+  {
+    value: "tmux",
+    label: "tmux",
+    description:
+      "Run agents in a tmux pane the user can attach to. Coming soon — currently uses the legacy spawn path; will move to the IPC adapter framework in a follow-up release.",
+    disabled: true,
+  },
+];
+
+export function SpawnRuntimeSelector({ settings, onSettingsChange }: SpawnRuntimeSelectorProps) {
+  const handleChange = async (runtime: SpawnRuntime) => {
+    // tmux is not yet selectable; guard prevents accidental selection
+    if (runtime === "tmux") return;
+    try {
+      await api.updateSpawnSettings({ runtime });
+      onSettingsChange({ ...settings, runtime });
+    } catch (_e) {}
+  };
+
+  return (
+    <div className="space-y-1.5">
+      <span className="text-xs text-zinc-400">Spawn runtime</span>
+      {RUNTIME_OPTIONS.map((opt) => {
+        const isSelected = settings.runtime === opt.value;
+        return (
+          <label
+            key={opt.value}
+            className={`flex items-start gap-3 rounded-md border p-2 transition-colors ${
+              opt.disabled ? "cursor-not-allowed" : "cursor-pointer hover:bg-white/[0.03]"
+            } ${isSelected ? "border-cyan-500/30 bg-cyan-500/5" : "border-white/5 bg-transparent"}`}
+          >
+            <input
+              type="radio"
+              name="spawn-runtime"
+              value={opt.value}
+              checked={isSelected}
+              disabled={opt.disabled}
+              onChange={() => handleChange(opt.value)}
+              className="mt-0.5 accent-cyan-500"
+              aria-label={opt.label}
+            />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-1.5">
+                <span
+                  className={`text-xs ${
+                    opt.disabled && !isSelected ? "text-zinc-600" : "text-zinc-300"
+                  }`}
+                >
+                  {opt.label}
+                </span>
+                {opt.disabled && (
+                  <span className="text-[10px] text-zinc-600 border border-zinc-700 rounded px-1">
+                    coming soon
+                  </span>
+                )}
+              </div>
+              <p className="text-[10px] text-zinc-600 mt-0.5">{opt.description}</p>
+            </div>
+          </label>
+        );
+      })}
+    </div>
+  );
+}

--- a/clients/react/src/components/settings/__tests__/SpawnRuntimeSelector.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SpawnRuntimeSelector.test.tsx
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SpawnSettings } from "@/lib/api";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      updateSpawnSettings: vi.fn(),
+    },
+  };
+});
+
+const { api } = await import("@/lib/api");
+const { SpawnRuntimeSelector } = await import("../SpawnRuntimeSelector");
+
+const BASE_SETTINGS: SpawnSettings = {
+  runtime: "native",
+  tmux_available: false,
+  tmux_window_name: "tmai",
+  worker_permission_mode: "acceptEdits",
+};
+
+describe("SpawnRuntimeSelector", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("selects native by default on a fresh load", () => {
+    render(<SpawnRuntimeSelector settings={BASE_SETTINGS} onSettingsChange={() => {}} />);
+    const nativeRadio = screen.getByRole("radio", { name: /native/i });
+    expect((nativeRadio as HTMLInputElement).checked).toBe(true);
+  });
+
+  it("renders the tmux option as disabled", () => {
+    render(<SpawnRuntimeSelector settings={BASE_SETTINGS} onSettingsChange={() => {}} />);
+    const tmuxRadio = screen.getByRole("radio", { name: /tmux/i });
+    expect((tmuxRadio as HTMLInputElement).disabled).toBe(true);
+  });
+
+  it("shows 'coming soon' badge on the tmux option", () => {
+    render(<SpawnRuntimeSelector settings={BASE_SETTINGS} onSettingsChange={() => {}} />);
+    expect(screen.getByText("coming soon")).toBeTruthy();
+  });
+
+  it("calls updateSpawnSettings with runtime: native when native is selected", async () => {
+    vi.mocked(api.updateSpawnSettings).mockResolvedValue(undefined as never);
+    const onSettingsChange = vi.fn();
+    // Start with runtime: "tmux" so native is not pre-checked; clicking it fires onChange
+    const tmuxSettings: SpawnSettings = { ...BASE_SETTINGS, runtime: "tmux" };
+    render(<SpawnRuntimeSelector settings={tmuxSettings} onSettingsChange={onSettingsChange} />);
+    const nativeRadio = screen.getByRole("radio", { name: /native/i });
+    fireEvent.click(nativeRadio);
+
+    await waitFor(() => {
+      expect(vi.mocked(api.updateSpawnSettings)).toHaveBeenCalledWith({ runtime: "native" });
+    });
+  });
+
+  it("calls onSettingsChange with updated runtime after successful PUT", async () => {
+    vi.mocked(api.updateSpawnSettings).mockResolvedValue(undefined as never);
+    const onSettingsChange = vi.fn();
+    // Start with runtime: "tmux" so native is not pre-checked; clicking it fires onChange
+    const tmuxSettings: SpawnSettings = { ...BASE_SETTINGS, runtime: "tmux" };
+    render(<SpawnRuntimeSelector settings={tmuxSettings} onSettingsChange={onSettingsChange} />);
+    fireEvent.click(screen.getByRole("radio", { name: /native/i }));
+
+    await waitFor(() => {
+      expect(onSettingsChange).toHaveBeenCalledWith(expect.objectContaining({ runtime: "native" }));
+    });
+  });
+
+  it("renders tmux as selected (but still disabled) when current config has runtime tmux", () => {
+    const tmuxSettings: SpawnSettings = { ...BASE_SETTINGS, runtime: "tmux" };
+    render(<SpawnRuntimeSelector settings={tmuxSettings} onSettingsChange={() => {}} />);
+    const tmuxRadio = screen.getByRole("radio", { name: /tmux/i });
+    expect((tmuxRadio as HTMLInputElement).checked).toBe(true);
+    expect((tmuxRadio as HTMLInputElement).disabled).toBe(true);
+  });
+});

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -8,6 +8,7 @@ import type { EntityUpdateEnvelope } from "@/types/generated/EntityUpdateEnvelop
 import type { QueueAgentEntry } from "@/types/generated/QueueAgentEntry";
 import type { QueueSnapshot } from "@/types/generated/QueueSnapshot";
 import type { RuntimeSnapshot } from "@/types/generated/RuntimeSnapshot";
+import type { SpawnRuntime } from "@/types/generated/SpawnRuntime";
 import type { TeamSnapshot } from "@/types/generated/TeamSnapshot";
 import type { TerminalSubscription } from "@/types/generated/TerminalSubscription";
 import type { WorkflowSnapshot } from "@/types/generated/WorkflowSnapshot";
@@ -17,6 +18,7 @@ export type {
   EntityUpdateEnvelope,
   QueueAgentEntry,
   QueueSnapshot,
+  SpawnRuntime,
   TerminalSubscription,
 };
 
@@ -670,9 +672,6 @@ export interface AutoApproveSettings {
 }
 
 export type WorkerPermissionMode = "default" | "plan" | "acceptEdits" | "dontAsk";
-
-/** How new agents are spawned. Only "native" (PTY-server) is selectable; "tmux" is coming soon. */
-export type SpawnRuntime = "native" | "tmux";
 
 export interface SpawnSettings {
   runtime: SpawnRuntime;

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -671,8 +671,11 @@ export interface AutoApproveSettings {
 
 export type WorkerPermissionMode = "default" | "plan" | "acceptEdits" | "dontAsk";
 
+/** How new agents are spawned. Only "native" (PTY-server) is selectable; "tmux" is coming soon. */
+export type SpawnRuntime = "native" | "tmux";
+
 export interface SpawnSettings {
-  use_tmux_window: boolean;
+  runtime: SpawnRuntime;
   tmux_available: boolean;
   tmux_window_name: string;
   /** Permission mode injected for dispatched workers (dispatch_issue / dispatch_review). */
@@ -1171,7 +1174,7 @@ export const api = {
   // Spawn settings
   getSpawnSettings: () => apiFetch<SpawnSettings>("/settings/spawn"),
   updateSpawnSettings: (params: {
-    use_tmux_window: boolean;
+    runtime: SpawnRuntime;
     tmux_window_name?: string;
     worker_permission_mode?: WorkerPermissionMode;
   }) =>

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -16,6 +16,7 @@ import type {
   OrchestratorRules,
   PrMonitorScope,
   SpawnRequest,
+  SpawnRuntime,
   UsageSettings,
   WorkerPermissionMode,
   WorkflowSettings,
@@ -202,7 +203,7 @@ export const api = {
   // Spawn settings
   getSpawnSettings: () => httpApi.getSpawnSettings(),
   updateSpawnSettings: (params: {
-    use_tmux_window: boolean;
+    runtime: SpawnRuntime;
     tmux_window_name?: string;
     worker_permission_mode?: WorkerPermissionMode;
   }) => httpApi.updateSpawnSettings(params),


### PR DESCRIPTION
## Summary

- Replace the `use_tmux_window` boolean toggle in the Settings → Spawn section with a labelled **radio group** ("Spawn runtime")
- `native` — selectable; PTY-server backed, required for preview/resize/programmatic input
- `tmux` — **disabled** with a "coming soon" badge; renders as selected-but-disabled if the user's config already has `runtime = "tmux"`, preserving current state visibility
- Add `SpawnRuntime = "native" | "tmux"` type and update `SpawnSettings.runtime` / `updateSpawnSettings` signature in both `api-http.ts` and `api-tauri.ts`
- New `SpawnRuntimeSelector` component + 6 component tests

## Test plan

- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm exec biome check ./src` — no new errors (5 pre-existing warnings in `useTerminal.test.ts`)
- [x] `pnpm test` — 251 passed, 2 skipped (all 30 test files pass)
- [x] `pnpm build` — clean build

**New component tests assert:**
- `native` is the default selection on a fresh load
- `tmux` renders as disabled
- `tmux` renders as selected-but-disabled when `runtime = "tmux"` in config
- Selecting `native` triggers `PUT /api/settings/spawn` with `{ runtime: "native" }`
- `onSettingsChange` is called with the updated runtime after a successful PUT

## Notes

- Depends on tmai-core#243 for the backend API surface (`runtime` field on `GET/PUT /api/settings/spawn`). The type definitions here match the expected new schema.
- The tmux window name field now shows only when `runtime === "tmux"` (preserving behavior for existing tmux users).

Closes #569

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * スポーン実行時の選択UI「Spawn Runtime Selector」を追加しました。

* **Refactor**
  * 設定パネルのスポーン設定UIを再設計し、新しいセレクタコンポーネントを導入しました。
  * ウィンドウ名フィールドの表示条件を改善しました。

* **Tests**
  * 新しいSpawn Runtime Selectorコンポーネントの包括的なテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->