### PR TITLE
chore(gen): sync generated spec + types from tmai-core@5ad3293d7f

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -2591,6 +2591,45 @@
       "type": "object"
     },
     {
+      "description": "A PR has been open without any CI run starting for longer than\n`OrchestrationSettings::pr_monitor_ci_start_timeout_secs`. Typically\nindicates GitHub Actions silently skipped (merge conflicts blocking\nCI, Actions disabled at the repo, etc.) — see #334. Counted from the\nfirst time the monitor observed the PR; warm-up baseline PRs are\nexempt so a tmai restart does not retro-fire the alarm. Emitted at\nmost once per PR.",
+      "properties": {
+        "branch": {
+          "description": "Head branch name",
+          "type": "string"
+        },
+        "pr_number": {
+          "description": "PR number",
+          "format": "int64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "title": {
+          "description": "PR title",
+          "type": "string"
+        },
+        "type": {
+          "enum": [
+            "PrCiStartTimeout"
+          ],
+          "type": "string"
+        },
+        "waited_secs": {
+          "description": "How many seconds the monitor has been watching this PR with no\nCI status. Always >= the configured timeout.",
+          "format": "int64",
+          "minimum": 0,
+          "type": "integer"
+        }
+      },
+      "required": [
+        "pr_number",
+        "title",
+        "branch",
+        "waited_secs",
+        "type"
+      ],
+      "type": "object"
+    },
+    {
       "description": "Git state changed for a repository (branches, HEAD, commit graph).\n\nEmitted by [`crate::git::monitor::GitMonitor`] when its poll detects\na transition. WebUI subscribers refetch `/api/git/*` in response so\nthe UI and the monitor snapshot observe the same tick (#423 — sibling\nof the PR Monitor SoT pattern).",
       "properties": {
         "repo": {

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -1056,6 +1056,45 @@
           },
           {
             "type": "object",
+            "description": "A PR has been open without any CI run starting for longer than\n`OrchestrationSettings::pr_monitor_ci_start_timeout_secs`. Typically\nindicates GitHub Actions silently skipped (merge conflicts blocking\nCI, Actions disabled at the repo, etc.) — see #334. Counted from the\nfirst time the monitor observed the PR; warm-up baseline PRs are\nexempt so a tmai restart does not retro-fire the alarm. Emitted at\nmost once per PR.",
+            "required": [
+              "pr_number",
+              "title",
+              "branch",
+              "waited_secs",
+              "type"
+            ],
+            "properties": {
+              "branch": {
+                "type": "string",
+                "description": "Head branch name"
+              },
+              "pr_number": {
+                "type": "integer",
+                "format": "int64",
+                "description": "PR number",
+                "minimum": 0
+              },
+              "title": {
+                "type": "string",
+                "description": "PR title"
+              },
+              "type": {
+                "type": "string",
+                "enum": [
+                  "PrCiStartTimeout"
+                ]
+              },
+              "waited_secs": {
+                "type": "integer",
+                "format": "int64",
+                "description": "How many seconds the monitor has been watching this PR with no\nCI status. Always >= the configured timeout.",
+                "minimum": 0
+              }
+            }
+          },
+          {
+            "type": "object",
             "description": "Git state changed for a repository (branches, HEAD, commit graph).\n\nEmitted by [`crate::git::monitor::GitMonitor`] when its poll detects\na transition. WebUI subscribers refetch `/api/git/*` in response so\nthe UI and the monitor snapshot observe the same tick (#423 — sibling\nof the PR Monitor SoT pattern).",
             "required": [
               "repo",

--- a/clients/ratatui/src/types/generated/core_event.rs
+++ b/clients/ratatui/src/types/generated/core_event.rs
@@ -110,6 +110,12 @@ pub enum CoreEvent {
         pr_number: i64,
         title: String,
     },
+    PrCiStartTimeout {
+        branch: String,
+        pr_number: i64,
+        title: String,
+        waited_secs: i64,
+    },
     GitStateChanged {
         repo: String,
     },

--- a/clients/react/src/types/generated/CoreEvent.ts
+++ b/clients/react/src/types/generated/CoreEvent.ts
@@ -247,7 +247,24 @@ title: string,
 /**
  * Head branch name
  */
-branch: string, } | { "type": "GitStateChanged", 
+branch: string, } | { "type": "PrCiStartTimeout", 
+/**
+ * PR number
+ */
+pr_number: bigint, 
+/**
+ * PR title
+ */
+title: string, 
+/**
+ * Head branch name
+ */
+branch: string, 
+/**
+ * How many seconds the monitor has been watching this PR with no
+ * CI status. Always >= the configured timeout.
+ */
+waited_secs: bigint, } | { "type": "GitStateChanged", 
 /**
  * Repository directory path
  */


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@5ad3293d7fda25afffc59fdf60bcb3673b1a6519

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/corevents.schema.json                    | 39 +++++++++++++++++++++++
 api-spec/openapi.json                             | 39 +++++++++++++++++++++++
 clients/ratatui/src/types/generated/core_event.rs |  6 ++++
 clients/react/src/types/generated/CoreEvent.ts    | 19 ++++++++++-
 4 files changed, 102 insertions(+), 1 deletion(-)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * PR CI開始タイムアウトイベントを追加。設定されたタイムアウト期間内にCI実行が開始されなかったプルリクエストの情報（プルリクエスト番号、ブランチ、タイトル、待機時間）を記録します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->