### PR TITLE
fix(react): wire OrchestrationDispatchSection to /settings/orchestrator; clean up Spawn section

### DIFF
--- a/clients/react/src/components/settings/DispatchBundleEditor.tsx
+++ b/clients/react/src/components/settings/DispatchBundleEditor.tsx
@@ -35,8 +35,9 @@ interface DispatchBundleEditorProps {
 
 /**
  * Edits a single dispatch bundle (vendor/model/permission_mode/effort).
- * When bundle is null the "Use legacy [spawn.*] config" checkbox is checked
- * and all inputs are disabled.
+ * When bundle is null the "Use vendor CLI default" checkbox is checked,
+ * all inputs are disabled, and the role launches with the vendor CLI's own
+ * defaults (no `--model` / `--permission-mode` flags injected by tmai).
  */
 export function DispatchBundleEditor({
   title,
@@ -89,9 +90,9 @@ export function DispatchBundleEditor({
             checked={useLegacy}
             onChange={(e) => handleLegacyToggle(e.target.checked)}
             className="accent-cyan-500"
-            aria-label={`Use legacy spawn config for ${title}`}
+            aria-label={`Use vendor CLI default for ${title}`}
           />
-          <span className="text-xs text-zinc-500">Use legacy [spawn.*] config (fallback)</span>
+          <span className="text-xs text-zinc-500">Use vendor CLI default</span>
         </label>
       </div>
 

--- a/clients/react/src/components/settings/OrchestrationDispatchSection.tsx
+++ b/clients/react/src/components/settings/OrchestrationDispatchSection.tsx
@@ -1,46 +1,65 @@
 import { useEffect, useState } from "react";
-import type { OrchestrationSettings } from "@/lib/api";
 import { api } from "@/lib/api";
 import type { DispatchBundle } from "@/types/generated/DispatchBundle";
+import type { WorkerDispatchMap } from "@/types/generated/WorkerDispatchMap";
 import { DispatchBundleEditor } from "./DispatchBundleEditor";
+
+interface DispatchState {
+  orchestrator: DispatchBundle | null;
+  dispatch: WorkerDispatchMap;
+}
 
 /**
  * Settings section that exposes per-role dispatch bundle editing for
  * orchestrator / implementer / reviewer.
  *
- * Sends PUT /settings/orchestration on save; surfaces validation errors
- * from the backend as inline error text (the server returns 400 with a
- * descriptive message when the vendor×model×permission_mode triple is invalid).
+ * Reads the bundles from `GET /settings/orchestrator` (the global settings
+ * endpoint that carries the dispatch fields alongside notify/guardrails/...)
+ * and saves them via the same endpoint's PUT — server-side `OrchestrationSettings`
+ * is the single source of truth, so this component only roundtrips the dispatch
+ * subset of fields.
+ *
+ * Surfaces validation errors from the backend as inline error text (the server
+ * returns 400 with a descriptive message when the vendor×model×permission_mode
+ * triple is invalid).
  */
 export function OrchestrationDispatchSection() {
-  const [settings, setSettings] = useState<OrchestrationSettings | null>(null);
+  const [state, setState] = useState<DispatchState | null>(null);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saving, setSaving] = useState(false);
   const [saved, setSaved] = useState(false);
 
   useEffect(() => {
-    api.getOrchestrationSettings().then(setSettings).catch(console.error);
+    api
+      .getOrchestratorSettings()
+      .then((s) =>
+        setState({
+          orchestrator: s.orchestrator ?? null,
+          dispatch: s.dispatch,
+        }),
+      )
+      .catch(console.error);
   }, []);
 
-  if (!settings) return null;
+  if (!state) return null;
 
   const handleOrchestratorChange = (bundle: DispatchBundle | null) => {
-    setSettings({ ...settings, orchestrator: bundle });
+    setState({ ...state, orchestrator: bundle });
     setSaved(false);
   };
 
   const handleImplementerChange = (bundle: DispatchBundle | null) => {
-    setSettings({
-      ...settings,
-      dispatch: { ...settings.dispatch, implementer: bundle },
+    setState({
+      ...state,
+      dispatch: { ...state.dispatch, implementer: bundle },
     });
     setSaved(false);
   };
 
   const handleReviewerChange = (bundle: DispatchBundle | null) => {
-    setSettings({
-      ...settings,
-      dispatch: { ...settings.dispatch, reviewer: bundle },
+    setState({
+      ...state,
+      dispatch: { ...state.dispatch, reviewer: bundle },
     });
     setSaved(false);
   };
@@ -49,9 +68,9 @@ export function OrchestrationDispatchSection() {
     setSaving(true);
     setSaveError(null);
     try {
-      await api.updateOrchestrationSettings({
-        orchestrator: settings.orchestrator,
-        dispatch: settings.dispatch,
+      await api.updateOrchestratorSettings({
+        orchestrator: state.orchestrator,
+        dispatch: state.dispatch,
       });
       setSaved(true);
     } catch (e) {
@@ -63,29 +82,30 @@ export function OrchestrationDispatchSection() {
 
   return (
     <section>
-      <h3 className="text-sm font-medium text-zinc-300">Orchestration</h3>
+      <h3 className="text-sm font-medium text-zinc-300">Orchestration dispatch</h3>
       <p className="mt-1 text-xs text-zinc-600">
         Per-role dispatch bundles: vendor, model, permission mode, and effort for each agent role.
-        Leave "Use legacy" checked to fall back to the <code>[spawn.*]</code> config.
+        Leave "Use vendor CLI default" checked to launch that role with the vendor CLI's own
+        defaults (no <code>--model</code> / <code>--permission-mode</code> flags injected).
       </p>
 
       <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-3">
         <DispatchBundleEditor
           title="Orchestrator"
           subtitle="the agent you attach to"
-          bundle={settings.orchestrator}
+          bundle={state.orchestrator}
           onChange={handleOrchestratorChange}
         />
         <DispatchBundleEditor
           title="Implementer"
           subtitle="dispatch_issue / spawn_worktree"
-          bundle={settings.dispatch.implementer ?? null}
+          bundle={state.dispatch.implementer ?? null}
           onChange={handleImplementerChange}
         />
         <DispatchBundleEditor
           title="Reviewer"
           subtitle="dispatch_review"
-          bundle={settings.dispatch.reviewer ?? null}
+          bundle={state.dispatch.reviewer ?? null}
           onChange={handleReviewerChange}
         />
 

--- a/clients/react/src/components/settings/SettingsPanel.tsx
+++ b/clients/react/src/components/settings/SettingsPanel.tsx
@@ -7,7 +7,6 @@ import {
   type OrchestratorSettings,
   type SpawnSettings,
   type UsageSettings,
-  type WorkerPermissionMode,
   type WorkflowSettings,
   type WorktreeSettings,
 } from "@/lib/api";
@@ -129,18 +128,6 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
       await api.updateSpawnSettings({
         runtime: spawnSettings.runtime,
         tmux_window_name: trimmed,
-      });
-    } catch (_e) {}
-  };
-
-  // Change worker permission mode (for dispatched workers)
-  const handleWorkerPermissionModeChange = async (mode: WorkerPermissionMode) => {
-    if (!spawnSettings) return;
-    setSpawnSettings({ ...spawnSettings, worker_permission_mode: mode });
-    try {
-      await api.updateSpawnSettings({
-        runtime: spawnSettings.runtime,
-        worker_permission_mode: mode,
       });
     } catch (_e) {}
   };
@@ -577,41 +564,14 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                   />
                 </div>
               )}
-
-              {/* Worker permission mode — applies to dispatched workers only */}
-              <div className="border-t border-white/5 pt-3">
-                <div className="flex items-center justify-between gap-3">
-                  <div className="flex-1">
-                    <span className="text-xs text-zinc-400">Worker permission mode</span>
-                    <p className="mt-0.5 text-[10px] text-zinc-600">
-                      Injected as <code>--permission-mode</code> for Claude Code workers spawned via
-                      <code> dispatch_issue</code> / <code>dispatch_review</code>. Does not apply to
-                      the orchestrator itself. <code>acceptEdits</code> lets workers edit files
-                      without per-tool approval while still gating Bash via tmai auto-approve.
-                    </p>
-                  </div>
-                  <select
-                    value={spawnSettings.worker_permission_mode}
-                    onChange={(e) =>
-                      handleWorkerPermissionModeChange(e.target.value as WorkerPermissionMode)
-                    }
-                    className="shrink-0 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
-                  >
-                    <option value="acceptEdits">acceptEdits (recommended)</option>
-                    <option value="default">default</option>
-                    <option value="plan">plan</option>
-                    <option value="dontAsk">dontAsk</option>
-                  </select>
-                </div>
-              </div>
             </div>
           </section>
         )}
 
-        {/* Orchestrator section */}
+        {/* Orchestration section */}
         {orchestrator && (
           <section>
-            <h3 className="text-sm font-medium text-zinc-300">Orchestrator</h3>
+            <h3 className="text-sm font-medium text-zinc-300">Orchestration</h3>
             <p className="mt-1 text-xs text-zinc-600">
               Configure the orchestrator agent that coordinates sub-agents for parallel development
               workflows.

--- a/clients/react/src/components/settings/__tests__/SettingsPanel-orchestration.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel-orchestration.test.tsx
@@ -1,15 +1,15 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { OrchestrationSettings } from "@/lib/api";
+import type { OrchestratorSettings } from "@/lib/api";
 
 vi.mock("@/lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/api")>();
   return {
     ...actual,
     api: {
-      getOrchestrationSettings: vi.fn(),
-      updateOrchestrationSettings: vi.fn(),
+      getOrchestratorSettings: vi.fn(),
+      updateOrchestratorSettings: vi.fn(),
     },
   };
 });
@@ -17,15 +17,78 @@ vi.mock("@/lib/api", async (importOriginal) => {
 const { api } = await import("@/lib/api");
 const { OrchestrationDispatchSection } = await import("../OrchestrationDispatchSection");
 
-const BASE_SETTINGS: OrchestrationSettings = {
-  orchestrator: null,
-  dispatch: {
-    implementer: null,
-    reviewer: null,
-  },
-};
+/**
+ * Build a minimal OrchestratorSettings for the dispatch-section tests.
+ * Other fields (notify, guardrails, role, ...) are filled with default-ish
+ * placeholders since the section under test only reads `orchestrator` /
+ * `dispatch`.
+ */
+function makeSettings(overrides: Partial<OrchestratorSettings>): OrchestratorSettings {
+  return {
+    enabled: true,
+    role: "",
+    rules: { branch: "", merge: "", review: "", custom: "" },
+    notify: {
+      on_agent_stopped: "off",
+      on_agent_error: "off",
+      on_rebase_conflict: "off",
+      on_ci_passed: "off",
+      on_ci_failed: "off",
+      on_pr_created: "off",
+      on_pr_comment: "off",
+      on_pr_closed: "off",
+      on_guardrail_exceeded: "off",
+      templates: {
+        agent_stopped: "",
+        agent_error: "",
+        ci_passed: "",
+        ci_failed: "",
+        pr_created: "",
+        pr_comment: "",
+        rebase_conflict: "",
+        pr_closed: "",
+        guardrail_exceeded: "",
+      },
+      default_templates: {
+        agent_stopped: "",
+        agent_error: "",
+        ci_passed: "",
+        ci_failed: "",
+        pr_created: "",
+        pr_comment: "",
+        rebase_conflict: "",
+        pr_closed: "",
+        guardrail_exceeded: "",
+      },
+      suppress_self: false,
+      notify_on_human_action: false,
+      notify_on_agent_action: false,
+      notify_on_system_action: false,
+    },
+    guardrails: {
+      max_ci_retries: 0,
+      max_review_loops: 0,
+      escalate_to_human_after: 0,
+    },
+    auto_action_templates: {
+      ci_failed_implementer: "",
+      review_feedback_implementer: "",
+    },
+    pr_monitor_enabled: false,
+    pr_monitor_interval_secs: 0,
+    pr_monitor_exclude_authors: [],
+    pr_monitor_scope: "current_project",
+    inject_state_snapshot: false,
+    is_project_override: false,
+    orchestrator: null,
+    dispatch: { implementer: null, reviewer: null },
+    ...overrides,
+  };
+}
 
-const EXPLICIT_SETTINGS: OrchestrationSettings = {
+const BASE_SETTINGS = makeSettings({});
+
+const EXPLICIT_SETTINGS = makeSettings({
   orchestrator: {
     vendor: "claude",
     model: "claude-opus-4-6",
@@ -41,7 +104,7 @@ const EXPLICIT_SETTINGS: OrchestrationSettings = {
     },
     reviewer: { vendor: "codex", model: "codex-1", permission_mode: null, effort: null },
   },
-};
+});
 
 describe("OrchestrationDispatchSection", () => {
   beforeEach(() => {
@@ -49,7 +112,7 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("renders all three bundle sections after load", async () => {
-    vi.mocked(api.getOrchestrationSettings).mockResolvedValue(BASE_SETTINGS);
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(BASE_SETTINGS);
     render(<OrchestrationDispatchSection />);
     await waitFor(() => {
       expect(screen.getByText("Orchestrator")).toBeTruthy();
@@ -58,24 +121,24 @@ describe("OrchestrationDispatchSection", () => {
     });
   });
 
-  it("shows legacy checkbox checked when bundles are null", async () => {
-    vi.mocked(api.getOrchestrationSettings).mockResolvedValue(BASE_SETTINGS);
+  it("shows default checkbox checked when bundles are null", async () => {
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(BASE_SETTINGS);
     render(<OrchestrationDispatchSection />);
     await waitFor(() => {
       const checkboxes = screen.getAllByRole("checkbox");
-      // All three bundles null → all three checkboxes should be checked
+      // All three bundles null → all three "Use vendor CLI default" checkboxes
+      // should be checked.
       for (const cb of checkboxes) {
         expect((cb as HTMLInputElement).checked).toBe(true);
       }
     });
   });
 
-  it("shows legacy checkbox unchecked when bundles are explicit", async () => {
-    vi.mocked(api.getOrchestrationSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+  it("shows default checkbox unchecked when bundles are explicit", async () => {
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
     render(<OrchestrationDispatchSection />);
     await waitFor(() => {
       const checkboxes = screen.getAllByRole("checkbox");
-      // All three bundles explicit → all three checkboxes should be unchecked
       for (const cb of checkboxes) {
         expect((cb as HTMLInputElement).checked).toBe(false);
       }
@@ -83,42 +146,36 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("switching vendor resets the model input to empty", async () => {
-    vi.mocked(api.getOrchestrationSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
     render(<OrchestrationDispatchSection />);
 
-    // Wait for render
     await waitFor(() => screen.getByText("Orchestrator"));
 
-    // Get the first vendor select (Orchestrator)
     const vendorSelects = screen.getAllByRole("combobox", { name: /vendor for/i });
     const orchestratorVendor = vendorSelects[0];
 
-    // Get corresponding model input (first model input)
     const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
     expect((modelInputs[0] as HTMLInputElement).value).toBe("claude-opus-4-6");
 
-    // Switch vendor
     fireEvent.change(orchestratorVendor, { target: { value: "codex" } });
 
-    // Model should be reset to empty
     await waitFor(() => {
       expect((modelInputs[0] as HTMLInputElement).value).toBe("");
     });
   });
 
   it("auto permission option is disabled for non-opus claude model", async () => {
-    vi.mocked(api.getOrchestrationSettings).mockResolvedValue({
-      ...BASE_SETTINGS,
-      orchestrator: { vendor: "claude", model: "claude-sonnet-4-6" },
-    });
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
+      makeSettings({
+        orchestrator: { vendor: "claude", model: "claude-sonnet-4-6" },
+      }),
+    );
     render(<OrchestrationDispatchSection />);
     await waitFor(() => screen.getByText("Orchestrator"));
 
-    // Find the permission select for orchestrator
     const permissionSelects = screen.getAllByRole("combobox", { name: /permission mode for/i });
     const orchestratorPerm = permissionSelects[0];
 
-    // auto option should be disabled
     const autoOption = Array.from(orchestratorPerm.querySelectorAll("option")).find(
       (o) => o.value === "auto",
     );
@@ -127,10 +184,11 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("auto permission option is enabled for opus model", async () => {
-    vi.mocked(api.getOrchestrationSettings).mockResolvedValue({
-      ...BASE_SETTINGS,
-      orchestrator: { vendor: "claude", model: "claude-opus-4-6" },
-    });
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
+      makeSettings({
+        orchestrator: { vendor: "claude", model: "claude-opus-4-6" },
+      }),
+    );
     render(<OrchestrationDispatchSection />);
     await waitFor(() => screen.getByText("Orchestrator"));
 
@@ -145,17 +203,17 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("auto permission option is disabled for non-claude vendor", async () => {
-    vi.mocked(api.getOrchestrationSettings).mockResolvedValue({
-      ...BASE_SETTINGS,
-      dispatch: {
-        implementer: null,
-        reviewer: { vendor: "codex", model: "codex-1" },
-      },
-    });
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
+      makeSettings({
+        dispatch: {
+          implementer: null,
+          reviewer: { vendor: "codex", model: "codex-1" },
+        },
+      }),
+    );
     render(<OrchestrationDispatchSection />);
     await waitFor(() => screen.getByText("Reviewer"));
 
-    // Third permission select → reviewer
     const permissionSelects = screen.getAllByRole("combobox", { name: /permission mode for/i });
     const reviewerPerm = permissionSelects[2];
 
@@ -167,36 +225,36 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("effort dropdown is hidden for codex vendor", async () => {
-    vi.mocked(api.getOrchestrationSettings).mockResolvedValue({
-      ...BASE_SETTINGS,
-      dispatch: {
-        implementer: null,
-        reviewer: { vendor: "codex", model: "codex-1" },
-      },
-    });
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
+      makeSettings({
+        dispatch: {
+          implementer: null,
+          reviewer: { vendor: "codex", model: "codex-1" },
+        },
+      }),
+    );
     render(<OrchestrationDispatchSection />);
     await waitFor(() => screen.getByText("Reviewer"));
 
-    // "n/a — codex" should be visible
     expect(screen.getByText("(n/a — codex)")).toBeTruthy();
   });
 
   it("effort dropdown is shown for claude vendor", async () => {
-    vi.mocked(api.getOrchestrationSettings).mockResolvedValue({
-      ...BASE_SETTINGS,
-      orchestrator: { vendor: "claude", model: "claude-opus-4-6" },
-    });
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
+      makeSettings({
+        orchestrator: { vendor: "claude", model: "claude-opus-4-6" },
+      }),
+    );
     render(<OrchestrationDispatchSection />);
     await waitFor(() => screen.getByText("Orchestrator"));
 
-    // Effort select should exist for orchestrator (first effort combobox)
     const effortSelects = screen.getAllByRole("combobox", { name: /effort for/i });
     expect(effortSelects.length).toBeGreaterThan(0);
   });
 
-  it("save calls updateOrchestrationSettings with the current bundle state", async () => {
-    vi.mocked(api.getOrchestrationSettings).mockResolvedValue(EXPLICIT_SETTINGS);
-    vi.mocked(api.updateOrchestrationSettings).mockResolvedValue(undefined as never);
+  it("save calls updateOrchestratorSettings with the current bundle state", async () => {
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
     render(<OrchestrationDispatchSection />);
 
     await waitFor(() => screen.getByText("Orchestrator"));
@@ -205,7 +263,7 @@ describe("OrchestrationDispatchSection", () => {
     fireEvent.click(saveBtn);
 
     await waitFor(() => {
-      expect(vi.mocked(api.updateOrchestrationSettings)).toHaveBeenCalledWith({
+      expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledWith({
         orchestrator: EXPLICIT_SETTINGS.orchestrator,
         dispatch: EXPLICIT_SETTINGS.dispatch,
       });
@@ -213,8 +271,8 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("displays backend error on save failure", async () => {
-    vi.mocked(api.getOrchestrationSettings).mockResolvedValue(EXPLICIT_SETTINGS);
-    vi.mocked(api.updateOrchestrationSettings).mockRejectedValue(
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateOrchestratorSettings).mockRejectedValue(
       new Error(
         "API error 400: [orchestration.dispatch.implementer] permission_mode `auto` is not allowed",
       ),
@@ -230,21 +288,20 @@ describe("OrchestrationDispatchSection", () => {
     });
   });
 
-  it("send null for bundle when legacy checkbox is checked", async () => {
-    vi.mocked(api.getOrchestrationSettings).mockResolvedValue(EXPLICIT_SETTINGS);
-    vi.mocked(api.updateOrchestrationSettings).mockResolvedValue(undefined as never);
+  it("sends null for the bundle when the default checkbox is checked", async () => {
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
     render(<OrchestrationDispatchSection />);
 
     await waitFor(() => screen.getByText("Orchestrator"));
 
-    // Check the orchestrator legacy checkbox
-    const legacyCheckboxes = screen.getAllByRole("checkbox");
-    fireEvent.click(legacyCheckboxes[0]); // orchestrator checkbox
+    const checkboxes = screen.getAllByRole("checkbox");
+    fireEvent.click(checkboxes[0]); // orchestrator's "Use vendor CLI default"
 
     fireEvent.click(screen.getByRole("button", { name: /save/i }));
 
     await waitFor(() => {
-      expect(vi.mocked(api.updateOrchestrationSettings)).toHaveBeenCalledWith(
+      expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledWith(
         expect.objectContaining({ orchestrator: null }),
       );
     });

--- a/clients/react/src/components/settings/__tests__/SpawnRuntimeSelector.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SpawnRuntimeSelector.test.tsx
@@ -20,7 +20,6 @@ const BASE_SETTINGS: SpawnSettings = {
   runtime: "native",
   tmux_available: false,
   tmux_window_name: "tmai",
-  worker_permission_mode: "acceptEdits",
 };
 
 describe("SpawnRuntimeSelector", () => {

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -675,14 +675,10 @@ export interface AutoApproveSettings {
   max_concurrent: number;
 }
 
-export type WorkerPermissionMode = "default" | "plan" | "acceptEdits" | "dontAsk";
-
 export interface SpawnSettings {
   runtime: SpawnRuntime;
   tmux_available: boolean;
   tmux_window_name: string;
-  /** Permission mode injected for dispatched workers (dispatch_issue / dispatch_review). */
-  worker_permission_mode: WorkerPermissionMode;
 }
 
 export interface OrchestratorRules {
@@ -759,6 +755,17 @@ export interface OrchestratorSettings {
   inject_state_snapshot: boolean;
   /** Whether this is a per-project override (true) or global fallback (false) */
   is_project_override: boolean;
+  /**
+   * Orchestrator's own dispatch bundle (`[orchestration.orchestrator]`).
+   * `null` / omitted when unset — the orchestrator launches with the vendor
+   * CLI's user-global default.
+   */
+  orchestrator?: DispatchBundle | null;
+  /**
+   * Per-role dispatch bundles for orchestration workers
+   * (`[orchestration.dispatch.<role>]`).
+   */
+  dispatch: WorkerDispatchMap;
 }
 
 export interface SpawnRequest {
@@ -798,17 +805,6 @@ export interface WorktreeSettings {
   setup_commands: string[];
   setup_timeout_secs: number;
   branch_depth_warning: number;
-}
-
-// ── Orchestration dispatch bundle settings (#573) ──
-
-/**
- * Per-role dispatch bundle settings persisted under [orchestration.*] in config.toml.
- * null bundle means "use legacy [spawn.*] fallback for that role".
- */
-export interface OrchestrationSettings {
-  orchestrator: DispatchBundle | null;
-  dispatch: WorkerDispatchMap;
 }
 
 // ── Scheduled kicks (Routines parity — #2) ──
@@ -1187,11 +1183,7 @@ export const api = {
 
   // Spawn settings
   getSpawnSettings: () => apiFetch<SpawnSettings>("/settings/spawn"),
-  updateSpawnSettings: (params: {
-    runtime: SpawnRuntime;
-    tmux_window_name?: string;
-    worker_permission_mode?: WorkerPermissionMode;
-  }) =>
+  updateSpawnSettings: (params: { runtime: SpawnRuntime; tmux_window_name?: string }) =>
     apiFetch("/settings/spawn", {
       method: "PUT",
       body: JSON.stringify(params),
@@ -1217,6 +1209,13 @@ export const api = {
       pr_monitor_exclude_authors?: string[];
       pr_monitor_scope?: PrMonitorScope;
       inject_state_snapshot?: boolean;
+      /**
+       * Tri-state: omit → leave unchanged. `null` → clear the bundle. Object →
+       * replace. Persists to `[orchestration.orchestrator]` in config.toml.
+       */
+      orchestrator?: DispatchBundle | null;
+      /** Replaces the entire `[orchestration.dispatch]` table. */
+      dispatch?: WorkerDispatchMap;
     },
     project?: string,
   ) =>
@@ -1256,17 +1255,6 @@ export const api = {
   getWorktreeSettings: () => apiFetch<WorktreeSettings>("/settings/worktree"),
   updateWorktreeSettings: (params: Partial<WorktreeSettings>) =>
     apiFetch("/settings/worktree", {
-      method: "PUT",
-      body: JSON.stringify(params),
-    }),
-
-  // Orchestration dispatch bundle settings (#573)
-  getOrchestrationSettings: () => apiFetch<OrchestrationSettings>("/settings/orchestration"),
-  updateOrchestrationSettings: (params: {
-    orchestrator?: DispatchBundle | null;
-    dispatch?: WorkerDispatchMap;
-  }) =>
-    apiFetch("/settings/orchestration", {
       method: "PUT",
       body: JSON.stringify(params),
     }),

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -14,14 +14,12 @@ import type {
   GuardrailsSettings,
   NotifySettings,
   NotifyTemplates,
-  OrchestrationSettings,
   OrchestratorRules,
   PrMonitorScope,
   SpawnRequest,
   SpawnRuntime,
   UsageSettings,
   WorkerDispatchMap,
-  WorkerPermissionMode,
   WorkflowSettings,
   WorktreeSettings,
 } from "./api-http";
@@ -205,11 +203,8 @@ export const api = {
 
   // Spawn settings
   getSpawnSettings: () => httpApi.getSpawnSettings(),
-  updateSpawnSettings: (params: {
-    runtime: SpawnRuntime;
-    tmux_window_name?: string;
-    worker_permission_mode?: WorkerPermissionMode;
-  }) => httpApi.updateSpawnSettings(params),
+  updateSpawnSettings: (params: { runtime: SpawnRuntime; tmux_window_name?: string }) =>
+    httpApi.updateSpawnSettings(params),
 
   // Orchestrator settings (per-project scope via optional project param)
   getOrchestratorSettings: (project?: string) => httpApi.getOrchestratorSettings(project),
@@ -228,6 +223,10 @@ export const api = {
       pr_monitor_exclude_authors?: string[];
       pr_monitor_scope?: PrMonitorScope;
       inject_state_snapshot?: boolean;
+      /** Tri-state: omit → unchanged. `null` → clear. Object → replace. */
+      orchestrator?: DispatchBundle | null;
+      /** Replaces the entire `[orchestration.dispatch]` table. */
+      dispatch?: WorkerDispatchMap;
     },
     project?: string,
   ) => httpApi.updateOrchestratorSettings(params, project),
@@ -250,14 +249,6 @@ export const api = {
   getWorktreeSettings: () => httpApi.getWorktreeSettings(),
   updateWorktreeSettings: (params: Partial<WorktreeSettings>) =>
     httpApi.updateWorktreeSettings(params),
-
-  // Orchestration dispatch bundle settings (#573)
-  getOrchestrationSettings: (): Promise<OrchestrationSettings> =>
-    httpApi.getOrchestrationSettings(),
-  updateOrchestrationSettings: (params: {
-    orchestrator?: DispatchBundle | null;
-    dispatch?: WorkerDispatchMap;
-  }) => httpApi.updateOrchestrationSettings(params),
 
   // Teams (HTTP only for now)
   listTeams: (): Promise<TeamSummary[]> => httpApi.listTeams(),


### PR DESCRIPTION
## What this fixes

Three user-visible Settings UI symptoms reported in dogfood after the Phase 2 series merged on `tmai-core`:

1. The Spawn section still shows a "Worker permission mode" dropdown — Phase 2.C (`trust-delta/tmai-core#252`) removed `worker_permission_mode` from the backend response.
2. The Settings panel heading still says "Orchestrator" — Phase 2.A (`trust-delta/tmai-core#250`) renamed the underlying struct / TOML section to `[orchestration]`.
3. The new dispatch-bundle editor never appears. Root cause: PR #574 targeted a non-existent `/settings/orchestration` endpoint, the GET silently 404'd, the component state stayed `null`, and `OrchestrationDispatchSection` returned `null`.

Backend PR `trust-delta/tmai-core#253` (just merged) extended the existing `/settings/orchestrator` endpoint to carry the dispatch fields on both GET and PUT, so the React side can collapse the dead `/settings/orchestration` API surface and read everything from the same endpoint that already serves `notify` / `guardrails` / `pr_monitor_*`.

## Changes

- **`OrchestrationDispatchSection.tsx`** — switches to `getOrchestratorSettings()` / `updateOrchestratorSettings()`. Internal `DispatchState` keeps only `{ orchestrator, dispatch }` so the component does not have to round-trip the rest of the OrchestratorSettings shape.

- **`lib/api-http.ts` / `lib/api-tauri.ts`**:
  - Drop dead `getOrchestrationSettings` / `updateOrchestrationSettings` methods.
  - Drop the standalone `OrchestrationSettings` interface (its fields now live on `OrchestratorSettings`).
  - Add `orchestrator?: DispatchBundle | null` and `dispatch: WorkerDispatchMap` to `OrchestratorSettings`.
  - Extend `updateOrchestratorSettings` payload with the same two fields.
  - Drop `WorkerPermissionMode` type and remove `worker_permission_mode` from `SpawnSettings` + `updateSpawnSettings` (backend stopped returning it in Phase 2.C).

- **`SettingsPanel.tsx`** — remove the "Worker permission mode" block from the Spawn section, rename the section heading "Orchestrator" → "Orchestration", drop the unused import / handler.

- **`DispatchBundleEditor.tsx`** — relabel the "Use legacy [spawn.*] config (fallback)" checkbox to "Use vendor CLI default". Phase 2.C removed the legacy fallback, so a `null` bundle now means the role launches with the vendor CLI's own user-global default, not "fall back to `[spawn.*]`".

- **Tests** — `SpawnRuntimeSelector.test.tsx` drops the dead `worker_permission_mode` from its fixture; `SettingsPanel-orchestration.test.tsx` is rewritten to mock `getOrchestratorSettings` / `updateOrchestratorSettings` with a `makeSettings()` helper that builds a complete `OrchestratorSettings` payload (the section under test reads only the dispatch fields).

## Test plan

- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm vitest run` — 263 passed / 2 skipped
- [x] `pnpm exec biome check` — no new errors (6 pre-existing warnings unrelated to this PR)
- [x] `pnpm build` — succeeds
- Manual smoke (post-merge): the Settings panel renders three labelled bundle editors (Orchestrator / Implementer / Reviewer), the Spawn section no longer shows the Worker permission mode field, and saving a bundle round-trips through `config.toml` under `[orchestration.orchestrator]` / `[orchestration.dispatch.<role>]`.

## Out of scope

- The `useLegacy` variable name inside `DispatchBundleEditor.tsx` — kept as-is because the component now correctly behaves as "is the bundle null", which is the same boolean. Renaming is cosmetic and would balloon this PR's diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)