### PR TITLE
refactor(settings): extract ProjectsSection from SettingsPanel

### DIFF
--- a/clients/react/src/components/settings/ProjectsSection.tsx
+++ b/clients/react/src/components/settings/ProjectsSection.tsx
@@ -1,0 +1,132 @@
+import { useState } from "react";
+import { DirBrowser } from "@/components/project/DirBrowser";
+import { api } from "@/lib/api";
+
+interface ProjectsSectionProps {
+  /** Project paths registered globally; rendered both here and in the
+   *  orchestration scope selector, so the parent owns the list and passes
+   *  it down. */
+  projects: string[];
+  /** Re-fetch the project list from the backend after add/remove so the
+   *  parent's copy stays in sync. */
+  refreshProjects: () => void;
+  /** Notify the App so it can refresh the sidebar's project tree. */
+  onProjectsChanged: () => void;
+}
+
+/**
+ * Settings section for managing the registered project directories.
+ * Owns the local add-flow state (`path` input, DirBrowser visibility,
+ * inline error) but defers the canonical project list to the parent —
+ * the orchestration scope selector also reads it.
+ */
+export function ProjectsSection({
+  projects,
+  refreshProjects,
+  onProjectsChanged,
+}: ProjectsSectionProps) {
+  const [path, setPath] = useState("");
+  const [browsing, setBrowsing] = useState(false);
+  const [error, setError] = useState("");
+
+  const handleAdd = async (projectPath?: string) => {
+    const trimmed = (projectPath ?? path).trim();
+    if (!trimmed) return;
+    setError("");
+    try {
+      await api.addProject(trimmed);
+      setPath("");
+      setBrowsing(false);
+      refreshProjects();
+      onProjectsChanged();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : "Failed to add project");
+    }
+  };
+
+  const handleRemove = async (projectPath: string) => {
+    try {
+      await api.removeProject(projectPath);
+      refreshProjects();
+      onProjectsChanged();
+    } catch (_e) {}
+  };
+
+  return (
+    <section>
+      <h3 className="text-sm font-medium text-zinc-300">Projects</h3>
+      <p className="mt-1 text-xs text-zinc-600">
+        Registered directories appear in the sidebar even with no agents running.
+      </p>
+
+      {/* Add project — always visible */}
+      <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3">
+        <div className="flex gap-1.5">
+          <input
+            type="text"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") void handleAdd();
+            }}
+            placeholder="/path/to/project"
+            className="flex-1 rounded-md border border-white/10 bg-white/5 px-2.5 py-1.5 text-xs text-zinc-200 placeholder-zinc-600 outline-none focus:border-cyan-500/30"
+            aria-label="Project path"
+          />
+          <button
+            type="button"
+            onClick={() => void handleAdd()}
+            className="rounded-md bg-cyan-500/20 px-3 py-1.5 text-xs text-cyan-400 transition-colors hover:bg-cyan-500/30"
+          >
+            Add
+          </button>
+          <button
+            type="button"
+            onClick={() => setBrowsing((v) => !v)}
+            className={`rounded-md border border-white/10 px-3 py-1.5 text-xs transition-colors hover:bg-white/10 ${
+              browsing ? "text-cyan-400" : "text-zinc-400 hover:text-zinc-200"
+            }`}
+          >
+            Browse
+          </button>
+        </div>
+        {error && <p className="mt-1.5 text-[11px] text-red-400">{error}</p>}
+        {browsing && (
+          <div className="mt-2">
+            <DirBrowser
+              onSelect={(selected) => void handleAdd(selected)}
+              onCancel={() => setBrowsing(false)}
+            />
+          </div>
+        )}
+      </div>
+
+      {/* Project list */}
+      <div className="mt-3 space-y-1">
+        {projects.length === 0 && (
+          <p className="py-4 text-center text-xs text-zinc-600">No projects registered</p>
+        )}
+        {projects.map((p) => (
+          <div
+            key={p}
+            className="group flex items-center gap-2 rounded-lg px-3 py-2 transition-colors hover:bg-white/5"
+          >
+            <span className="text-xs text-zinc-500">●</span>
+            <div className="flex-1 truncate">
+              <span className="text-sm text-zinc-300">{p.split("/").filter(Boolean).pop()}</span>
+              <span className="ml-2 text-[11px] text-zinc-600">{p}</span>
+            </div>
+            <button
+              type="button"
+              onClick={() => void handleRemove(p)}
+              className="shrink-0 rounded px-2 py-0.5 text-xs text-zinc-600 opacity-0 transition-all hover:bg-red-500/10 hover:text-red-400 group-hover:opacity-100"
+              aria-label={`Remove project ${p}`}
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/clients/react/src/components/settings/ProjectsSection.tsx
+++ b/clients/react/src/components/settings/ProjectsSection.tsx
@@ -45,11 +45,17 @@ export function ProjectsSection({
   };
 
   const handleRemove = async (projectPath: string) => {
+    setError("");
     try {
       await api.removeProject(projectPath);
       refreshProjects();
       onProjectsChanged();
-    } catch (_e) {}
+    } catch (e) {
+      // Surface the failure in the same inline error region as add — pre-PR
+      // this catch swallowed the error silently, leaving the user wondering
+      // why the project was still listed after a failed remove.
+      setError(e instanceof Error ? e.message : "Failed to remove project");
+    }
   };
 
   return (
@@ -90,7 +96,11 @@ export function ProjectsSection({
             Browse
           </button>
         </div>
-        {error && <p className="mt-1.5 text-[11px] text-red-400">{error}</p>}
+        {error && (
+          <p role="alert" aria-live="assertive" className="mt-1.5 text-[11px] text-red-400">
+            {error}
+          </p>
+        )}
         {browsing && (
           <div className="mt-2">
             <DirBrowser

--- a/clients/react/src/components/settings/SettingsPanel.tsx
+++ b/clients/react/src/components/settings/SettingsPanel.tsx
@@ -1,5 +1,4 @@
 import { useCallback, useEffect, useState } from "react";
-import { DirBrowser } from "@/components/project/DirBrowser";
 import { useSaveTracker } from "@/hooks/useSaveTracker";
 import {
   api,
@@ -13,6 +12,7 @@ import {
 import { AutoApproveSection } from "./AutoApproveSection";
 import { buildNotifyEventHelp } from "./notify-event-help";
 import { OrchestrationDispatchSection } from "./OrchestrationDispatchSection";
+import { ProjectsSection } from "./ProjectsSection";
 import { SaveStatus } from "./SaveStatus";
 import { ScheduledKicksSection } from "./ScheduledKicksSection";
 import { SpawnRuntimeSelector } from "./SpawnRuntimeSelector";
@@ -77,9 +77,6 @@ function OrchestrationRuleTextarea({
 // Settings panel displayed in the main area
 export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps) {
   const [projects, setProjects] = useState<string[]>([]);
-  const [browsing, setBrowsing] = useState(false);
-  const [path, setPath] = useState("");
-  const [error, setError] = useState("");
   const [spawnSettings, setSpawnSettings] = useState<SpawnSettings | null>(null);
   const [usageSettings, setUsageSettings] = useState<UsageSettings | null>(null);
   const [notifyOnIdle, setNotifyOnIdle] = useState(true);
@@ -137,31 +134,6 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
       .then(setWorktreeSettings)
       .catch(() => {});
   }, [refreshProjects, refreshSpawnSettings, refreshUsageSettings, refreshOrchestrator]);
-
-  // Add a project directory
-  const handleAdd = async (projectPath?: string) => {
-    const trimmed = (projectPath ?? path).trim();
-    if (!trimmed) return;
-    setError("");
-    try {
-      await api.addProject(trimmed);
-      setPath("");
-      setBrowsing(false);
-      refreshProjects();
-      onProjectsChanged();
-    } catch (e) {
-      setError(e instanceof Error ? e.message : "Failed to add project");
-    }
-  };
-
-  // Remove a project directory
-  const handleRemove = async (projectPath: string) => {
-    try {
-      await api.removeProject(projectPath);
-      refreshProjects();
-      onProjectsChanged();
-    } catch (_e) {}
-  };
 
   // Update tmux window name
   const handleWindowNameChange = async (name: string) => {
@@ -775,79 +747,11 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
         )}
 
         {/* Projects section */}
-        <section>
-          <h3 className="text-sm font-medium text-zinc-300">Projects</h3>
-          <p className="mt-1 text-xs text-zinc-600">
-            Registered directories appear in the sidebar even with no agents running.
-          </p>
-
-          {/* Add project — always visible */}
-          <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3">
-            <div className="flex gap-1.5">
-              <input
-                type="text"
-                value={path}
-                onChange={(e) => setPath(e.target.value)}
-                onKeyDown={(e) => {
-                  if (e.key === "Enter") handleAdd();
-                }}
-                placeholder="/path/to/project"
-                className="flex-1 rounded-md border border-white/10 bg-white/5 px-2.5 py-1.5 text-xs text-zinc-200 placeholder-zinc-600 outline-none focus:border-cyan-500/30"
-              />
-              <button
-                type="button"
-                onClick={() => handleAdd()}
-                className="rounded-md bg-cyan-500/20 px-3 py-1.5 text-xs text-cyan-400 transition-colors hover:bg-cyan-500/30"
-              >
-                Add
-              </button>
-              <button
-                type="button"
-                onClick={() => setBrowsing((v) => !v)}
-                className={`rounded-md border border-white/10 px-3 py-1.5 text-xs transition-colors hover:bg-white/10 ${browsing ? "text-cyan-400" : "text-zinc-400 hover:text-zinc-200"}`}
-              >
-                Browse
-              </button>
-            </div>
-            {error && <p className="mt-1.5 text-[11px] text-red-400">{error}</p>}
-            {browsing && (
-              <div className="mt-2">
-                <DirBrowser
-                  onSelect={(selected) => handleAdd(selected)}
-                  onCancel={() => setBrowsing(false)}
-                />
-              </div>
-            )}
-          </div>
-
-          {/* Project list */}
-          <div className="mt-3 space-y-1">
-            {projects.length === 0 && (
-              <p className="py-4 text-center text-xs text-zinc-600">No projects registered</p>
-            )}
-            {projects.map((p) => (
-              <div
-                key={p}
-                className="group flex items-center gap-2 rounded-lg px-3 py-2 transition-colors hover:bg-white/5"
-              >
-                <span className="text-xs text-zinc-500">●</span>
-                <div className="flex-1 truncate">
-                  <span className="text-sm text-zinc-300">
-                    {p.split("/").filter(Boolean).pop()}
-                  </span>
-                  <span className="ml-2 text-[11px] text-zinc-600">{p}</span>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => handleRemove(p)}
-                  className="shrink-0 rounded px-2 py-0.5 text-xs text-zinc-600 opacity-0 transition-all hover:bg-red-500/10 hover:text-red-400 group-hover:opacity-100"
-                >
-                  Remove
-                </button>
-              </div>
-            ))}
-          </div>
-        </section>
+        <ProjectsSection
+          projects={projects}
+          refreshProjects={refreshProjects}
+          onProjectsChanged={onProjectsChanged}
+        />
       </div>
     </div>
   );

--- a/clients/react/src/components/settings/__tests__/ProjectsSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/ProjectsSection.test.tsx
@@ -1,0 +1,129 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      addProject: vi.fn(),
+      removeProject: vi.fn(),
+    },
+  };
+});
+
+vi.mock("@/components/project/DirBrowser", () => ({
+  DirBrowser: ({ onSelect }: { onSelect: (path: string) => void }) => (
+    <button type="button" onClick={() => onSelect("/picked")}>
+      mock-pick
+    </button>
+  ),
+}));
+
+const { api } = await import("@/lib/api");
+const { ProjectsSection } = await import("../ProjectsSection");
+
+function setup(projects: string[] = []) {
+  const refreshProjects = vi.fn();
+  const onProjectsChanged = vi.fn();
+  render(
+    <ProjectsSection
+      projects={projects}
+      refreshProjects={refreshProjects}
+      onProjectsChanged={onProjectsChanged}
+    />,
+  );
+  return { refreshProjects, onProjectsChanged };
+}
+
+describe("ProjectsSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a placeholder when the project list is empty", () => {
+    setup([]);
+    expect(screen.getByText(/No projects registered/i)).toBeTruthy();
+  });
+
+  it("renders one row per project with a Remove button", () => {
+    setup(["/a/b/proj-one", "/c/d/proj-two"]);
+    expect(screen.getByText("proj-one")).toBeTruthy();
+    expect(screen.getByText("proj-two")).toBeTruthy();
+    expect(screen.getAllByLabelText(/Remove project/)).toHaveLength(2);
+  });
+
+  it("Add button calls api.addProject + refreshProjects + onProjectsChanged", async () => {
+    vi.mocked(api.addProject).mockResolvedValue(undefined as never);
+    const { refreshProjects, onProjectsChanged } = setup([]);
+
+    const input = screen.getByLabelText("Project path") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "/new/path" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Add$/ }));
+
+    await waitFor(() => {
+      expect(vi.mocked(api.addProject)).toHaveBeenCalledWith("/new/path");
+      expect(refreshProjects).toHaveBeenCalledTimes(1);
+      expect(onProjectsChanged).toHaveBeenCalledTimes(1);
+    });
+    expect(input.value).toBe("");
+  });
+
+  it("Enter on the path field triggers Add", async () => {
+    vi.mocked(api.addProject).mockResolvedValue(undefined as never);
+    setup([]);
+    const input = screen.getByLabelText("Project path") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "/p" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    await waitFor(() => expect(vi.mocked(api.addProject)).toHaveBeenCalledWith("/p"));
+  });
+
+  it("trimmed-empty input does not call api.addProject", () => {
+    setup([]);
+    const input = screen.getByLabelText("Project path") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.click(screen.getByRole("button", { name: /^Add$/ }));
+    expect(vi.mocked(api.addProject)).not.toHaveBeenCalled();
+  });
+
+  it("Add failure surfaces inline error text and does NOT clear input", async () => {
+    vi.mocked(api.addProject).mockRejectedValue(new Error("path not found"));
+    const { refreshProjects } = setup([]);
+    const input = screen.getByLabelText("Project path") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "/missing" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Add$/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/path not found/)).toBeTruthy();
+    });
+    expect(input.value).toBe("/missing");
+    expect(refreshProjects).not.toHaveBeenCalled();
+  });
+
+  it("Browse toggles the DirBrowser; selecting a path triggers Add", async () => {
+    vi.mocked(api.addProject).mockResolvedValue(undefined as never);
+    const { refreshProjects, onProjectsChanged } = setup([]);
+    fireEvent.click(screen.getByRole("button", { name: /Browse/ }));
+    fireEvent.click(screen.getByText("mock-pick"));
+
+    await waitFor(() => {
+      expect(vi.mocked(api.addProject)).toHaveBeenCalledWith("/picked");
+      expect(refreshProjects).toHaveBeenCalledTimes(1);
+      expect(onProjectsChanged).toHaveBeenCalledTimes(1);
+    });
+    // DirBrowser should auto-close on successful add
+    expect(screen.queryByText("mock-pick")).toBeNull();
+  });
+
+  it("Remove calls api.removeProject + refreshProjects + onProjectsChanged", async () => {
+    vi.mocked(api.removeProject).mockResolvedValue(undefined as never);
+    const { refreshProjects, onProjectsChanged } = setup(["/x/y/foo"]);
+    fireEvent.click(screen.getByLabelText("Remove project /x/y/foo"));
+    await waitFor(() => {
+      expect(vi.mocked(api.removeProject)).toHaveBeenCalledWith("/x/y/foo");
+      expect(refreshProjects).toHaveBeenCalledTimes(1);
+      expect(onProjectsChanged).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/clients/react/src/components/settings/__tests__/ProjectsSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/ProjectsSection.test.tsx
@@ -126,4 +126,25 @@ describe("ProjectsSection", () => {
       expect(onProjectsChanged).toHaveBeenCalledTimes(1);
     });
   });
+
+  it("Remove failure surfaces inline error and does NOT call refresh callbacks", async () => {
+    vi.mocked(api.removeProject).mockRejectedValue(new Error("permission denied"));
+    const { refreshProjects, onProjectsChanged } = setup(["/x/y/foo"]);
+    fireEvent.click(screen.getByLabelText("Remove project /x/y/foo"));
+    await waitFor(() => {
+      expect(screen.getByText(/permission denied/)).toBeTruthy();
+    });
+    expect(refreshProjects).not.toHaveBeenCalled();
+    expect(onProjectsChanged).not.toHaveBeenCalled();
+  });
+
+  it("the error region is announced to assistive tech (role=alert)", async () => {
+    vi.mocked(api.addProject).mockRejectedValue(new Error("bad"));
+    setup([]);
+    const input = screen.getByLabelText("Project path") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "/p" } });
+    fireEvent.click(screen.getByRole("button", { name: /^Add$/ }));
+    const alert = await screen.findByRole("alert");
+    expect(alert.textContent).toMatch(/bad/);
+  });
 });


### PR DESCRIPTION
## Summary

Pull the projects section (~75 lines of inline JSX + `handleAdd` / `handleRemove`) out of `SettingsPanel` into its own `ProjectsSection` component. The section owns the add-flow local state (`path` input, DirBrowser visibility, inline error) but defers the canonical project list to the parent — the orchestration scope selector also reads `projects`, so keeping the list in `SettingsPanel` avoids dual fetches.

Same pattern as `AutoApproveSection` (#583): the section handles its own UX state and side effects, the parent provides the shared data and the `onProjectsChanged` callback to refresh the App's sidebar tree.

- **SettingsPanel.tsx: 1585 → 1489 lines** (−96).
- DirBrowser import + handleAdd / handleRemove gone from the parent; unused `path` / `browsing` / `error` state removed.

## Test plan

- [x] 8 new tests in `ProjectsSection.test.tsx` covering empty placeholder, list rendering, Add via button + Enter, trimmed-empty no-op, Add failure inline error + input preservation, Browse → DirBrowser pick → Add, Remove path. DirBrowser is mocked.
- [x] `pnpm exec vitest run src/components/settings/__tests__/` — 80/80 pass
- [x] `pnpm exec biome check` clean
- [x] `pnpm build` clean (`tsc -b && vite build`)
- [ ] Manual: Settings → Projects → Add via path / Browse / Enter / fail-case / Remove

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 設定画面でプロジェクトディレクトリパスを管理できるようになりました。プロジェクトの追加・削除に対応し、ファイルブラウザーでの選択もサポートします。

* **リファクタ**
  * 設定パネルの内部構造を最適化しました。

* **テスト**
  * 新機能のテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->