### PR TITLE
refactor(settings): extract WorktreeSection from SettingsPanel

### DIFF
--- a/clients/react/src/components/settings/SettingsPanel.tsx
+++ b/clients/react/src/components/settings/SettingsPanel.tsx
@@ -1,12 +1,6 @@
 import { useCallback, useEffect, useState } from "react";
 import { useSaveTracker } from "@/hooks/useSaveTracker";
-import {
-  api,
-  type SpawnSettings,
-  type UsageSettings,
-  type WorkflowSettings,
-  type WorktreeSettings,
-} from "@/lib/api";
+import { api, type SpawnSettings, type UsageSettings, type WorkflowSettings } from "@/lib/api";
 import { AutoApproveSection } from "./AutoApproveSection";
 import { OrchestrationDispatchSection } from "./OrchestrationDispatchSection";
 import { OrchestrationSection } from "./OrchestrationSection";
@@ -14,6 +8,7 @@ import { ProjectsSection } from "./ProjectsSection";
 import { SaveStatus } from "./SaveStatus";
 import { ScheduledKicksSection } from "./ScheduledKicksSection";
 import { SpawnRuntimeSelector } from "./SpawnRuntimeSelector";
+import { WorktreeSection } from "./WorktreeSection";
 
 interface SettingsPanelProps {
   onClose: () => void;
@@ -28,8 +23,6 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
   const [notifyOnIdle, setNotifyOnIdle] = useState(true);
   const [notifyThresholdSecs, setNotifyThresholdSecs] = useState(10);
   const [workflowSettings, setWorkflowSettings] = useState<WorkflowSettings | null>(null);
-  const [worktreeSettings, setWorktreeSettings] = useState<WorktreeSettings | null>(null);
-  const [newSetupCommand, setNewSetupCommand] = useState("");
 
   // Per-section auto-save status (#578). Each tracker runs independently so a
   // failure in one section does not blank out the indicator on another.
@@ -37,7 +30,6 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
   const usageSave = useSaveTracker();
   const notifySave = useSaveTracker();
   const workflowSave = useSaveTracker();
-  const worktreeSave = useSaveTracker();
 
   const refreshProjects = useCallback(() => {
     api.listProjects().then(setProjects).catch(console.error);
@@ -65,10 +57,6 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
     api
       .getWorkflowSettings()
       .then(setWorkflowSettings)
-      .catch(() => {});
-    api
-      .getWorktreeSettings()
-      .then(setWorktreeSettings)
       .catch(() => {});
   }, [refreshProjects, refreshSpawnSettings, refreshUsageSettings]);
 
@@ -365,158 +353,7 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
         )}
 
         {/* Worktree section */}
-        {worktreeSettings && (
-          <section>
-            <div className="flex items-center gap-2">
-              <h3 className="text-sm font-medium text-zinc-300">Worktree</h3>
-              <SaveStatus
-                status={worktreeSave.status}
-                error={worktreeSave.error}
-                variant="section"
-              />
-            </div>
-            <p className="mt-1 text-xs text-zinc-600">Git worktree settings for spawned agents.</p>
-
-            <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-3">
-              <div>
-                <span className="text-xs text-zinc-500">Setup commands</span>
-                <p className="text-[10px] text-zinc-600 mt-0.5">
-                  Commands to run after creating a new worktree (e.g., npm install).
-                </p>
-                <div className="mt-2 space-y-1">
-                  {worktreeSettings.setup_commands.map((cmd) => (
-                    <div key={cmd} className="flex items-center gap-1.5">
-                      <code className="flex-1 rounded bg-white/5 px-2 py-1 text-xs text-zinc-300">
-                        {cmd}
-                      </code>
-                      <button
-                        type="button"
-                        onClick={() => {
-                          const previous = worktreeSettings.setup_commands;
-                          const cmds = previous.filter((c) => c !== cmd);
-                          setWorktreeSettings({ ...worktreeSettings, setup_commands: cmds });
-                          void worktreeSave.track(
-                            () => api.updateWorktreeSettings({ setup_commands: cmds }),
-                            {
-                              onError: () =>
-                                setWorktreeSettings({
-                                  ...worktreeSettings,
-                                  setup_commands: previous,
-                                }),
-                            },
-                          );
-                        }}
-                        className="rounded px-1.5 py-0.5 text-[10px] text-zinc-600 hover:bg-red-500/10 hover:text-red-400"
-                      >
-                        Remove
-                      </button>
-                    </div>
-                  ))}
-                </div>
-                <div className="mt-2 flex gap-1.5">
-                  <input
-                    type="text"
-                    value={newSetupCommand}
-                    onChange={(e) => setNewSetupCommand(e.target.value)}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter" && newSetupCommand.trim()) {
-                        const previous = worktreeSettings.setup_commands;
-                        const cmds = [...previous, newSetupCommand.trim()];
-                        setWorktreeSettings({ ...worktreeSettings, setup_commands: cmds });
-                        setNewSetupCommand("");
-                        void worktreeSave.track(
-                          () => api.updateWorktreeSettings({ setup_commands: cmds }),
-                          {
-                            onError: () =>
-                              setWorktreeSettings({
-                                ...worktreeSettings,
-                                setup_commands: previous,
-                              }),
-                          },
-                        );
-                      }
-                    }}
-                    placeholder="e.g., npm install"
-                    className="flex-1 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 placeholder-zinc-600 outline-none focus:border-cyan-500/30"
-                  />
-                  <button
-                    type="button"
-                    onClick={() => {
-                      if (!newSetupCommand.trim()) return;
-                      const previous = worktreeSettings.setup_commands;
-                      const cmds = [...previous, newSetupCommand.trim()];
-                      setWorktreeSettings({ ...worktreeSettings, setup_commands: cmds });
-                      setNewSetupCommand("");
-                      void worktreeSave.track(
-                        () => api.updateWorktreeSettings({ setup_commands: cmds }),
-                        {
-                          onError: () =>
-                            setWorktreeSettings({
-                              ...worktreeSettings,
-                              setup_commands: previous,
-                            }),
-                        },
-                      );
-                    }}
-                    className="rounded-md bg-cyan-500/20 px-3 py-1 text-xs text-cyan-400 transition-colors hover:bg-cyan-500/30"
-                  >
-                    Add
-                  </button>
-                </div>
-              </div>
-
-              <div className="flex items-center gap-2">
-                <span className="shrink-0 text-xs text-zinc-500">Setup timeout</span>
-                <input
-                  type="number"
-                  min={30}
-                  max={3600}
-                  value={worktreeSettings.setup_timeout_secs}
-                  onChange={(e) => {
-                    const val = parseInt(e.target.value, 10);
-                    if (!Number.isNaN(val)) {
-                      worktreeSave.clearError();
-                      setWorktreeSettings({ ...worktreeSettings, setup_timeout_secs: val });
-                    }
-                  }}
-                  onBlur={() => {
-                    const val = Math.max(30, worktreeSettings.setup_timeout_secs);
-                    void worktreeSave.track(() =>
-                      api.updateWorktreeSettings({ setup_timeout_secs: val }),
-                    );
-                  }}
-                  className="w-20 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
-                />
-                <span className="text-xs text-zinc-500">seconds</span>
-              </div>
-
-              <div className="flex items-center gap-2">
-                <span className="shrink-0 text-xs text-zinc-500">Branch depth warning</span>
-                <input
-                  type="number"
-                  min={1}
-                  max={100}
-                  value={worktreeSettings.branch_depth_warning}
-                  onChange={(e) => {
-                    const val = parseInt(e.target.value, 10);
-                    if (!Number.isNaN(val)) {
-                      worktreeSave.clearError();
-                      setWorktreeSettings({ ...worktreeSettings, branch_depth_warning: val });
-                    }
-                  }}
-                  onBlur={() => {
-                    const val = Math.max(1, worktreeSettings.branch_depth_warning);
-                    void worktreeSave.track(() =>
-                      api.updateWorktreeSettings({ branch_depth_warning: val }),
-                    );
-                  }}
-                  className="w-20 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
-                />
-                <span className="text-xs text-zinc-500">levels</span>
-              </div>
-            </div>
-          </section>
-        )}
+        <WorktreeSection />
 
         {/* Projects section */}
         <ProjectsSection

--- a/clients/react/src/components/settings/WorktreeSection.tsx
+++ b/clients/react/src/components/settings/WorktreeSection.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from "react";
+import { useSaveTracker } from "@/hooks/useSaveTracker";
+import { api, type WorktreeSettings } from "@/lib/api";
+import { SaveStatus } from "./SaveStatus";
+
+const NUMERIC_FIELDS = [
+  {
+    key: "setup_timeout_secs",
+    label: "Setup timeout",
+    unit: "seconds",
+    min: 30,
+    max: 3600,
+  },
+  {
+    key: "branch_depth_warning",
+    label: "Branch depth warning",
+    unit: "levels",
+    min: 1,
+    max: 100,
+  },
+] as const satisfies ReadonlyArray<{
+  key: keyof Pick<WorktreeSettings, "setup_timeout_secs" | "branch_depth_warning">;
+  label: string;
+  unit: string;
+  min: number;
+  max: number;
+}>;
+
+/**
+ * Worktree settings section: setup commands list (add / remove) + numeric
+ * tunables (setup timeout, branch-depth warning threshold).
+ *
+ * Owns its own state and load (`api.getWorktreeSettings`) so the parent
+ * SettingsPanel does not need to refresh it. Auto-saves on every
+ * interaction via `useSaveTracker`; list-mutation roll back on backend
+ * error so the rendered list stays in sync with the server.
+ */
+export function WorktreeSection() {
+  const [worktree, setWorktree] = useState<WorktreeSettings | null>(null);
+  const [newSetupCommand, setNewSetupCommand] = useState("");
+  const save = useSaveTracker();
+
+  useEffect(() => {
+    api.getWorktreeSettings().then(setWorktree).catch(console.error);
+  }, []);
+
+  if (!worktree) return null;
+
+  const updateCommands = (next: string[]) => {
+    const previous = worktree.setup_commands;
+    setWorktree({ ...worktree, setup_commands: next });
+    void save.track(() => api.updateWorktreeSettings({ setup_commands: next }), {
+      onError: () => setWorktree({ ...worktree, setup_commands: previous }),
+    });
+  };
+
+  const removeCommand = (cmd: string) => {
+    updateCommands(worktree.setup_commands.filter((c) => c !== cmd));
+  };
+
+  const addCommand = () => {
+    const trimmed = newSetupCommand.trim();
+    if (!trimmed) return;
+    updateCommands([...worktree.setup_commands, trimmed]);
+    setNewSetupCommand("");
+  };
+
+  return (
+    <section>
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-medium text-zinc-300">Worktree</h3>
+        <SaveStatus status={save.status} error={save.error} variant="section" />
+      </div>
+      <p className="mt-1 text-xs text-zinc-600">Git worktree settings for spawned agents.</p>
+
+      <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-3">
+        {/* Setup commands list */}
+        <div>
+          <span className="text-xs text-zinc-500">Setup commands</span>
+          <p className="text-[10px] text-zinc-600 mt-0.5">
+            Commands to run after creating a new worktree (e.g., npm install).
+          </p>
+          <div className="mt-2 space-y-1">
+            {worktree.setup_commands.map((cmd) => (
+              <div key={cmd} className="flex items-center gap-1.5">
+                <code className="flex-1 rounded bg-white/5 px-2 py-1 text-xs text-zinc-300">
+                  {cmd}
+                </code>
+                <button
+                  type="button"
+                  onClick={() => removeCommand(cmd)}
+                  className="rounded px-1.5 py-0.5 text-[10px] text-zinc-600 hover:bg-red-500/10 hover:text-red-400"
+                  aria-label={`Remove setup command ${cmd}`}
+                >
+                  Remove
+                </button>
+              </div>
+            ))}
+          </div>
+          <div className="mt-2 flex gap-1.5">
+            <input
+              type="text"
+              value={newSetupCommand}
+              onChange={(e) => setNewSetupCommand(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  addCommand();
+                }
+              }}
+              placeholder="e.g., npm install"
+              className="flex-1 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 placeholder-zinc-600 outline-none focus:border-cyan-500/30"
+              aria-label="Add setup command"
+            />
+            <button
+              type="button"
+              onClick={addCommand}
+              className="rounded-md bg-cyan-500/20 px-3 py-1 text-xs text-cyan-400 transition-colors hover:bg-cyan-500/30"
+            >
+              Add
+            </button>
+          </div>
+        </div>
+
+        {/* Numeric tunables — driven from a small table so adding new fields
+            is one row, not a fork-and-rename of the full block. */}
+        {NUMERIC_FIELDS.map(({ key, label, unit, min, max }) => (
+          <div key={key} className="flex items-center gap-2">
+            <span className="shrink-0 text-xs text-zinc-500">{label}</span>
+            <input
+              type="number"
+              min={min}
+              max={max}
+              value={worktree[key]}
+              onChange={(e) => {
+                const val = parseInt(e.target.value, 10);
+                if (!Number.isNaN(val)) {
+                  save.clearError();
+                  setWorktree({ ...worktree, [key]: val });
+                }
+              }}
+              onBlur={() => {
+                const val = Math.max(min, worktree[key]);
+                void save.track(() => api.updateWorktreeSettings({ [key]: val }));
+              }}
+              className="w-20 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
+              aria-label={label}
+            />
+            <span className="text-xs text-zinc-500">{unit}</span>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/clients/react/src/components/settings/__tests__/WorktreeSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/WorktreeSection.test.tsx
@@ -1,0 +1,115 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorktreeSettings } from "@/lib/api";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      getWorktreeSettings: vi.fn(),
+      updateWorktreeSettings: vi.fn(),
+    },
+  };
+});
+
+const { api } = await import("@/lib/api");
+const { WorktreeSection } = await import("../WorktreeSection");
+
+function makeSettings(overrides: Partial<WorktreeSettings> = {}): WorktreeSettings {
+  return {
+    setup_commands: [],
+    setup_timeout_secs: 300,
+    branch_depth_warning: 5,
+    ...overrides,
+  };
+}
+
+describe("WorktreeSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing while settings are loading", () => {
+    vi.mocked(api.getWorktreeSettings).mockReturnValue(new Promise(() => {}));
+    const { container } = render(<WorktreeSection />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("loads and renders both numeric tunables + setup commands", async () => {
+    vi.mocked(api.getWorktreeSettings).mockResolvedValue(
+      makeSettings({ setup_commands: ["pnpm install", "cargo build"] }),
+    );
+    render(<WorktreeSection />);
+    await waitFor(() => screen.getByText("Worktree"));
+    expect(screen.getByText("pnpm install")).toBeTruthy();
+    expect(screen.getByText("cargo build")).toBeTruthy();
+    expect(screen.getByLabelText("Setup timeout")).toBeTruthy();
+    expect(screen.getByLabelText("Branch depth warning")).toBeTruthy();
+  });
+
+  it("Add command via Enter calls api.updateWorktreeSettings", async () => {
+    vi.mocked(api.getWorktreeSettings).mockResolvedValue(makeSettings());
+    vi.mocked(api.updateWorktreeSettings).mockResolvedValue(undefined as never);
+    render(<WorktreeSection />);
+    await waitFor(() => screen.getByText("Worktree"));
+
+    const input = screen.getByLabelText("Add setup command") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "npm install" } });
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    await waitFor(() => {
+      expect(vi.mocked(api.updateWorktreeSettings)).toHaveBeenCalledWith({
+        setup_commands: ["npm install"],
+      });
+    });
+    expect(input.value).toBe("");
+  });
+
+  it("Remove command rolls back on backend error", async () => {
+    vi.mocked(api.getWorktreeSettings).mockResolvedValue(
+      makeSettings({ setup_commands: ["pnpm install"] }),
+    );
+    vi.mocked(api.updateWorktreeSettings).mockRejectedValue(new Error("permission denied"));
+    render(<WorktreeSection />);
+    await waitFor(() => screen.getByText("Worktree"));
+
+    fireEvent.click(screen.getByLabelText("Remove setup command pnpm install"));
+
+    await waitFor(() => {
+      expect(screen.getByText(/permission denied/)).toBeTruthy();
+    });
+    // The rollback puts the command back in the rendered list.
+    expect(screen.getByText("pnpm install")).toBeTruthy();
+  });
+
+  it("Setup timeout commits on blur with the at-least-min clamp", async () => {
+    vi.mocked(api.getWorktreeSettings).mockResolvedValue(makeSettings({ setup_timeout_secs: 60 }));
+    vi.mocked(api.updateWorktreeSettings).mockResolvedValue(undefined as never);
+    render(<WorktreeSection />);
+    await waitFor(() => screen.getByText("Worktree"));
+
+    const input = screen.getByLabelText("Setup timeout") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "10" } }); // below the 30s min
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(vi.mocked(api.updateWorktreeSettings)).toHaveBeenCalledWith({
+        setup_timeout_secs: 30,
+      });
+    });
+  });
+
+  it("Add button no-ops on whitespace-only input", async () => {
+    vi.mocked(api.getWorktreeSettings).mockResolvedValue(makeSettings());
+    render(<WorktreeSection />);
+    await waitFor(() => screen.getByText("Worktree"));
+
+    const input = screen.getByLabelText("Add setup command") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.click(screen.getByRole("button", { name: /^Add$/ }));
+
+    expect(vi.mocked(api.updateWorktreeSettings)).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary

Pull the worktree section (~150 lines of inline JSX + setup-commands list, two numeric tunables, and their handlers) out of `SettingsPanel` into its own `WorktreeSection`. Same pattern as `AutoApproveSection` (#583) and `ProjectsSection` (#585): the section owns its state, save tracker, and `getWorktreeSettings` load.

Beyond the relocation, the new file collapses the two near-identical numeric-field blocks (`setup_timeout_secs`, `branch_depth_warning`) into a `NUMERIC_FIELDS` table-driven render, and routes both add-command paths (button click + Enter on input) through a single `addCommand()` helper. Same DRY pattern as #582 (`OrchestrationDispatchSection` ROLES) and #584 (`OrchestrationRuleTextarea`).

- **SettingsPanel.tsx: 530 → 367 lines (−163).** Cumulative since #581: 2097 → 367 = **−1730** (~83% smaller).

## Test plan

- [x] 6 new tests in `WorktreeSection.test.tsx`: load placeholder, list + tunables render, Enter add, error rollback on remove, blur commit with at-least-min clamp, whitespace no-op
- [x] `pnpm exec vitest run src/components/settings/__tests__/` — 88/88 pass
- [x] `pnpm exec biome check` clean
- [x] `pnpm build` clean (`tsc -b && vite build`)
- [ ] Manual: open Settings → Worktree, exercise add/remove command, edit setup timeout (test the at-least-30s clamp), edit branch depth warning, error simulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)