### PR TITLE
refactor(worktree): extract IssueActionView from ActionPanel — split issue / branch right-rail flows

### DIFF
--- a/clients/react/src/components/worktree/ActionPanel.tsx
+++ b/clients/react/src/components/worktree/ActionPanel.tsx
@@ -1,4 +1,4 @@
-import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useState } from "react";
 import { useConfirm } from "@/components/layout/ConfirmDialog";
 import {
   api,
@@ -6,9 +6,8 @@ import {
   type CiSummary,
   type IssueInfo,
   type PrInfo,
-  type WorktreeSnapshot,
 } from "@/lib/api";
-import { extractIssueNumbers, extractIssueRefs, issueToWorktreeName } from "@/lib/issue-utils";
+import { extractIssueNumbers, extractIssueRefs } from "@/lib/issue-utils";
 import { branchStateBadgeClass, branchStateLabel, deriveBranchState } from "./branch-state";
 import { CreateWorktreeForm } from "./CreateWorktreeForm";
 import type { DetailView } from "./DetailPanel";
@@ -28,25 +27,22 @@ interface ActionPanelProps {
   onSelectNode: (name: string | null) => void;
   onFocusAgent: (target: string) => void;
   onOpenDetail: (view: DetailView | null) => void;
-  // Issue mode (when Issues tab is active)
-  issueMode?: boolean;
-  selectedIssue?: IssueInfo | null;
-  defaultBranch?: string;
-  worktrees?: WorktreeSnapshot[];
-  onStartWorkDone?: (worktreeName: string) => void;
-  onSelectWorktreeBranch?: (branch: string) => void;
   /** Navigate to issue in Issues tab */
   onNavigateToIssue?: (issue: IssueInfo) => void;
   /** Navigate to branch in Branches tab (used from PrCard) */
   onNavigateToBranch?: (branch: string) => void;
 }
 
-// Right-side action panel for selected branch. Wrapped in React.memo so
-// the 1–2 Hz `agents` SSE churn (Claude Code spinner-glyph animation)
-// doesn't repeat this ~1000-line widget's render on every parent tick.
-// Parent (BranchGraph) passes memoized props (activeNode / nodeDepth /
+// Right-side action panel for the selected branch (Branches tab). Wrapped
+// in React.memo so the 1–2 Hz `agents` SSE churn (Claude Code spinner-glyph
+// animation) doesn't repeat this ~1000-line widget's render on every parent
+// tick. Parent (BranchGraph) passes memoized props (activeNode / nodeDepth /
 // targetPrs via a stable EMPTY_PRS fallback) so shallow equality holds on
 // quiet ticks.
+//
+// The Issues-tab counterpart lives in `IssueActionView` — issue and branch
+// flows used to share this component via an `issueMode` prop, but the
+// surface area was completely disjoint, so they were split (#TBD).
 export const ActionPanel = memo(function ActionPanel({
   activeNode,
   branches,
@@ -60,12 +56,6 @@ export const ActionPanel = memo(function ActionPanel({
   onSelectNode,
   onFocusAgent,
   onOpenDetail,
-  issueMode,
-  selectedIssue,
-  defaultBranch,
-  worktrees,
-  onStartWorkDone,
-  onSelectWorktreeBranch,
   onNavigateToIssue,
   onNavigateToBranch,
 }: ActionPanelProps) {
@@ -84,11 +74,6 @@ export const ActionPanel = memo(function ActionPanel({
     insertions: number;
     deletions: number;
   } | null>(null);
-  // Issue start-work form state
-  const [startWorkName, setStartWorkName] = useState("");
-  const [startWorkBusy, setStartWorkBusy] = useState(false);
-  const [startWorkError, setStartWorkError] = useState<string | null>(null);
-  const startWorkInputRef = useRef<HTMLInputElement>(null);
 
   // Reset all ephemeral state when branch changes
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional reset on branch name change
@@ -119,17 +104,6 @@ export const ActionPanel = memo(function ActionPanel({
       .catch(() => setCiSummary(null))
       .finally(() => setCiLoading(false));
   }, [activeNode.name, projectPath]);
-
-  // Pre-fill start-work name when issue selection changes
-  useEffect(() => {
-    if (selectedIssue) {
-      setStartWorkName(issueToWorktreeName(selectedIssue));
-      setStartWorkError(null);
-      setStartWorkBusy(false);
-      // Focus the input after render
-      setTimeout(() => startWorkInputRef.current?.focus(), 50);
-    }
-  }, [selectedIssue]);
 
   // Fetch diff stat vs parent branch when branch changes (for non-main branches without worktree diffSummary)
   useEffect(() => {
@@ -324,211 +298,6 @@ export const ActionPanel = memo(function ActionPanel({
       setRerunBusy(false);
     }
   }, [ciSummary, rerunBusy, projectPath, activeNode.name]);
-
-  // Start work on an issue: create worktree + launch agent
-  // Build a resolve prompt from the selected issue
-  const buildResolvePrompt = useCallback(
-    (issue: IssueInfo) =>
-      `GitHub Issue #${issue.number} "${issue.title}" に対応してください。\n\nまず \`gh issue view ${issue.number}\` でissueの詳細を確認し、実装方針を立ててください。\n実装・テスト完了後、PRを作成してください（Closes #${issue.number} をPR本文に含めること）。`,
-    [],
-  );
-
-  // Create worktree + launch agent (optionally with initial prompt)
-  const handleStartWork = useCallback(
-    async (initialPrompt?: string) => {
-      if (!selectedIssue || startWorkBusy || !startWorkName.trim()) return;
-      const trimmed = startWorkName.trim();
-      if (!/^[a-zA-Z0-9_-]+$/.test(trimmed) || trimmed.length > 64) {
-        setStartWorkError("a-z, 0-9, -, _ only (max 64)");
-        return;
-      }
-      setStartWorkBusy(true);
-      setStartWorkError(null);
-      try {
-        const base = defaultBranch ?? "main";
-        await api.spawnWorktree({
-          name: trimmed,
-          cwd: projectPath,
-          base_branch: base,
-          ...(initialPrompt ? { initial_prompt: initialPrompt } : {}),
-        });
-        onStartWorkDone?.(trimmed);
-      } catch (e) {
-        setStartWorkError(e instanceof Error ? e.message : "Failed to create worktree");
-      } finally {
-        setStartWorkBusy(false);
-      }
-    },
-    [selectedIssue, startWorkBusy, startWorkName, defaultBranch, projectPath, onStartWorkDone],
-  );
-
-  // Find matching worktree for selected issue
-  const matchingWorktree = (() => {
-    if (!selectedIssue || !worktrees) return null;
-    for (const wt of worktrees) {
-      if (wt.is_main) continue;
-      const branch = wt.branch ?? wt.name;
-      const nums = extractIssueNumbers(branch);
-      if (nums.includes(selectedIssue.number)) return wt;
-    }
-    return null;
-  })();
-
-  // Issue mode: show issue details + start work form (or worktree status)
-  if (issueMode) {
-    return (
-      <div className="w-80 shrink-0 overflow-y-auto border-l border-white/5 bg-black/20">
-        <div className="p-4">
-          {selectedIssue ? (
-            <>
-              {/* Issue header */}
-              <div className="mb-4">
-                <div className="flex items-center gap-2">
-                  <span className="text-lg font-semibold text-green-400">
-                    #{selectedIssue.number}
-                  </span>
-                  <a
-                    href={selectedIssue.url}
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    className="text-[10px] text-zinc-500 hover:text-zinc-300"
-                  >
-                    open in GitHub
-                  </a>
-                </div>
-                <h3 className="mt-1 text-sm font-medium text-zinc-100">{selectedIssue.title}</h3>
-                {/* Labels */}
-                {selectedIssue.labels.length > 0 && (
-                  <div className="mt-2 flex flex-wrap gap-1">
-                    {selectedIssue.labels.map((label) => (
-                      <span
-                        key={label.name}
-                        className="rounded-full px-1.5 py-0.5 text-[10px]"
-                        style={{
-                          backgroundColor: `#${label.color}22`,
-                          color: `#${label.color}`,
-                        }}
-                      >
-                        {label.name}
-                      </span>
-                    ))}
-                  </div>
-                )}
-                {/* Assignees */}
-                {selectedIssue.assignees.length > 0 && (
-                  <div className="mt-2 text-[11px] text-zinc-500">
-                    Assigned: {selectedIssue.assignees.join(", ")}
-                  </div>
-                )}
-              </div>
-
-              {matchingWorktree ? (
-                /* Existing worktree status */
-                <div className="rounded-lg border border-cyan-500/20 bg-cyan-500/5 p-3">
-                  <div className="mb-2 text-[11px] font-medium text-cyan-400">
-                    {matchingWorktree.agent_status === "in-progress" ||
-                    matchingWorktree.agent_status === "waiting"
-                      ? "Agent In Progress"
-                      : "Worktree Exists"}
-                  </div>
-                  <div className="mb-1 text-[11px] text-zinc-400">
-                    <span className="text-zinc-500">branch:</span>{" "}
-                    <span className="text-cyan-400">
-                      {matchingWorktree.branch ?? matchingWorktree.name}
-                    </span>
-                  </div>
-                  {matchingWorktree.agent_target && (
-                    <div className="mb-1 text-[11px] text-zinc-400">
-                      <span className="text-zinc-500">agent:</span>{" "}
-                      <span className="text-cyan-400">{matchingWorktree.agent_target}</span>
-                    </div>
-                  )}
-                  {matchingWorktree.agent_status && (
-                    <div className="mb-2 text-[11px] text-zinc-400">
-                      <span className="text-zinc-500">status:</span>{" "}
-                      <span
-                        className={
-                          matchingWorktree.agent_status === "in-progress" ||
-                          matchingWorktree.agent_status === "waiting"
-                            ? "text-cyan-400"
-                            : "text-amber-400"
-                        }
-                      >
-                        {matchingWorktree.agent_status}
-                      </span>
-                    </div>
-                  )}
-                  <button
-                    type="button"
-                    onClick={() => {
-                      const branch = matchingWorktree.branch ?? matchingWorktree.name;
-                      onSelectWorktreeBranch?.(branch);
-                    }}
-                    className="mt-1 w-full rounded-lg bg-cyan-500/20 px-3 py-2 text-xs font-medium text-cyan-400 transition-colors hover:bg-cyan-500/30"
-                  >
-                    Go to Worktree
-                  </button>
-                </div>
-              ) : (
-                /* Start Work form */
-                <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3">
-                  <div className="mb-2 text-[11px] font-medium text-emerald-400">Start Work</div>
-                  <div className="mb-1.5 text-[11px] text-zinc-500">
-                    base: <span className="text-emerald-400">{defaultBranch ?? "main"}</span>
-                  </div>
-                  <div className="flex items-center gap-1">
-                    <input
-                      ref={startWorkInputRef}
-                      type="text"
-                      value={startWorkName}
-                      onChange={(e) => {
-                        setStartWorkName(e.target.value);
-                        setStartWorkError(null);
-                      }}
-                      onKeyDown={(e) => {
-                        if (e.key === "Enter") handleStartWork();
-                      }}
-                      placeholder="worktree name"
-                      className="flex-1 rounded bg-black/30 px-2 py-1.5 text-xs text-zinc-200 placeholder-zinc-600 outline-none ring-1 ring-emerald-500/30 focus:ring-emerald-500/60"
-                    />
-                  </div>
-                  <div className="mt-1 text-[10px] text-zinc-600">
-                    Creates worktree + launches agent
-                  </div>
-                  {startWorkError && (
-                    <div className="mt-1 text-[10px] text-red-400">{startWorkError}</div>
-                  )}
-                  <div className="mt-2 flex gap-2">
-                    <button
-                      type="button"
-                      onClick={() => handleStartWork()}
-                      disabled={!startWorkName.trim() || startWorkBusy}
-                      className="flex-1 rounded-lg bg-emerald-500/20 px-3 py-2 text-xs font-medium text-emerald-400 transition-colors hover:bg-emerald-500/30 disabled:opacity-40"
-                    >
-                      {startWorkBusy ? "Creating..." : "Launch Agent"}
-                    </button>
-                    <button
-                      type="button"
-                      onClick={() =>
-                        selectedIssue && handleStartWork(buildResolvePrompt(selectedIssue))
-                      }
-                      disabled={!startWorkName.trim() || startWorkBusy}
-                      className="flex-1 rounded-lg bg-amber-500/20 px-3 py-2 text-xs font-medium text-amber-400 transition-colors hover:bg-amber-500/30 disabled:opacity-40"
-                      title="Worktree作成 → issue内容を含むプロンプトでエージェント起動 → 実装・テスト・PR作成まで自動実行"
-                    >
-                      {startWorkBusy ? "Creating..." : "Create & Resolve ▶"}
-                    </button>
-                  </div>
-                </div>
-              )}
-            </>
-          ) : (
-            <div className="text-sm text-zinc-500">Select an issue to start work</div>
-          )}
-        </div>
-      </div>
-    );
-  }
 
   return (
     <div className="w-80 shrink-0 overflow-y-auto border-l border-white/5 bg-black/20">

--- a/clients/react/src/components/worktree/BranchGraph.tsx
+++ b/clients/react/src/components/worktree/BranchGraph.tsx
@@ -16,6 +16,7 @@ import { DetailPanel, type DetailView } from "./DetailPanel";
 import { LaneGraph } from "./graph/LaneGraph";
 import { computeLayout } from "./graph/layout";
 import type { BranchNode } from "./graph/types";
+import { IssueActionView } from "./IssueActionView";
 import { IssueDetailPanel } from "./IssueDetailPanel";
 import { IssuesPanel } from "./IssuesPanel";
 
@@ -664,31 +665,17 @@ export function BranchGraph({
               />
             )}
 
-            {/* Action panel toggle + panel in issue mode */}
+            {/* Action panel toggle + Issues-tab right rail */}
             <ActionPanelToggle collapsed={actionPanelCollapsed} onToggle={onToggleActionPanel} />
             {!actionPanelCollapsed && (
               <div className="animate-slide-in-right">
-                <ActionPanel
-                  activeNode={activeNode ?? nodes[0]}
-                  branches={branches}
-                  projectPath={projectPath}
-                  nodeDepth={nodeDepth}
-                  branchDepthWarning={BRANCH_DEPTH_WARNING}
-                  prInfo={undefined}
-                  targetPrs={EMPTY_PRS}
-                  issues={issues}
-                  onRefresh={refreshBranches}
-                  onSelectNode={setSelectedNode}
-                  onFocusAgent={onFocusAgent}
-                  onOpenDetail={setDetailView}
-                  issueMode
+                <IssueActionView
                   selectedIssue={selectedIssue}
                   defaultBranch={branches?.default_branch ?? "main"}
                   worktrees={projectWorktrees}
-                  onStartWorkDone={handleStartWorkDone}
+                  projectPath={projectPath}
                   onSelectWorktreeBranch={navigateToBranch}
-                  onNavigateToIssue={navigateToIssue}
-                  onNavigateToBranch={navigateToBranch}
+                  onStartWorkDone={handleStartWorkDone}
                 />
               </div>
             )}

--- a/clients/react/src/components/worktree/IssueActionView.tsx
+++ b/clients/react/src/components/worktree/IssueActionView.tsx
@@ -1,0 +1,258 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api, type IssueInfo, type WorktreeSnapshot } from "@/lib/api";
+import { extractIssueNumbers, issueToWorktreeName } from "@/lib/issue-utils";
+
+interface IssueActionViewProps {
+  /** Issue selected in the Issues tab. `null` shows an empty placeholder. */
+  selectedIssue: IssueInfo | null;
+  /** Repository default branch — used as the base for worktree creation. */
+  defaultBranch?: string;
+  /** Snapshot of registered worktrees for the project; we look up an existing
+   *  worktree whose branch references the selected issue's number. */
+  worktrees?: WorktreeSnapshot[];
+  /** Project path passed to `api.spawnWorktree`. */
+  projectPath: string;
+  /** Caller-side navigation: jump the user to an existing worktree's branch. */
+  onSelectWorktreeBranch?: (branch: string) => void;
+  /** Caller-side navigation: jump the user to the just-created worktree. */
+  onStartWorkDone?: (worktreeName: string) => void;
+}
+
+/**
+ * Right-rail panel shown while the Issues tab has focus. Two modes:
+ * - **Existing worktree** for this issue: surface its agent status + a
+ *   "Go to Worktree" button.
+ * - **Start Work**: pre-filled name input + Launch / Create-and-Resolve
+ *   buttons. Resolve mode includes a Japanese prompt shaped around the
+ *   selected issue's number and title.
+ *
+ * Extracted from `ActionPanel`'s `issueMode === true` branch — issue and
+ * branch flows are completely disjoint and were forced through one
+ * component only because they share the same right-rail slot. Splitting
+ * them lets each side carry only the props it needs (BranchGraph no
+ * longer has to thread `EMPTY_PRS` and a synthetic `activeNode` through
+ * here).
+ */
+export function IssueActionView({
+  selectedIssue,
+  defaultBranch,
+  worktrees,
+  projectPath,
+  onSelectWorktreeBranch,
+  onStartWorkDone,
+}: IssueActionViewProps) {
+  const [startWorkName, setStartWorkName] = useState("");
+  const [startWorkBusy, setStartWorkBusy] = useState(false);
+  const [startWorkError, setStartWorkError] = useState<string | null>(null);
+  const startWorkInputRef = useRef<HTMLInputElement>(null);
+
+  // Pre-fill the worktree name from the selected issue and focus the input.
+  useEffect(() => {
+    if (selectedIssue) {
+      setStartWorkName(issueToWorktreeName(selectedIssue));
+      setStartWorkError(null);
+      setStartWorkBusy(false);
+      // Focus runs after render — the timeout (rather than a useLayoutEffect)
+      // gives the slide-in animation room to start before the focus jump.
+      setTimeout(() => startWorkInputRef.current?.focus(), 50);
+    }
+  }, [selectedIssue]);
+
+  const buildResolvePrompt = useCallback(
+    (issue: IssueInfo) =>
+      `GitHub Issue #${issue.number} "${issue.title}" に対応してください。\n\nまず \`gh issue view ${issue.number}\` でissueの詳細を確認し、実装方針を立ててください。\n実装・テスト完了後、PRを作成してください（Closes #${issue.number} をPR本文に含めること）。`,
+    [],
+  );
+
+  const handleStartWork = useCallback(
+    async (initialPrompt?: string) => {
+      if (!selectedIssue || startWorkBusy || !startWorkName.trim()) return;
+      const trimmed = startWorkName.trim();
+      if (!/^[a-zA-Z0-9_-]+$/.test(trimmed) || trimmed.length > 64) {
+        setStartWorkError("a-z, 0-9, -, _ only (max 64)");
+        return;
+      }
+      setStartWorkBusy(true);
+      setStartWorkError(null);
+      try {
+        const base = defaultBranch ?? "main";
+        await api.spawnWorktree({
+          name: trimmed,
+          cwd: projectPath,
+          base_branch: base,
+          ...(initialPrompt ? { initial_prompt: initialPrompt } : {}),
+        });
+        onStartWorkDone?.(trimmed);
+      } catch (e) {
+        setStartWorkError(e instanceof Error ? e.message : "Failed to create worktree");
+      } finally {
+        setStartWorkBusy(false);
+      }
+    },
+    [selectedIssue, startWorkBusy, startWorkName, defaultBranch, projectPath, onStartWorkDone],
+  );
+
+  // Look up an existing worktree whose branch references the selected
+  // issue. `is_main` worktrees are skipped — they exist for every project.
+  const matchingWorktree = (() => {
+    if (!selectedIssue || !worktrees) return null;
+    for (const wt of worktrees) {
+      if (wt.is_main) continue;
+      const branch = wt.branch ?? wt.name;
+      const nums = extractIssueNumbers(branch);
+      if (nums.includes(selectedIssue.number)) return wt;
+    }
+    return null;
+  })();
+
+  return (
+    <div className="w-80 shrink-0 overflow-y-auto border-l border-white/5 bg-black/20">
+      <div className="p-4">
+        {selectedIssue ? (
+          <>
+            {/* Issue header */}
+            <div className="mb-4">
+              <div className="flex items-center gap-2">
+                <span className="text-lg font-semibold text-green-400">
+                  #{selectedIssue.number}
+                </span>
+                <a
+                  href={selectedIssue.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-[10px] text-zinc-500 hover:text-zinc-300"
+                >
+                  open in GitHub
+                </a>
+              </div>
+              <h3 className="mt-1 text-sm font-medium text-zinc-100">{selectedIssue.title}</h3>
+              {selectedIssue.labels.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-1">
+                  {selectedIssue.labels.map((label) => (
+                    <span
+                      key={label.name}
+                      className="rounded-full px-1.5 py-0.5 text-[10px]"
+                      style={{
+                        backgroundColor: `#${label.color}22`,
+                        color: `#${label.color}`,
+                      }}
+                    >
+                      {label.name}
+                    </span>
+                  ))}
+                </div>
+              )}
+              {selectedIssue.assignees.length > 0 && (
+                <div className="mt-2 text-[11px] text-zinc-500">
+                  Assigned: {selectedIssue.assignees.join(", ")}
+                </div>
+              )}
+            </div>
+
+            {matchingWorktree ? (
+              /* Existing worktree status */
+              <div className="rounded-lg border border-cyan-500/20 bg-cyan-500/5 p-3">
+                <div className="mb-2 text-[11px] font-medium text-cyan-400">
+                  {matchingWorktree.agent_status === "in-progress" ||
+                  matchingWorktree.agent_status === "waiting"
+                    ? "Agent In Progress"
+                    : "Worktree Exists"}
+                </div>
+                <div className="mb-1 text-[11px] text-zinc-400">
+                  <span className="text-zinc-500">branch:</span>{" "}
+                  <span className="text-cyan-400">
+                    {matchingWorktree.branch ?? matchingWorktree.name}
+                  </span>
+                </div>
+                {matchingWorktree.agent_target && (
+                  <div className="mb-1 text-[11px] text-zinc-400">
+                    <span className="text-zinc-500">agent:</span>{" "}
+                    <span className="text-cyan-400">{matchingWorktree.agent_target}</span>
+                  </div>
+                )}
+                {matchingWorktree.agent_status && (
+                  <div className="mb-2 text-[11px] text-zinc-400">
+                    <span className="text-zinc-500">status:</span>{" "}
+                    <span
+                      className={
+                        matchingWorktree.agent_status === "in-progress" ||
+                        matchingWorktree.agent_status === "waiting"
+                          ? "text-cyan-400"
+                          : "text-amber-400"
+                      }
+                    >
+                      {matchingWorktree.agent_status}
+                    </span>
+                  </div>
+                )}
+                <button
+                  type="button"
+                  onClick={() => {
+                    const branch = matchingWorktree.branch ?? matchingWorktree.name;
+                    onSelectWorktreeBranch?.(branch);
+                  }}
+                  className="mt-1 w-full rounded-lg bg-cyan-500/20 px-3 py-2 text-xs font-medium text-cyan-400 transition-colors hover:bg-cyan-500/30"
+                >
+                  Go to Worktree
+                </button>
+              </div>
+            ) : (
+              /* Start Work form */
+              <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3">
+                <div className="mb-2 text-[11px] font-medium text-emerald-400">Start Work</div>
+                <div className="mb-1.5 text-[11px] text-zinc-500">
+                  base: <span className="text-emerald-400">{defaultBranch ?? "main"}</span>
+                </div>
+                <div className="flex items-center gap-1">
+                  <input
+                    ref={startWorkInputRef}
+                    type="text"
+                    value={startWorkName}
+                    onChange={(e) => {
+                      setStartWorkName(e.target.value);
+                      setStartWorkError(null);
+                    }}
+                    onKeyDown={(e) => {
+                      if (e.key === "Enter") handleStartWork();
+                    }}
+                    placeholder="worktree name"
+                    className="flex-1 rounded bg-black/30 px-2 py-1.5 text-xs text-zinc-200 placeholder-zinc-600 outline-none ring-1 ring-emerald-500/30 focus:ring-emerald-500/60"
+                  />
+                </div>
+                <div className="mt-1 text-[10px] text-zinc-600">
+                  Creates worktree + launches agent
+                </div>
+                {startWorkError && (
+                  <div className="mt-1 text-[10px] text-red-400">{startWorkError}</div>
+                )}
+                <div className="mt-2 flex gap-2">
+                  <button
+                    type="button"
+                    onClick={() => handleStartWork()}
+                    disabled={!startWorkName.trim() || startWorkBusy}
+                    className="flex-1 rounded-lg bg-emerald-500/20 px-3 py-2 text-xs font-medium text-emerald-400 transition-colors hover:bg-emerald-500/30 disabled:opacity-40"
+                  >
+                    {startWorkBusy ? "Creating..." : "Launch Agent"}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() =>
+                      selectedIssue && handleStartWork(buildResolvePrompt(selectedIssue))
+                    }
+                    disabled={!startWorkName.trim() || startWorkBusy}
+                    className="flex-1 rounded-lg bg-amber-500/20 px-3 py-2 text-xs font-medium text-amber-400 transition-colors hover:bg-amber-500/30 disabled:opacity-40"
+                    title="Worktree作成 → issue内容を含むプロンプトでエージェント起動 → 実装・テスト・PR作成まで自動実行"
+                  >
+                    {startWorkBusy ? "Creating..." : "Create & Resolve ▶"}
+                  </button>
+                </div>
+              </div>
+            )}
+          </>
+        ) : (
+          <div className="text-sm text-zinc-500">Select an issue to start work</div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

The right-rail panel in `BranchGraph` multiplexed two completely-disjoint flows through one component via an `issueMode` prop:

- **Branch mode** (default): action surface for the selected branch — CI summary, PR card, delete confirmation, launch agent, focus agent, rebase, merge, etc. (~750 lines of JSX + handlers).
- **Issue mode** (Issues-tab focus): pre-filled Start Work form that creates a worktree and launches an agent against the selected issue, or surfaces an existing matching worktree.

The two never share state and don't co-render. The shared shell forced `BranchGraph`'s call site to thread irrelevant props through (`activeNode` defaulted to `nodes[0]`, `prInfo` to `undefined`, `targetPrs` to `EMPTY_PRS`, etc.) just to satisfy the type signature for the issue-mode branch — a long-standing API smell.

## What changed

- New **`IssueActionView`** carries the issue-mode JSX, the start-work state (`startWorkName` / `startWorkBusy` / `startWorkError` / `startWorkInputRef`), the `buildResolvePrompt` / `handleStartWork` callbacks, and the `matchingWorktree` lookup. Required props shrink to just `selectedIssue` / `defaultBranch` / `worktrees` / `projectPath` / `onSelectWorktreeBranch` / `onStartWorkDone` — six instead of seventeen.
- **`ActionPanel`** drops `issueMode` / `selectedIssue` / `defaultBranch` / `worktrees` / `onStartWorkDone` / `onSelectWorktreeBranch` from its prop list, and the `if (issueMode) { return ...; }` early-out from its body. `WorktreeSnapshot` and `issueToWorktreeName` imports follow the extracted state.
- **`BranchGraph`** issues-tab call site swaps `<ActionPanel issueMode>` for `<IssueActionView />` — six clean props, no synthetic `activeNode`, no `EMPTY_PRS` masquerade.

## Numbers

| File | Before | After | Δ |
|---|---|---|---|
| `ActionPanel.tsx` | 1128 | 897 | **−231 (~20% smaller)** |
| `IssueActionView.tsx` | — | 258 | +258 (new) |

Net: +27 lines (the new file gets its own imports + docstring) but with cleaner separation: ActionPanel is now the single-responsibility branch-action widget the comment block always claimed it was.

## Test plan

- [x] `pnpm exec vitest run` — 331/333 pass (2 pre-existing skips unrelated)
- [x] `pnpm exec biome check` clean
- [x] `pnpm build` clean (`tsc -b && vite build`)
- [ ] Manual: Branches tab — verify CI summary / PR card / delete flow / launch / focus / rebase / merge all still work
- [ ] Manual: Issues tab — pick an issue, verify the pre-filled Start Work form, Launch Agent, and Create & Resolve all still work; pick an issue with an existing worktree, verify Go to Worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * イシュー処理パネルを専用コンポーネントに変更し、UIの整理と操作性を向上させました
  * イシューとブランチ間のナビゲーション機能を強化しました
  * ワークツリー作成ワークフローのユーザーインターフェースを最適化しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->