### PR TITLE
refactor(settings): extract Spawn / Usage / Notification / Workflow sections — SettingsPanel becomes a thin layout shell

### DIFF
--- a/clients/react/src/components/settings/NotificationSection.tsx
+++ b/clients/react/src/components/settings/NotificationSection.tsx
@@ -1,0 +1,109 @@
+import { useEffect, useState } from "react";
+import { useSaveTracker } from "@/hooks/useSaveTracker";
+import { api } from "@/lib/api";
+import { SaveStatus } from "./SaveStatus";
+
+const MIN_THRESHOLD_SECS = 0;
+const MAX_THRESHOLD_SECS = 300;
+const DEFAULT_THRESHOLD_SECS = 10;
+
+/**
+ * Browser-notification settings: notify-on-idle toggle + idle threshold
+ * (seconds). Distinct from the orchestrator's per-event notification
+ * routing (`NotifySettingsSection`) — this controls whether the browser
+ * itself raises a notification on the idle transition.
+ */
+export function NotificationSection() {
+  const [notifyOnIdle, setNotifyOnIdle] = useState(true);
+  const [thresholdSecs, setThresholdSecs] = useState(DEFAULT_THRESHOLD_SECS);
+  const save = useSaveTracker();
+
+  useEffect(() => {
+    api
+      .getNotificationSettings()
+      .then((s) => {
+        setNotifyOnIdle(s.notify_on_idle);
+        setThresholdSecs(s.notify_idle_threshold_secs);
+      })
+      .catch(() => {});
+  }, []);
+
+  return (
+    <section>
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-medium text-zinc-300">Notifications</h3>
+        <SaveStatus status={save.status} error={save.error} variant="section" />
+      </div>
+      <p className="mt-1 text-xs text-zinc-600">
+        Browser notifications when agents finish processing and become idle.
+      </p>
+
+      <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-3">
+        <label className="flex items-center justify-between gap-3">
+          <div className="flex-1">
+            <span className="text-sm text-zinc-300">Notify on idle</span>
+            <p className="text-[11px] text-zinc-600 mt-0.5">
+              Send a browser notification when an agent transitions from Processing to Idle.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              const prev = notifyOnIdle;
+              const next = !prev;
+              setNotifyOnIdle(next);
+              void save.track(() => api.updateNotificationSettings({ notify_on_idle: next }), {
+                onError: () => setNotifyOnIdle(prev),
+              });
+            }}
+            className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
+              notifyOnIdle ? "bg-cyan-500/40" : "bg-white/10"
+            }`}
+            aria-label="Notify on idle"
+          >
+            <span
+              className={`inline-block h-3.5 w-3.5 rounded-full transition-transform ${
+                notifyOnIdle ? "translate-x-[18px] bg-cyan-400" : "translate-x-0.5 bg-zinc-500"
+              }`}
+            />
+          </button>
+        </label>
+
+        {notifyOnIdle && (
+          <div className="flex items-center gap-2">
+            <span className="shrink-0 text-xs text-zinc-500">Idle threshold</span>
+            <input
+              type="number"
+              min={MIN_THRESHOLD_SECS}
+              max={MAX_THRESHOLD_SECS}
+              value={thresholdSecs}
+              onChange={(e) => {
+                const val = parseInt(e.target.value, 10);
+                if (!Number.isNaN(val)) {
+                  save.clearError();
+                  setThresholdSecs(val);
+                }
+              }}
+              onBlur={() => {
+                const val = Math.max(MIN_THRESHOLD_SECS, thresholdSecs);
+                void save.track(() =>
+                  api.updateNotificationSettings({ notify_idle_threshold_secs: val }),
+                );
+              }}
+              className="w-20 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
+              aria-label="Idle threshold seconds"
+            />
+            <span className="text-xs text-zinc-500">seconds</span>
+          </div>
+        )}
+
+        {notifyOnIdle && (
+          <p className="text-[10px] text-zinc-600">
+            Hook-detected (◈) agents notify immediately. Capture-pane (●) agents wait the full
+            threshold to filter out transient state flickers.
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/clients/react/src/components/settings/SettingsPanel.tsx
+++ b/clients/react/src/components/settings/SettingsPanel.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useEffect, useState } from "react";
-import { useSaveTracker } from "@/hooks/useSaveTracker";
-import { api, type SpawnSettings, type UsageSettings, type WorkflowSettings } from "@/lib/api";
+import { api } from "@/lib/api";
 import { AutoApproveSection } from "./AutoApproveSection";
+import { NotificationSection } from "./NotificationSection";
 import { OrchestrationDispatchSection } from "./OrchestrationDispatchSection";
 import { OrchestrationSection } from "./OrchestrationSection";
 import { ProjectsSection } from "./ProjectsSection";
-import { SaveStatus } from "./SaveStatus";
 import { ScheduledKicksSection } from "./ScheduledKicksSection";
-import { SpawnRuntimeSelector } from "./SpawnRuntimeSelector";
+import { SpawnSection } from "./SpawnSection";
+import { UsageSection } from "./UsageSection";
+import { WorkflowSection } from "./WorkflowSection";
 import { WorktreeSection } from "./WorktreeSection";
 
 interface SettingsPanelProps {
@@ -15,70 +16,22 @@ interface SettingsPanelProps {
   onProjectsChanged: () => void;
 }
 
-// Settings panel displayed in the main area
+/**
+ * Settings panel layout shell. Each section component owns its own state,
+ * save tracker, and load — the parent only carries the project list (used
+ * by both `OrchestrationSection`'s scope selector and `ProjectsSection`'s
+ * registered-project view) and the cross-component refresh callback.
+ */
 export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps) {
   const [projects, setProjects] = useState<string[]>([]);
-  const [spawnSettings, setSpawnSettings] = useState<SpawnSettings | null>(null);
-  const [usageSettings, setUsageSettings] = useState<UsageSettings | null>(null);
-  const [notifyOnIdle, setNotifyOnIdle] = useState(true);
-  const [notifyThresholdSecs, setNotifyThresholdSecs] = useState(10);
-  const [workflowSettings, setWorkflowSettings] = useState<WorkflowSettings | null>(null);
-
-  // Per-section auto-save status (#578). Each tracker runs independently so a
-  // failure in one section does not blank out the indicator on another.
-  const spawnSave = useSaveTracker();
-  const usageSave = useSaveTracker();
-  const notifySave = useSaveTracker();
-  const workflowSave = useSaveTracker();
 
   const refreshProjects = useCallback(() => {
     api.listProjects().then(setProjects).catch(console.error);
   }, []);
 
-  const refreshSpawnSettings = useCallback(() => {
-    api.getSpawnSettings().then(setSpawnSettings).catch(console.error);
-  }, []);
-
-  const refreshUsageSettings = useCallback(() => {
-    api.getUsageSettings().then(setUsageSettings).catch(console.error);
-  }, []);
-
   useEffect(() => {
     refreshProjects();
-    refreshSpawnSettings();
-    refreshUsageSettings();
-    api
-      .getNotificationSettings()
-      .then((s) => {
-        setNotifyOnIdle(s.notify_on_idle);
-        setNotifyThresholdSecs(s.notify_idle_threshold_secs);
-      })
-      .catch(() => {});
-    api
-      .getWorkflowSettings()
-      .then(setWorkflowSettings)
-      .catch(() => {});
-  }, [refreshProjects, refreshSpawnSettings, refreshUsageSettings]);
-
-  // Update tmux window name
-  const handleWindowNameChange = async (name: string) => {
-    if (!spawnSettings) return;
-    setSpawnSettings({ ...spawnSettings, tmux_window_name: name });
-  };
-
-  // Save window name on blur or Enter (text-field commit; no rollback so the
-  // user can edit and retry if the backend rejects the value).
-  const handleWindowNameSave = () => {
-    if (!spawnSettings) return;
-    const trimmed = spawnSettings.tmux_window_name.trim();
-    if (!trimmed) return;
-    void spawnSave.track(() =>
-      api.updateSpawnSettings({
-        runtime: spawnSettings.runtime,
-        tmux_window_name: trimmed,
-      }),
-    );
-  };
+  }, [refreshProjects]);
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
@@ -95,267 +48,15 @@ export function SettingsPanel({ onClose, onProjectsChanged }: SettingsPanelProps
       </div>
 
       <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6">
-        {/* Auto-approve section */}
         <AutoApproveSection />
-
-        {/* Spawn section */}
-        {spawnSettings && (
-          <section>
-            <div className="flex items-center gap-2">
-              <h3 className="text-sm font-medium text-zinc-300">Spawn</h3>
-              <SaveStatus status={spawnSave.status} error={spawnSave.error} variant="section" />
-            </div>
-            <p className="mt-1 text-xs text-zinc-600">
-              How new agents are started from the Web UI.
-            </p>
-
-            <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-3">
-              <SpawnRuntimeSelector
-                settings={spawnSettings}
-                onSettingsChange={setSpawnSettings}
-                save={spawnSave}
-              />
-
-              {/* Window name field — shown when runtime is tmux */}
-              {spawnSettings.runtime === "tmux" && (
-                <div className="flex items-center gap-2">
-                  <span className="shrink-0 text-xs text-zinc-500">Window name</span>
-                  <input
-                    type="text"
-                    value={spawnSettings.tmux_window_name}
-                    onChange={(e) => {
-                      spawnSave.clearError();
-                      handleWindowNameChange(e.target.value);
-                    }}
-                    onBlur={handleWindowNameSave}
-                    onKeyDown={(e) => {
-                      if (e.key === "Enter") {
-                        e.preventDefault();
-                        (e.currentTarget as HTMLInputElement).blur();
-                      }
-                    }}
-                    className="flex-1 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
-                  />
-                </div>
-              )}
-            </div>
-          </section>
-        )}
-
-        {/* Orchestration section */}
+        <SpawnSection />
         <OrchestrationSection projects={projects} />
-
-        {/* Orchestration dispatch bundles section (#573) */}
         <OrchestrationDispatchSection />
-
-        {/* Scheduled kicks / Routines section */}
         <ScheduledKicksSection />
-
-        {/* Usage monitoring section */}
-        {usageSettings && (
-          <section>
-            <div className="flex items-center gap-2">
-              <h3 className="text-sm font-medium text-zinc-300">Usage Monitoring</h3>
-              <SaveStatus status={usageSave.status} error={usageSave.error} variant="section" />
-            </div>
-            <p className="mt-1 text-xs text-zinc-600">
-              Periodically fetch Claude Code subscription usage. Spawns a temporary Claude Code
-              instance (Haiku) for each refresh.
-            </p>
-
-            <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-3">
-              <label className="flex items-center justify-between gap-3">
-                <div className="flex-1">
-                  <span className="text-sm text-zinc-300">Auto-refresh</span>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    const newEnabled = !usageSettings.enabled;
-                    setUsageSettings({ ...usageSettings, enabled: newEnabled });
-                    void usageSave.track(() => api.updateUsageSettings({ enabled: newEnabled }), {
-                      onError: () => setUsageSettings({ ...usageSettings, enabled: !newEnabled }),
-                    });
-                  }}
-                  className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
-                    usageSettings.enabled ? "bg-cyan-500/40" : "bg-white/10"
-                  }`}
-                >
-                  <span
-                    className={`inline-block h-3.5 w-3.5 rounded-full transition-transform ${
-                      usageSettings.enabled
-                        ? "translate-x-[18px] bg-cyan-400"
-                        : "translate-x-0.5 bg-zinc-500"
-                    }`}
-                  />
-                </button>
-              </label>
-
-              {usageSettings.enabled && (
-                <div className="flex items-center gap-2">
-                  <span className="shrink-0 text-xs text-zinc-500">Interval</span>
-                  <input
-                    type="number"
-                    min={5}
-                    max={1440}
-                    value={usageSettings.auto_refresh_min || 30}
-                    onChange={(e) => {
-                      const val = parseInt(e.target.value, 10);
-                      if (!Number.isNaN(val)) {
-                        usageSave.clearError();
-                        setUsageSettings({ ...usageSettings, auto_refresh_min: val });
-                      }
-                    }}
-                    onBlur={() => {
-                      const val = Math.max(5, usageSettings.auto_refresh_min || 30);
-                      void usageSave.track(() =>
-                        api.updateUsageSettings({ auto_refresh_min: val }),
-                      );
-                    }}
-                    className="w-20 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
-                  />
-                  <span className="text-xs text-zinc-500">minutes</span>
-                </div>
-              )}
-            </div>
-          </section>
-        )}
-
-        {/* Notification section */}
-        <section>
-          <div className="flex items-center gap-2">
-            <h3 className="text-sm font-medium text-zinc-300">Notifications</h3>
-            <SaveStatus status={notifySave.status} error={notifySave.error} variant="section" />
-          </div>
-          <p className="mt-1 text-xs text-zinc-600">
-            Browser notifications when agents finish processing and become idle.
-          </p>
-
-          <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-3">
-            <label className="flex items-center justify-between gap-3">
-              <div className="flex-1">
-                <span className="text-sm text-zinc-300">Notify on idle</span>
-                <p className="text-[11px] text-zinc-600 mt-0.5">
-                  Send a browser notification when an agent transitions from Processing to Idle.
-                </p>
-              </div>
-              <button
-                type="button"
-                onClick={() => {
-                  const prev = notifyOnIdle;
-                  const next = !prev;
-                  setNotifyOnIdle(next);
-                  void notifySave.track(
-                    () => api.updateNotificationSettings({ notify_on_idle: next }),
-                    { onError: () => setNotifyOnIdle(prev) },
-                  );
-                }}
-                className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
-                  notifyOnIdle ? "bg-cyan-500/40" : "bg-white/10"
-                }`}
-              >
-                <span
-                  className={`inline-block h-3.5 w-3.5 rounded-full transition-transform ${
-                    notifyOnIdle ? "translate-x-[18px] bg-cyan-400" : "translate-x-0.5 bg-zinc-500"
-                  }`}
-                />
-              </button>
-            </label>
-
-            {notifyOnIdle && (
-              <div className="flex items-center gap-2">
-                <span className="shrink-0 text-xs text-zinc-500">Idle threshold</span>
-                <input
-                  type="number"
-                  min={0}
-                  max={300}
-                  value={notifyThresholdSecs}
-                  onChange={(e) => {
-                    const val = parseInt(e.target.value, 10);
-                    if (!Number.isNaN(val)) {
-                      notifySave.clearError();
-                      setNotifyThresholdSecs(val);
-                    }
-                  }}
-                  onBlur={() => {
-                    const val = Math.max(0, notifyThresholdSecs);
-                    void notifySave.track(() =>
-                      api.updateNotificationSettings({ notify_idle_threshold_secs: val }),
-                    );
-                  }}
-                  className="w-20 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
-                />
-                <span className="text-xs text-zinc-500">seconds</span>
-              </div>
-            )}
-
-            {notifyOnIdle && (
-              <p className="text-[10px] text-zinc-600">
-                Hook-detected (◈) agents notify immediately. Capture-pane (●) agents wait the full
-                threshold to filter out transient state flickers.
-              </p>
-            )}
-          </div>
-        </section>
-
-        {/* Workflow section */}
-        {workflowSettings && (
-          <section>
-            <div className="flex items-center gap-2">
-              <h3 className="text-sm font-medium text-zinc-300">Workflow</h3>
-              <SaveStatus
-                status={workflowSave.status}
-                error={workflowSave.error}
-                variant="section"
-              />
-            </div>
-            <p className="mt-1 text-xs text-zinc-600">Workflow automation settings.</p>
-
-            <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3">
-              <label className="flex items-center justify-between gap-3">
-                <div className="flex-1">
-                  <span className="text-sm text-zinc-300">Auto-rebase on merge</span>
-                  <p className="text-[11px] text-zinc-600 mt-0.5">
-                    Automatically rebase open worktree branches onto main after a PR merge.
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => {
-                    const next = !workflowSettings.auto_rebase_on_merge;
-                    setWorkflowSettings({ ...workflowSettings, auto_rebase_on_merge: next });
-                    void workflowSave.track(
-                      () => api.updateWorkflowSettings({ auto_rebase_on_merge: next }),
-                      {
-                        onError: () =>
-                          setWorkflowSettings({
-                            ...workflowSettings,
-                            auto_rebase_on_merge: !next,
-                          }),
-                      },
-                    );
-                  }}
-                  className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
-                    workflowSettings.auto_rebase_on_merge ? "bg-cyan-500/40" : "bg-white/10"
-                  }`}
-                >
-                  <span
-                    className={`inline-block h-3.5 w-3.5 rounded-full transition-transform ${
-                      workflowSettings.auto_rebase_on_merge
-                        ? "translate-x-[18px] bg-cyan-400"
-                        : "translate-x-0.5 bg-zinc-500"
-                    }`}
-                  />
-                </button>
-              </label>
-            </div>
-          </section>
-        )}
-
-        {/* Worktree section */}
+        <UsageSection />
+        <NotificationSection />
+        <WorkflowSection />
         <WorktreeSection />
-
-        {/* Projects section */}
         <ProjectsSection
           projects={projects}
           refreshProjects={refreshProjects}

--- a/clients/react/src/components/settings/SpawnSection.tsx
+++ b/clients/react/src/components/settings/SpawnSection.tsx
@@ -1,0 +1,71 @@
+import { useEffect, useState } from "react";
+import { useSaveTracker } from "@/hooks/useSaveTracker";
+import { api, type SpawnSettings } from "@/lib/api";
+import { SaveStatus } from "./SaveStatus";
+import { SpawnRuntimeSelector } from "./SpawnRuntimeSelector";
+
+/**
+ * Spawn settings section: runtime selector (native / tmux) + the tmux
+ * window-name field that's only relevant when runtime = "tmux".
+ *
+ * Owns its own state and load (`api.getSpawnSettings`). Auto-saves on
+ * every interaction via `useSaveTracker`.
+ */
+export function SpawnSection() {
+  const [spawn, setSpawn] = useState<SpawnSettings | null>(null);
+  const save = useSaveTracker();
+
+  useEffect(() => {
+    api.getSpawnSettings().then(setSpawn).catch(console.error);
+  }, []);
+
+  if (!spawn) return null;
+
+  // Window-name commits on blur or Enter (text-field commit; no rollback so
+  // the user can edit and retry if the backend rejects the value).
+  const commitWindowName = () => {
+    const trimmed = spawn.tmux_window_name.trim();
+    if (!trimmed) return;
+    void save.track(() =>
+      api.updateSpawnSettings({ runtime: spawn.runtime, tmux_window_name: trimmed }),
+    );
+  };
+
+  return (
+    <section>
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-medium text-zinc-300">Spawn</h3>
+        <SaveStatus status={save.status} error={save.error} variant="section" />
+      </div>
+      <p className="mt-1 text-xs text-zinc-600">How new agents are started from the Web UI.</p>
+
+      <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-3">
+        <SpawnRuntimeSelector settings={spawn} onSettingsChange={setSpawn} save={save} />
+
+        {/* Window name field — shown when runtime is tmux */}
+        {spawn.runtime === "tmux" && (
+          <div className="flex items-center gap-2">
+            <span className="shrink-0 text-xs text-zinc-500">Window name</span>
+            <input
+              type="text"
+              value={spawn.tmux_window_name}
+              onChange={(e) => {
+                save.clearError();
+                setSpawn({ ...spawn, tmux_window_name: e.target.value });
+              }}
+              onBlur={commitWindowName}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") {
+                  e.preventDefault();
+                  (e.currentTarget as HTMLInputElement).blur();
+                }
+              }}
+              className="flex-1 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
+              aria-label="tmux window name"
+            />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/clients/react/src/components/settings/UsageSection.tsx
+++ b/clients/react/src/components/settings/UsageSection.tsx
@@ -1,0 +1,94 @@
+import { useEffect, useState } from "react";
+import { useSaveTracker } from "@/hooks/useSaveTracker";
+import { api, type UsageSettings } from "@/lib/api";
+import { SaveStatus } from "./SaveStatus";
+
+const DEFAULT_INTERVAL_MIN = 30;
+const MIN_INTERVAL_MIN = 5;
+const MAX_INTERVAL_MIN = 1440;
+
+/**
+ * Usage monitoring settings: enabled toggle + auto-refresh interval (in
+ * minutes). When enabled, tmai-core periodically spawns a temporary
+ * Claude Code instance (Haiku) to fetch the subscription usage.
+ */
+export function UsageSection() {
+  const [usage, setUsage] = useState<UsageSettings | null>(null);
+  const save = useSaveTracker();
+
+  useEffect(() => {
+    api.getUsageSettings().then(setUsage).catch(console.error);
+  }, []);
+
+  if (!usage) return null;
+
+  return (
+    <section>
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-medium text-zinc-300">Usage Monitoring</h3>
+        <SaveStatus status={save.status} error={save.error} variant="section" />
+      </div>
+      <p className="mt-1 text-xs text-zinc-600">
+        Periodically fetch Claude Code subscription usage. Spawns a temporary Claude Code instance
+        (Haiku) for each refresh.
+      </p>
+
+      <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-3">
+        <label className="flex items-center justify-between gap-3">
+          <div className="flex-1">
+            <span className="text-sm text-zinc-300">Auto-refresh</span>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              const next = !usage.enabled;
+              setUsage({ ...usage, enabled: next });
+              void save.track(() => api.updateUsageSettings({ enabled: next }), {
+                onError: () => setUsage({ ...usage, enabled: !next }),
+              });
+            }}
+            className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
+              usage.enabled ? "bg-cyan-500/40" : "bg-white/10"
+            }`}
+            aria-label="Usage auto-refresh"
+          >
+            <span
+              className={`inline-block h-3.5 w-3.5 rounded-full transition-transform ${
+                usage.enabled ? "translate-x-[18px] bg-cyan-400" : "translate-x-0.5 bg-zinc-500"
+              }`}
+            />
+          </button>
+        </label>
+
+        {usage.enabled && (
+          <div className="flex items-center gap-2">
+            <span className="shrink-0 text-xs text-zinc-500">Interval</span>
+            <input
+              type="number"
+              min={MIN_INTERVAL_MIN}
+              max={MAX_INTERVAL_MIN}
+              value={usage.auto_refresh_min || DEFAULT_INTERVAL_MIN}
+              onChange={(e) => {
+                const val = parseInt(e.target.value, 10);
+                if (!Number.isNaN(val)) {
+                  save.clearError();
+                  setUsage({ ...usage, auto_refresh_min: val });
+                }
+              }}
+              onBlur={() => {
+                const val = Math.max(
+                  MIN_INTERVAL_MIN,
+                  usage.auto_refresh_min || DEFAULT_INTERVAL_MIN,
+                );
+                void save.track(() => api.updateUsageSettings({ auto_refresh_min: val }));
+              }}
+              className="w-20 rounded-md border border-white/10 bg-white/5 px-2.5 py-1 text-xs text-zinc-200 outline-none focus:border-cyan-500/30"
+              aria-label="Usage auto-refresh interval"
+            />
+            <span className="text-xs text-zinc-500">minutes</span>
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/clients/react/src/components/settings/WorkflowSection.tsx
+++ b/clients/react/src/components/settings/WorkflowSection.tsx
@@ -1,0 +1,67 @@
+import { useEffect, useState } from "react";
+import { useSaveTracker } from "@/hooks/useSaveTracker";
+import { api, type WorkflowSettings } from "@/lib/api";
+import { SaveStatus } from "./SaveStatus";
+
+/**
+ * Workflow automation settings — currently a single toggle for auto-rebase
+ * on PR merge. Kept as its own section so future workflow tunables (queue
+ * caps, branch-protection retries, etc.) drop in alongside without
+ * crowding `SettingsPanel`.
+ */
+export function WorkflowSection() {
+  const [workflow, setWorkflow] = useState<WorkflowSettings | null>(null);
+  const save = useSaveTracker();
+
+  useEffect(() => {
+    api
+      .getWorkflowSettings()
+      .then(setWorkflow)
+      .catch(() => {});
+  }, []);
+
+  if (!workflow) return null;
+
+  return (
+    <section>
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-medium text-zinc-300">Workflow</h3>
+        <SaveStatus status={save.status} error={save.error} variant="section" />
+      </div>
+      <p className="mt-1 text-xs text-zinc-600">Workflow automation settings.</p>
+
+      <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3">
+        <label className="flex items-center justify-between gap-3">
+          <div className="flex-1">
+            <span className="text-sm text-zinc-300">Auto-rebase on merge</span>
+            <p className="text-[11px] text-zinc-600 mt-0.5">
+              Automatically rebase open worktree branches onto main after a PR merge.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              const next = !workflow.auto_rebase_on_merge;
+              setWorkflow({ ...workflow, auto_rebase_on_merge: next });
+              void save.track(() => api.updateWorkflowSettings({ auto_rebase_on_merge: next }), {
+                onError: () => setWorkflow({ ...workflow, auto_rebase_on_merge: !next }),
+              });
+            }}
+            className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
+              workflow.auto_rebase_on_merge ? "bg-cyan-500/40" : "bg-white/10"
+            }`}
+            aria-label="Auto-rebase on merge"
+          >
+            <span
+              className={`inline-block h-3.5 w-3.5 rounded-full transition-transform ${
+                workflow.auto_rebase_on_merge
+                  ? "translate-x-[18px] bg-cyan-400"
+                  : "translate-x-0.5 bg-zinc-500"
+              }`}
+            />
+          </button>
+        </label>
+      </div>
+    </section>
+  );
+}

--- a/clients/react/src/components/settings/__tests__/NotificationSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/NotificationSection.test.tsx
@@ -1,0 +1,61 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      getNotificationSettings: vi.fn(),
+      updateNotificationSettings: vi.fn(),
+    },
+  };
+});
+
+const { api } = await import("@/lib/api");
+const { NotificationSection } = await import("../NotificationSection");
+
+describe("NotificationSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders heading even before settings load (defaults to enabled)", async () => {
+    vi.mocked(api.getNotificationSettings).mockReturnValue(new Promise(() => {}));
+    render(<NotificationSection />);
+    expect(screen.getByText("Notifications")).toBeTruthy();
+    // Threshold input is rendered because the default is enabled.
+    expect(screen.getByLabelText("Idle threshold seconds")).toBeTruthy();
+  });
+
+  it("hides the threshold input when notify_on_idle loads as false", async () => {
+    vi.mocked(api.getNotificationSettings).mockResolvedValue({
+      notify_on_idle: false,
+      notify_idle_threshold_secs: 10,
+    });
+    render(<NotificationSection />);
+    await waitFor(() => {
+      expect(screen.queryByLabelText("Idle threshold seconds")).toBeNull();
+    });
+  });
+
+  it("toggling notify_on_idle persists and rolls back on error", async () => {
+    vi.mocked(api.getNotificationSettings).mockResolvedValue({
+      notify_on_idle: true,
+      notify_idle_threshold_secs: 10,
+    });
+    vi.mocked(api.updateNotificationSettings).mockRejectedValue(new Error("rejected"));
+    render(<NotificationSection />);
+    await waitFor(() => screen.getByText("Notifications"));
+
+    fireEvent.click(screen.getByLabelText("Notify on idle"));
+
+    await waitFor(() => {
+      expect(vi.mocked(api.updateNotificationSettings)).toHaveBeenCalledWith({
+        notify_on_idle: false,
+      });
+      expect(screen.getByText(/rejected/)).toBeTruthy();
+    });
+  });
+});

--- a/clients/react/src/components/settings/__tests__/SpawnSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SpawnSection.test.tsx
@@ -1,0 +1,66 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { SpawnSettings } from "@/lib/api";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      getSpawnSettings: vi.fn(),
+      updateSpawnSettings: vi.fn(),
+    },
+  };
+});
+
+const { api } = await import("@/lib/api");
+const { SpawnSection } = await import("../SpawnSection");
+
+function makeSettings(overrides: Partial<SpawnSettings> = {}): SpawnSettings {
+  return {
+    runtime: "native",
+    tmux_available: false,
+    tmux_window_name: "tmai",
+    ...overrides,
+  };
+}
+
+describe("SpawnSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing while loading", () => {
+    vi.mocked(api.getSpawnSettings).mockReturnValue(new Promise(() => {}));
+    const { container } = render(<SpawnSection />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("hides the tmux window-name field when runtime is native", async () => {
+    vi.mocked(api.getSpawnSettings).mockResolvedValue(makeSettings({ runtime: "native" }));
+    render(<SpawnSection />);
+    await waitFor(() => screen.getByText("Spawn"));
+    expect(screen.queryByLabelText("tmux window name")).toBeNull();
+  });
+
+  it("shows the tmux window-name field when runtime is tmux, commits on blur", async () => {
+    vi.mocked(api.getSpawnSettings).mockResolvedValue(
+      makeSettings({ runtime: "tmux", tmux_window_name: "tmai" }),
+    );
+    vi.mocked(api.updateSpawnSettings).mockResolvedValue(undefined as never);
+    render(<SpawnSection />);
+    await waitFor(() => screen.getByText("Spawn"));
+
+    const input = screen.getByLabelText("tmux window name") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "claude-pane" } });
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(vi.mocked(api.updateSpawnSettings)).toHaveBeenCalledWith({
+        runtime: "tmux",
+        tmux_window_name: "claude-pane",
+      });
+    });
+  });
+});

--- a/clients/react/src/components/settings/__tests__/UsageSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/UsageSection.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UsageSettings } from "@/lib/api";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      getUsageSettings: vi.fn(),
+      updateUsageSettings: vi.fn(),
+    },
+  };
+});
+
+const { api } = await import("@/lib/api");
+const { UsageSection } = await import("../UsageSection");
+
+function makeSettings(overrides: Partial<UsageSettings> = {}): UsageSettings {
+  return { enabled: true, auto_refresh_min: 30, ...overrides };
+}
+
+describe("UsageSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing while loading", () => {
+    vi.mocked(api.getUsageSettings).mockReturnValue(new Promise(() => {}));
+    const { container } = render(<UsageSection />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("hides the interval input when disabled", async () => {
+    vi.mocked(api.getUsageSettings).mockResolvedValue(makeSettings({ enabled: false }));
+    render(<UsageSection />);
+    await waitFor(() => screen.getByText("Usage Monitoring"));
+    expect(screen.queryByLabelText("Usage auto-refresh interval")).toBeNull();
+  });
+
+  it("toggling enabled triggers updateUsageSettings and rolls back on error", async () => {
+    vi.mocked(api.getUsageSettings).mockResolvedValue(makeSettings({ enabled: true }));
+    vi.mocked(api.updateUsageSettings).mockRejectedValue(new Error("boom"));
+    render(<UsageSection />);
+    await waitFor(() => screen.getByText("Usage Monitoring"));
+
+    fireEvent.click(screen.getByLabelText("Usage auto-refresh"));
+
+    await waitFor(() => {
+      expect(vi.mocked(api.updateUsageSettings)).toHaveBeenCalledWith({ enabled: false });
+      expect(screen.getByText(/boom/)).toBeTruthy();
+    });
+  });
+
+  it("commits the interval on blur with the at-least-min clamp", async () => {
+    vi.mocked(api.getUsageSettings).mockResolvedValue(
+      makeSettings({ enabled: true, auto_refresh_min: 10 }),
+    );
+    vi.mocked(api.updateUsageSettings).mockResolvedValue(undefined as never);
+    render(<UsageSection />);
+    await waitFor(() => screen.getByText("Usage Monitoring"));
+
+    const input = screen.getByLabelText("Usage auto-refresh interval") as HTMLInputElement;
+    fireEvent.change(input, { target: { value: "1" } }); // below the 5-minute min
+    fireEvent.blur(input);
+
+    await waitFor(() => {
+      expect(vi.mocked(api.updateUsageSettings)).toHaveBeenCalledWith({ auto_refresh_min: 5 });
+    });
+  });
+});

--- a/clients/react/src/components/settings/__tests__/WorkflowSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/WorkflowSection.test.tsx
@@ -1,0 +1,53 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkflowSettings } from "@/lib/api";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      getWorkflowSettings: vi.fn(),
+      updateWorkflowSettings: vi.fn(),
+    },
+  };
+});
+
+const { api } = await import("@/lib/api");
+const { WorkflowSection } = await import("../WorkflowSection");
+
+function makeSettings(overrides: Partial<WorkflowSettings> = {}): WorkflowSettings {
+  return { auto_rebase_on_merge: false, ...overrides };
+}
+
+describe("WorkflowSection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders nothing while loading", () => {
+    vi.mocked(api.getWorkflowSettings).mockReturnValue(new Promise(() => {}));
+    const { container } = render(<WorkflowSection />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("toggling auto-rebase persists and rolls back on error", async () => {
+    vi.mocked(api.getWorkflowSettings).mockResolvedValue(
+      makeSettings({ auto_rebase_on_merge: false }),
+    );
+    vi.mocked(api.updateWorkflowSettings).mockRejectedValue(new Error("nope"));
+    render(<WorkflowSection />);
+    await waitFor(() => screen.getByText("Workflow"));
+
+    const toggle = screen.getByLabelText("Auto-rebase on merge");
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(vi.mocked(api.updateWorkflowSettings)).toHaveBeenCalledWith({
+        auto_rebase_on_merge: true,
+      });
+      expect(screen.getByText(/nope/)).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Pull the four small inline sections out of `SettingsPanel` into their own components. Same pattern as the prior extractions (#583 #585 #587 #593): each section owns its state, save tracker, and load.

After this PR, `SettingsPanel` is purely a thin layout shell — it owns the project list (shared between `OrchestrationSection`'s scope selector and `ProjectsSection`'s registered-project view) and nothing else.

## Sections extracted

| Section | New file | Notes |
|---|---|---|
| Spawn | `SpawnSection.tsx` | Wraps `SpawnRuntimeSelector` + the tmux window-name field that's only relevant when runtime = `"tmux"`. Picked up the `handleWindowName{Change,Save}` helpers as a single `commitWindowName` closure. |
| Usage monitoring | `UsageSection.tsx` | Auto-refresh toggle + interval (5–1440 min). Magic numbers extracted to module constants. |
| Browser notifications | `NotificationSection.tsx` | `notify_on_idle` toggle + threshold (0–300 s). Distinct from `NotifySettingsSection`'s per-event routing. |
| Workflow | `WorkflowSection.tsx` | Auto-rebase toggle. Self-contained; future workflow tunables drop alongside without crowding the parent. |

## Numbers

| | Before #581 | After this PR | Δ |
|---|---|---|---|
| `SettingsPanel.tsx` | 2097 | **68** | **−2029 (~97% smaller)** |
| Settings sub-components | 1 monolith + 3 helpers | 14 files | +11 |

The new `SettingsPanel.tsx` is just `useEffect(refreshProjects)` plus a vertical stack of `<…Section />` invocations.

## Test plan

- [x] 12 new focused tests across `__tests__/{Spawn,Usage,Notification,Workflow}Section.test.tsx` — render gate, toggle + rollback, blur-clamp, visibility-controlled subfields
- [x] `pnpm exec vitest run src/components/settings/__tests__/` — 100/100 pass
- [x] `pnpm exec biome check` clean
- [x] `pnpm build` clean (`tsc -b && vite build`)
- [ ] Manual: open Settings → exercise each of the four sections

## Note on the extraction series

This is the last of the major Settings UI extractions. The remaining inline content in `SettingsPanel.tsx` is just the layout shell (header, scrollable section stack, close button) — no further extractions warranted unless the page itself grows new sections.

🤖 Generated with [Claude Code](https://claude.com/claude-code)