### PR TITLE
refactor(settings): extract OrchestrationSection (PR 4b — completes the cluster split)

### DIFF
--- a/clients/react/src/components/settings/OrchestrationSection.tsx
+++ b/clients/react/src/components/settings/OrchestrationSection.tsx
@@ -1,0 +1,263 @@
+import { useCallback, useEffect, useState } from "react";
+import { useSaveTracker } from "@/hooks/useSaveTracker";
+import { api, type OrchestratorSettings } from "@/lib/api";
+import { GuardrailsSection } from "./GuardrailsSection";
+import { NotifySettingsSection } from "./NotifySettingsSection";
+import { PrMonitorSection } from "./PrMonitorSection";
+import { SaveStatus } from "./SaveStatus";
+
+const ROW_INPUT_CLS =
+  "w-full rounded-md border border-white/10 bg-white/5 px-2.5 py-1.5 text-xs text-zinc-200 placeholder-zinc-600 outline-none focus:border-cyan-500/30 resize-y";
+
+const RULE_FIELDS = [
+  {
+    key: "branch",
+    label: "Branch rules",
+    placeholder: "Rules for branch naming and strategy...",
+    rows: 2,
+  },
+  {
+    key: "merge",
+    label: "Merge rules",
+    placeholder: "Rules for merge strategy and conflict resolution...",
+    rows: 2,
+  },
+  {
+    key: "review",
+    label: "Review rules",
+    placeholder: "Rules for code review process...",
+    rows: 2,
+  },
+  {
+    key: "custom",
+    label: "Custom rules",
+    placeholder: "Additional custom rules for the orchestrator...",
+    rows: 3,
+  },
+] as const satisfies ReadonlyArray<{
+  key: keyof OrchestratorSettings["rules"];
+  label: string;
+  placeholder: string;
+  rows: number;
+}>;
+
+interface OrchestrationSectionProps {
+  /** Project paths registered globally — needed by the scope selector to
+   *  list per-project overrides alongside `Global (default)`. */
+  projects: string[];
+}
+
+/**
+ * Settings section that hosts the orchestrator agent's full configuration:
+ * scope (global vs per-project override), enabled toggle, role + workflow
+ * rule textareas, and the three composed sub-sections (PR Monitor, Notify,
+ * Guardrails).
+ *
+ * Owns its own state (`orchestrator`, `orchScope`, `orchestratorSave`) and
+ * load — the parent SettingsPanel does not need to refresh this section.
+ * Switching `orchScope` re-fetches the merged settings for that scope.
+ */
+export function OrchestrationSection({ projects }: OrchestrationSectionProps) {
+  const [orchestrator, setOrchestrator] = useState<OrchestratorSettings | null>(null);
+  const [orchScope, setOrchScope] = useState<string>("global");
+  const save = useSaveTracker();
+
+  const orchProject = orchScope === "global" ? undefined : orchScope;
+  const refreshOrchestrator = useCallback(() => {
+    api.getOrchestratorSettings(orchProject).then(setOrchestrator).catch(console.error);
+  }, [orchProject]);
+
+  useEffect(() => {
+    refreshOrchestrator();
+  }, [refreshOrchestrator]);
+
+  if (!orchestrator) return null;
+
+  return (
+    <section>
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-medium text-zinc-300">Orchestration</h3>
+        <SaveStatus status={save.status} error={save.error} variant="section" />
+      </div>
+      <p className="mt-1 text-xs text-zinc-600">
+        Configure the orchestrator agent that coordinates sub-agents for parallel development
+        workflows.
+      </p>
+
+      <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-4">
+        {/* Scope selector */}
+        <div>
+          <span className="block text-xs text-zinc-400 mb-1">Scope</span>
+          <select
+            value={orchScope}
+            onChange={(e) => setOrchScope(e.target.value)}
+            className="w-full rounded-md border border-white/10 bg-white/5 px-2.5 py-1.5 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
+            aria-label="Orchestration scope"
+          >
+            <option value="global">Global (default)</option>
+            {projects.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </select>
+          {orchScope !== "global" && (
+            <p className="mt-1 text-[10px] text-zinc-600">
+              {orchestrator.is_project_override
+                ? "Project-level override active"
+                : "Using global settings (no project override)"}
+            </p>
+          )}
+        </div>
+
+        {/* Enable toggle */}
+        <label className="flex items-center justify-between gap-3">
+          <div className="flex-1">
+            <span className="text-sm text-zinc-300">Enabled</span>
+            <p className="text-[11px] text-zinc-600 mt-0.5">
+              Enable orchestrator workflow features.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              const next = !orchestrator.enabled;
+              setOrchestrator({ ...orchestrator, enabled: next });
+              void save.track(
+                async () => {
+                  await api.updateOrchestratorSettings({ enabled: next }, orchProject);
+                  refreshOrchestrator();
+                },
+                { onError: () => setOrchestrator({ ...orchestrator, enabled: !next }) },
+              );
+            }}
+            className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
+              orchestrator.enabled ? "bg-cyan-500/40" : "bg-white/10"
+            }`}
+            aria-label="Orchestrator enabled"
+          >
+            <span
+              className={`inline-block h-3.5 w-3.5 rounded-full transition-transform ${
+                orchestrator.enabled
+                  ? "translate-x-[18px] bg-cyan-400"
+                  : "translate-x-0.5 bg-zinc-500"
+              }`}
+            />
+          </button>
+        </label>
+
+        {orchestrator.enabled && (
+          <div className="space-y-3 border-t border-white/5 pt-3">
+            <OrchestrationRuleTextarea
+              label="Role"
+              placeholder="Describe the orchestrator's role and persona..."
+              rows={2}
+              value={orchestrator.role}
+              save={save}
+              onDraft={(role) => setOrchestrator({ ...orchestrator, role })}
+              onCommit={(role) => api.updateOrchestratorSettings({ role }, orchProject)}
+            />
+
+            <p className="text-[11px] font-medium text-zinc-400 uppercase tracking-wider">
+              Workflow Rules
+            </p>
+
+            {RULE_FIELDS.map(({ key, label, placeholder, rows }) => (
+              <OrchestrationRuleTextarea
+                key={key}
+                label={label}
+                placeholder={placeholder}
+                rows={rows}
+                value={orchestrator.rules[key]}
+                save={save}
+                onDraft={(value) =>
+                  setOrchestrator({
+                    ...orchestrator,
+                    rules: { ...orchestrator.rules, [key]: value },
+                  })
+                }
+                onCommit={(value) =>
+                  api.updateOrchestratorSettings({ rules: { [key]: value } }, orchProject)
+                }
+              />
+            ))}
+
+            <PrMonitorSection
+              orchestrator={orchestrator}
+              setOrchestrator={setOrchestrator}
+              orchProject={orchProject}
+              save={save}
+            />
+
+            <NotifySettingsSection
+              orchestrator={orchestrator}
+              setOrchestrator={setOrchestrator}
+              orchProject={orchProject}
+              save={save}
+            />
+
+            <GuardrailsSection
+              orchestrator={orchestrator}
+              setOrchestrator={setOrchestrator}
+              orchProject={orchProject}
+              save={save}
+            />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}
+
+/**
+ * Auto-saved textarea used by the orchestration role / workflow-rule fields.
+ * Local edits stream through `onDraft`; on blur (or Cmd/Ctrl+Enter) the value
+ * is committed via `onCommit`, routed through the section's save tracker so
+ * Saving / Saved / error indicators stay in sync. Mid-typing keystrokes clear
+ * a stale error so the inline message doesn't linger after the user starts
+ * correcting it.
+ */
+function OrchestrationRuleTextarea({
+  label,
+  placeholder,
+  rows,
+  value,
+  save,
+  onDraft,
+  onCommit,
+}: {
+  label: string;
+  placeholder: string;
+  rows: number;
+  value: string;
+  save: ReturnType<typeof useSaveTracker>;
+  onDraft: (value: string) => void;
+  onCommit: (value: string) => Promise<unknown>;
+}) {
+  return (
+    <div>
+      <span className="block text-xs text-zinc-400 mb-1">{label}</span>
+      <textarea
+        value={value}
+        onChange={(e) => {
+          save.clearError();
+          onDraft(e.target.value);
+        }}
+        onBlur={() => {
+          const commit = value;
+          void save.track(() => onCommit(commit));
+        }}
+        onKeyDown={(e) => {
+          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
+            e.preventDefault();
+            (e.currentTarget as HTMLTextAreaElement).blur();
+          }
+        }}
+        rows={rows}
+        placeholder={placeholder}
+        className={ROW_INPUT_CLS}
+        aria-label={label}
+      />
+    </div>
+  );
+}

--- a/clients/react/src/components/settings/SettingsPanel.tsx
+++ b/clients/react/src/components/settings/SettingsPanel.tsx
@@ -2,17 +2,14 @@ import { useCallback, useEffect, useState } from "react";
 import { useSaveTracker } from "@/hooks/useSaveTracker";
 import {
   api,
-  type OrchestratorSettings,
   type SpawnSettings,
   type UsageSettings,
   type WorkflowSettings,
   type WorktreeSettings,
 } from "@/lib/api";
 import { AutoApproveSection } from "./AutoApproveSection";
-import { GuardrailsSection } from "./GuardrailsSection";
-import { NotifySettingsSection } from "./NotifySettingsSection";
 import { OrchestrationDispatchSection } from "./OrchestrationDispatchSection";
-import { PrMonitorSection } from "./PrMonitorSection";
+import { OrchestrationSection } from "./OrchestrationSection";
 import { ProjectsSection } from "./ProjectsSection";
 import { SaveStatus } from "./SaveStatus";
 import { ScheduledKicksSection } from "./ScheduledKicksSection";
@@ -23,58 +20,6 @@ interface SettingsPanelProps {
   onProjectsChanged: () => void;
 }
 
-/**
- * Auto-saved textarea used by the orchestration role / workflow-rule fields.
- * Local edits stream through `onDraft`; on blur (or Cmd/Ctrl+Enter) the value
- * is committed via `onCommit`, routed through the section's save tracker so
- * Saving / Saved / error indicators stay in sync. Mid-typing keystrokes clear
- * a stale error so the inline message doesn't linger after the user starts
- * correcting it.
- */
-function OrchestrationRuleTextarea({
-  label,
-  placeholder,
-  rows,
-  value,
-  save,
-  onDraft,
-  onCommit,
-}: {
-  label: string;
-  placeholder: string;
-  rows: number;
-  value: string;
-  save: ReturnType<typeof useSaveTracker>;
-  onDraft: (value: string) => void;
-  onCommit: (value: string) => Promise<unknown>;
-}) {
-  return (
-    <div>
-      <span className="block text-xs text-zinc-400 mb-1">{label}</span>
-      <textarea
-        value={value}
-        onChange={(e) => {
-          save.clearError();
-          onDraft(e.target.value);
-        }}
-        onBlur={() => {
-          const commit = value;
-          void save.track(() => onCommit(commit));
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-            e.preventDefault();
-            (e.currentTarget as HTMLTextAreaElement).blur();
-          }
-        }}
-        rows={rows}
-        placeholder={placeholder}
-        className="w-full rounded-md border border-white/10 bg-white/5 px-2.5 py-1.5 text-xs text-zinc-200 placeholder-zinc-600 outline-none focus:border-cyan-500/30 resize-y"
-      />
-    </div>
-  );
-}
-
 // Settings panel displayed in the main area
 export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps) {
   const [projects, setProjects] = useState<string[]>([]);
@@ -82,8 +27,6 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
   const [usageSettings, setUsageSettings] = useState<UsageSettings | null>(null);
   const [notifyOnIdle, setNotifyOnIdle] = useState(true);
   const [notifyThresholdSecs, setNotifyThresholdSecs] = useState(10);
-  const [orchestrator, setOrchestrator] = useState<OrchestratorSettings | null>(null);
-  const [orchScope, setOrchScope] = useState<string>("global");
   const [workflowSettings, setWorkflowSettings] = useState<WorkflowSettings | null>(null);
   const [worktreeSettings, setWorktreeSettings] = useState<WorktreeSettings | null>(null);
   const [newSetupCommand, setNewSetupCommand] = useState("");
@@ -91,7 +34,6 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
   // Per-section auto-save status (#578). Each tracker runs independently so a
   // failure in one section does not blank out the indicator on another.
   const spawnSave = useSaveTracker();
-  const orchestratorSave = useSaveTracker();
   const usageSave = useSaveTracker();
   const notifySave = useSaveTracker();
   const workflowSave = useSaveTracker();
@@ -109,16 +51,10 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
     api.getUsageSettings().then(setUsageSettings).catch(console.error);
   }, []);
 
-  const orchProject = orchScope === "global" ? undefined : orchScope;
-  const refreshOrchestrator = useCallback(() => {
-    api.getOrchestratorSettings(orchProject).then(setOrchestrator).catch(console.error);
-  }, [orchProject]);
-
   useEffect(() => {
     refreshProjects();
     refreshSpawnSettings();
     refreshUsageSettings();
-    refreshOrchestrator();
     api
       .getNotificationSettings()
       .then((s) => {
@@ -134,7 +70,7 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
       .getWorktreeSettings()
       .then(setWorktreeSettings)
       .catch(() => {});
-  }, [refreshProjects, refreshSpawnSettings, refreshUsageSettings, refreshOrchestrator]);
+  }, [refreshProjects, refreshSpawnSettings, refreshUsageSettings]);
 
   // Update tmux window name
   const handleWindowNameChange = async (name: string) => {
@@ -219,172 +155,7 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
         )}
 
         {/* Orchestration section */}
-        {orchestrator && (
-          <section>
-            <div className="flex items-center gap-2">
-              <h3 className="text-sm font-medium text-zinc-300">Orchestration</h3>
-              <SaveStatus
-                status={orchestratorSave.status}
-                error={orchestratorSave.error}
-                variant="section"
-              />
-            </div>
-            <p className="mt-1 text-xs text-zinc-600">
-              Configure the orchestrator agent that coordinates sub-agents for parallel development
-              workflows.
-            </p>
-
-            <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-4">
-              {/* Scope selector */}
-              <div>
-                <span className="block text-xs text-zinc-400 mb-1">Scope</span>
-                <select
-                  value={orchScope}
-                  onChange={(e) => setOrchScope(e.target.value)}
-                  className="w-full rounded-md border border-white/10 bg-white/5 px-2.5 py-1.5 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
-                >
-                  <option value="global">Global (default)</option>
-                  {projects.map((p) => (
-                    <option key={p} value={p}>
-                      {p}
-                    </option>
-                  ))}
-                </select>
-                {orchScope !== "global" && (
-                  <p className="mt-1 text-[10px] text-zinc-600">
-                    {orchestrator.is_project_override
-                      ? "Project-level override active"
-                      : "Using global settings (no project override)"}
-                  </p>
-                )}
-              </div>
-
-              {/* Enable toggle */}
-              <label className="flex items-center justify-between gap-3">
-                <div className="flex-1">
-                  <span className="text-sm text-zinc-300">Enabled</span>
-                  <p className="text-[11px] text-zinc-600 mt-0.5">
-                    Enable orchestrator workflow features.
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    const next = !orchestrator.enabled;
-                    setOrchestrator({ ...orchestrator, enabled: next });
-                    void orchestratorSave.track(
-                      async () => {
-                        await api.updateOrchestratorSettings({ enabled: next }, orchProject);
-                        refreshOrchestrator();
-                      },
-                      { onError: () => setOrchestrator({ ...orchestrator, enabled: !next }) },
-                    );
-                  }}
-                  className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
-                    orchestrator.enabled ? "bg-cyan-500/40" : "bg-white/10"
-                  }`}
-                >
-                  <span
-                    className={`inline-block h-3.5 w-3.5 rounded-full transition-transform ${
-                      orchestrator.enabled
-                        ? "translate-x-[18px] bg-cyan-400"
-                        : "translate-x-0.5 bg-zinc-500"
-                    }`}
-                  />
-                </button>
-              </label>
-
-              {orchestrator.enabled && (
-                <div className="space-y-3 border-t border-white/5 pt-3">
-                  <OrchestrationRuleTextarea
-                    label="Role"
-                    placeholder="Describe the orchestrator's role and persona..."
-                    rows={2}
-                    value={orchestrator.role}
-                    save={orchestratorSave}
-                    onDraft={(role) => setOrchestrator({ ...orchestrator, role })}
-                    onCommit={(role) => api.updateOrchestratorSettings({ role }, orchProject)}
-                  />
-
-                  <p className="text-[11px] font-medium text-zinc-400 uppercase tracking-wider">
-                    Workflow Rules
-                  </p>
-
-                  {(
-                    [
-                      {
-                        key: "branch",
-                        label: "Branch rules",
-                        placeholder: "Rules for branch naming and strategy...",
-                        rows: 2,
-                      },
-                      {
-                        key: "merge",
-                        label: "Merge rules",
-                        placeholder: "Rules for merge strategy and conflict resolution...",
-                        rows: 2,
-                      },
-                      {
-                        key: "review",
-                        label: "Review rules",
-                        placeholder: "Rules for code review process...",
-                        rows: 2,
-                      },
-                      {
-                        key: "custom",
-                        label: "Custom rules",
-                        placeholder: "Additional custom rules for the orchestrator...",
-                        rows: 3,
-                      },
-                    ] as const
-                  ).map(({ key, label, placeholder, rows }) => (
-                    <OrchestrationRuleTextarea
-                      key={key}
-                      label={label}
-                      placeholder={placeholder}
-                      rows={rows}
-                      value={orchestrator.rules[key]}
-                      save={orchestratorSave}
-                      onDraft={(value) =>
-                        setOrchestrator({
-                          ...orchestrator,
-                          rules: { ...orchestrator.rules, [key]: value },
-                        })
-                      }
-                      onCommit={(value) =>
-                        api.updateOrchestratorSettings({ rules: { [key]: value } }, orchProject)
-                      }
-                    />
-                  ))}
-
-                  {/* PR Monitor */}
-                  <PrMonitorSection
-                    orchestrator={orchestrator}
-                    setOrchestrator={setOrchestrator}
-                    orchProject={orchProject}
-                    save={orchestratorSave}
-                  />
-
-                  {/* Notifications */}
-                  <NotifySettingsSection
-                    orchestrator={orchestrator}
-                    setOrchestrator={setOrchestrator}
-                    orchProject={orchProject}
-                    save={orchestratorSave}
-                  />
-
-                  {/* Guardrails */}
-                  <GuardrailsSection
-                    orchestrator={orchestrator}
-                    setOrchestrator={setOrchestrator}
-                    orchProject={orchProject}
-                    save={orchestratorSave}
-                  />
-                </div>
-              )}
-            </div>
-          </section>
-        )}
+        <OrchestrationSection projects={projects} />
 
         {/* Orchestration dispatch bundles section (#573) */}
         <OrchestrationDispatchSection />


### PR DESCRIPTION
## Summary

Pull the orchestration parent section out of `SettingsPanel` into `OrchestrationSection.tsx`, completing the cluster split started in #586. The new section owns its full state — `orchestrator`, `orchScope`, save tracker, and `getOrchestratorSettings` load — and composes the three sub-components (`PrMonitorSection`, `NotifySettingsSection`, `GuardrailsSection`) that moved to their own files in #586. The `OrchestrationRuleTextarea` helper that lived next to `SettingsPanel` since #584 moves into the new file since it has no other consumers.

After this PR, `SettingsPanel.tsx` is a thin layout shell over the section components — no orchestrator state, no orchestrator-specific save tracker, no `refreshOrchestrator` callback. The parent only passes `projects` (used by the new section's scope selector).

## Numbers

| | Before #581 | After this PR | Δ |
|---|---|---|---|
| SettingsPanel.tsx | 2097 | 530 | **−1567 (75% reduction)** |
| `settings/` per-section files | 1 monolith + 3 helpers | 12 files | +9 |

## Test plan

- [x] `pnpm exec vitest run src/components/settings/__tests__/` — 82/82 pass
- [x] `pnpm exec biome check` clean
- [x] `pnpm build` clean (`tsc -b && vite build`)
- [ ] Manual: open Settings → Orchestration, exercise scope selector (global ↔ per-project), enable toggle, role + 4 rule textareas (Cmd+Enter blur, paste-detection), and the three nested sub-sections (PR Monitor, Notify, Guardrails). Verify auto-save + per-section indicators still behave.

## Note on the extraction series

This is the last of the major Settings UI extractions. After this lands, the remaining inline sections in `SettingsPanel.tsx` (Spawn ~44 lines, Browser Notifications ~75, Workflow ~54, Worktree ~155, Usage ~70) are smaller and could be batched in a single follow-up PR (~+1 file each, similar to ProjectsSection in #585).

🤖 Generated with [Claude Code](https://claude.com/claude-code)