### PR TITLE
feat(react): #578 hybrid auto-save in Settings panel

### DIFF
--- a/clients/react/src/components/settings/DispatchBundleEditor.tsx
+++ b/clients/react/src/components/settings/DispatchBundleEditor.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from "react";
 import type { DispatchBundle } from "@/types/generated/DispatchBundle";
 import type { PermissionMode } from "@/types/generated/PermissionMode";
 import type { Vendor } from "@/types/generated/Vendor";
@@ -30,7 +31,20 @@ interface DispatchBundleEditorProps {
   title: string;
   subtitle: string;
   bundle: DispatchBundle | null | undefined;
-  onChange: (bundle: DispatchBundle | null) => void;
+  /**
+   * Atomic-field change (vendor / permission_mode / effort dropdowns and the
+   * "Use vendor CLI default" checkbox). Caller persists immediately.
+   */
+  onAtomicChange: (bundle: DispatchBundle | null) => void;
+  /**
+   * Text-field draft (model input) — caller updates local state without saving.
+   * Used while the user is mid-typing.
+   */
+  onTextDraft: (bundle: DispatchBundle | null) => void;
+  /**
+   * Text-field commit (model input on blur or Enter). Caller persists.
+   */
+  onTextCommit: (bundle: DispatchBundle | null) => void;
 }
 
 /**
@@ -38,37 +52,65 @@ interface DispatchBundleEditorProps {
  * When bundle is null the "Use vendor CLI default" checkbox is checked,
  * all inputs are disabled, and the role launches with the vendor CLI's own
  * defaults (no `--model` / `--permission-mode` flags injected by tmai).
+ *
+ * Auto-save (#578): atomic fields persist on change; the model field
+ * persists on blur or Enter. The local model draft tracks user typing so
+ * we do not call onTextCommit on every keystroke.
  */
 export function DispatchBundleEditor({
   title,
   subtitle,
   bundle,
-  onChange,
+  onAtomicChange,
+  onTextDraft,
+  onTextCommit,
 }: DispatchBundleEditorProps) {
   const useLegacy = bundle == null;
   // Maintain a working copy for when the checkbox is unchecked.
   const active: DispatchBundle = bundle ?? { vendor: "claude" };
 
+  // Local draft for the model text field — keeps typing fluid without
+  // round-tripping to the backend on every keystroke.
+  const [modelDraft, setModelDraft] = useState<string>(active.model ?? "");
+
+  // Re-sync the draft when the upstream bundle changes (e.g., after a
+  // commit, a vendor switch reset the model, or initial load).
+  // Skipping the sync when the draft already matches avoids stomping on
+  // an in-progress edit.
+  useEffect(() => {
+    const upstream = bundle?.model ?? "";
+    setModelDraft(upstream);
+    // We deliberately re-sync only when the upstream model identity changes —
+    // not on every render — so user typing isn't reset between renders that
+    // happen while a save is in flight.
+  }, [bundle?.model]);
+
   const handleLegacyToggle = (checked: boolean) => {
-    onChange(checked ? null : { vendor: "claude" });
+    onAtomicChange(checked ? null : { vendor: "claude" });
   };
 
   const handleVendorChange = (vendor: Vendor) => {
     // Changing vendor resets model — no point keeping a cross-vendor model name.
-    onChange({ ...active, vendor, model: null });
+    setModelDraft("");
+    onAtomicChange({ ...active, vendor, model: null });
   };
 
-  const handleModelChange = (model: string) => {
-    onChange({ ...active, model: model || null });
+  const handleModelDraftChange = (model: string) => {
+    setModelDraft(model);
+    onTextDraft({ ...active, model: model || null });
+  };
+
+  const handleModelCommit = () => {
+    onTextCommit({ ...active, model: modelDraft || null });
   };
 
   const handlePermissionChange = (value: string) => {
     const mode = value === "" ? null : (value as PermissionMode);
-    onChange({ ...active, permission_mode: mode });
+    onAtomicChange({ ...active, permission_mode: mode });
   };
 
   const handleEffortChange = (value: string) => {
-    onChange({ ...active, effort: value || null });
+    onAtomicChange({ ...active, effort: value || null });
   };
 
   const inputCls =
@@ -124,9 +166,16 @@ export function DispatchBundleEditor({
           <span className="w-24 shrink-0 text-xs text-zinc-500">Model</span>
           <input
             type="text"
-            value={active.model ?? ""}
+            value={modelDraft}
             placeholder={MODEL_PLACEHOLDERS[active.vendor]}
-            onChange={(e) => handleModelChange(e.target.value)}
+            onChange={(e) => handleModelDraftChange(e.target.value)}
+            onBlur={handleModelCommit}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                handleModelCommit();
+              }
+            }}
             disabled={useLegacy}
             className={inputCls}
             aria-label={`Model for ${title}`}

--- a/clients/react/src/components/settings/OrchestrationDispatchSection.tsx
+++ b/clients/react/src/components/settings/OrchestrationDispatchSection.tsx
@@ -1,8 +1,10 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { AutoSaveStatus } from "@/hooks/useAutoSave";
 import { api } from "@/lib/api";
 import type { DispatchBundle } from "@/types/generated/DispatchBundle";
 import type { WorkerDispatchMap } from "@/types/generated/WorkerDispatchMap";
 import { DispatchBundleEditor } from "./DispatchBundleEditor";
+import { SaveStatus } from "./SaveStatus";
 
 interface DispatchState {
   orchestrator: DispatchBundle | null;
@@ -11,7 +13,11 @@ interface DispatchState {
 
 /**
  * Settings section that exposes per-role dispatch bundle editing for
- * orchestrator / implementer / reviewer.
+ * orchestrator / implementer / reviewer (#578 — auto-save).
+ *
+ * Atomic fields (vendor / permission_mode / effort dropdowns and the "Use
+ * vendor CLI default" checkbox) persist on change; the model text field
+ * persists on blur or Enter so we do not flicker validation errors mid-typing.
  *
  * Reads the bundles from `GET /settings/orchestrator` (the global settings
  * endpoint that carries the dispatch fields alongside notify/guardrails/...)
@@ -19,70 +25,126 @@ interface DispatchState {
  * is the single source of truth, so this component only roundtrips the dispatch
  * subset of fields.
  *
- * Surfaces validation errors from the backend as inline error text (the server
- * returns 400 with a descriptive message when the vendor×model×permission_mode
- * triple is invalid).
+ * Backend 400s surface as inline error text. For atomic changes we roll back
+ * to the last-saved bundle; for text-commit errors we leave the user's draft
+ * in place so they can correct it.
  */
 export function OrchestrationDispatchSection() {
   const [state, setState] = useState<DispatchState | null>(null);
-  const [saveError, setSaveError] = useState<string | null>(null);
-  const [saving, setSaving] = useState(false);
-  const [saved, setSaved] = useState(false);
+  const [status, setStatus] = useState<AutoSaveStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const lastSavedRef = useRef<DispatchState | null>(null);
+  const fadeRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     api
       .getOrchestratorSettings()
-      .then((s) =>
-        setState({
+      .then((s) => {
+        const initial = {
           orchestrator: s.orchestrator ?? null,
           dispatch: s.dispatch,
-        }),
-      )
+        };
+        setState(initial);
+        lastSavedRef.current = initial;
+      })
       .catch(console.error);
+    return () => {
+      if (fadeRef.current !== null) clearTimeout(fadeRef.current);
+    };
   }, []);
+
+  const persist = useCallback(
+    async (next: DispatchState, options: { rollbackOnError: boolean }) => {
+      if (fadeRef.current !== null) clearTimeout(fadeRef.current);
+      setStatus("saving");
+      setError(null);
+      try {
+        await api.updateOrchestratorSettings({
+          orchestrator: next.orchestrator,
+          dispatch: next.dispatch,
+        });
+        lastSavedRef.current = next;
+        setStatus("saved");
+        fadeRef.current = setTimeout(() => {
+          fadeRef.current = null;
+          setStatus((s) => (s === "saved" ? "idle" : s));
+        }, 1000);
+      } catch (e) {
+        if (options.rollbackOnError && lastSavedRef.current) {
+          setState(lastSavedRef.current);
+        }
+        setStatus("error");
+        setError(e instanceof Error ? e.message : "Save failed");
+      }
+    },
+    [],
+  );
 
   if (!state) return null;
 
-  const handleOrchestratorChange = (bundle: DispatchBundle | null) => {
+  // ── Orchestrator role ──────────────────────────────────────────
+  const handleOrchestratorAtomic = (bundle: DispatchBundle | null) => {
+    const next = { ...state, orchestrator: bundle };
+    setState(next);
+    void persist(next, { rollbackOnError: true });
+  };
+  const handleOrchestratorTextDraft = (bundle: DispatchBundle | null) => {
     setState({ ...state, orchestrator: bundle });
-    setSaved(false);
-  };
-
-  const handleImplementerChange = (bundle: DispatchBundle | null) => {
-    setState({
-      ...state,
-      dispatch: { ...state.dispatch, implementer: bundle },
-    });
-    setSaved(false);
-  };
-
-  const handleReviewerChange = (bundle: DispatchBundle | null) => {
-    setState({
-      ...state,
-      dispatch: { ...state.dispatch, reviewer: bundle },
-    });
-    setSaved(false);
-  };
-
-  const handleSave = async () => {
-    setSaving(true);
-    setSaveError(null);
-    try {
-      await api.updateOrchestratorSettings({
-        orchestrator: state.orchestrator,
-        dispatch: state.dispatch,
-      });
-      setSaved(true);
-    } catch (e) {
-      setSaveError(e instanceof Error ? e.message : "Save failed");
-    } finally {
-      setSaving(false);
+    if (status === "error") {
+      setStatus("idle");
+      setError(null);
     }
+  };
+  const handleOrchestratorTextCommit = (bundle: DispatchBundle | null) => {
+    const next = { ...state, orchestrator: bundle };
+    setState(next);
+    void persist(next, { rollbackOnError: false });
+  };
+
+  // ── Implementer role ───────────────────────────────────────────
+  const handleImplementerAtomic = (bundle: DispatchBundle | null) => {
+    const next = { ...state, dispatch: { ...state.dispatch, implementer: bundle } };
+    setState(next);
+    void persist(next, { rollbackOnError: true });
+  };
+  const handleImplementerTextDraft = (bundle: DispatchBundle | null) => {
+    setState({ ...state, dispatch: { ...state.dispatch, implementer: bundle } });
+    if (status === "error") {
+      setStatus("idle");
+      setError(null);
+    }
+  };
+  const handleImplementerTextCommit = (bundle: DispatchBundle | null) => {
+    const next = { ...state, dispatch: { ...state.dispatch, implementer: bundle } };
+    setState(next);
+    void persist(next, { rollbackOnError: false });
+  };
+
+  // ── Reviewer role ──────────────────────────────────────────────
+  const handleReviewerAtomic = (bundle: DispatchBundle | null) => {
+    const next = { ...state, dispatch: { ...state.dispatch, reviewer: bundle } };
+    setState(next);
+    void persist(next, { rollbackOnError: true });
+  };
+  const handleReviewerTextDraft = (bundle: DispatchBundle | null) => {
+    setState({ ...state, dispatch: { ...state.dispatch, reviewer: bundle } });
+    if (status === "error") {
+      setStatus("idle");
+      setError(null);
+    }
+  };
+  const handleReviewerTextCommit = (bundle: DispatchBundle | null) => {
+    const next = { ...state, dispatch: { ...state.dispatch, reviewer: bundle } };
+    setState(next);
+    void persist(next, { rollbackOnError: false });
   };
 
   return (
     <section>
-      <h3 className="text-sm font-medium text-zinc-300">Orchestration dispatch</h3>
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-medium text-zinc-300">Orchestration dispatch</h3>
+        <SaveStatus status={status} error={error} variant="section" />
+      </div>
       <p className="mt-1 text-xs text-zinc-600">
         Per-role dispatch bundles: vendor, model, permission mode, and effort for each agent role.
         Leave "Use vendor CLI default" checked to launch that role with the vendor CLI's own
@@ -94,38 +156,26 @@ export function OrchestrationDispatchSection() {
           title="Orchestrator"
           subtitle="the agent you attach to"
           bundle={state.orchestrator}
-          onChange={handleOrchestratorChange}
+          onAtomicChange={handleOrchestratorAtomic}
+          onTextDraft={handleOrchestratorTextDraft}
+          onTextCommit={handleOrchestratorTextCommit}
         />
         <DispatchBundleEditor
           title="Implementer"
           subtitle="dispatch_issue / spawn_worktree"
           bundle={state.dispatch.implementer ?? null}
-          onChange={handleImplementerChange}
+          onAtomicChange={handleImplementerAtomic}
+          onTextDraft={handleImplementerTextDraft}
+          onTextCommit={handleImplementerTextCommit}
         />
         <DispatchBundleEditor
           title="Reviewer"
           subtitle="dispatch_review"
           bundle={state.dispatch.reviewer ?? null}
-          onChange={handleReviewerChange}
+          onAtomicChange={handleReviewerAtomic}
+          onTextDraft={handleReviewerTextDraft}
+          onTextCommit={handleReviewerTextCommit}
         />
-
-        {saveError && (
-          <p className="text-xs text-red-400 break-words" role="alert">
-            {saveError}
-          </p>
-        )}
-
-        <div className="flex items-center gap-3">
-          <button
-            type="button"
-            onClick={handleSave}
-            disabled={saving}
-            className="rounded-md px-3 py-1.5 text-xs font-medium bg-cyan-600 text-white hover:bg-cyan-500 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            {saving ? "Saving…" : "Save"}
-          </button>
-          {saved && !saving && <span className="text-xs text-zinc-500">Saved</span>}
-        </div>
       </div>
     </section>
   );

--- a/clients/react/src/components/settings/SaveStatus.tsx
+++ b/clients/react/src/components/settings/SaveStatus.tsx
@@ -1,0 +1,49 @@
+import type { AutoSaveStatus } from "@/hooks/useAutoSave";
+
+interface SaveStatusProps {
+  status: AutoSaveStatus;
+  error?: string | null;
+  /**
+   * Where the indicator is rendered. "inline" is for next to a single field;
+   * "section" is for the section header. Both share the same visual language
+   * but section adds a leading spacing margin.
+   */
+  variant?: "inline" | "section";
+  className?: string;
+}
+
+const baseCls = "text-[10px] inline-flex items-center gap-1 select-none";
+
+/**
+ * Compact saved/saving/error indicator used by the auto-saved Settings fields.
+ * The "saved" tick is intentionally low-contrast so it does not draw attention
+ * away from the field — it is a confirmation, not an alert.
+ */
+export function SaveStatus({ status, error, variant = "inline", className = "" }: SaveStatusProps) {
+  if (status === "idle") return null;
+  const root = `${baseCls} ${variant === "section" ? "ml-2" : ""} ${className}`.trim();
+
+  if (status === "saving") {
+    return (
+      <span className={`${root} text-zinc-500`} role="status" aria-live="polite">
+        <span className="inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-zinc-500" />
+        Saving…
+      </span>
+    );
+  }
+  if (status === "saved") {
+    return (
+      <span className={`${root} text-emerald-500/80`} role="status" aria-live="polite">
+        <span aria-hidden="true">✓</span>
+        Saved
+      </span>
+    );
+  }
+  // error
+  return (
+    <span className={`${root} text-red-400`} role="alert">
+      <span aria-hidden="true">⚠</span>
+      <span className="break-words">{error ?? "Save failed"}</span>
+    </span>
+  );
+}

--- a/clients/react/src/components/settings/SettingsPanel.tsx
+++ b/clients/react/src/components/settings/SettingsPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { DirBrowser } from "@/components/project/DirBrowser";
+import { useSaveTracker } from "@/hooks/useSaveTracker";
 import {
   type AutoApproveSettings,
   api,
@@ -12,6 +13,7 @@ import {
 } from "@/lib/api";
 import { buildNotifyEventHelp } from "./notify-event-help";
 import { OrchestrationDispatchSection } from "./OrchestrationDispatchSection";
+import { SaveStatus } from "./SaveStatus";
 import { ScheduledKicksSection } from "./ScheduledKicksSection";
 import { SpawnRuntimeSelector } from "./SpawnRuntimeSelector";
 
@@ -37,6 +39,16 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
   const [workflowSettings, setWorkflowSettings] = useState<WorkflowSettings | null>(null);
   const [worktreeSettings, setWorktreeSettings] = useState<WorktreeSettings | null>(null);
   const [newSetupCommand, setNewSetupCommand] = useState("");
+
+  // Per-section auto-save status (#578). Each tracker runs independently so a
+  // failure in one section does not blank out the indicator on another.
+  const autoApproveSave = useSaveTracker();
+  const spawnSave = useSaveTracker();
+  const orchestratorSave = useSaveTracker();
+  const usageSave = useSaveTracker();
+  const notifySave = useSaveTracker();
+  const workflowSave = useSaveTracker();
+  const worktreeSave = useSaveTracker();
 
   const refreshProjects = useCallback(() => {
     api.listProjects().then(setProjects).catch(console.error);
@@ -119,17 +131,18 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
     setSpawnSettings({ ...spawnSettings, tmux_window_name: name });
   };
 
-  // Save window name on blur or Enter
-  const handleWindowNameSave = async () => {
+  // Save window name on blur or Enter (text-field commit; no rollback so the
+  // user can edit and retry if the backend rejects the value).
+  const handleWindowNameSave = () => {
     if (!spawnSettings) return;
     const trimmed = spawnSettings.tmux_window_name.trim();
     if (!trimmed) return;
-    try {
-      await api.updateSpawnSettings({
+    void spawnSave.track(() =>
+      api.updateSpawnSettings({
         runtime: spawnSettings.runtime,
         tmux_window_name: trimmed,
-      });
-    } catch (_e) {}
+      }),
+    );
   };
 
   return (
@@ -150,7 +163,14 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
         {/* Auto-approve section */}
         {autoApprove && (
           <section>
-            <h3 className="text-sm font-medium text-zinc-300">Auto-approve</h3>
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-medium text-zinc-300">Auto-approve</h3>
+              <SaveStatus
+                status={autoApproveSave.status}
+                error={autoApproveSave.error}
+                variant="section"
+              />
+            </div>
             <p className="mt-1 text-xs text-zinc-600">
               Automatically approve agent actions. Changes apply on restart.
             </p>
@@ -161,12 +181,13 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                 <span className="shrink-0 text-xs text-zinc-500">Mode</span>
                 <select
                   value={autoApprove.mode}
-                  onChange={async (e) => {
+                  onChange={(e) => {
                     const mode = e.target.value;
+                    const prev = autoApprove.mode;
                     setAutoApprove({ ...autoApprove, mode });
-                    try {
-                      await api.updateAutoApproveMode(mode);
-                    } catch (_err) {}
+                    void autoApproveSave.track(() => api.updateAutoApproveMode(mode), {
+                      onError: () => setAutoApprove({ ...autoApprove, mode: prev }),
+                    });
                   }}
                   className="flex-1 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
                 >
@@ -185,12 +206,13 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                 </div>
                 <button
                   type="button"
-                  onClick={async () => {
+                  onClick={() => {
                     const next = !autoApprove.enabled;
                     setAutoApprove({ ...autoApprove, enabled: next });
-                    try {
-                      await api.updateAutoApproveFields({ enabled: next });
-                    } catch (_err) {}
+                    void autoApproveSave.track(
+                      () => api.updateAutoApproveFields({ enabled: next }),
+                      { onError: () => setAutoApprove({ ...autoApprove, enabled: !next }) },
+                    );
                   }}
                   className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
                     autoApprove.enabled ? "bg-cyan-500/40" : "bg-white/10"
@@ -225,11 +247,19 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                     <input
                       type="text"
                       value={autoApprove.provider}
-                      onChange={(e) => setAutoApprove({ ...autoApprove, provider: e.target.value })}
-                      onBlur={async () => {
-                        try {
-                          await api.updateAutoApproveFields({ provider: autoApprove.provider });
-                        } catch (_err) {}
+                      onChange={(e) => {
+                        autoApproveSave.clearError();
+                        setAutoApprove({ ...autoApprove, provider: e.target.value });
+                      }}
+                      onBlur={() => {
+                        const provider = autoApprove.provider;
+                        void autoApproveSave.track(() => api.updateAutoApproveFields({ provider }));
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          (e.currentTarget as HTMLInputElement).blur();
+                        }
                       }}
                       className="flex-1 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
                     />
@@ -239,11 +269,19 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                     <input
                       type="text"
                       value={autoApprove.model}
-                      onChange={(e) => setAutoApprove({ ...autoApprove, model: e.target.value })}
-                      onBlur={async () => {
-                        try {
-                          await api.updateAutoApproveFields({ model: autoApprove.model });
-                        } catch (_err) {}
+                      onChange={(e) => {
+                        autoApproveSave.clearError();
+                        setAutoApprove({ ...autoApprove, model: e.target.value });
+                      }}
+                      onBlur={() => {
+                        const model = autoApprove.model;
+                        void autoApproveSave.track(() => api.updateAutoApproveFields({ model }));
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") {
+                          e.preventDefault();
+                          (e.currentTarget as HTMLInputElement).blur();
+                        }
                       }}
                       className="flex-1 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
                     />
@@ -293,13 +331,15 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                         onChange={(e) => {
                           const val = Number.parseInt(e.target.value, 10);
                           if (!Number.isNaN(val) && val >= 0) {
+                            autoApproveSave.clearError();
                             setAutoApprove({ ...autoApprove, [key]: val });
                           }
                         }}
-                        onBlur={async () => {
-                          try {
-                            await api.updateAutoApproveFields({ [key]: autoApprove[key] });
-                          } catch (_err) {}
+                        onBlur={() => {
+                          const val = autoApprove[key];
+                          void autoApproveSave.track(() =>
+                            api.updateAutoApproveFields({ [key]: val }),
+                          );
                         }}
                         className="w-20 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 text-right outline-none focus:border-cyan-500/30"
                       />
@@ -325,12 +365,20 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                             <code className="flex-1 text-[11px] text-zinc-300 font-mono">{t}</code>
                             <button
                               type="button"
-                              onClick={async () => {
-                                const updated = autoApprove.allowed_types.filter((x) => x !== t);
+                              onClick={() => {
+                                const previous = autoApprove.allowed_types;
+                                const updated = previous.filter((x) => x !== t);
                                 setAutoApprove({ ...autoApprove, allowed_types: updated });
-                                try {
-                                  await api.updateAutoApproveFields({ allowed_types: updated });
-                                } catch (_err) {}
+                                void autoApproveSave.track(
+                                  () => api.updateAutoApproveFields({ allowed_types: updated }),
+                                  {
+                                    onError: () =>
+                                      setAutoApprove({
+                                        ...autoApprove,
+                                        allowed_types: previous,
+                                      }),
+                                  },
+                                );
                               }}
                               className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-zinc-600 opacity-0 transition-all hover:bg-red-500/10 hover:text-red-400 group-hover:opacity-100"
                             >
@@ -345,17 +393,22 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                       <input
                         type="text"
                         placeholder="e.g. Bash, Read, Write"
-                        onKeyDown={async (e) => {
+                        onKeyDown={(e) => {
                           if (e.key === "Enter") {
                             const input = e.currentTarget;
                             const val = input.value.trim();
                             if (!val) return;
-                            const updated = [...autoApprove.allowed_types, val];
+                            const previous = autoApprove.allowed_types;
+                            const updated = [...previous, val];
                             setAutoApprove({ ...autoApprove, allowed_types: updated });
                             input.value = "";
-                            try {
-                              await api.updateAutoApproveFields({ allowed_types: updated });
-                            } catch (_err) {}
+                            void autoApproveSave.track(
+                              () => api.updateAutoApproveFields({ allowed_types: updated }),
+                              {
+                                onError: () =>
+                                  setAutoApprove({ ...autoApprove, allowed_types: previous }),
+                              },
+                            );
                           }
                         }}
                         className="flex-1 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs font-mono text-zinc-200 placeholder-zinc-600 outline-none focus:border-cyan-500/30"
@@ -412,15 +465,22 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                       </div>
                       <button
                         type="button"
-                        onClick={async () => {
+                        onClick={() => {
                           const newVal = !autoApprove.rules[key];
                           setAutoApprove({
                             ...autoApprove,
                             rules: { ...autoApprove.rules, [key]: newVal },
                           });
-                          try {
-                            await api.updateAutoApproveRules({ [key]: newVal });
-                          } catch (_err) {}
+                          void autoApproveSave.track(
+                            () => api.updateAutoApproveRules({ [key]: newVal }),
+                            {
+                              onError: () =>
+                                setAutoApprove({
+                                  ...autoApprove,
+                                  rules: { ...autoApprove.rules, [key]: !newVal },
+                                }),
+                            },
+                          );
                         }}
                         className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
                           autoApprove.rules[key] ? "bg-cyan-500/40" : "bg-white/10"
@@ -459,19 +519,29 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                             </code>
                             <button
                               type="button"
-                              onClick={async () => {
-                                const updated = autoApprove.rules.allow_patterns.filter(
-                                  (p) => p !== pat,
-                                );
+                              onClick={() => {
+                                const previous = autoApprove.rules.allow_patterns;
+                                const updated = previous.filter((p) => p !== pat);
                                 setAutoApprove({
                                   ...autoApprove,
                                   rules: { ...autoApprove.rules, allow_patterns: updated },
                                 });
-                                try {
-                                  await api.updateAutoApproveRules({
-                                    allow_patterns: updated,
-                                  });
-                                } catch (_err) {}
+                                void autoApproveSave.track(
+                                  () =>
+                                    api.updateAutoApproveRules({
+                                      allow_patterns: updated,
+                                    }),
+                                  {
+                                    onError: () =>
+                                      setAutoApprove({
+                                        ...autoApprove,
+                                        rules: {
+                                          ...autoApprove.rules,
+                                          allow_patterns: previous,
+                                        },
+                                      }),
+                                  },
+                                );
                               }}
                               className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-zinc-600 opacity-0 transition-all hover:bg-red-500/10 hover:text-red-400 group-hover:opacity-100"
                             >
@@ -488,22 +558,28 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                         type="text"
                         value={newPattern}
                         onChange={(e) => setNewPattern(e.target.value)}
-                        onKeyDown={async (e) => {
+                        onKeyDown={(e) => {
                           if (e.key === "Enter" && newPattern.trim()) {
-                            const updated = [
-                              ...autoApprove.rules.allow_patterns,
-                              newPattern.trim(),
-                            ];
+                            const previous = autoApprove.rules.allow_patterns;
+                            const updated = [...previous, newPattern.trim()];
                             setAutoApprove({
                               ...autoApprove,
                               rules: { ...autoApprove.rules, allow_patterns: updated },
                             });
                             setNewPattern("");
-                            try {
-                              await api.updateAutoApproveRules({
-                                allow_patterns: updated,
-                              });
-                            } catch (_err) {}
+                            void autoApproveSave.track(
+                              () => api.updateAutoApproveRules({ allow_patterns: updated }),
+                              {
+                                onError: () =>
+                                  setAutoApprove({
+                                    ...autoApprove,
+                                    rules: {
+                                      ...autoApprove.rules,
+                                      allow_patterns: previous,
+                                    },
+                                  }),
+                              },
+                            );
                           }
                         }}
                         placeholder="e.g. cargo build.*"
@@ -511,19 +587,28 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                       />
                       <button
                         type="button"
-                        onClick={async () => {
+                        onClick={() => {
                           if (!newPattern.trim()) return;
-                          const updated = [...autoApprove.rules.allow_patterns, newPattern.trim()];
+                          const previous = autoApprove.rules.allow_patterns;
+                          const updated = [...previous, newPattern.trim()];
                           setAutoApprove({
                             ...autoApprove,
                             rules: { ...autoApprove.rules, allow_patterns: updated },
                           });
                           setNewPattern("");
-                          try {
-                            await api.updateAutoApproveRules({
-                              allow_patterns: updated,
-                            });
-                          } catch (_err) {}
+                          void autoApproveSave.track(
+                            () => api.updateAutoApproveRules({ allow_patterns: updated }),
+                            {
+                              onError: () =>
+                                setAutoApprove({
+                                  ...autoApprove,
+                                  rules: {
+                                    ...autoApprove.rules,
+                                    allow_patterns: previous,
+                                  },
+                                }),
+                            },
+                          );
                         }}
                         className="rounded-md bg-cyan-500/20 px-3 py-1 text-xs text-cyan-400 transition-colors hover:bg-cyan-500/30"
                       >
@@ -540,13 +625,20 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
         {/* Spawn section */}
         {spawnSettings && (
           <section>
-            <h3 className="text-sm font-medium text-zinc-300">Spawn</h3>
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-medium text-zinc-300">Spawn</h3>
+              <SaveStatus status={spawnSave.status} error={spawnSave.error} variant="section" />
+            </div>
             <p className="mt-1 text-xs text-zinc-600">
               How new agents are started from the Web UI.
             </p>
 
             <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-3">
-              <SpawnRuntimeSelector settings={spawnSettings} onSettingsChange={setSpawnSettings} />
+              <SpawnRuntimeSelector
+                settings={spawnSettings}
+                onSettingsChange={setSpawnSettings}
+                save={spawnSave}
+              />
 
               {/* Window name field — shown when runtime is tmux */}
               {spawnSettings.runtime === "tmux" && (
@@ -555,10 +647,16 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                   <input
                     type="text"
                     value={spawnSettings.tmux_window_name}
-                    onChange={(e) => handleWindowNameChange(e.target.value)}
+                    onChange={(e) => {
+                      spawnSave.clearError();
+                      handleWindowNameChange(e.target.value);
+                    }}
                     onBlur={handleWindowNameSave}
                     onKeyDown={(e) => {
-                      if (e.key === "Enter") handleWindowNameSave();
+                      if (e.key === "Enter") {
+                        e.preventDefault();
+                        (e.currentTarget as HTMLInputElement).blur();
+                      }
                     }}
                     className="flex-1 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
                   />
@@ -571,7 +669,14 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
         {/* Orchestration section */}
         {orchestrator && (
           <section>
-            <h3 className="text-sm font-medium text-zinc-300">Orchestration</h3>
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-medium text-zinc-300">Orchestration</h3>
+              <SaveStatus
+                status={orchestratorSave.status}
+                error={orchestratorSave.error}
+                variant="section"
+              />
+            </div>
             <p className="mt-1 text-xs text-zinc-600">
               Configure the orchestrator agent that coordinates sub-agents for parallel development
               workflows.
@@ -612,15 +717,16 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                 </div>
                 <button
                   type="button"
-                  onClick={async () => {
+                  onClick={() => {
                     const next = !orchestrator.enabled;
                     setOrchestrator({ ...orchestrator, enabled: next });
-                    try {
-                      await api.updateOrchestratorSettings({ enabled: next }, orchProject);
-                      refreshOrchestrator();
-                    } catch (_e) {
-                      setOrchestrator({ ...orchestrator, enabled: !next });
-                    }
+                    void orchestratorSave.track(
+                      async () => {
+                        await api.updateOrchestratorSettings({ enabled: next }, orchProject);
+                        refreshOrchestrator();
+                      },
+                      { onError: () => setOrchestrator({ ...orchestrator, enabled: !next }) },
+                    );
                   }}
                   className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
                     orchestrator.enabled ? "bg-cyan-500/40" : "bg-white/10"
@@ -643,14 +749,21 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                     <span className="block text-xs text-zinc-400 mb-1">Role</span>
                     <textarea
                       value={orchestrator.role}
-                      onChange={(e) => setOrchestrator({ ...orchestrator, role: e.target.value })}
-                      onBlur={async () => {
-                        try {
-                          await api.updateOrchestratorSettings(
-                            { role: orchestrator.role },
-                            orchProject,
-                          );
-                        } catch (_e) {}
+                      onChange={(e) => {
+                        orchestratorSave.clearError();
+                        setOrchestrator({ ...orchestrator, role: e.target.value });
+                      }}
+                      onBlur={() => {
+                        const role = orchestrator.role;
+                        void orchestratorSave.track(() =>
+                          api.updateOrchestratorSettings({ role }, orchProject),
+                        );
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                          e.preventDefault();
+                          (e.currentTarget as HTMLTextAreaElement).blur();
+                        }
                       }}
                       rows={2}
                       placeholder="Describe the orchestrator's role and persona..."
@@ -668,19 +781,24 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                     <span className="block text-xs text-zinc-400 mb-1">Branch rules</span>
                     <textarea
                       value={orchestrator.rules.branch}
-                      onChange={(e) =>
+                      onChange={(e) => {
+                        orchestratorSave.clearError();
                         setOrchestrator({
                           ...orchestrator,
                           rules: { ...orchestrator.rules, branch: e.target.value },
-                        })
-                      }
-                      onBlur={async () => {
-                        try {
-                          await api.updateOrchestratorSettings(
-                            { rules: { branch: orchestrator.rules.branch } },
-                            orchProject,
-                          );
-                        } catch (_e) {}
+                        });
+                      }}
+                      onBlur={() => {
+                        const branch = orchestrator.rules.branch;
+                        void orchestratorSave.track(() =>
+                          api.updateOrchestratorSettings({ rules: { branch } }, orchProject),
+                        );
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                          e.preventDefault();
+                          (e.currentTarget as HTMLTextAreaElement).blur();
+                        }
                       }}
                       rows={2}
                       placeholder="Rules for branch naming and strategy..."
@@ -693,19 +811,24 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                     <span className="block text-xs text-zinc-400 mb-1">Merge rules</span>
                     <textarea
                       value={orchestrator.rules.merge}
-                      onChange={(e) =>
+                      onChange={(e) => {
+                        orchestratorSave.clearError();
                         setOrchestrator({
                           ...orchestrator,
                           rules: { ...orchestrator.rules, merge: e.target.value },
-                        })
-                      }
-                      onBlur={async () => {
-                        try {
-                          await api.updateOrchestratorSettings(
-                            { rules: { merge: orchestrator.rules.merge } },
-                            orchProject,
-                          );
-                        } catch (_e) {}
+                        });
+                      }}
+                      onBlur={() => {
+                        const merge = orchestrator.rules.merge;
+                        void orchestratorSave.track(() =>
+                          api.updateOrchestratorSettings({ rules: { merge } }, orchProject),
+                        );
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                          e.preventDefault();
+                          (e.currentTarget as HTMLTextAreaElement).blur();
+                        }
                       }}
                       rows={2}
                       placeholder="Rules for merge strategy and conflict resolution..."
@@ -718,19 +841,24 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                     <span className="block text-xs text-zinc-400 mb-1">Review rules</span>
                     <textarea
                       value={orchestrator.rules.review}
-                      onChange={(e) =>
+                      onChange={(e) => {
+                        orchestratorSave.clearError();
                         setOrchestrator({
                           ...orchestrator,
                           rules: { ...orchestrator.rules, review: e.target.value },
-                        })
-                      }
-                      onBlur={async () => {
-                        try {
-                          await api.updateOrchestratorSettings(
-                            { rules: { review: orchestrator.rules.review } },
-                            orchProject,
-                          );
-                        } catch (_e) {}
+                        });
+                      }}
+                      onBlur={() => {
+                        const review = orchestrator.rules.review;
+                        void orchestratorSave.track(() =>
+                          api.updateOrchestratorSettings({ rules: { review } }, orchProject),
+                        );
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                          e.preventDefault();
+                          (e.currentTarget as HTMLTextAreaElement).blur();
+                        }
                       }}
                       rows={2}
                       placeholder="Rules for code review process..."
@@ -743,19 +871,24 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                     <span className="block text-xs text-zinc-400 mb-1">Custom rules</span>
                     <textarea
                       value={orchestrator.rules.custom}
-                      onChange={(e) =>
+                      onChange={(e) => {
+                        orchestratorSave.clearError();
                         setOrchestrator({
                           ...orchestrator,
                           rules: { ...orchestrator.rules, custom: e.target.value },
-                        })
-                      }
-                      onBlur={async () => {
-                        try {
-                          await api.updateOrchestratorSettings(
-                            { rules: { custom: orchestrator.rules.custom } },
-                            orchProject,
-                          );
-                        } catch (_e) {}
+                        });
+                      }}
+                      onBlur={() => {
+                        const custom = orchestrator.rules.custom;
+                        void orchestratorSave.track(() =>
+                          api.updateOrchestratorSettings({ rules: { custom } }, orchProject),
+                        );
+                      }}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+                          e.preventDefault();
+                          (e.currentTarget as HTMLTextAreaElement).blur();
+                        }
                       }}
                       rows={3}
                       placeholder="Additional custom rules for the orchestrator..."
@@ -768,6 +901,7 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                     orchestrator={orchestrator}
                     setOrchestrator={setOrchestrator}
                     orchProject={orchProject}
+                    save={orchestratorSave}
                   />
 
                   {/* Notifications */}
@@ -775,6 +909,7 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                     orchestrator={orchestrator}
                     setOrchestrator={setOrchestrator}
                     orchProject={orchProject}
+                    save={orchestratorSave}
                   />
 
                   {/* Guardrails */}
@@ -782,6 +917,7 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                     orchestrator={orchestrator}
                     setOrchestrator={setOrchestrator}
                     orchProject={orchProject}
+                    save={orchestratorSave}
                   />
                 </div>
               )}
@@ -798,7 +934,10 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
         {/* Usage monitoring section */}
         {usageSettings && (
           <section>
-            <h3 className="text-sm font-medium text-zinc-300">Usage Monitoring</h3>
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-medium text-zinc-300">Usage Monitoring</h3>
+              <SaveStatus status={usageSave.status} error={usageSave.error} variant="section" />
+            </div>
             <p className="mt-1 text-xs text-zinc-600">
               Periodically fetch Claude Code subscription usage. Spawns a temporary Claude Code
               instance (Haiku) for each refresh.
@@ -811,12 +950,12 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                 </div>
                 <button
                   type="button"
-                  onClick={async () => {
+                  onClick={() => {
                     const newEnabled = !usageSettings.enabled;
                     setUsageSettings({ ...usageSettings, enabled: newEnabled });
-                    try {
-                      await api.updateUsageSettings({ enabled: newEnabled });
-                    } catch (_e) {}
+                    void usageSave.track(() => api.updateUsageSettings({ enabled: newEnabled }), {
+                      onError: () => setUsageSettings({ ...usageSettings, enabled: !newEnabled }),
+                    });
                   }}
                   className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
                     usageSettings.enabled ? "bg-cyan-500/40" : "bg-white/10"
@@ -843,14 +982,15 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                     onChange={(e) => {
                       const val = parseInt(e.target.value, 10);
                       if (!Number.isNaN(val)) {
+                        usageSave.clearError();
                         setUsageSettings({ ...usageSettings, auto_refresh_min: val });
                       }
                     }}
-                    onBlur={async () => {
+                    onBlur={() => {
                       const val = Math.max(5, usageSettings.auto_refresh_min || 30);
-                      try {
-                        await api.updateUsageSettings({ auto_refresh_min: val });
-                      } catch (_e) {}
+                      void usageSave.track(() =>
+                        api.updateUsageSettings({ auto_refresh_min: val }),
+                      );
                     }}
                     className="w-20 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
                   />
@@ -863,7 +1003,10 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
 
         {/* Notification section */}
         <section>
-          <h3 className="text-sm font-medium text-zinc-300">Notifications</h3>
+          <div className="flex items-center gap-2">
+            <h3 className="text-sm font-medium text-zinc-300">Notifications</h3>
+            <SaveStatus status={notifySave.status} error={notifySave.error} variant="section" />
+          </div>
           <p className="mt-1 text-xs text-zinc-600">
             Browser notifications when agents finish processing and become idle.
           </p>
@@ -878,15 +1021,14 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
               </div>
               <button
                 type="button"
-                onClick={async () => {
+                onClick={() => {
                   const prev = notifyOnIdle;
                   const next = !prev;
                   setNotifyOnIdle(next);
-                  try {
-                    await api.updateNotificationSettings({ notify_on_idle: next });
-                  } catch (_e) {
-                    setNotifyOnIdle(prev);
-                  }
+                  void notifySave.track(
+                    () => api.updateNotificationSettings({ notify_on_idle: next }),
+                    { onError: () => setNotifyOnIdle(prev) },
+                  );
                 }}
                 className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
                   notifyOnIdle ? "bg-cyan-500/40" : "bg-white/10"
@@ -911,16 +1053,15 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                   onChange={(e) => {
                     const val = parseInt(e.target.value, 10);
                     if (!Number.isNaN(val)) {
+                      notifySave.clearError();
                       setNotifyThresholdSecs(val);
                     }
                   }}
-                  onBlur={async () => {
+                  onBlur={() => {
                     const val = Math.max(0, notifyThresholdSecs);
-                    try {
-                      await api.updateNotificationSettings({
-                        notify_idle_threshold_secs: val,
-                      });
-                    } catch (_e) {}
+                    void notifySave.track(() =>
+                      api.updateNotificationSettings({ notify_idle_threshold_secs: val }),
+                    );
                   }}
                   className="w-20 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
                 />
@@ -940,7 +1081,14 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
         {/* Workflow section */}
         {workflowSettings && (
           <section>
-            <h3 className="text-sm font-medium text-zinc-300">Workflow</h3>
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-medium text-zinc-300">Workflow</h3>
+              <SaveStatus
+                status={workflowSave.status}
+                error={workflowSave.error}
+                variant="section"
+              />
+            </div>
             <p className="mt-1 text-xs text-zinc-600">Workflow automation settings.</p>
 
             <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3">
@@ -953,12 +1101,19 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                 </div>
                 <button
                   type="button"
-                  onClick={async () => {
+                  onClick={() => {
                     const next = !workflowSettings.auto_rebase_on_merge;
                     setWorkflowSettings({ ...workflowSettings, auto_rebase_on_merge: next });
-                    try {
-                      await api.updateWorkflowSettings({ auto_rebase_on_merge: next });
-                    } catch (_e) {}
+                    void workflowSave.track(
+                      () => api.updateWorkflowSettings({ auto_rebase_on_merge: next }),
+                      {
+                        onError: () =>
+                          setWorkflowSettings({
+                            ...workflowSettings,
+                            auto_rebase_on_merge: !next,
+                          }),
+                      },
+                    );
                   }}
                   className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
                     workflowSettings.auto_rebase_on_merge ? "bg-cyan-500/40" : "bg-white/10"
@@ -980,7 +1135,14 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
         {/* Worktree section */}
         {worktreeSettings && (
           <section>
-            <h3 className="text-sm font-medium text-zinc-300">Worktree</h3>
+            <div className="flex items-center gap-2">
+              <h3 className="text-sm font-medium text-zinc-300">Worktree</h3>
+              <SaveStatus
+                status={worktreeSave.status}
+                error={worktreeSave.error}
+                variant="section"
+              />
+            </div>
             <p className="mt-1 text-xs text-zinc-600">Git worktree settings for spawned agents.</p>
 
             <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-3">
@@ -997,12 +1159,20 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                       </code>
                       <button
                         type="button"
-                        onClick={async () => {
-                          const cmds = worktreeSettings.setup_commands.filter((c) => c !== cmd);
+                        onClick={() => {
+                          const previous = worktreeSettings.setup_commands;
+                          const cmds = previous.filter((c) => c !== cmd);
                           setWorktreeSettings({ ...worktreeSettings, setup_commands: cmds });
-                          try {
-                            await api.updateWorktreeSettings({ setup_commands: cmds });
-                          } catch (_e) {}
+                          void worktreeSave.track(
+                            () => api.updateWorktreeSettings({ setup_commands: cmds }),
+                            {
+                              onError: () =>
+                                setWorktreeSettings({
+                                  ...worktreeSettings,
+                                  setup_commands: previous,
+                                }),
+                            },
+                          );
                         }}
                         className="rounded px-1.5 py-0.5 text-[10px] text-zinc-600 hover:bg-red-500/10 hover:text-red-400"
                       >
@@ -1016,14 +1186,22 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                     type="text"
                     value={newSetupCommand}
                     onChange={(e) => setNewSetupCommand(e.target.value)}
-                    onKeyDown={async (e) => {
+                    onKeyDown={(e) => {
                       if (e.key === "Enter" && newSetupCommand.trim()) {
-                        const cmds = [...worktreeSettings.setup_commands, newSetupCommand.trim()];
+                        const previous = worktreeSettings.setup_commands;
+                        const cmds = [...previous, newSetupCommand.trim()];
                         setWorktreeSettings({ ...worktreeSettings, setup_commands: cmds });
                         setNewSetupCommand("");
-                        try {
-                          await api.updateWorktreeSettings({ setup_commands: cmds });
-                        } catch (_e) {}
+                        void worktreeSave.track(
+                          () => api.updateWorktreeSettings({ setup_commands: cmds }),
+                          {
+                            onError: () =>
+                              setWorktreeSettings({
+                                ...worktreeSettings,
+                                setup_commands: previous,
+                              }),
+                          },
+                        );
                       }
                     }}
                     placeholder="e.g., npm install"
@@ -1031,14 +1209,22 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                   />
                   <button
                     type="button"
-                    onClick={async () => {
+                    onClick={() => {
                       if (!newSetupCommand.trim()) return;
-                      const cmds = [...worktreeSettings.setup_commands, newSetupCommand.trim()];
+                      const previous = worktreeSettings.setup_commands;
+                      const cmds = [...previous, newSetupCommand.trim()];
                       setWorktreeSettings({ ...worktreeSettings, setup_commands: cmds });
                       setNewSetupCommand("");
-                      try {
-                        await api.updateWorktreeSettings({ setup_commands: cmds });
-                      } catch (_e) {}
+                      void worktreeSave.track(
+                        () => api.updateWorktreeSettings({ setup_commands: cmds }),
+                        {
+                          onError: () =>
+                            setWorktreeSettings({
+                              ...worktreeSettings,
+                              setup_commands: previous,
+                            }),
+                        },
+                      );
                     }}
                     className="rounded-md bg-cyan-500/20 px-3 py-1 text-xs text-cyan-400 transition-colors hover:bg-cyan-500/30"
                   >
@@ -1057,14 +1243,15 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                   onChange={(e) => {
                     const val = parseInt(e.target.value, 10);
                     if (!Number.isNaN(val)) {
+                      worktreeSave.clearError();
                       setWorktreeSettings({ ...worktreeSettings, setup_timeout_secs: val });
                     }
                   }}
-                  onBlur={async () => {
+                  onBlur={() => {
                     const val = Math.max(30, worktreeSettings.setup_timeout_secs);
-                    try {
-                      await api.updateWorktreeSettings({ setup_timeout_secs: val });
-                    } catch (_e) {}
+                    void worktreeSave.track(() =>
+                      api.updateWorktreeSettings({ setup_timeout_secs: val }),
+                    );
                   }}
                   className="w-20 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
                 />
@@ -1081,14 +1268,15 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
                   onChange={(e) => {
                     const val = parseInt(e.target.value, 10);
                     if (!Number.isNaN(val)) {
+                      worktreeSave.clearError();
                       setWorktreeSettings({ ...worktreeSettings, branch_depth_warning: val });
                     }
                   }}
-                  onBlur={async () => {
+                  onBlur={() => {
                     const val = Math.max(1, worktreeSettings.branch_depth_warning);
-                    try {
-                      await api.updateWorktreeSettings({ branch_depth_warning: val });
-                    } catch (_e) {}
+                    void worktreeSave.track(() =>
+                      api.updateWorktreeSettings({ branch_depth_warning: val }),
+                    );
                   }}
                   className="w-20 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
                 />
@@ -1295,56 +1483,53 @@ function NotifySettingsSection({
   orchestrator,
   setOrchestrator,
   orchProject,
+  save,
 }: {
   orchestrator: OrchestratorSettings;
   setOrchestrator: (v: OrchestratorSettings) => void;
   orchProject: string | undefined;
+  save: ReturnType<typeof useSaveTracker>;
 }) {
   const [expandedTemplate, setExpandedTemplate] = useState<string | null>(null);
 
   // Change the per-event handling mode (off / notify / auto_action) and persist
-  const setHandling = async (
-    key: NotifyEventDef["key"],
-    value: import("@/lib/api").EventHandling,
-  ) => {
+  const setHandling = (key: NotifyEventDef["key"], value: import("@/lib/api").EventHandling) => {
     const updated = {
       ...orchestrator,
       notify: { ...orchestrator.notify, [key]: value },
     };
     setOrchestrator(updated);
-    try {
-      await api.updateOrchestratorSettings({ notify: { [key]: value } }, orchProject);
-    } catch (_e) {
-      // Revert on error
-      setOrchestrator(orchestrator);
-    }
+    void save.track(
+      () => api.updateOrchestratorSettings({ notify: { [key]: value } }, orchProject),
+      { onError: () => setOrchestrator(orchestrator) },
+    );
   };
 
-  // Save a notify-mode template change
-  const saveTemplate = async (templateKey: NotifyEventDef["templateKey"], value: string) => {
-    try {
-      const templates: Record<string, string> = { [templateKey]: value };
-      await api.updateOrchestratorSettings(
+  // Save a notify-mode template change (text-field commit; no rollback)
+  const saveTemplate = (templateKey: NotifyEventDef["templateKey"], value: string) => {
+    const templates: Record<string, string> = { [templateKey]: value };
+    void save.track(() =>
+      api.updateOrchestratorSettings(
         { notify: { templates: templates as Partial<import("@/lib/api").NotifyTemplates> } },
         orchProject,
-      );
-    } catch (_e) {}
+      ),
+    );
   };
 
-  // Save an auto-action template change
-  const saveAutoActionTemplate = async (
+  // Save an auto-action template change (text-field commit; no rollback)
+  const saveAutoActionTemplate = (
     templateKey: keyof import("@/lib/api").AutoActionTemplates,
     value: string,
   ) => {
-    try {
-      const templates: Record<string, string> = { [templateKey]: value };
-      await api.updateOrchestratorSettings(
+    const templates: Record<string, string> = { [templateKey]: value };
+    void save.track(() =>
+      api.updateOrchestratorSettings(
         {
           auto_action_templates: templates as Partial<import("@/lib/api").AutoActionTemplates>,
         },
         orchProject,
-      );
-    } catch (_e) {}
+      ),
+    );
   };
 
   // Toggle one of the origin-aware filter booleans (#440)
@@ -1353,17 +1538,16 @@ function NotifySettingsSection({
     | "notify_on_human_action"
     | "notify_on_agent_action"
     | "notify_on_system_action";
-  const setOriginFlag = async (key: OriginFilterKey, value: boolean) => {
+  const setOriginFlag = (key: OriginFilterKey, value: boolean) => {
     const updated = {
       ...orchestrator,
       notify: { ...orchestrator.notify, [key]: value },
     };
     setOrchestrator(updated);
-    try {
-      await api.updateOrchestratorSettings({ notify: { [key]: value } }, orchProject);
-    } catch (_e) {
-      setOrchestrator(orchestrator);
-    }
+    void save.track(
+      () => api.updateOrchestratorSettings({ notify: { [key]: value } }, orchProject),
+      { onError: () => setOrchestrator(orchestrator) },
+    );
   };
 
   return (
@@ -1485,7 +1669,7 @@ function NotifySettingsSection({
                     {templateValue && (
                       <button
                         type="button"
-                        onClick={async () => {
+                        onClick={() => {
                           const updated = {
                             ...orchestrator,
                             notify: {
@@ -1497,7 +1681,7 @@ function NotifySettingsSection({
                             },
                           };
                           setOrchestrator(updated);
-                          await saveTemplate(evt.templateKey, "");
+                          saveTemplate(evt.templateKey, "");
                         }}
                         className="absolute top-1.5 right-1.5 text-zinc-600 hover:text-zinc-300 transition-colors"
                         title="Reset to default template"
@@ -1730,17 +1914,19 @@ function PrMonitorSection({
   orchestrator,
   setOrchestrator,
   orchProject,
+  save,
 }: {
   orchestrator: OrchestratorSettings;
   setOrchestrator: (v: OrchestratorSettings) => void;
   orchProject: string | undefined;
+  save: ReturnType<typeof useSaveTracker>;
 }) {
-  const updateInterval = async (value: number) => {
+  const updateInterval = (value: number) => {
     const clamped = Math.max(10, Math.min(3600, value));
     setOrchestrator({ ...orchestrator, pr_monitor_interval_secs: clamped });
-    try {
-      await api.updateOrchestratorSettings({ pr_monitor_interval_secs: clamped }, orchProject);
-    } catch (_e) {}
+    void save.track(() =>
+      api.updateOrchestratorSettings({ pr_monitor_interval_secs: clamped }, orchProject),
+    );
   };
 
   return (
@@ -1758,12 +1944,15 @@ function PrMonitorSection({
           </div>
           <button
             type="button"
-            onClick={async () => {
+            onClick={() => {
               const next = !orchestrator.pr_monitor_enabled;
               setOrchestrator({ ...orchestrator, pr_monitor_enabled: next });
-              try {
-                await api.updateOrchestratorSettings({ pr_monitor_enabled: next }, orchProject);
-              } catch (_e) {}
+              void save.track(
+                () => api.updateOrchestratorSettings({ pr_monitor_enabled: next }, orchProject),
+                {
+                  onError: () => setOrchestrator({ ...orchestrator, pr_monitor_enabled: !next }),
+                },
+              );
             }}
             className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
               orchestrator.pr_monitor_enabled ? "bg-cyan-500/40" : "bg-white/10"
@@ -1802,6 +1991,7 @@ function PrMonitorSection({
             onChange={(e) => {
               const val = parseInt(e.target.value, 10);
               if (!Number.isNaN(val)) {
+                save.clearError();
                 setOrchestrator({ ...orchestrator, pr_monitor_interval_secs: val });
               }
             }}
@@ -1824,10 +2014,12 @@ function GuardrailsSection({
   orchestrator,
   setOrchestrator,
   orchProject,
+  save,
 }: {
   orchestrator: OrchestratorSettings;
   setOrchestrator: (v: OrchestratorSettings) => void;
   orchProject: string | undefined;
+  save: ReturnType<typeof useSaveTracker>;
 }) {
   const guardrailFields: {
     key: keyof OrchestratorSettings["guardrails"];
@@ -1851,16 +2043,16 @@ function GuardrailsSection({
     },
   ];
 
-  const updateField = async (key: keyof OrchestratorSettings["guardrails"], value: number) => {
+  const updateField = (key: keyof OrchestratorSettings["guardrails"], value: number) => {
     if (value < 1) return;
     const updated = {
       ...orchestrator,
       guardrails: { ...orchestrator.guardrails, [key]: value },
     };
     setOrchestrator(updated);
-    try {
-      await api.updateOrchestratorSettings({ guardrails: { [key]: value } }, orchProject);
-    } catch (_e) {}
+    void save.track(() =>
+      api.updateOrchestratorSettings({ guardrails: { [key]: value } }, orchProject),
+    );
   };
 
   return (
@@ -1882,6 +2074,7 @@ function GuardrailsSection({
               onChange={(e) => {
                 const val = parseInt(e.target.value, 10);
                 if (!Number.isNaN(val)) {
+                  save.clearError();
                   setOrchestrator({
                     ...orchestrator,
                     guardrails: { ...orchestrator.guardrails, [field.key]: val },

--- a/clients/react/src/components/settings/SpawnRuntimeSelector.tsx
+++ b/clients/react/src/components/settings/SpawnRuntimeSelector.tsx
@@ -1,9 +1,17 @@
+import type { UseSaveTrackerResult } from "@/hooks/useSaveTracker";
 import type { SpawnRuntime, SpawnSettings } from "@/lib/api";
 import { api } from "@/lib/api";
 
 interface SpawnRuntimeSelectorProps {
   settings: SpawnSettings;
   onSettingsChange: (updated: SpawnSettings) => void;
+  /**
+   * Optional save tracker (#578). When provided, runtime-radio changes route
+   * through it so the parent section can render Saving / Saved / error state.
+   * Falls back to a fire-and-forget call (silent failure) for backwards
+   * compatibility with callers that have not yet adopted the tracker.
+   */
+  save?: UseSaveTrackerResult;
 }
 
 interface RuntimeOption {
@@ -30,14 +38,27 @@ const RUNTIME_OPTIONS: RuntimeOption[] = [
   },
 ];
 
-export function SpawnRuntimeSelector({ settings, onSettingsChange }: SpawnRuntimeSelectorProps) {
+export function SpawnRuntimeSelector({
+  settings,
+  onSettingsChange,
+  save,
+}: SpawnRuntimeSelectorProps) {
   const handleChange = async (runtime: SpawnRuntime) => {
     // tmux is not yet selectable; guard prevents accidental selection
     if (runtime === "tmux") return;
-    try {
-      await api.updateSpawnSettings({ runtime });
-      onSettingsChange({ ...settings, runtime });
-    } catch (_e) {}
+    const previous = settings.runtime;
+    onSettingsChange({ ...settings, runtime });
+    if (save) {
+      void save.track(() => api.updateSpawnSettings({ runtime }), {
+        onError: () => onSettingsChange({ ...settings, runtime: previous }),
+      });
+    } else {
+      try {
+        await api.updateSpawnSettings({ runtime });
+      } catch (_e) {
+        onSettingsChange({ ...settings, runtime: previous });
+      }
+    }
   };
 
   return (

--- a/clients/react/src/components/settings/__tests__/SettingsPanel-autosave.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel-autosave.test.tsx
@@ -1,0 +1,284 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  AutoApproveSettings,
+  OrchestratorSettings,
+  SpawnSettings,
+  UsageSettings,
+  WorkflowSettings,
+  WorktreeSettings,
+} from "@/lib/api";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      listProjects: vi.fn(),
+      getSpawnSettings: vi.fn(),
+      updateSpawnSettings: vi.fn(),
+      getAutoApproveSettings: vi.fn(),
+      updateAutoApproveMode: vi.fn(),
+      updateAutoApproveFields: vi.fn(),
+      updateAutoApproveRules: vi.fn(),
+      getUsageSettings: vi.fn(),
+      updateUsageSettings: vi.fn(),
+      getOrchestratorSettings: vi.fn(),
+      updateOrchestratorSettings: vi.fn(),
+      getNotificationSettings: vi.fn(),
+      updateNotificationSettings: vi.fn(),
+      getWorkflowSettings: vi.fn(),
+      updateWorkflowSettings: vi.fn(),
+      getWorktreeSettings: vi.fn(),
+      updateWorktreeSettings: vi.fn(),
+      // ScheduledKicksSection (rendered as part of SettingsPanel) loads its
+      // own data on mount — stub the read so the section does not throw.
+      listScheduledKicks: vi.fn().mockResolvedValue([]),
+      createScheduledKick: vi.fn(),
+      updateScheduledKick: vi.fn(),
+      deleteScheduledKick: vi.fn(),
+      dryRunKick: vi.fn(),
+    },
+  };
+});
+
+const { api } = await import("@/lib/api");
+const { SettingsPanel } = await import("../SettingsPanel");
+
+// ── Fixtures ──────────────────────────────────────────────────────────
+
+const SPAWN: SpawnSettings = {
+  runtime: "tmux",
+  tmux_available: true,
+  tmux_window_name: "tmai",
+};
+
+const AUTO_APPROVE: AutoApproveSettings = {
+  enabled: false,
+  mode: "off",
+  running: false,
+  provider: "claude_haiku",
+  model: "claude-haiku-4-5",
+  timeout_secs: 30,
+  cooldown_secs: 5,
+  check_interval_ms: 1000,
+  max_concurrent: 4,
+  allowed_types: [],
+  rules: {
+    allow_read: true,
+    allow_tests: true,
+    allow_fetch: false,
+    allow_git_readonly: true,
+    allow_format_lint: true,
+    allow_tmai_mcp: true,
+    allow_patterns: [],
+  },
+};
+
+const USAGE: UsageSettings = {
+  enabled: false,
+  auto_refresh_min: 30,
+};
+
+const WORKFLOW: WorkflowSettings = { auto_rebase_on_merge: false };
+const WORKTREE: WorktreeSettings = {
+  setup_commands: [],
+  setup_timeout_secs: 300,
+  branch_depth_warning: 5,
+};
+
+function makeOrchestrator(): OrchestratorSettings {
+  return {
+    enabled: true,
+    role: "",
+    rules: { branch: "", merge: "", review: "", custom: "" },
+    notify: {
+      on_agent_stopped: "off",
+      on_agent_error: "off",
+      on_rebase_conflict: "off",
+      on_ci_passed: "off",
+      on_ci_failed: "off",
+      on_pr_created: "off",
+      on_pr_comment: "off",
+      on_pr_closed: "off",
+      on_guardrail_exceeded: "off",
+      templates: {
+        agent_stopped: "",
+        agent_error: "",
+        ci_passed: "",
+        ci_failed: "",
+        pr_created: "",
+        pr_comment: "",
+        rebase_conflict: "",
+        pr_closed: "",
+        guardrail_exceeded: "",
+      },
+      default_templates: {
+        agent_stopped: "",
+        agent_error: "",
+        ci_passed: "",
+        ci_failed: "",
+        pr_created: "",
+        pr_comment: "",
+        rebase_conflict: "",
+        pr_closed: "",
+        guardrail_exceeded: "",
+      },
+      suppress_self: false,
+      notify_on_human_action: false,
+      notify_on_agent_action: false,
+      notify_on_system_action: false,
+    },
+    guardrails: { max_ci_retries: 3, max_review_loops: 3, escalate_to_human_after: 3 },
+    auto_action_templates: {
+      ci_failed_implementer: "",
+      review_feedback_implementer: "",
+    },
+    pr_monitor_enabled: false,
+    pr_monitor_interval_secs: 60,
+    pr_monitor_exclude_authors: [],
+    pr_monitor_scope: "current_project",
+    inject_state_snapshot: false,
+    is_project_override: false,
+    orchestrator: null,
+    dispatch: { implementer: null, reviewer: null },
+  };
+}
+
+function setupDefaults() {
+  vi.mocked(api.listProjects).mockResolvedValue([]);
+  vi.mocked(api.getSpawnSettings).mockResolvedValue(SPAWN);
+  vi.mocked(api.getAutoApproveSettings).mockResolvedValue(AUTO_APPROVE);
+  vi.mocked(api.getUsageSettings).mockResolvedValue(USAGE);
+  vi.mocked(api.getOrchestratorSettings).mockResolvedValue(makeOrchestrator());
+  vi.mocked(api.getNotificationSettings).mockResolvedValue({
+    notify_on_idle: true,
+    notify_idle_threshold_secs: 10,
+  });
+  vi.mocked(api.getWorkflowSettings).mockResolvedValue(WORKFLOW);
+  vi.mocked(api.getWorktreeSettings).mockResolvedValue(WORKTREE);
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────
+
+describe("SettingsPanel — auto-save acceptance (#578)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupDefaults();
+  });
+
+  it("atomic dropdown change persists with a single PUT", async () => {
+    vi.mocked(api.updateAutoApproveMode).mockResolvedValue(undefined as never);
+    render(<SettingsPanel onClose={() => {}} onProjectsChanged={() => {}} />);
+
+    // Wait for the auto-approve mode <select> to appear.
+    const modeSelect = await waitFor(() => {
+      const sel = screen.getAllByRole("combobox").find((s) => {
+        const opts = Array.from(s.querySelectorAll("option")).map((o) => o.value);
+        return opts.includes("rules") && opts.includes("ai");
+      });
+      if (!sel) throw new Error("auto-approve mode select not found yet");
+      return sel as HTMLSelectElement;
+    });
+
+    fireEvent.change(modeSelect, { target: { value: "rules" } });
+
+    await waitFor(() => {
+      expect(vi.mocked(api.updateAutoApproveMode)).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(api.updateAutoApproveMode)).toHaveBeenCalledWith("rules");
+  });
+
+  it("typing in the tmux window-name text field does NOT trigger PUT mid-stream", async () => {
+    vi.mocked(api.updateSpawnSettings).mockResolvedValue(undefined as never);
+    render(<SettingsPanel onClose={() => {}} onProjectsChanged={() => {}} />);
+
+    // Window name input only renders when runtime === "tmux" (our fixture).
+    const input = await waitFor(() => {
+      const candidate = screen
+        .getAllByRole("textbox")
+        .find((el) => (el as HTMLInputElement).value === "tmai");
+      if (!candidate) throw new Error("tmux window-name input not found yet");
+      return candidate as HTMLInputElement;
+    });
+
+    fireEvent.change(input, { target: { value: "tma" } });
+    fireEvent.change(input, { target: { value: "tmai-renamed" } });
+
+    expect(vi.mocked(api.updateSpawnSettings)).not.toHaveBeenCalled();
+  });
+
+  it("blurring the tmux window-name text field commits with a PUT", async () => {
+    vi.mocked(api.updateSpawnSettings).mockResolvedValue(undefined as never);
+    render(<SettingsPanel onClose={() => {}} onProjectsChanged={() => {}} />);
+
+    const input = await waitFor(() => {
+      const candidate = screen
+        .getAllByRole("textbox")
+        .find((el) => (el as HTMLInputElement).value === "tmai");
+      if (!candidate) throw new Error("tmux window-name input not found yet");
+      return candidate as HTMLInputElement;
+    });
+
+    fireEvent.change(input, { target: { value: "renamed" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(vi.mocked(api.updateSpawnSettings)).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(api.updateSpawnSettings)).toHaveBeenCalledWith({
+      runtime: "tmux",
+      tmux_window_name: "renamed",
+    });
+  });
+
+  it("backend 400 on an atomic toggle surfaces inline under the section and rolls back", async () => {
+    vi.mocked(api.updateWorkflowSettings).mockRejectedValue(
+      new Error("API error 400: cannot enable auto-rebase while a rebase is in progress"),
+    );
+    render(<SettingsPanel onClose={() => {}} onProjectsChanged={() => {}} />);
+
+    // Wait for the workflow section to load and find the auto-rebase toggle.
+    await waitFor(() => screen.getByText("Workflow"));
+    const toggleLabel = screen.getByText("Auto-rebase on merge").closest("label");
+    expect(toggleLabel).toBeTruthy();
+    const toggleBtn = toggleLabel?.querySelector("button[type='button']");
+    expect(toggleBtn).toBeTruthy();
+
+    fireEvent.click(toggleBtn as HTMLButtonElement);
+
+    await waitFor(() => {
+      expect(
+        screen.getByText(/cannot enable auto-rebase while a rebase is in progress/i),
+      ).toBeTruthy();
+    });
+    // The PUT was attempted exactly once.
+    expect(vi.mocked(api.updateWorkflowSettings)).toHaveBeenCalledTimes(1);
+  });
+
+  it("backend 400 on a text-field commit keeps the user's input intact", async () => {
+    vi.mocked(api.updateSpawnSettings).mockRejectedValue(
+      new Error("API error 400: window name `bad name` contains invalid character"),
+    );
+    render(<SettingsPanel onClose={() => {}} onProjectsChanged={() => {}} />);
+
+    const input = await waitFor(() => {
+      const candidate = screen
+        .getAllByRole("textbox")
+        .find((el) => (el as HTMLInputElement).value === "tmai");
+      if (!candidate) throw new Error("tmux window-name input not found yet");
+      return candidate as HTMLInputElement;
+    });
+
+    fireEvent.change(input, { target: { value: "bad name" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(screen.getByText(/window name `bad name` contains invalid character/i)).toBeTruthy();
+    });
+
+    // Local draft preserved so the user can edit and retry.
+    expect(input.value).toBe("bad name");
+  });
+});

--- a/clients/react/src/components/settings/__tests__/SettingsPanel-orchestration.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel-orchestration.test.tsx
@@ -147,6 +147,7 @@ describe("OrchestrationDispatchSection", () => {
 
   it("switching vendor resets the model input to empty", async () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
     render(<OrchestrationDispatchSection />);
 
     await waitFor(() => screen.getByText("Orchestrator"));
@@ -252,25 +253,81 @@ describe("OrchestrationDispatchSection", () => {
     expect(effortSelects.length).toBeGreaterThan(0);
   });
 
-  it("save calls updateOrchestratorSettings with the current bundle state", async () => {
+  // ── #578 auto-save behaviour ──────────────────────────────────────
+
+  it("no Save button is rendered (auto-save replaces explicit Save)", async () => {
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    render(<OrchestrationDispatchSection />);
+    await waitFor(() => screen.getByText("Orchestrator"));
+    expect(screen.queryByRole("button", { name: /^save/i })).toBeNull();
+  });
+
+  it("changing an atomic field (effort) triggers a single PUT immediately", async () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
     vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
     render(<OrchestrationDispatchSection />);
-
     await waitFor(() => screen.getByText("Orchestrator"));
 
-    const saveBtn = screen.getByRole("button", { name: /save/i });
-    fireEvent.click(saveBtn);
+    const effortSelects = screen.getAllByRole("combobox", { name: /effort for/i });
+    fireEvent.change(effortSelects[0], { target: { value: "low" } });
 
     await waitFor(() => {
-      expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledWith({
-        orchestrator: EXPLICIT_SETTINGS.orchestrator,
-        dispatch: EXPLICIT_SETTINGS.dispatch,
-      });
+      expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(api.updateOrchestratorSettings).mock.calls[0][0]).toMatchObject({
+      orchestrator: expect.objectContaining({ effort: "low" }),
     });
   });
 
-  it("displays backend error on save failure", async () => {
+  it("typing in the model field does NOT trigger a PUT mid-stream", async () => {
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
+    render(<OrchestrationDispatchSection />);
+    await waitFor(() => screen.getByText("Orchestrator"));
+
+    const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
+    fireEvent.change(modelInputs[0], { target: { value: "claude-opus-4-7" } });
+    fireEvent.change(modelInputs[0], { target: { value: "claude-opus-4-7-extra" } });
+
+    // No await — the PUT should never be called from typing alone.
+    expect(vi.mocked(api.updateOrchestratorSettings)).not.toHaveBeenCalled();
+    expect((modelInputs[0] as HTMLInputElement).value).toBe("claude-opus-4-7-extra");
+  });
+
+  it("blurring the model field commits the draft as a PUT", async () => {
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
+    render(<OrchestrationDispatchSection />);
+    await waitFor(() => screen.getByText("Orchestrator"));
+
+    const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
+    fireEvent.change(modelInputs[0], { target: { value: "claude-opus-4-7" } });
+    fireEvent.blur(modelInputs[0]);
+
+    await waitFor(() => {
+      expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(api.updateOrchestratorSettings).mock.calls[0][0]).toMatchObject({
+      orchestrator: expect.objectContaining({ model: "claude-opus-4-7" }),
+    });
+  });
+
+  it("Enter on the model field commits the draft as a PUT", async () => {
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
+    render(<OrchestrationDispatchSection />);
+    await waitFor(() => screen.getByText("Orchestrator"));
+
+    const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
+    fireEvent.change(modelInputs[0], { target: { value: "claude-opus-4-7" } });
+    fireEvent.keyDown(modelInputs[0], { key: "Enter" });
+
+    await waitFor(() => {
+      expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("backend 400 on atomic change rolls back local state and surfaces inline error", async () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
     vi.mocked(api.updateOrchestratorSettings).mockRejectedValue(
       new Error(
@@ -278,32 +335,53 @@ describe("OrchestrationDispatchSection", () => {
       ),
     );
     render(<OrchestrationDispatchSection />);
-
     await waitFor(() => screen.getByText("Orchestrator"));
 
-    fireEvent.click(screen.getByRole("button", { name: /save/i }));
+    const effortSelects = screen.getAllByRole("combobox", { name: /effort for/i });
+    fireEvent.change(effortSelects[0], { target: { value: "low" } });
 
     await waitFor(() => {
       expect(screen.getByText(/permission_mode `auto` is not allowed/i)).toBeTruthy();
     });
+
+    // Rollback: the value should snap back to the previously-saved value.
+    expect((effortSelects[0] as HTMLSelectElement).value).toBe("high");
   });
 
-  it("sends null for the bundle when the default checkbox is checked", async () => {
+  it("backend 400 on text-field commit keeps the user's draft so they can correct", async () => {
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateOrchestratorSettings).mockRejectedValue(
+      new Error("API error 400: model `not-a-model` is unknown"),
+    );
+    render(<OrchestrationDispatchSection />);
+    await waitFor(() => screen.getByText("Orchestrator"));
+
+    const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
+    fireEvent.change(modelInputs[0], { target: { value: "not-a-model" } });
+    fireEvent.blur(modelInputs[0]);
+
+    await waitFor(() => {
+      expect(screen.getByText(/model `not-a-model` is unknown/i)).toBeTruthy();
+    });
+
+    // Draft preserved so the user can edit and retry.
+    expect((modelInputs[0] as HTMLInputElement).value).toBe("not-a-model");
+  });
+
+  it("toggling 'Use vendor CLI default' sends null and persists immediately", async () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
     vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
     render(<OrchestrationDispatchSection />);
-
     await waitFor(() => screen.getByText("Orchestrator"));
 
     const checkboxes = screen.getAllByRole("checkbox");
     fireEvent.click(checkboxes[0]); // orchestrator's "Use vendor CLI default"
 
-    fireEvent.click(screen.getByRole("button", { name: /save/i }));
-
     await waitFor(() => {
-      expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledWith(
-        expect.objectContaining({ orchestrator: null }),
-      );
+      expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledTimes(1);
+    });
+    expect(vi.mocked(api.updateOrchestratorSettings).mock.calls[0][0]).toMatchObject({
+      orchestrator: null,
     });
   });
 });

--- a/clients/react/src/hooks/__tests__/useAutoSave.test.tsx
+++ b/clients/react/src/hooks/__tests__/useAutoSave.test.tsx
@@ -1,0 +1,218 @@
+// @vitest-environment jsdom
+import { act, render, renderHook, waitFor } from "@testing-library/react";
+import { useEffect } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useAutoSave } from "../useAutoSave";
+
+beforeEach(() => {
+  vi.useRealTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("useAutoSave — atomic flow (change)", () => {
+  it("invokes save once and transitions idle → saving → saved → idle", async () => {
+    vi.useFakeTimers();
+    const save = vi.fn(async (_next: number) => {});
+    const { result } = renderHook(() => useAutoSave<number>(0, save, { savedFadeMs: 50 }));
+
+    expect(result.current.status).toBe("idle");
+    expect(result.current.value).toBe(0);
+
+    await act(async () => {
+      result.current.change(1);
+    });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith(1);
+    expect(result.current.value).toBe(1);
+    expect(result.current.status).toBe("saved");
+
+    await act(async () => {
+      vi.advanceTimersByTime(60);
+    });
+    expect(result.current.status).toBe("idle");
+  });
+
+  it("rolls back local state on error and surfaces the error message", async () => {
+    const save = vi.fn(async (_next: string) => {
+      throw new Error("API error 400: bad value");
+    });
+    const { result } = renderHook(() => useAutoSave<string>("a", save));
+
+    await act(async () => {
+      result.current.change("b");
+    });
+
+    expect(result.current.value).toBe("a");
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toMatch(/bad value/);
+  });
+
+  it("adopts a server-normalised value when save resolves with one", async () => {
+    const save = vi.fn(async (next: string) => next.trim());
+    const { result } = renderHook(() => useAutoSave<string>("hello", save));
+
+    await act(async () => {
+      result.current.change("  trimmed  ");
+    });
+
+    expect(result.current.value).toBe("trimmed");
+  });
+});
+
+describe("useAutoSave — text flow (setDraft + commit)", () => {
+  it("setDraft does not invoke save", () => {
+    const save = vi.fn(async (_next: string) => {});
+    const { result } = renderHook(() => useAutoSave<string>("", save));
+
+    act(() => {
+      result.current.setDraft("p");
+    });
+    act(() => {
+      result.current.setDraft("pa");
+    });
+    act(() => {
+      result.current.setDraft("pat");
+    });
+
+    expect(save).not.toHaveBeenCalled();
+    expect(result.current.value).toBe("pat");
+  });
+
+  it("commit triggers a single save with the current draft value", async () => {
+    const save = vi.fn(async (_next: string) => {});
+    const { result } = renderHook(() => useAutoSave<string>("", save));
+
+    act(() => {
+      result.current.setDraft("hello");
+    });
+
+    await act(async () => {
+      result.current.commit();
+    });
+
+    expect(save).toHaveBeenCalledTimes(1);
+    expect(save).toHaveBeenCalledWith("hello");
+  });
+
+  it("when rollbackOnError=false, keeps draft on error so the user can correct", async () => {
+    const save = vi.fn(async (_next: string) => {
+      throw new Error("validation rejected");
+    });
+    const { result } = renderHook(() =>
+      useAutoSave<string>("orig", save, { rollbackOnError: false }),
+    );
+
+    act(() => {
+      result.current.setDraft("typed-but-invalid");
+    });
+    await act(async () => {
+      result.current.commit();
+    });
+
+    expect(result.current.value).toBe("typed-but-invalid");
+    expect(result.current.status).toBe("error");
+    expect(result.current.error).toMatch(/validation rejected/);
+  });
+
+  it("setDraft after an error clears the error state", async () => {
+    const save = vi.fn<(value: string) => Promise<void>>().mockRejectedValueOnce(new Error("nope"));
+    const { result } = renderHook(() => useAutoSave<string>("a", save, { rollbackOnError: false }));
+
+    act(() => {
+      result.current.setDraft("bad");
+    });
+    await act(async () => {
+      result.current.commit();
+    });
+    expect(result.current.status).toBe("error");
+
+    act(() => {
+      result.current.setDraft("good");
+    });
+    expect(result.current.status).toBe("idle");
+    expect(result.current.error).toBeNull();
+  });
+});
+
+describe("useAutoSave — concurrency", () => {
+  it("drops stale save responses (newer save wins)", async () => {
+    const resolvers: Array<() => void> = [];
+    const save = vi.fn(
+      (_next: number) =>
+        new Promise<void>((resolve) => {
+          resolvers.push(resolve);
+        }),
+    );
+
+    const { result } = renderHook(() => useAutoSave<number>(0, save));
+
+    // Fire two saves; second should win.
+    act(() => {
+      result.current.change(1);
+    });
+    act(() => {
+      result.current.change(2);
+    });
+
+    expect(save).toHaveBeenCalledTimes(2);
+
+    // Resolve the second one first (newer, wins).
+    await act(async () => {
+      resolvers[1]();
+      // Then resolve the older one — its result should be ignored.
+      resolvers[0]();
+    });
+
+    await waitFor(() => {
+      expect(result.current.status).toBe("saved");
+    });
+    expect(result.current.value).toBe(2);
+  });
+});
+
+describe("useAutoSave — reset baseline", () => {
+  it("reset() updates the rollback baseline without firing a save", () => {
+    const save = vi.fn(async (_next: number) => {});
+    const { result } = renderHook(() => useAutoSave<number>(0, save));
+
+    act(() => {
+      result.current.reset(42);
+    });
+
+    expect(save).not.toHaveBeenCalled();
+    expect(result.current.value).toBe(42);
+    expect(result.current.status).toBe("idle");
+  });
+});
+
+// Ensure the hook does not leak the saved-fade timeout when the consumer
+// unmounts mid-save (no act() warning, no setState-after-unmount).
+describe("useAutoSave — cleanup", () => {
+  it("does not warn when unmounting after a successful save", async () => {
+    vi.useFakeTimers();
+    const save = vi.fn(async (_next: number) => {});
+
+    function Probe() {
+      const { change } = useAutoSave<number>(0, save, { savedFadeMs: 1000 });
+      useEffect(() => {
+        change(1);
+      }, [change]);
+      return null;
+    }
+
+    const { unmount } = render(<Probe />);
+    await act(async () => {
+      vi.advanceTimersByTime(0);
+    });
+    unmount();
+    // If the timer leaked it would fire here and call setState on an unmounted
+    // tree. clearFade in the unmount effect should have cancelled it.
+    await act(async () => {
+      vi.advanceTimersByTime(2000);
+    });
+  });
+});

--- a/clients/react/src/hooks/useAutoSave.ts
+++ b/clients/react/src/hooks/useAutoSave.ts
@@ -1,0 +1,140 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type AutoSaveStatus = "idle" | "saving" | "saved" | "error";
+
+export interface UseAutoSaveOptions {
+  /**
+   * For atomic fields (toggles, dropdowns) we roll back local state on
+   * backend rejection so the UI reflects the persisted value. For text
+   * fields the user is actively editing, so we leave the input intact and
+   * only surface the inline error — set this to false in that case.
+   * Default: true.
+   */
+  rollbackOnError?: boolean;
+  /** Milliseconds the "saved" tick stays visible before fading to idle. */
+  savedFadeMs?: number;
+}
+
+export interface UseAutoSaveResult<T> {
+  /** Current local value — render this in inputs. */
+  value: T;
+  /** Atomic update — sets local state and immediately persists. */
+  change: (next: T) => void;
+  /** Draft update — sets local state only (for text fields mid-typing). */
+  setDraft: (next: T) => void;
+  /** Persist current local state (for blur / Enter on text fields). */
+  commit: () => void;
+  /** Persist an explicit value (alternative to setDraft + commit). */
+  commitWith: (next: T) => void;
+  /** Reset local state to a new baseline without firing a save. */
+  reset: (next: T) => void;
+  status: AutoSaveStatus;
+  /** Backend error message when status is "error", null otherwise. */
+  error: string | null;
+}
+
+/**
+ * Centralised auto-save behaviour for the Settings panel (issue #578).
+ *
+ * Hybrid strategy:
+ *   - atomic fields (boolean toggles, dropdowns, radios) call `change()` —
+ *     local state updates and a PUT fires immediately;
+ *   - text fields call `setDraft()` while typing and `commit()` on blur or
+ *     Enter so the user does not see flickering validation errors mid-typing.
+ *
+ * On error the hook rolls back to the last known-saved value (atomic) or
+ * leaves local state intact (text, via {@link UseAutoSaveOptions.rollbackOnError}
+ * = false) so the user can correct the input. The save callback may return
+ * a normalised value that the hook adopts as the new local + saved baseline.
+ */
+export function useAutoSave<T>(
+  initial: T,
+  save: (value: T) => Promise<T | undefined> | Promise<void>,
+  options?: UseAutoSaveOptions,
+): UseAutoSaveResult<T> {
+  const { rollbackOnError = true, savedFadeMs = 1000 } = options ?? {};
+  const [value, setValue] = useState<T>(initial);
+  const [status, setStatus] = useState<AutoSaveStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+
+  const lastSavedRef = useRef<T>(initial);
+  const fadeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Pending save token — stale completions are dropped so a slow PUT does not
+  // overwrite a newer field state with its (now outdated) response.
+  const pendingTokenRef = useRef(0);
+  const saveRef = useRef(save);
+  saveRef.current = save;
+
+  const clearFade = useCallback(() => {
+    if (fadeTimerRef.current !== null) {
+      clearTimeout(fadeTimerRef.current);
+      fadeTimerRef.current = null;
+    }
+  }, []);
+
+  useEffect(() => clearFade, [clearFade]);
+
+  const performSave = useCallback(
+    async (next: T) => {
+      const previous = lastSavedRef.current;
+      const token = ++pendingTokenRef.current;
+      clearFade();
+      setStatus("saving");
+      setError(null);
+      try {
+        const returned = await saveRef.current(next);
+        if (token !== pendingTokenRef.current) return; // newer save in-flight
+        const persisted = (returned ?? next) as T;
+        lastSavedRef.current = persisted;
+        setValue(persisted);
+        setStatus("saved");
+        fadeTimerRef.current = setTimeout(() => {
+          fadeTimerRef.current = null;
+          setStatus((s) => (s === "saved" ? "idle" : s));
+        }, savedFadeMs);
+      } catch (e) {
+        if (token !== pendingTokenRef.current) return;
+        if (rollbackOnError) setValue(previous);
+        setStatus("error");
+        setError(e instanceof Error ? e.message : "Save failed");
+      }
+    },
+    [clearFade, rollbackOnError, savedFadeMs],
+  );
+
+  const change = useCallback(
+    (next: T) => {
+      setValue(next);
+      void performSave(next);
+    },
+    [performSave],
+  );
+
+  const setDraft = useCallback((next: T) => {
+    setValue(next);
+    setStatus((s) => (s === "error" ? "idle" : s));
+    setError(null);
+  }, []);
+
+  const commit = useCallback(() => {
+    void performSave(value);
+  }, [performSave, value]);
+
+  const commitWith = useCallback(
+    (next: T) => {
+      setValue(next);
+      void performSave(next);
+    },
+    [performSave],
+  );
+
+  const reset = useCallback((next: T) => {
+    pendingTokenRef.current++;
+    lastSavedRef.current = next;
+    setValue(next);
+    setStatus("idle");
+    setError(null);
+  }, []);
+
+  return { value, change, setDraft, commit, commitWith, reset, status, error };
+}

--- a/clients/react/src/hooks/useSaveTracker.ts
+++ b/clients/react/src/hooks/useSaveTracker.ts
@@ -1,0 +1,68 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import type { AutoSaveStatus } from "./useAutoSave";
+
+export interface UseSaveTrackerResult {
+  status: AutoSaveStatus;
+  error: string | null;
+  /**
+   * Wraps a save operation with status transitions
+   * (saving → saved → idle, or → error). The optional `onError` runs after
+   * the catch — use it to roll back optimistic local state for atomic
+   * fields. Text fields should leave their draft alone.
+   */
+  track: (op: () => Promise<unknown>, opts?: { onError?: () => void }) => Promise<void>;
+  /** Manually clear the error state (e.g., when the user edits a draft after a failed commit). */
+  clearError: () => void;
+}
+
+/**
+ * Lightweight section-level save status helper used by the Settings panel
+ * auto-save (#578). Compared to {@link useAutoSave} this hook does not
+ * manage the field value itself — it only wraps an existing PUT call so the
+ * existing setState-then-API pattern can keep working with minimal churn.
+ */
+export function useSaveTracker(savedFadeMs = 1000): UseSaveTrackerResult {
+  const [status, setStatus] = useState<AutoSaveStatus>("idle");
+  const [error, setError] = useState<string | null>(null);
+  const fadeRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Token guards against stale completions when multiple saves overlap.
+  const tokenRef = useRef(0);
+
+  useEffect(
+    () => () => {
+      if (fadeRef.current !== null) clearTimeout(fadeRef.current);
+    },
+    [],
+  );
+
+  const track = useCallback(
+    async (op: () => Promise<unknown>, opts?: { onError?: () => void }) => {
+      const token = ++tokenRef.current;
+      if (fadeRef.current !== null) clearTimeout(fadeRef.current);
+      setStatus("saving");
+      setError(null);
+      try {
+        await op();
+        if (token !== tokenRef.current) return;
+        setStatus("saved");
+        fadeRef.current = setTimeout(() => {
+          fadeRef.current = null;
+          setStatus((s) => (s === "saved" ? "idle" : s));
+        }, savedFadeMs);
+      } catch (e) {
+        if (token !== tokenRef.current) return;
+        opts?.onError?.();
+        setStatus("error");
+        setError(e instanceof Error ? e.message : "Save failed");
+      }
+    },
+    [savedFadeMs],
+  );
+
+  const clearError = useCallback(() => {
+    setStatus((s) => (s === "error" ? "idle" : s));
+    setError(null);
+  }, []);
+
+  return { status, error, track, clearError };
+}


### PR DESCRIPTION
Closes #578.

## Summary

- Replace the OrchestrationDispatchSection's explicit Save button with field-level auto-save and surface saving / saved / error state across every Settings section.
- Atomic fields (toggles, dropdowns, radios) PUT immediately on change. Text inputs commit on blur or Enter so we never flicker validation errors mid-typing.
- Backend 4xx errors surface inline; atomic changes roll back to the last-saved value, text-field drafts are preserved so the user can correct and retry.

## Implementation

- `useAutoSave<T>` hook (`clients/react/src/hooks/useAutoSave.ts`) — atomic `change()` + draft `setDraft()` / `commit()`, status (`idle | saving | saved | error`), per-call `rollbackOnError` semantics, stale-completion guard for overlapping saves.
- `useSaveTracker` hook — section-level wrapper that the SettingsPanel uses to keep its existing setState-then-API pattern with minimal churn.
- `SaveStatus` component — compact indicator (`Saving…` / `✓ Saved` / `⚠ <message>`).
- `OrchestrationDispatchSection` rewritten: per-bundle atomic vs commit callbacks, no Save button, inline error.
- `DispatchBundleEditor` exposes `onAtomicChange` / `onTextDraft` / `onTextCommit`; the model field maintains its own draft state to avoid stomping on edits while a save is in flight.
- `SpawnRuntimeSelector` accepts an optional save tracker.
- Per-section trackers wired into Auto-approve, Spawn, Orchestrator (role / rules / PR Monitor / Notify / Guardrails), Notifications, Workflow, Worktree, Usage.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm exec biome check src/` no errors (5 pre-existing warnings)
- [x] `pnpm exec vitest run` — 33 files, 283 passed, 2 skipped
- [x] `pnpm build` succeeds
- [x] New `useAutoSave` tests cover atomic save, rollback on error, server-normalised value adoption, text draft / commit, no-rollback for text, error clear on next draft, stale-completion concurrency, reset baseline, cleanup.
- [x] New `SettingsPanel-autosave.test.tsx` covers acceptance: atomic dropdown change PUTs once, text-field typing does NOT PUT mid-stream, blur commits, atomic 4xx surfaces inline + rolls back, text 4xx surfaces inline + preserves draft.
- [x] Existing `OrchestrationDispatchSection` tests updated for the new auto-save flow (no Save button, atomic effort fires PUT immediately, text model commits on blur and Enter, errors surface inline with the right rollback semantics).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 設定パネルの自動保存機能を実装。変更は即座に保存されるようになりました。
  * テキスト入力はフォーカス喪失またはEnterキー時に保存されるようになりました。
  * 保存状態の表示（「保存中」「保存済」「エラー」）をUIに追加。

* **Bug Fixes**
  * 保存エラー時、原子的な変更は前回保存時の状態に自動的にロールバック。
  * テキスト入力エラーはユーザーの入力を保持したまま表示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->