### PR TITLE
feat(react): #573 per-role dispatch bundle editor in Settings UI

### DIFF
--- a/clients/react/src/components/settings/DispatchBundleEditor.tsx
+++ b/clients/react/src/components/settings/DispatchBundleEditor.tsx
@@ -1,0 +1,183 @@
+import type { DispatchBundle } from "@/types/generated/DispatchBundle";
+import type { PermissionMode } from "@/types/generated/PermissionMode";
+import type { Vendor } from "@/types/generated/Vendor";
+
+const VENDORS: Vendor[] = ["claude", "codex", "gemini"];
+
+const PERMISSION_MODES: { value: PermissionMode; label: string }[] = [
+  { value: "plan", label: "plan" },
+  { value: "acceptEdits", label: "accept_edits" },
+  { value: "dontAsk", label: "dont_ask" },
+  { value: "auto", label: "auto" },
+  { value: "default", label: "default" },
+];
+
+const EFFORT_VALUES = ["low", "medium", "high", "xhigh", "max"] as const;
+
+const MODEL_PLACEHOLDERS: Record<Vendor, string> = {
+  claude: "claude-opus-4-6",
+  codex: "codex-1",
+  gemini: "gemini-2.5-pro",
+};
+
+/** auto is only valid for claude vendor with an opus-tier model. */
+function isAutoDisabled(vendor: Vendor, model: string): boolean {
+  if (vendor !== "claude") return true;
+  return !model.startsWith("claude-opus-");
+}
+
+interface DispatchBundleEditorProps {
+  title: string;
+  subtitle: string;
+  bundle: DispatchBundle | null | undefined;
+  onChange: (bundle: DispatchBundle | null) => void;
+}
+
+/**
+ * Edits a single dispatch bundle (vendor/model/permission_mode/effort).
+ * When bundle is null the "Use legacy [spawn.*] config" checkbox is checked
+ * and all inputs are disabled.
+ */
+export function DispatchBundleEditor({
+  title,
+  subtitle,
+  bundle,
+  onChange,
+}: DispatchBundleEditorProps) {
+  const useLegacy = bundle == null;
+  // Maintain a working copy for when the checkbox is unchecked.
+  const active: DispatchBundle = bundle ?? { vendor: "claude" };
+
+  const handleLegacyToggle = (checked: boolean) => {
+    onChange(checked ? null : { vendor: "claude" });
+  };
+
+  const handleVendorChange = (vendor: Vendor) => {
+    // Changing vendor resets model — no point keeping a cross-vendor model name.
+    onChange({ ...active, vendor, model: null });
+  };
+
+  const handleModelChange = (model: string) => {
+    onChange({ ...active, model: model || null });
+  };
+
+  const handlePermissionChange = (value: string) => {
+    const mode = value === "" ? null : (value as PermissionMode);
+    onChange({ ...active, permission_mode: mode });
+  };
+
+  const handleEffortChange = (value: string) => {
+    onChange({ ...active, effort: value || null });
+  };
+
+  const inputCls =
+    "w-full rounded-md border border-white/10 bg-white/5 px-2.5 py-1.5 text-xs text-zinc-200 outline-none focus:border-cyan-500/30 disabled:opacity-40 disabled:cursor-not-allowed";
+
+  const autoDisabled = isAutoDisabled(active.vendor, active.model ?? "");
+
+  return (
+    <div className="rounded-md border border-white/10 bg-white/[0.02] p-3 space-y-3">
+      {/* Header row */}
+      <div className="flex items-center justify-between gap-2 flex-wrap">
+        <div>
+          <span className="text-xs font-medium text-zinc-300">{title}</span>
+          <span className="ml-1 text-xs text-zinc-600">({subtitle})</span>
+        </div>
+        <label className="flex items-center gap-1.5 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={useLegacy}
+            onChange={(e) => handleLegacyToggle(e.target.checked)}
+            className="accent-cyan-500"
+            aria-label={`Use legacy spawn config for ${title}`}
+          />
+          <span className="text-xs text-zinc-500">Use legacy [spawn.*] config (fallback)</span>
+        </label>
+      </div>
+
+      {/* Field grid — disabled when using legacy fallback */}
+      <div
+        className={`space-y-2 transition-opacity ${useLegacy ? "opacity-40 pointer-events-none" : ""}`}
+        aria-disabled={useLegacy}
+      >
+        {/* Vendor */}
+        <div className="flex items-center gap-3">
+          <span className="w-24 shrink-0 text-xs text-zinc-500">Vendor</span>
+          <select
+            value={active.vendor}
+            onChange={(e) => handleVendorChange(e.target.value as Vendor)}
+            disabled={useLegacy}
+            className={inputCls}
+            aria-label={`Vendor for ${title}`}
+          >
+            {VENDORS.map((v) => (
+              <option key={v} value={v}>
+                {v}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Model */}
+        <div className="flex items-center gap-3">
+          <span className="w-24 shrink-0 text-xs text-zinc-500">Model</span>
+          <input
+            type="text"
+            value={active.model ?? ""}
+            placeholder={MODEL_PLACEHOLDERS[active.vendor]}
+            onChange={(e) => handleModelChange(e.target.value)}
+            disabled={useLegacy}
+            className={inputCls}
+            aria-label={`Model for ${title}`}
+          />
+        </div>
+
+        {/* Permission mode */}
+        <div className="flex items-center gap-3">
+          <span className="w-24 shrink-0 text-xs text-zinc-500">Permission</span>
+          <select
+            value={active.permission_mode ?? ""}
+            onChange={(e) => handlePermissionChange(e.target.value)}
+            disabled={useLegacy}
+            className={inputCls}
+            aria-label={`Permission mode for ${title}`}
+          >
+            <option value="">— (default)</option>
+            {PERMISSION_MODES.filter((o) => o.value !== "default").map((opt) => {
+              const disabled = opt.value === "auto" && autoDisabled;
+              return (
+                <option key={opt.value} value={opt.value} disabled={disabled}>
+                  {opt.label}
+                  {opt.value === "auto" && autoDisabled ? " (requires opus-tier model)" : ""}
+                </option>
+              );
+            })}
+          </select>
+        </div>
+
+        {/* Effort (claude only) */}
+        <div className="flex items-center gap-3">
+          <span className="w-24 shrink-0 text-xs text-zinc-500">Effort</span>
+          {active.vendor === "claude" ? (
+            <select
+              value={active.effort ?? ""}
+              onChange={(e) => handleEffortChange(e.target.value)}
+              disabled={useLegacy}
+              className={inputCls}
+              aria-label={`Effort for ${title}`}
+            >
+              <option value="">— (default)</option>
+              {EFFORT_VALUES.map((e) => (
+                <option key={e} value={e}>
+                  {e}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <span className="text-xs text-zinc-600">(n/a — {active.vendor})</span>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/clients/react/src/components/settings/OrchestrationDispatchSection.tsx
+++ b/clients/react/src/components/settings/OrchestrationDispatchSection.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useState } from "react";
+import type { OrchestrationSettings } from "@/lib/api";
+import { api } from "@/lib/api";
+import type { DispatchBundle } from "@/types/generated/DispatchBundle";
+import { DispatchBundleEditor } from "./DispatchBundleEditor";
+
+/**
+ * Settings section that exposes per-role dispatch bundle editing for
+ * orchestrator / implementer / reviewer.
+ *
+ * Sends PUT /settings/orchestration on save; surfaces validation errors
+ * from the backend as inline error text (the server returns 400 with a
+ * descriptive message when the vendor×model×permission_mode triple is invalid).
+ */
+export function OrchestrationDispatchSection() {
+  const [settings, setSettings] = useState<OrchestrationSettings | null>(null);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saved, setSaved] = useState(false);
+
+  useEffect(() => {
+    api.getOrchestrationSettings().then(setSettings).catch(console.error);
+  }, []);
+
+  if (!settings) return null;
+
+  const handleOrchestratorChange = (bundle: DispatchBundle | null) => {
+    setSettings({ ...settings, orchestrator: bundle });
+    setSaved(false);
+  };
+
+  const handleImplementerChange = (bundle: DispatchBundle | null) => {
+    setSettings({
+      ...settings,
+      dispatch: { ...settings.dispatch, implementer: bundle },
+    });
+    setSaved(false);
+  };
+
+  const handleReviewerChange = (bundle: DispatchBundle | null) => {
+    setSettings({
+      ...settings,
+      dispatch: { ...settings.dispatch, reviewer: bundle },
+    });
+    setSaved(false);
+  };
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      await api.updateOrchestrationSettings({
+        orchestrator: settings.orchestrator,
+        dispatch: settings.dispatch,
+      });
+      setSaved(true);
+    } catch (e) {
+      setSaveError(e instanceof Error ? e.message : "Save failed");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <section>
+      <h3 className="text-sm font-medium text-zinc-300">Orchestration</h3>
+      <p className="mt-1 text-xs text-zinc-600">
+        Per-role dispatch bundles: vendor, model, permission mode, and effort for each agent role.
+        Leave "Use legacy" checked to fall back to the <code>[spawn.*]</code> config.
+      </p>
+
+      <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-3">
+        <DispatchBundleEditor
+          title="Orchestrator"
+          subtitle="the agent you attach to"
+          bundle={settings.orchestrator}
+          onChange={handleOrchestratorChange}
+        />
+        <DispatchBundleEditor
+          title="Implementer"
+          subtitle="dispatch_issue / spawn_worktree"
+          bundle={settings.dispatch.implementer ?? null}
+          onChange={handleImplementerChange}
+        />
+        <DispatchBundleEditor
+          title="Reviewer"
+          subtitle="dispatch_review"
+          bundle={settings.dispatch.reviewer ?? null}
+          onChange={handleReviewerChange}
+        />
+
+        {saveError && (
+          <p className="text-xs text-red-400 break-words" role="alert">
+            {saveError}
+          </p>
+        )}
+
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            className="rounded-md px-3 py-1.5 text-xs font-medium bg-cyan-600 text-white hover:bg-cyan-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+          >
+            {saving ? "Saving…" : "Save"}
+          </button>
+          {saved && !saving && <span className="text-xs text-zinc-500">Saved</span>}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/clients/react/src/components/settings/SettingsPanel.tsx
+++ b/clients/react/src/components/settings/SettingsPanel.tsx
@@ -12,6 +12,7 @@ import {
   type WorktreeSettings,
 } from "@/lib/api";
 import { buildNotifyEventHelp } from "./notify-event-help";
+import { OrchestrationDispatchSection } from "./OrchestrationDispatchSection";
 import { ScheduledKicksSection } from "./ScheduledKicksSection";
 import { SpawnRuntimeSelector } from "./SpawnRuntimeSelector";
 
@@ -827,6 +828,9 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
             </div>
           </section>
         )}
+
+        {/* Orchestration dispatch bundles section (#573) */}
+        <OrchestrationDispatchSection />
 
         {/* Scheduled kicks / Routines section */}
         <ScheduledKicksSection />

--- a/clients/react/src/components/settings/__tests__/SettingsPanel-orchestration.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel-orchestration.test.tsx
@@ -1,0 +1,252 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OrchestrationSettings } from "@/lib/api";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      getOrchestrationSettings: vi.fn(),
+      updateOrchestrationSettings: vi.fn(),
+    },
+  };
+});
+
+const { api } = await import("@/lib/api");
+const { OrchestrationDispatchSection } = await import("../OrchestrationDispatchSection");
+
+const BASE_SETTINGS: OrchestrationSettings = {
+  orchestrator: null,
+  dispatch: {
+    implementer: null,
+    reviewer: null,
+  },
+};
+
+const EXPLICIT_SETTINGS: OrchestrationSettings = {
+  orchestrator: {
+    vendor: "claude",
+    model: "claude-opus-4-6",
+    permission_mode: "auto",
+    effort: "high",
+  },
+  dispatch: {
+    implementer: {
+      vendor: "claude",
+      model: "claude-opus-4-6",
+      permission_mode: "auto",
+      effort: "high",
+    },
+    reviewer: { vendor: "codex", model: "codex-1", permission_mode: null, effort: null },
+  },
+};
+
+describe("OrchestrationDispatchSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders all three bundle sections after load", async () => {
+    vi.mocked(api.getOrchestrationSettings).mockResolvedValue(BASE_SETTINGS);
+    render(<OrchestrationDispatchSection />);
+    await waitFor(() => {
+      expect(screen.getByText("Orchestrator")).toBeTruthy();
+      expect(screen.getByText("Implementer")).toBeTruthy();
+      expect(screen.getByText("Reviewer")).toBeTruthy();
+    });
+  });
+
+  it("shows legacy checkbox checked when bundles are null", async () => {
+    vi.mocked(api.getOrchestrationSettings).mockResolvedValue(BASE_SETTINGS);
+    render(<OrchestrationDispatchSection />);
+    await waitFor(() => {
+      const checkboxes = screen.getAllByRole("checkbox");
+      // All three bundles null → all three checkboxes should be checked
+      for (const cb of checkboxes) {
+        expect((cb as HTMLInputElement).checked).toBe(true);
+      }
+    });
+  });
+
+  it("shows legacy checkbox unchecked when bundles are explicit", async () => {
+    vi.mocked(api.getOrchestrationSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    render(<OrchestrationDispatchSection />);
+    await waitFor(() => {
+      const checkboxes = screen.getAllByRole("checkbox");
+      // All three bundles explicit → all three checkboxes should be unchecked
+      for (const cb of checkboxes) {
+        expect((cb as HTMLInputElement).checked).toBe(false);
+      }
+    });
+  });
+
+  it("switching vendor resets the model input to empty", async () => {
+    vi.mocked(api.getOrchestrationSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    render(<OrchestrationDispatchSection />);
+
+    // Wait for render
+    await waitFor(() => screen.getByText("Orchestrator"));
+
+    // Get the first vendor select (Orchestrator)
+    const vendorSelects = screen.getAllByRole("combobox", { name: /vendor for/i });
+    const orchestratorVendor = vendorSelects[0];
+
+    // Get corresponding model input (first model input)
+    const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
+    expect((modelInputs[0] as HTMLInputElement).value).toBe("claude-opus-4-6");
+
+    // Switch vendor
+    fireEvent.change(orchestratorVendor, { target: { value: "codex" } });
+
+    // Model should be reset to empty
+    await waitFor(() => {
+      expect((modelInputs[0] as HTMLInputElement).value).toBe("");
+    });
+  });
+
+  it("auto permission option is disabled for non-opus claude model", async () => {
+    vi.mocked(api.getOrchestrationSettings).mockResolvedValue({
+      ...BASE_SETTINGS,
+      orchestrator: { vendor: "claude", model: "claude-sonnet-4-6" },
+    });
+    render(<OrchestrationDispatchSection />);
+    await waitFor(() => screen.getByText("Orchestrator"));
+
+    // Find the permission select for orchestrator
+    const permissionSelects = screen.getAllByRole("combobox", { name: /permission mode for/i });
+    const orchestratorPerm = permissionSelects[0];
+
+    // auto option should be disabled
+    const autoOption = Array.from(orchestratorPerm.querySelectorAll("option")).find(
+      (o) => o.value === "auto",
+    );
+    expect(autoOption).toBeTruthy();
+    expect((autoOption as HTMLOptionElement).disabled).toBe(true);
+  });
+
+  it("auto permission option is enabled for opus model", async () => {
+    vi.mocked(api.getOrchestrationSettings).mockResolvedValue({
+      ...BASE_SETTINGS,
+      orchestrator: { vendor: "claude", model: "claude-opus-4-6" },
+    });
+    render(<OrchestrationDispatchSection />);
+    await waitFor(() => screen.getByText("Orchestrator"));
+
+    const permissionSelects = screen.getAllByRole("combobox", { name: /permission mode for/i });
+    const orchestratorPerm = permissionSelects[0];
+
+    const autoOption = Array.from(orchestratorPerm.querySelectorAll("option")).find(
+      (o) => o.value === "auto",
+    );
+    expect(autoOption).toBeTruthy();
+    expect((autoOption as HTMLOptionElement).disabled).toBe(false);
+  });
+
+  it("auto permission option is disabled for non-claude vendor", async () => {
+    vi.mocked(api.getOrchestrationSettings).mockResolvedValue({
+      ...BASE_SETTINGS,
+      dispatch: {
+        implementer: null,
+        reviewer: { vendor: "codex", model: "codex-1" },
+      },
+    });
+    render(<OrchestrationDispatchSection />);
+    await waitFor(() => screen.getByText("Reviewer"));
+
+    // Third permission select → reviewer
+    const permissionSelects = screen.getAllByRole("combobox", { name: /permission mode for/i });
+    const reviewerPerm = permissionSelects[2];
+
+    const autoOption = Array.from(reviewerPerm.querySelectorAll("option")).find(
+      (o) => o.value === "auto",
+    );
+    expect(autoOption).toBeTruthy();
+    expect((autoOption as HTMLOptionElement).disabled).toBe(true);
+  });
+
+  it("effort dropdown is hidden for codex vendor", async () => {
+    vi.mocked(api.getOrchestrationSettings).mockResolvedValue({
+      ...BASE_SETTINGS,
+      dispatch: {
+        implementer: null,
+        reviewer: { vendor: "codex", model: "codex-1" },
+      },
+    });
+    render(<OrchestrationDispatchSection />);
+    await waitFor(() => screen.getByText("Reviewer"));
+
+    // "n/a — codex" should be visible
+    expect(screen.getByText("(n/a — codex)")).toBeTruthy();
+  });
+
+  it("effort dropdown is shown for claude vendor", async () => {
+    vi.mocked(api.getOrchestrationSettings).mockResolvedValue({
+      ...BASE_SETTINGS,
+      orchestrator: { vendor: "claude", model: "claude-opus-4-6" },
+    });
+    render(<OrchestrationDispatchSection />);
+    await waitFor(() => screen.getByText("Orchestrator"));
+
+    // Effort select should exist for orchestrator (first effort combobox)
+    const effortSelects = screen.getAllByRole("combobox", { name: /effort for/i });
+    expect(effortSelects.length).toBeGreaterThan(0);
+  });
+
+  it("save calls updateOrchestrationSettings with the current bundle state", async () => {
+    vi.mocked(api.getOrchestrationSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateOrchestrationSettings).mockResolvedValue(undefined as never);
+    render(<OrchestrationDispatchSection />);
+
+    await waitFor(() => screen.getByText("Orchestrator"));
+
+    const saveBtn = screen.getByRole("button", { name: /save/i });
+    fireEvent.click(saveBtn);
+
+    await waitFor(() => {
+      expect(vi.mocked(api.updateOrchestrationSettings)).toHaveBeenCalledWith({
+        orchestrator: EXPLICIT_SETTINGS.orchestrator,
+        dispatch: EXPLICIT_SETTINGS.dispatch,
+      });
+    });
+  });
+
+  it("displays backend error on save failure", async () => {
+    vi.mocked(api.getOrchestrationSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateOrchestrationSettings).mockRejectedValue(
+      new Error(
+        "API error 400: [orchestration.dispatch.implementer] permission_mode `auto` is not allowed",
+      ),
+    );
+    render(<OrchestrationDispatchSection />);
+
+    await waitFor(() => screen.getByText("Orchestrator"));
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/permission_mode `auto` is not allowed/i)).toBeTruthy();
+    });
+  });
+
+  it("send null for bundle when legacy checkbox is checked", async () => {
+    vi.mocked(api.getOrchestrationSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateOrchestrationSettings).mockResolvedValue(undefined as never);
+    render(<OrchestrationDispatchSection />);
+
+    await waitFor(() => screen.getByText("Orchestrator"));
+
+    // Check the orchestrator legacy checkbox
+    const legacyCheckboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(legacyCheckboxes[0]); // orchestrator checkbox
+
+    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => {
+      expect(vi.mocked(api.updateOrchestrationSettings)).toHaveBeenCalledWith(
+        expect.objectContaining({ orchestrator: null }),
+      );
+    });
+  });
+});

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -3,6 +3,7 @@
 
 import type { ApprovalSnapshot } from "@/types/generated/ApprovalSnapshot";
 import type { BootstrapRequiredEvent } from "@/types/generated/BootstrapRequiredEvent";
+import type { DispatchBundle } from "@/types/generated/DispatchBundle";
 import type { DispatchSnapshot } from "@/types/generated/DispatchSnapshot";
 import type { EntityUpdateEnvelope } from "@/types/generated/EntityUpdateEnvelope";
 import type { QueueAgentEntry } from "@/types/generated/QueueAgentEntry";
@@ -11,15 +12,18 @@ import type { RuntimeSnapshot } from "@/types/generated/RuntimeSnapshot";
 import type { SpawnRuntime } from "@/types/generated/SpawnRuntime";
 import type { TeamSnapshot } from "@/types/generated/TeamSnapshot";
 import type { TerminalSubscription } from "@/types/generated/TerminalSubscription";
+import type { WorkerDispatchMap } from "@/types/generated/WorkerDispatchMap";
 import type { WorkflowSnapshot } from "@/types/generated/WorkflowSnapshot";
 
 export type {
   BootstrapRequiredEvent,
+  DispatchBundle,
   EntityUpdateEnvelope,
   QueueAgentEntry,
   QueueSnapshot,
   SpawnRuntime,
   TerminalSubscription,
+  WorkerDispatchMap,
 };
 
 // ── Connection config ──
@@ -796,6 +800,17 @@ export interface WorktreeSettings {
   branch_depth_warning: number;
 }
 
+// ── Orchestration dispatch bundle settings (#573) ──
+
+/**
+ * Per-role dispatch bundle settings persisted under [orchestration.*] in config.toml.
+ * null bundle means "use legacy [spawn.*] fallback for that role".
+ */
+export interface OrchestrationSettings {
+  orchestrator: DispatchBundle | null;
+  dispatch: WorkerDispatchMap;
+}
+
 // ── Scheduled kicks (Routines parity — #2) ──
 
 /** Interval-based or cron-based schedule for an orchestrator kick */
@@ -1241,6 +1256,17 @@ export const api = {
   getWorktreeSettings: () => apiFetch<WorktreeSettings>("/settings/worktree"),
   updateWorktreeSettings: (params: Partial<WorktreeSettings>) =>
     apiFetch("/settings/worktree", {
+      method: "PUT",
+      body: JSON.stringify(params),
+    }),
+
+  // Orchestration dispatch bundle settings (#573)
+  getOrchestrationSettings: () => apiFetch<OrchestrationSettings>("/settings/orchestration"),
+  updateOrchestrationSettings: (params: {
+    orchestrator?: DispatchBundle | null;
+    dispatch?: WorkerDispatchMap;
+  }) =>
+    apiFetch("/settings/orchestration", {
       method: "PUT",
       body: JSON.stringify(params),
     }),

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -10,14 +10,17 @@ import type {
   AutoActionTemplates,
   AutoApproveRules,
   AutoApproveSettings,
+  DispatchBundle,
   GuardrailsSettings,
   NotifySettings,
   NotifyTemplates,
+  OrchestrationSettings,
   OrchestratorRules,
   PrMonitorScope,
   SpawnRequest,
   SpawnRuntime,
   UsageSettings,
+  WorkerDispatchMap,
   WorkerPermissionMode,
   WorkflowSettings,
   WorktreeSettings,
@@ -247,6 +250,14 @@ export const api = {
   getWorktreeSettings: () => httpApi.getWorktreeSettings(),
   updateWorktreeSettings: (params: Partial<WorktreeSettings>) =>
     httpApi.updateWorktreeSettings(params),
+
+  // Orchestration dispatch bundle settings (#573)
+  getOrchestrationSettings: (): Promise<OrchestrationSettings> =>
+    httpApi.getOrchestrationSettings(),
+  updateOrchestrationSettings: (params: {
+    orchestrator?: DispatchBundle | null;
+    dispatch?: WorkerDispatchMap;
+  }) => httpApi.updateOrchestrationSettings(params),
 
   // Teams (HTTP only for now)
   listTeams: (): Promise<TeamSummary[]> => httpApi.listTeams(),


### PR DESCRIPTION
## Summary

- Add **Orchestration** section to Settings panel with three `DispatchBundleEditor` cards: Orchestrator, Implementer, Reviewer
- Each card exposes **Vendor** dropdown, **Model** free-text, **Permission mode** dropdown (with `auto` disabled for non-opus-claude), and **Effort** dropdown (hidden / n/a for codex / gemini)
- A "Use legacy [spawn.*] config (fallback)" checkbox per bundle — when checked the bundle is `null` and inputs are disabled; saves `null` to the backend
- New API wiring: `OrchestrationSettings` type + `getOrchestrationSettings` / `updateOrchestrationSettings` targeting `GET/PUT /settings/orchestration`
- Save button in the section surfaces backend 400 validation errors (e.g. `permission_mode auto is not allowed for vendor=claude model=claude-sonnet-4-6`) inline

## Files changed

| File | What |
|------|------|
| `api-http.ts` | `OrchestrationSettings` type, imports for `DispatchBundle`/`WorkerDispatchMap`, GET/PUT `/settings/orchestration` methods |
| `api-tauri.ts` | Proxy delegates to `httpApi` |
| `DispatchBundleEditor.tsx` | Single-bundle controlled editor card |
| `OrchestrationDispatchSection.tsx` | Section with 3 editors + Save button |
| `SettingsPanel.tsx` | Mount `OrchestrationDispatchSection` after Orchestrator section |
| `SettingsPanel-orchestration.test.tsx` | 12 component tests |

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm exec biome check` — clean
- [x] `pnpm vitest run` — 263 passed (12 new), 2 skipped
- [x] `pnpm build` — clean
- [ ] Manual smoke: Settings panel shows Orchestration section; configuring `dispatch.implementer = {claude, opus, auto, high}` survives `config.toml` round-trip (requires backend from tmai-core#250)

Closes #573

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * オーケストレーション設定にディスパッチバンドル管理機能を追加。ベンダー、モデル、パーミッションモード、リソースレベルの設定を、ロール別（オーケストレータ、実装者、レビュアー）に編集可能に。
  * 設定の保存・読み込み機能を実装。

* **テスト**
  * オーケストレーションディスパッチ設定機能のテストスイートを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->