### PR TITLE
fix(settings): mirror vendor_compat permission_mode matrix in DispatchBundleEditor

### DIFF
--- a/clients/react/src/components/settings/DispatchBundleEditor.tsx
+++ b/clients/react/src/components/settings/DispatchBundleEditor.tsx
@@ -34,12 +34,11 @@ function isPermissionModeAllowed(vendor: Vendor, model: string, mode: Permission
       return mode === "default" || mode === "acceptEdits";
     case "gemini":
       return mode === "default";
-    default: {
+    default:
       // Exhaustiveness: a new Vendor variant must extend this matrix
       // explicitly rather than silently disabling every mode.
-      const _exhaustive: never = vendor;
+      vendor satisfies never;
       return false;
-    }
   }
 }
 

--- a/clients/react/src/components/settings/DispatchBundleEditor.tsx
+++ b/clients/react/src/components/settings/DispatchBundleEditor.tsx
@@ -16,15 +16,30 @@ const PERMISSION_MODES: { value: PermissionMode; label: string }[] = [
 const EFFORT_VALUES = ["low", "medium", "high", "xhigh", "max"] as const;
 
 const MODEL_PLACEHOLDERS: Record<Vendor, string> = {
-  claude: "claude-opus-4-6",
+  claude: "claude-opus-4-7",
   codex: "codex-1",
   gemini: "gemini-2.5-pro",
 };
 
-/** auto is only valid for claude vendor with an opus-tier model. */
-function isAutoDisabled(vendor: Vendor, model: string): boolean {
-  if (vendor !== "claude") return true;
-  return !model.startsWith("claude-opus-");
+// Mirrors `vendor_compat::permission_mode_allowed` in tmai-core so the UI
+// disables combinations the backend would reject. Keep in sync with
+// `crates/tmai-core/src/config/vendor_compat.rs` — the codex / gemini rows
+// are placeholders and will tighten once vendor CLI docs are confirmed.
+function isPermissionModeAllowed(vendor: Vendor, model: string, mode: PermissionMode): boolean {
+  switch (vendor) {
+    case "claude":
+      if (mode === "auto") return model.startsWith("claude-opus-");
+      return mode === "default" || mode === "plan" || mode === "dontAsk" || mode === "acceptEdits";
+    case "codex":
+      return mode === "default" || mode === "acceptEdits";
+    case "gemini":
+      return mode === "default";
+  }
+}
+
+function permissionModeReason(vendor: Vendor, mode: PermissionMode): string {
+  if (vendor === "claude" && mode === "auto") return "requires opus-tier model";
+  return `not supported by ${vendor}`;
 }
 
 interface DispatchBundleEditorProps {
@@ -92,7 +107,14 @@ export function DispatchBundleEditor({
   const handleVendorChange = (vendor: Vendor) => {
     // Changing vendor resets model — no point keeping a cross-vendor model name.
     setModelDraft("");
-    onAtomicChange({ ...active, vendor, model: null });
+    // Drop the persisted permission_mode if it's no longer valid for the new
+    // vendor (e.g. `auto` after switching from claude to codex). Otherwise
+    // the next save would 400 on the backend's matrix check.
+    const next: DispatchBundle = { ...active, vendor, model: null };
+    if (active.permission_mode && !isPermissionModeAllowed(vendor, "", active.permission_mode)) {
+      next.permission_mode = null;
+    }
+    onAtomicChange(next);
   };
 
   const handleModelDraftChange = (model: string) => {
@@ -101,7 +123,16 @@ export function DispatchBundleEditor({
   };
 
   const handleModelCommit = () => {
-    onTextCommit({ ...active, model: modelDraft || null });
+    const next: DispatchBundle = { ...active, model: modelDraft || null };
+    // Drop `auto` if the new model isn't opus-tier — same matrix rule as
+    // handleVendorChange but triggered by the model field.
+    if (
+      next.permission_mode &&
+      !isPermissionModeAllowed(next.vendor, next.model ?? "", next.permission_mode)
+    ) {
+      next.permission_mode = null;
+    }
+    onTextCommit(next);
   };
 
   const handlePermissionChange = (value: string) => {
@@ -115,8 +146,6 @@ export function DispatchBundleEditor({
 
   const inputCls =
     "w-full rounded-md border border-white/10 bg-white/5 px-2.5 py-1.5 text-xs text-zinc-200 outline-none focus:border-cyan-500/30 disabled:opacity-40 disabled:cursor-not-allowed";
-
-  const autoDisabled = isAutoDisabled(active.vendor, active.model ?? "");
 
   return (
     <div className="rounded-md border border-white/10 bg-white/[0.02] p-3 space-y-3">
@@ -194,11 +223,11 @@ export function DispatchBundleEditor({
           >
             <option value="">— (default)</option>
             {PERMISSION_MODES.filter((o) => o.value !== "default").map((opt) => {
-              const disabled = opt.value === "auto" && autoDisabled;
+              const allowed = isPermissionModeAllowed(active.vendor, active.model ?? "", opt.value);
               return (
-                <option key={opt.value} value={opt.value} disabled={disabled}>
+                <option key={opt.value} value={opt.value} disabled={!allowed}>
                   {opt.label}
-                  {opt.value === "auto" && autoDisabled ? " (requires opus-tier model)" : ""}
+                  {!allowed ? ` (${permissionModeReason(active.vendor, opt.value)})` : ""}
                 </option>
               );
             })}

--- a/clients/react/src/components/settings/DispatchBundleEditor.tsx
+++ b/clients/react/src/components/settings/DispatchBundleEditor.tsx
@@ -34,6 +34,12 @@ function isPermissionModeAllowed(vendor: Vendor, model: string, mode: Permission
       return mode === "default" || mode === "acceptEdits";
     case "gemini":
       return mode === "default";
+    default: {
+      // Exhaustiveness: a new Vendor variant must extend this matrix
+      // explicitly rather than silently disabling every mode.
+      const _exhaustive: never = vendor;
+      return false;
+    }
   }
 }
 

--- a/clients/react/src/components/settings/__tests__/DispatchBundleEditor.test.tsx
+++ b/clients/react/src/components/settings/__tests__/DispatchBundleEditor.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { DispatchBundle } from "@/types/generated/DispatchBundle";
+import { DispatchBundleEditor } from "../DispatchBundleEditor";
+
+const noop = () => {};
+
+function renderEditor(bundle: DispatchBundle | null) {
+  const onAtomic = vi.fn();
+  const onDraft = vi.fn();
+  const onCommit = vi.fn();
+  render(
+    <DispatchBundleEditor
+      title="Implementer"
+      subtitle="dispatch_issue / spawn_worktree"
+      bundle={bundle}
+      onAtomicChange={onAtomic}
+      onTextDraft={onDraft}
+      onTextCommit={onCommit}
+    />,
+  );
+  return { onAtomic, onDraft, onCommit };
+}
+
+function permissionOption(label: string): HTMLOptionElement {
+  const select = screen.getByLabelText(/Permission mode for/i) as HTMLSelectElement;
+  const opt = Array.from(select.options).find((o) => o.value === label);
+  if (!opt) throw new Error(`option ${label} not found`);
+  return opt;
+}
+
+describe("DispatchBundleEditor — validity matrix", () => {
+  it("disables auto for claude when model is not opus-tier", () => {
+    renderEditor({ vendor: "claude", model: "claude-sonnet-4-6" });
+    expect(permissionOption("auto").disabled).toBe(true);
+    expect(permissionOption("auto").textContent).toMatch(/requires opus-tier model/);
+  });
+
+  it("enables auto for claude when model is opus-tier", () => {
+    renderEditor({ vendor: "claude", model: "claude-opus-4-7" });
+    expect(permissionOption("auto").disabled).toBe(false);
+  });
+
+  it("disables plan and dont_ask for codex (matches vendor_compat.rs)", () => {
+    renderEditor({ vendor: "codex", model: "codex-1" });
+    expect(permissionOption("plan").disabled).toBe(true);
+    expect(permissionOption("dontAsk").disabled).toBe(true);
+    expect(permissionOption("acceptEdits").disabled).toBe(false);
+    expect(permissionOption("auto").disabled).toBe(true);
+  });
+
+  it("only allows default for gemini (matches vendor_compat.rs)", () => {
+    renderEditor({ vendor: "gemini", model: "gemini-2.5-pro" });
+    expect(permissionOption("plan").disabled).toBe(true);
+    expect(permissionOption("dontAsk").disabled).toBe(true);
+    expect(permissionOption("acceptEdits").disabled).toBe(true);
+    expect(permissionOption("auto").disabled).toBe(true);
+  });
+
+  it("clears permission_mode when vendor change makes it invalid", () => {
+    const { onAtomic } = renderEditor({
+      vendor: "claude",
+      model: "claude-opus-4-7",
+      permission_mode: "auto",
+    });
+    const vendorSelect = screen.getByLabelText(/Vendor for/i) as HTMLSelectElement;
+    fireEvent.change(vendorSelect, { target: { value: "codex" } });
+    expect(onAtomic).toHaveBeenCalledTimes(1);
+    const next = onAtomic.mock.calls[0][0] as DispatchBundle;
+    expect(next.vendor).toBe("codex");
+    expect(next.model).toBeNull();
+    expect(next.permission_mode).toBeNull();
+  });
+
+  it("preserves permission_mode when vendor change keeps it valid", () => {
+    const { onAtomic } = renderEditor({
+      vendor: "claude",
+      model: "claude-sonnet-4-6",
+      permission_mode: "acceptEdits",
+    });
+    const vendorSelect = screen.getByLabelText(/Vendor for/i) as HTMLSelectElement;
+    fireEvent.change(vendorSelect, { target: { value: "codex" } });
+    const next = onAtomic.mock.calls[0][0] as DispatchBundle;
+    expect(next.permission_mode).toBe("acceptEdits");
+  });
+
+  it("clears auto when model commit downgrades from opus to non-opus", () => {
+    const { onCommit } = renderEditor({
+      vendor: "claude",
+      model: "claude-opus-4-7",
+      permission_mode: "auto",
+    });
+    const modelInput = screen.getByLabelText(/Model for/i) as HTMLInputElement;
+    fireEvent.change(modelInput, { target: { value: "claude-sonnet-4-6" } });
+    fireEvent.blur(modelInput);
+    expect(onCommit).toHaveBeenCalledTimes(1);
+    const next = onCommit.mock.calls[0][0] as DispatchBundle;
+    expect(next.model).toBe("claude-sonnet-4-6");
+    expect(next.permission_mode).toBeNull();
+  });
+});
+
+describe("DispatchBundleEditor — placeholders", () => {
+  it("shows the latest claude-opus model as placeholder", () => {
+    renderEditor({ vendor: "claude" });
+    const modelInput = screen.getByLabelText(/Model for/i) as HTMLInputElement;
+    expect(modelInput.placeholder).toBe("claude-opus-4-7");
+  });
+});
+
+describe("DispatchBundleEditor — legacy fallback", () => {
+  it("renders the 'Use vendor CLI default' checkbox checked when bundle is null", () => {
+    renderEditor(null);
+    const checkbox = screen.getByLabelText(/Use vendor CLI default for/i) as HTMLInputElement;
+    expect(checkbox.checked).toBe(true);
+  });
+
+  it("emits null on toggle on, claude default on toggle off", () => {
+    const { onAtomic } = renderEditor({ vendor: "codex", model: "codex-1" });
+    const checkbox = screen.getByLabelText(/Use vendor CLI default for/i);
+    fireEvent.click(checkbox);
+    expect(onAtomic).toHaveBeenLastCalledWith(null);
+  });
+});
+
+// quiet unused import warning when noop is not referenced
+void noop;

--- a/clients/react/src/components/settings/__tests__/DispatchBundleEditor.test.tsx
+++ b/clients/react/src/components/settings/__tests__/DispatchBundleEditor.test.tsx
@@ -4,8 +4,6 @@ import { describe, expect, it, vi } from "vitest";
 import type { DispatchBundle } from "@/types/generated/DispatchBundle";
 import { DispatchBundleEditor } from "../DispatchBundleEditor";
 
-const noop = () => {};
-
 function renderEditor(bundle: DispatchBundle | null) {
   const onAtomic = vi.fn();
   const onDraft = vi.fn();
@@ -116,13 +114,17 @@ describe("DispatchBundleEditor — legacy fallback", () => {
     expect(checkbox.checked).toBe(true);
   });
 
-  it("emits null on toggle on, claude default on toggle off", () => {
+  it("emits null on toggle on (concrete bundle → legacy)", () => {
     const { onAtomic } = renderEditor({ vendor: "codex", model: "codex-1" });
     const checkbox = screen.getByLabelText(/Use vendor CLI default for/i);
     fireEvent.click(checkbox);
     expect(onAtomic).toHaveBeenLastCalledWith(null);
   });
-});
 
-// quiet unused import warning when noop is not referenced
-void noop;
+  it("emits a fresh claude bundle on toggle off (legacy → concrete)", () => {
+    const { onAtomic } = renderEditor(null);
+    const checkbox = screen.getByLabelText(/Use vendor CLI default for/i);
+    fireEvent.click(checkbox);
+    expect(onAtomic).toHaveBeenLastCalledWith({ vendor: "claude" });
+  });
+});


### PR DESCRIPTION
## Summary

The Settings UI's permission-mode dropdown only disabled `auto` for non-opus claude models. Codex/Gemini bundles let users pick `plan`, `dont_ask`, etc. — combinations the backend rejects via `vendor_compat::permission_mode_allowed` with a 400. This PR mirrors the matrix in the React side so invalid options are disabled inline with a vendor-aware reason, and a now-invalid `permission_mode` is cleared automatically when a vendor or model change downgrades the (vendor × model) tuple.

- Match `crates/tmai-core/src/config/vendor_compat.rs`: claude allows `default | plan | dontAsk | acceptEdits` always and `auto` only for opus-tier models; codex allows `default | acceptEdits`; gemini allows `default` only.
- On `handleVendorChange`: reset `permission_mode` to `null` if it's not allowed for the new vendor.
- On `handleModelCommit`: reset `auto` to `null` when the new model isn't opus-tier.
- Bump the claude placeholder to `claude-opus-4-7`.

## Test plan

- [x] `pnpm exec vitest run src/components/settings/__tests__/` — 62/62 pass (10 new in `DispatchBundleEditor.test.tsx` covering matrix per vendor + the auto-clear paths)
- [x] `pnpm exec biome check` clean
- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm build` clean
- [ ] Manual: open Settings → Orchestration dispatch, switch a role to vendor=codex with a saved auto/plan permission_mode → confirm the value is cleared without a 400 round-trip

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * ベンダーとモデルの選択に基づいて権限モードの互換性を強化し、無効な設定の組み合わせを防止
  * ベンダーまたはモデル変更時に互換性のない権限モードを自動的にクリアし、エラーを削減
  * Claude モデルプレースホルダーを最新バージョンに更新

<!-- end of auto-generated comment: release notes by coderabbit.ai -->