### PR TITLE
chore(gen): sync generated spec + types from tmai-core@0baba7d764

### DIFF
--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "2.2.0"
+    "version": "2.3.0"
   },
   "paths": {
     "/api/agents/{id}/subscribe-terminal": {

--- a/versions.toml
+++ b/versions.toml
@@ -6,7 +6,7 @@
 # release.yml refuses to bundle while any key is 0.0.0, so placeholders are
 # an active safety net rather than a pending TODO.
 
-core = "2.2.0"      # tmai-core private Release
+core = "2.3.0"      # tmai-core private Release
 react = "1.2.0"     # clients/react/package.json version
 ratatui = "0.1.0"   # clients/ratatui/Cargo.toml version
-api_spec = "2.2.0"  # api-spec/openapi.json info.version
+api_spec = "2.3.0"  # api-spec/openapi.json info.version


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@0baba7d7645e20b28bf4a7a220a5d3a709b4511b

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/openapi.json | 2 +-
 versions.toml         | 4 ++--
 2 files changed, 3 insertions(+), 3 deletions(-)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * OpenAPI仕様ドキュメントのバージョンを2.2.0から2.3.0にアップデート
  * コアおよびAPI仕様の関連バージョンを2.2.0から2.3.0に統一

<!-- end of auto-generated comment: release notes by coderabbit.ai -->