### PR TITLE
chore(gen): sync generated spec + types from tmai-core@be86d26b02

### DIFF
--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "2.1.0"
+    "version": "2.2.0"
   },
   "paths": {
     "/api/agents/{id}/subscribe-terminal": {

--- a/versions.toml
+++ b/versions.toml
@@ -6,7 +6,7 @@
 # release.yml refuses to bundle while any key is 0.0.0, so placeholders are
 # an active safety net rather than a pending TODO.
 
-core = "2.1.0"      # tmai-core private Release (core-v2.1.0 pending push)
+core = "2.2.0"      # tmai-core private Release (core-v2.1.0 pending push)
 react = "1.1.0"     # clients/react/package.json version
 ratatui = "0.1.0"   # clients/ratatui/Cargo.toml version
-api_spec = "2.1.0"  # api-spec/openapi.json info.version
+api_spec = "2.2.0"  # api-spec/openapi.json info.version


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@be86d26b02f2e2888fdcd541a1add0c0bb4a7459

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/openapi.json | 2 +-
 versions.toml         | 4 ++--
 2 files changed, 3 insertions(+), 3 deletions(-)
```

</details>