### PR TITLE
fix(spawn): re-fetch default_project_root every time the picker opens

### DIFF
--- a/clients/react/src/components/project/NewAgentLauncher.tsx
+++ b/clients/react/src/components/project/NewAgentLauncher.tsx
@@ -24,16 +24,25 @@ export function NewAgentLauncher({ onSpawned }: NewAgentLauncherProps) {
   const [error, setError] = useState("");
   const [defaultRoot, setDefaultRoot] = useState<string | null>(null);
 
-  // Seeded from `[general] default_project_root` so the picker opens at the
-  // user's preferred root instead of `~`. AgentList (our parent) un-mounts
-  // while Settings is open, so re-fetching on mount is enough to pick up
-  // edits made in the GeneralSection without a manual refresh hook.
-  useEffect(() => {
+  // `[general] default_project_root` seeds DirBrowser's start path. AgentList
+  // (our parent) lives in the always-mounted sidebar — it does NOT unmount
+  // when Settings opens, contrary to what an earlier comment here claimed —
+  // so we have to re-fetch every time the user opens the picker, otherwise
+  // an edit in GeneralSection won't show up until a hard reload.
+  const refreshDefaultRoot = useCallback(() => {
     api
       .getGeneralSettings()
       .then((g) => setDefaultRoot(g.default_project_root))
       .catch(() => {});
   }, []);
+  useEffect(() => {
+    refreshDefaultRoot();
+  }, [refreshDefaultRoot]);
+
+  const handleOpenBrowser = useCallback(() => {
+    refreshDefaultRoot();
+    setBrowsing(true);
+  }, [refreshDefaultRoot]);
 
   const handleDirSelected = useCallback((path: string) => {
     setPickedDir(path);
@@ -67,7 +76,7 @@ export function NewAgentLauncher({ onSpawned }: NewAgentLauncherProps) {
     <div className="mb-2">
       <button
         type="button"
-        onClick={() => setBrowsing(true)}
+        onClick={handleOpenBrowser}
         disabled={spawning}
         className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-white/10 bg-white/[0.02] px-3 py-2 text-xs text-zinc-400 transition-colors hover:border-cyan-500/30 hover:bg-cyan-500/5 hover:text-cyan-300 disabled:opacity-50"
       >

--- a/clients/react/src/components/project/NewAgentLauncher.tsx
+++ b/clients/react/src/components/project/NewAgentLauncher.tsx
@@ -29,18 +29,24 @@ export function NewAgentLauncher({ onSpawned }: NewAgentLauncherProps) {
   // when Settings opens, contrary to what an earlier comment here claimed —
   // so we have to re-fetch every time the user opens the picker, otherwise
   // an edit in GeneralSection won't show up until a hard reload.
-  const refreshDefaultRoot = useCallback(() => {
-    api
-      .getGeneralSettings()
-      .then((g) => setDefaultRoot(g.default_project_root))
-      .catch(() => {});
+  const refreshDefaultRoot = useCallback(async () => {
+    try {
+      const g = await api.getGeneralSettings();
+      setDefaultRoot(g.default_project_root);
+    } catch {
+      // Leave the previous value in place — a transient fetch failure
+      // shouldn't reset the user's configured root to null.
+    }
   }, []);
   useEffect(() => {
-    refreshDefaultRoot();
+    void refreshDefaultRoot();
   }, [refreshDefaultRoot]);
 
-  const handleOpenBrowser = useCallback(() => {
-    refreshDefaultRoot();
+  const handleOpenBrowser = useCallback(async () => {
+    // Await the fetch before opening so DirBrowser mounts with the latest
+    // startPath in one shot — opening first and updating on the next render
+    // would briefly flash the previous root's listing.
+    await refreshDefaultRoot();
     setBrowsing(true);
   }, [refreshDefaultRoot]);
 
@@ -76,7 +82,7 @@ export function NewAgentLauncher({ onSpawned }: NewAgentLauncherProps) {
     <div className="mb-2">
       <button
         type="button"
-        onClick={handleOpenBrowser}
+        onClick={() => void handleOpenBrowser()}
         disabled={spawning}
         className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-white/10 bg-white/[0.02] px-3 py-2 text-xs text-zinc-400 transition-colors hover:border-cyan-500/30 hover:bg-cyan-500/5 hover:text-cyan-300 disabled:opacity-50"
       >

--- a/clients/react/src/components/project/__tests__/NewAgentLauncher.test.tsx
+++ b/clients/react/src/components/project/__tests__/NewAgentLauncher.test.tsx
@@ -39,9 +39,14 @@ describe("NewAgentLauncher", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /new agent/i }));
 
+    // Lock order + count: the *first* listDirectories call must be `/new`.
+    // Without `toHaveBeenNthCalledWith` a regression that opens DirBrowser
+    // before the refresh finishes — and so loads `/old` first then `/new`
+    // on a re-render — would still pass `toHaveBeenCalledWith("/new")`.
     await waitFor(() => {
       expect(vi.mocked(api.getGeneralSettings)).toHaveBeenCalledTimes(2);
-      expect(vi.mocked(api.listDirectories)).toHaveBeenCalledWith("/new");
+      expect(vi.mocked(api.listDirectories)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(api.listDirectories)).toHaveBeenNthCalledWith(1, "/new");
     });
   });
 });

--- a/clients/react/src/components/project/__tests__/NewAgentLauncher.test.tsx
+++ b/clients/react/src/components/project/__tests__/NewAgentLauncher.test.tsx
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api")>();
+  return {
+    ...actual,
+    api: {
+      getGeneralSettings: vi.fn(),
+      listDirectories: vi.fn().mockResolvedValue([]),
+      spawnPty: vi.fn(),
+    },
+  };
+});
+
+const { api } = await import("@/lib/api");
+const { NewAgentLauncher } = await import("../NewAgentLauncher");
+
+describe("NewAgentLauncher", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("re-fetches default_project_root every time the picker opens", async () => {
+    // Initial mount sees one value, the user then edits it in Settings
+    // (which lives in a different mount tree), then comes back and clicks
+    // `+ New agent`. Without the on-click refresh, the picker would still
+    // open at the stale initial value.
+    vi.mocked(api.getGeneralSettings)
+      .mockResolvedValueOnce({ default_project_root: "/old" })
+      .mockResolvedValueOnce({ default_project_root: "/new" });
+
+    render(<NewAgentLauncher onSpawned={() => {}} />);
+
+    // Wait for the initial fetch so the second click is the second call,
+    // not the first.
+    await waitFor(() => expect(vi.mocked(api.getGeneralSettings)).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: /new agent/i }));
+
+    await waitFor(() => {
+      expect(vi.mocked(api.getGeneralSettings)).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(api.listDirectories)).toHaveBeenCalledWith("/new");
+    });
+  });
+});


### PR DESCRIPTION
## Summary
`NewAgentLauncher` only fetched `default_project_root` once on mount, with a stale comment claiming AgentList unmounts when Settings opens. AgentList actually lives in the always-mounted sidebar (only the main panel content cycles), so an edit in `GeneralSection` never reached the launcher's `defaultRoot` until a hard reload — and `+ New agent` kept opening the picker at the original (or unset) value.

Fix: re-fetch on the `+ New agent` click, mirroring the pattern already used for `OrchestrationSection`'s Browse button (introduced in #615 fixup). Added a regression test that mocks two consecutive `getGeneralSettings` results and asserts `listDirectories` is invoked with the second value.

## Repro on main
1. Open Settings → General, set `Default project root` to `/home/works`, blur to commit
2. Close Settings → click `+ New agent` → DirBrowser opens at `~`, not `/home/works`

After this PR the second click opens at the saved value.

## Test plan
- [x] `pnpm test` — 42 files / 309 passed (+1 NewAgentLauncher case)
- [x] `pnpm exec tsc -b --noEmit` clean
- [x] `pnpm lint` clean (existing 6 useTerminal warnings unchanged)
- [x] `pnpm build` clean
- [ ] Smoke after merge: edit default root, close Settings, click `+ New agent` and confirm picker opens at the new path

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 新しいエージェントピッカーを開く際に、プロジェクトルート設定を最新の状態に更新するよう改善しました。これにより、常に最新の設定を反映したディレクトリブラウザが表示されます。

* **テスト**
  * 新しいエージェント起動機能の信頼性を確保するためのテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->