### PR TITLE
refactor(terminal): share footer controls + per-agent auto-scroll between TerminalPanel and PreviewPanel

### DIFF
--- a/clients/react/src/components/agent/PreviewPanel.tsx
+++ b/clients/react/src/components/agent/PreviewPanel.tsx
@@ -1,9 +1,11 @@
 import { AnsiUp } from "ansi_up";
 import DOMPurify from "dompurify";
 import { useCallback, useDeferredValue, useEffect, useMemo, useRef, useState } from "react";
+import { AutoScrollToggleButton, ModeHint, ModeToggleButton } from "@/components/terminal/controls";
 import { QueueBadge } from "@/components/ui/QueueBadge";
 import { QueuePopover } from "@/components/ui/QueuePopover";
 import { useAgentTerminalStream } from "@/hooks/useAgentTerminalStream";
+import { useAutoScrollPerAgent } from "@/hooks/useAutoScrollPerAgent";
 import { useQueuedPrompts } from "@/hooks/useQueuedPrompts";
 import { api } from "@/lib/api";
 import type { QueuedPrompt, TranscriptRecord } from "@/lib/api-http";
@@ -39,9 +41,6 @@ function originLabel(o: ActionOrigin): string {
       return `System:${o.subsystem}`;
   }
 }
-
-// Per-agent auto-scroll preference (persists across agent switches)
-const agentAutoScrollMap = new Map<string, boolean>();
 
 const MONO_FONT_STACK =
   "'JetBrainsMono Nerd Font', 'JetBrainsMono NF', " +
@@ -95,19 +94,7 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
     composingRef.current = composing;
   }, [composing]);
 
-  const [autoScroll, setAutoScrollRaw] = useState(() => agentAutoScrollMap.get(agentId) ?? true);
-
-  // Wrap setter to persist preference per agent
-  const setAutoScroll = useCallback(
-    (v: boolean | ((prev: boolean) => boolean)) => {
-      setAutoScrollRaw((prev) => {
-        const next = typeof v === "function" ? v(prev) : v;
-        agentAutoScrollMap.set(agentId, next);
-        return next;
-      });
-    },
-    [agentId],
-  );
+  const [autoScroll, setAutoScroll] = useAutoScrollPerAgent(agentId);
   const containerRef = useRef<HTMLDivElement>(null);
   const inputRef = useRef<HTMLInputElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
@@ -172,14 +159,14 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
     onData: onWsData,
   });
 
-  // Reset state when switching agents (autoScroll restored from per-agent map)
+  // Reset state when switching agents. autoScroll syncs through
+  // `useAutoScrollPerAgent`, which has its own agentId-keyed effect.
   useEffect(() => {
     setHistory("");
     setLive("");
     setTranscriptRecords([]);
     setFocused(true);
     setHasDomFocus(true);
-    setAutoScrollRaw(agentAutoScrollMap.get(agentId) ?? true);
     setComposing(false);
     lastHistoryHtmlRef.current = "";
     lastLiveHtmlRef.current = "";
@@ -666,34 +653,11 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
             Transcript
           </button>
         </div>
-        <button
-          type="button"
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={focused ? enterSelectMode : enterInputMode}
-          className={`touch-target-sm rounded px-2 py-1 text-xs transition-colors ${
-            focused ? "bg-cyan-500/20 text-cyan-400" : "bg-amber-500/20 text-amber-400"
-          }`}
-          title={
-            focused
-              ? "Input mode — keystrokes sent to agent (click for select mode)"
-              : "Select mode — click to copy text (click for input mode)"
-          }
-        >
-          {focused ? "⌨ Input" : "📋 Select"}
-        </button>
-        <button
-          type="button"
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={() => setAutoScroll((v) => !v)}
-          className={`touch-target-sm rounded px-2 py-1 text-xs transition-colors ${
-            autoScroll
-              ? "bg-cyan-500/15 text-cyan-400"
-              : "bg-white/5 text-zinc-600 hover:text-zinc-400"
-          }`}
-          title={autoScroll ? "Auto-scroll: ON" : "Auto-scroll: OFF"}
-        >
-          {autoScroll ? "⇩ Auto" : "⇩ Off"}
-        </button>
+        <ModeToggleButton
+          inputMode={focused}
+          onToggle={focused ? enterSelectMode : enterInputMode}
+        />
+        <AutoScrollToggleButton autoScroll={autoScroll} onToggle={() => setAutoScroll((v) => !v)} />
         <div className="relative">
           <QueueBadge
             count={queueItems.length}
@@ -721,9 +685,7 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
           />
         </div>
         <div className="flex-1" />
-        <span className="hidden text-[10px] text-zinc-600 sm:block">
-          {focused ? "click to select" : "Enter or click ⌨ to input"}
-        </span>
+        <ModeHint inputMode={focused} />
       </div>
     </div>
   );

--- a/clients/react/src/components/terminal/TerminalPanel.tsx
+++ b/clients/react/src/components/terminal/TerminalPanel.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import { useAutoScrollPerAgent } from "@/hooks/useAutoScrollPerAgent";
 import { useTerminal } from "@/hooks/useTerminal";
 import "@xterm/xterm/css/xterm.css";
+import { AutoScrollToggleButton, ModeHint, ModeToggleButton } from "./controls";
 
 // Trim the canonical id (`<scheme>:<id>`) to `<scheme>:<first-8-chars>`
 // for the panel header. `provisional:abcd1234` is more useful than the
@@ -23,7 +25,7 @@ interface TerminalPanelProps {
 export function TerminalPanel({ agentId }: TerminalPanelProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const [inputMode, setInputMode] = useState(true);
-  const [autoScroll, setAutoScroll] = useState(true);
+  const [autoScroll, setAutoScroll] = useAutoScrollPerAgent(agentId);
 
   const { setAttachable } = useTerminal({ agentId, containerRef, autoScroll });
 
@@ -82,38 +84,13 @@ export function TerminalPanel({ agentId }: TerminalPanelProps) {
 
       {/* Footer status bar */}
       <div className="flex items-center gap-2 border-t border-white/5 px-3 py-1.5">
-        <button
-          type="button"
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={inputMode ? enterSelectMode : enterInputMode}
-          className={`touch-target-sm rounded px-2 py-1 text-xs transition-colors ${
-            inputMode ? "bg-cyan-500/20 text-cyan-400" : "bg-amber-500/20 text-amber-400"
-          }`}
-          title={
-            inputMode
-              ? "Input mode — keystrokes sent to agent (click for select mode)"
-              : "Select mode — click to copy text (click for input mode)"
-          }
-        >
-          {inputMode ? "⌨ Input" : "📋 Select"}
-        </button>
-        <button
-          type="button"
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={() => setAutoScroll((v) => !v)}
-          className={`touch-target-sm rounded px-2 py-1 text-xs transition-colors ${
-            autoScroll
-              ? "bg-cyan-500/15 text-cyan-400"
-              : "bg-white/5 text-zinc-600 hover:text-zinc-400"
-          }`}
-          title={autoScroll ? "Auto-scroll: ON" : "Auto-scroll: OFF"}
-        >
-          {autoScroll ? "⇩ Auto" : "⇩ Off"}
-        </button>
+        <ModeToggleButton
+          inputMode={inputMode}
+          onToggle={inputMode ? enterSelectMode : enterInputMode}
+        />
+        <AutoScrollToggleButton autoScroll={autoScroll} onToggle={() => setAutoScroll((v) => !v)} />
         <div className="flex-1" />
-        <span className="hidden text-[10px] text-zinc-600 sm:block">
-          {inputMode ? "click to select" : "Enter or click ⌨ to input"}
-        </span>
+        <ModeHint inputMode={inputMode} />
       </div>
     </section>
   );

--- a/clients/react/src/components/terminal/controls.tsx
+++ b/clients/react/src/components/terminal/controls.tsx
@@ -1,0 +1,67 @@
+// Shared footer-bar controls used by both the live `TerminalPanel` (xterm.js)
+// and the legacy `PreviewPanel` (AnsiUp). The two panels render different
+// content above the footer (xterm canvas vs. AnsiUp HTML, optional
+// Live/Transcript tabs, queue badge, etc.) but their mode + auto-scroll
+// toggles are identical — DRY them here so future tweaks land once.
+
+interface ModeToggleButtonProps {
+  /** True when keystrokes flow to the agent (Input mode). False when the
+   *  user can drag-select text without typing into the agent (Select mode). */
+  inputMode: boolean;
+  onToggle: () => void;
+}
+
+/** Pill button that flips between Input and Select mode. */
+export function ModeToggleButton({ inputMode, onToggle }: ModeToggleButtonProps) {
+  return (
+    <button
+      type="button"
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onToggle}
+      className={`touch-target-sm rounded px-2 py-1 text-xs transition-colors ${
+        inputMode ? "bg-cyan-500/20 text-cyan-400" : "bg-amber-500/20 text-amber-400"
+      }`}
+      title={
+        inputMode
+          ? "Input mode — keystrokes sent to agent (click for select mode)"
+          : "Select mode — click to copy text (click for input mode)"
+      }
+    >
+      {inputMode ? "⌨ Input" : "📋 Select"}
+    </button>
+  );
+}
+
+interface AutoScrollToggleButtonProps {
+  autoScroll: boolean;
+  onToggle: () => void;
+}
+
+/** Pill button that flips auto-scroll on/off. */
+export function AutoScrollToggleButton({ autoScroll, onToggle }: AutoScrollToggleButtonProps) {
+  return (
+    <button
+      type="button"
+      onMouseDown={(e) => e.preventDefault()}
+      onClick={onToggle}
+      className={`touch-target-sm rounded px-2 py-1 text-xs transition-colors ${
+        autoScroll ? "bg-cyan-500/15 text-cyan-400" : "bg-white/5 text-zinc-600 hover:text-zinc-400"
+      }`}
+      title={autoScroll ? "Auto-scroll: ON" : "Auto-scroll: OFF"}
+    >
+      {autoScroll ? "⇩ Auto" : "⇩ Off"}
+    </button>
+  );
+}
+
+/**
+ * Right-aligned hint text shown at the end of the footer row. Hidden on
+ * narrow viewports (`sm:block`) since the buttons themselves carry tooltips.
+ */
+export function ModeHint({ inputMode }: { inputMode: boolean }) {
+  return (
+    <span className="hidden text-[10px] text-zinc-600 sm:block">
+      {inputMode ? "click to select" : "Enter or click ⌨ to input"}
+    </span>
+  );
+}

--- a/clients/react/src/hooks/useAutoScrollPerAgent.ts
+++ b/clients/react/src/hooks/useAutoScrollPerAgent.ts
@@ -1,0 +1,42 @@
+import { useCallback, useEffect, useState } from "react";
+
+// Module-level Map so the user's per-agent auto-scroll preference survives
+// across remounts and across host components (e.g. switching between
+// `TerminalPanel` and `PreviewPanel` for the same agent). Living here
+// rather than per-component state lets both consumers see the same value.
+const autoScrollByAgent = new Map<string, boolean>();
+
+/**
+ * `useState`-shaped wrapper that persists the chosen value into a per-agent
+ * map keyed by `agentId`. New agents default to `true` (auto-scroll on).
+ *
+ * The setter accepts both a value and an updater function, mirroring the
+ * `useState` setter shape so callers can drop it in without changing
+ * call sites. When `agentId` changes (the parent reuses the same component
+ * instance with a different agent), the state is re-synchronized from the
+ * cache so the UI reflects the previously-toggled preference for the
+ * newly-focused agent.
+ */
+export function useAutoScrollPerAgent(
+  agentId: string,
+): [boolean, (next: boolean | ((prev: boolean) => boolean)) => void] {
+  const [autoScroll, setRaw] = useState<boolean>(() => autoScrollByAgent.get(agentId) ?? true);
+
+  // Re-sync from the cache when the host swaps agents without remounting.
+  useEffect(() => {
+    setRaw(autoScrollByAgent.get(agentId) ?? true);
+  }, [agentId]);
+
+  const setAutoScroll = useCallback(
+    (next: boolean | ((prev: boolean) => boolean)) => {
+      setRaw((prev) => {
+        const value = typeof next === "function" ? next(prev) : next;
+        autoScrollByAgent.set(agentId, value);
+        return value;
+      });
+    },
+    [agentId],
+  );
+
+  return [autoScroll, setAutoScroll];
+}


### PR DESCRIPTION
## Summary

`TerminalPanel` (xterm.js) and `PreviewPanel` (AnsiUp) duplicated three nearly-identical pieces in their footer rows: the Input/Select mode toggle, the auto-scroll toggle, and the right-aligned mode hint. PreviewPanel additionally carried a module-level `agentAutoScrollMap` to persist auto-scroll per agent across remounts; TerminalPanel had no such persistence, so toggling auto-scroll OFF on one agent and switching to another silently reset the preference — inconsistent with the user's mental model.

## What changed

- New `clients/react/src/components/terminal/controls.tsx` exports `<ModeToggleButton>`, `<AutoScrollToggleButton>`, `<ModeHint>`. Both panels now compose the footer from those primitives. Future visual / aria / shortcut tweaks land in one place.
- New `clients/react/src/hooks/useAutoScrollPerAgent.ts` lifts PreviewPanel's per-agent persistence Map into a shared module-level cache. Toggling auto-scroll in one panel now reflects in the other for the same agent, and the choice survives both panel swaps and agent swaps. The hook re-syncs on `agentId` change so a single host swapping agents (without remounting) still sees the cached preference.
- PreviewPanel kept its `focused` state name because it intersects with its own `hasDomFocus` tracking (DOM-level focus, distinct from input/select mode); the prop binding to `<ModeToggleButton inputMode>` is the abstraction boundary.

## Numbers

| File | Before | After | Δ |
|---|---|---|---|
| `TerminalPanel.tsx` | 120 | 95 | −25 |
| `PreviewPanel.tsx` | 730 | 691 | −39 |
| `controls.tsx` | — | 67 | +67 |
| `useAutoScrollPerAgent.ts` | — | 42 | +42 |

Net: **−81 lines** across the two panels, **+109 lines** in the shared modules — but those modules now serve any future terminal-flavored panel (e.g. when PreviewPanel migrates to xterm.js per the Phase 4 roadmap).

## Test plan

- [x] `pnpm exec vitest run` — 319/321 pass (2 pre-existing skips unrelated)
- [x] `pnpm exec biome check` clean
- [x] `pnpm build` clean (`tsc -b && vite build`)
- [ ] Manual: open Settings → switch between TerminalPanel and PreviewPanel for the same agent, toggle auto-scroll, verify it survives the panel swap; toggle Input/Select mode, verify the hint flips
- [ ] Manual: switch agents on a single panel, verify the per-agent auto-scroll preference is restored

🤖 Generated with [Claude Code](https://claude.com/claude-code)