### PR TITLE
feat(agents): hide auto-discovered CC sessions; expose via dev toggle

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -19,6 +19,7 @@ import { useIdleNotification } from "@/hooks/useIdleNotification";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useNotificationConfig } from "@/hooks/useNotificationConfig";
 import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
+import { useShowAutoDiscovered } from "@/hooks/useShowAutoDiscovered";
 import { useSplitPane } from "@/hooks/useSplitPane";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { groupByProject, isAiAgent, type Selection, setCallerCwd, statusName } from "@/lib/api";
@@ -102,9 +103,25 @@ export function App() {
     setCallerCwd(currentProject);
   }, [currentProject]);
 
+  // Hide CC sessions tmai never spawned by default — they pollute the
+  // operational view with the user's own driving sessions firing hooks
+  // through the shared `/hooks/event` URL. Dev toggle in Settings flips
+  // this for tmai/CC dev work; preference is per-browser localStorage.
+  const { show: showAutoDiscovered } = useShowAutoDiscovered();
+  const visibleAgents = useMemo(
+    () => (showAutoDiscovered ? agents : agents.filter((a) => !a.is_auto_discovered)),
+    [agents, showAutoDiscovered],
+  );
+
   // Split agents into AI agents and plain terminals
-  const aiAgents = useMemo(() => agents.filter((a) => isAiAgent(a.agent_type)), [agents]);
-  const terminals = useMemo(() => agents.filter((a) => !isAiAgent(a.agent_type)), [agents]);
+  const aiAgents = useMemo(
+    () => visibleAgents.filter((a) => isAiAgent(a.agent_type)),
+    [visibleAgents],
+  );
+  const terminals = useMemo(
+    () => visibleAgents.filter((a) => !isAiAgent(a.agent_type)),
+    [visibleAgents],
+  );
 
   // Project list derived from active agents (replaces the pre-registered list).
   // Used by the keyboard shortcuts to cycle the X-Tmai-Origin scope and by

--- a/clients/react/src/components/settings/DeveloperSection.tsx
+++ b/clients/react/src/components/settings/DeveloperSection.tsx
@@ -1,0 +1,53 @@
+import { useShowAutoDiscovered } from "@/hooks/useShowAutoDiscovered";
+
+/**
+ * Settings section for tmai/CC dev affordances. Lives at the bottom of
+ * the panel and is intentionally tiny — these are toggles for people
+ * working on tmai itself, not regular operators.
+ *
+ * Preferences here are stored in `localStorage` (per-browser), not in
+ * `tmai-core` settings, because they describe how *this* WebUI shows
+ * the same backend data — not what the backend should do.
+ */
+export function DeveloperSection() {
+  const { show, set } = useShowAutoDiscovered();
+
+  return (
+    <section>
+      <h3 className="text-sm font-medium text-zinc-300">Developer</h3>
+      <p className="mt-1 text-xs text-zinc-600">
+        Toggles for tmai / Claude Code dev work. Preferences are local to this browser.
+      </p>
+
+      <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3">
+        <label className="flex items-center justify-between gap-3">
+          <div className="flex-1">
+            <span className="text-sm text-zinc-300">Show auto-discovered agents</span>
+            <p className="text-[11px] text-zinc-600 mt-0.5">
+              Surface Claude Code sessions tmai never spawned (e.g. an interactive{" "}
+              <code className="rounded bg-white/5 px-1">claude</code> you started in tmux). They
+              fire hooks at tmai-core's shared{" "}
+              <code className="rounded bg-white/5 px-1">/hooks/event</code> URL and land in the
+              registry as auto-discovered. Off by default.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => set(!show)}
+            className={`relative inline-flex h-5 w-9 shrink-0 items-center rounded-full transition-colors ${
+              show ? "bg-cyan-500/40" : "bg-white/10"
+            }`}
+            aria-label="Show auto-discovered agents"
+            aria-pressed={show}
+          >
+            <span
+              className={`inline-block h-3.5 w-3.5 rounded-full transition-transform ${
+                show ? "translate-x-[18px] bg-cyan-400" : "translate-x-0.5 bg-zinc-500"
+              }`}
+            />
+          </button>
+        </label>
+      </div>
+    </section>
+  );
+}

--- a/clients/react/src/components/settings/SettingsPanel.tsx
+++ b/clients/react/src/components/settings/SettingsPanel.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { type AgentSnapshot, api, groupByProject } from "@/lib/api";
 import { AutoApproveSection } from "./AutoApproveSection";
+import { DeveloperSection } from "./DeveloperSection";
 import { GeneralSection } from "./GeneralSection";
 import { NotificationSection } from "./NotificationSection";
 import { OrchestrationDispatchSection } from "./OrchestrationDispatchSection";
@@ -59,6 +60,7 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
         <NotificationSection />
         <WorkflowSection />
         <WorktreeSection />
+        <DeveloperSection />
       </div>
     </div>
   );

--- a/clients/react/src/components/settings/__tests__/DeveloperSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/DeveloperSection.test.tsx
@@ -1,0 +1,36 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { DeveloperSection } from "../DeveloperSection";
+
+const STORAGE_KEY = "tmai:dev-show-auto-discovered";
+
+describe("DeveloperSection", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("toggle starts off when localStorage is empty", () => {
+    render(<DeveloperSection />);
+    const btn = screen.getByLabelText("Show auto-discovered agents");
+    expect(btn.getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("clicking the toggle persists to localStorage and flips aria-pressed", () => {
+    render(<DeveloperSection />);
+    const btn = screen.getByLabelText("Show auto-discovered agents");
+    fireEvent.click(btn);
+    expect(btn.getAttribute("aria-pressed")).toBe("true");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("true");
+    fireEvent.click(btn);
+    expect(btn.getAttribute("aria-pressed")).toBe("false");
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("false");
+  });
+
+  it("reads the existing localStorage value on mount", () => {
+    localStorage.setItem(STORAGE_KEY, "true");
+    render(<DeveloperSection />);
+    const btn = screen.getByLabelText("Show auto-discovered agents");
+    expect(btn.getAttribute("aria-pressed")).toBe("true");
+  });
+});

--- a/clients/react/src/hooks/useShowAutoDiscovered.ts
+++ b/clients/react/src/hooks/useShowAutoDiscovered.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from "react";
+
+const STORAGE_KEY = "tmai:dev-show-auto-discovered";
+
+function readStored(): boolean {
+  try {
+    return localStorage.getItem(STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Per-browser developer preference: when true, the sidebar agent list
+ * surfaces Claude Code sessions tmai never spawned (`is_auto_discovered`).
+ * Defaults to `false` — auto-discovered agents are hidden from the
+ * regular operational view because they pollute it with the user's own
+ * driving sessions (e.g. the CC running in tmux that fires hooks at
+ * tmai-core's shared `/hooks/event` URL).
+ *
+ * Stored in localStorage rather than tmai-core settings because this is
+ * a per-developer / per-browser dev affordance, not a workspace-wide
+ * preference.
+ */
+export function useShowAutoDiscovered(): {
+  show: boolean;
+  toggle: () => void;
+  set: (next: boolean) => void;
+} {
+  const [show, setShow] = useState(readStored);
+
+  // Cross-tab sync: when the toggle is flipped in another tab/window
+  // (or via DevTools), reflect it here without a manual reload.
+  useEffect(() => {
+    const onStorage = (e: StorageEvent) => {
+      if (e.key === STORAGE_KEY) setShow(readStored());
+    };
+    window.addEventListener("storage", onStorage);
+    return () => window.removeEventListener("storage", onStorage);
+  }, []);
+
+  const set = useCallback((next: boolean) => {
+    setShow(next);
+    try {
+      localStorage.setItem(STORAGE_KEY, String(next));
+    } catch {
+      // localStorage may be unavailable (private browsing, quota); the
+      // in-memory state still applies for the current tab.
+    }
+  }, []);
+
+  const toggle = useCallback(() => set(!show), [show, set]);
+
+  return { show, toggle, set };
+}

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -204,6 +204,13 @@ export interface AgentSnapshot {
   has_pending_approval?: boolean;
   primary_worktree_path?: string | null;
   current_dispatch_id?: string | null;
+  /** True when tmai did NOT spawn this agent — the Claude Code session
+   *  was started independently (e.g. interactive `claude` in a tmux
+   *  pane the user opened) and only became visible because every CC
+   *  session fires hooks at the master socket. Surfaced from
+   *  tmai-core PR #282; older servers omit the field, which we treat
+   *  as `false` (i.e. show the agent). */
+  is_auto_discovered?: boolean;
 }
 
 // ── Bootstrap payload (all 9 domain snapshots in one shot) ──


### PR DESCRIPTION
## Summary
Phase 2 of the auto-discovered classification (Phase 1 was [trust-delta/tmai-core#282](https://github.com/trust-delta/tmai-core/pull/282), merged). Hides Claude Code sessions tmai never spawned from the regular sidebar; surfaces them behind a per-browser dev toggle.

## Why
Every CC session in the user's tmux fires hooks at tmai-core's shared `/hooks/event` URL — including ones the user started by hand (e.g. the conversation driving this PR). They show up in the registry as auto-discovered and clutter the operational view alongside agents tmai actually managed.

Per the design discussion (2026-05-06): unmanaged sessions are dev/debug surface, not regular UI. Hide by default; expose under a small toggle so tmai/CC dev work still has visibility.

## Plumbing
- `AgentSnapshot.is_auto_discovered?: boolean` added to the wire type. Optional so older tmai-core servers (omitted = false) stay compatible.
- `useShowAutoDiscovered` hook, localStorage-backed (`tmai:dev-show-auto-discovered`) with cross-tab `storage`-event sync.
- `App.tsx` filters `agents` → `visibleAgents` before splitting into `aiAgents` / `terminals`; the existing project derivation cascades off the filtered list automatically.
- New `DeveloperSection` rendered at the bottom of `SettingsPanel` — intentionally tiny because this section is for tmai/CC dev work, not regular operators.

## Where the toggle lives
Settings → Developer → "Show auto-discovered agents" (default off).

The Developer section is the only entry today and explicitly labelled "Toggles for tmai / Claude Code dev work. Preferences are local to this browser." — keeping the framing distinct from `General` (workspace prefs persisted server-side via `[general]`).

## Tests
- New `DeveloperSection.test.tsx`: empty-localStorage default, toggle persists, mount reads existing value.
- Pre-existing 43-file suite still passes; total 312 + 2 skipped.
- `tsc -b --noEmit`, `biome check`, `vite build` clean.

## Smoke after merge
1. With both PRs live: this conversation's CC session disappears from the sidebar by default.
2. Settings → Developer → toggle on → it reappears (with the existing `agent_type=ClaudeCode` styling).
3. Toggle off again → gone.
4. Refresh the page or open another tab → preference persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
- 設定パネルに開発者向けセクションを追加し、自動検出されたエージェント・セッションの表示・非表示を制御するトグルスイッチを実装しました。この設定はブラウザのローカルストレージに自動保持され、複数のタブ間でリアルタイムに同期されます。開発者はこの機能を使って作業環境をカスタマイズできます。

## テスト
- 新しいトグル機能の初期状態、ユーザー操作時の状態更新、設定の永続性、複数タブ間での同期を検証するテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->