### PR TITLE
feat(ui): consume new attention axis (Step 5 React)

### DIFF
--- a/clients/react/src/components/agent/AgentCard.tsx
+++ b/clients/react/src/components/agent/AgentCard.tsx
@@ -2,6 +2,7 @@ import {
   type AgentSnapshot,
   type AgentType,
   api,
+  type AttentionReason,
   type ConnectionChannels,
   type DetectionSource,
   isAiAgent,
@@ -23,6 +24,35 @@ const statusGlow: Record<string, string> = {
   Processing: "glow-cyan",
   AwaitingApproval: "glow-red",
 };
+
+// Step 5 of the agent-state attention rebuild (decision tmai-core@2026-05-07).
+// Map the new `attention.reason` hint to a badge label / pill style.
+// `Completed` (CC `Stop` hook) → blue waiting-for-input look; `Halted`
+// (`PermissionDenied` after auto-approve fall-through) → red action-needed
+// look. Reason-less `required: true` (the PTY-server quiet-signal fallback
+// path) falls back to a generic "Wait" amber pill so the visual still
+// matches the glow.
+function attentionPill(reason: AttentionReason | null | undefined): {
+  label: string;
+  style: string;
+} {
+  if (reason === "completed") {
+    return {
+      label: "Done",
+      style: "bg-sky-500/20 text-sky-300 border-sky-500/30",
+    };
+  }
+  if (reason === "halted") {
+    return {
+      label: "Halted",
+      style: "bg-rose-500/20 text-rose-300 border-rose-500/30",
+    };
+  }
+  return {
+    label: "Wait",
+    style: "bg-amber-500/20 text-amber-300 border-amber-500/30",
+  };
+}
 
 // Agent type display: short label + color
 function agentTypeLabel(agentType: AgentType): {
@@ -119,7 +149,12 @@ interface AgentCardProps {
 // Card displaying a single agent's status and info
 export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
   const name = statusName(agent.status);
-  const attention = agent.needs_attention ?? false;
+  // Step 5 of the rebuild: prefer the new `attention` axis when present;
+  // fall back to legacy `needs_attention` so a snapshot from an older
+  // tmai-core (pre-Step 4) still renders correctly through the parallel
+  // run period. Step 6 retires the fallback.
+  const attentionRequired = agent.attention?.required ?? agent.needs_attention ?? false;
+  const attentionReason = agent.attention?.reason ?? null;
   const typeInfo = agentTypeLabel(agent.agent_type);
   const isAi = isAiAgent(agent.agent_type);
   // Auto-approve state
@@ -127,16 +162,27 @@ export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
     agent.auto_approve_override !== null && agent.auto_approve_override !== undefined;
   const isAutoApproveOn = autoApproveEffective(agent);
 
-  // Auto-approve overrides status display when active
+  // Display priority for the right-hand pill:
+  //   1. Auto-approve phase (Judging / Approved) — highest, drives the
+  //      orange / emerald accents that operator already trusts.
+  //   2. New attention axis when `required` — reason-aware label so the
+  //      operator can tell "agent finished, waiting for next prompt" from
+  //      "agent halted on a permission ask".
+  //   3. Legacy `status` name as the baseline.
   const phase = agent.auto_approve_phase;
   const isJudging = phase === "Judging";
   const isAutoApproved = phase === "ApprovedByRule" || phase === "ApprovedByAi";
-  const displayName = isJudging ? "Judging" : isAutoApproved ? "Approved" : name;
+  const attentionPillInfo = attentionRequired ? attentionPill(attentionReason) : null;
+  const displayName = isJudging
+    ? "Judging"
+    : isAutoApproved
+      ? "Approved"
+      : (attentionPillInfo?.label ?? name);
   const statusStyle = isJudging
     ? "bg-amber-500/20 text-amber-400 border-amber-500/30"
     : isAutoApproved
       ? "bg-emerald-500/20 text-emerald-400 border-emerald-500/30"
-      : (statusColors[name] ?? statusColors.Unknown);
+      : (attentionPillInfo?.style ?? statusColors[name] ?? statusColors.Unknown);
   const glow = isJudging || isAutoApproved ? "" : (statusGlow[name] ?? "");
 
   // Connection channels (with fallback for older API)
@@ -175,7 +221,7 @@ export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
         "hover:bg-white/[0.08] hover:border-white/10",
         agent.is_orchestrator && "!border-cyan-500/20 bg-cyan-500/[0.04]",
         selected && "!border-cyan-500/30 !bg-cyan-500/10",
-        attention && "!border-amber-500/30 animate-glow-pulse",
+        attentionRequired && "!border-amber-500/30 animate-glow-pulse",
         glow && selected && glow,
       )}
     >

--- a/clients/react/src/components/agent/AgentCard.tsx
+++ b/clients/react/src/components/agent/AgentCard.tsx
@@ -1,8 +1,8 @@
 import {
   type AgentSnapshot,
   type AgentType,
-  api,
   type AttentionReason,
+  api,
   type ConnectionChannels,
   type DetectionSource,
   isAiAgent,

--- a/clients/react/src/hooks/useAgents.ts
+++ b/clients/react/src/hooks/useAgents.ts
@@ -11,8 +11,13 @@ import { type CoreEvent, useTauriEvents } from "./useTauriEvents";
 export function useAgents() {
   const { cache, refreshCache } = useSSEContext();
   const { agents, loading } = cache;
-  // needs_attention is a derived field computed by tmai-core (#521)
-  const attentionCount = agents.filter((a) => a.needs_attention ?? false).length;
+  // Step 5 of the agent-state attention rebuild (decision tmai-core@2026-05-07):
+  // prefer the new `attention.required` axis when present, fall back to the
+  // legacy `needs_attention` boolean (#521) so older tmai-core snapshots
+  // still aggregate. Step 6 retires the fallback.
+  const attentionCount = agents.filter(
+    (a) => a.attention?.required ?? a.needs_attention ?? false,
+  ).length;
 
   // refreshCache triggers a full re-bootstrap; used by the Tauri event path
   // to pull a fresh snapshot when the desktop app signals an agent change.

--- a/clients/react/src/hooks/useIdleNotification.test.ts
+++ b/clients/react/src/hooks/useIdleNotification.test.ts
@@ -86,13 +86,16 @@ describe("sendNotification body — last_assistant_message isolation (#9)", () =
 describe("attention axis triggering — Step 5 transitions", () => {
   // Mirrors the per-agent block in useIdleNotification.ts
   // `justBecameNeedsHuman = attentionTrigger || statusTrigger`.
+  // The attention path uses `prevAttention === false` (not `!prevAttention`)
+  // so the first observation of an agent (`prevAttention === undefined`)
+  // does NOT count as a transition — see CodeRabbit comment on tmai#618.
   function justBecameNeedsHuman(args: {
-    prevAttention: boolean;
+    prevAttention: boolean | undefined;
     attentionRequired: boolean;
     prevStatus: string | undefined;
     status: string;
   }): boolean {
-    const attentionTrigger = !args.prevAttention && args.attentionRequired;
+    const attentionTrigger = args.prevAttention === false && args.attentionRequired;
     const statusTrigger =
       args.prevStatus === "Processing" && (args.status === "Idle" || args.status === "Offline");
     return attentionTrigger || statusTrigger;
@@ -107,6 +110,31 @@ describe("attention axis triggering — Step 5 transitions", () => {
         status: "Unknown",
       }),
     ).toBe(true);
+  });
+
+  test("first observation with attention.required=true does NOT fire", () => {
+    // Tab just opened on an agent that has been requiring attention for
+    // hours — the user should see the visual badge but not get a stale
+    // browser notification. CodeRabbit tmai#618.
+    expect(
+      justBecameNeedsHuman({
+        prevAttention: undefined,
+        attentionRequired: true,
+        prevStatus: undefined,
+        status: "Unknown",
+      }),
+    ).toBe(false);
+  });
+
+  test("first observation with attention.required=false does not fire", () => {
+    expect(
+      justBecameNeedsHuman({
+        prevAttention: undefined,
+        attentionRequired: false,
+        prevStatus: undefined,
+        status: "Unknown",
+      }),
+    ).toBe(false);
   });
 
   test("attention.required held true → true does not retrigger", () => {

--- a/clients/react/src/hooks/useIdleNotification.test.ts
+++ b/clients/react/src/hooks/useIdleNotification.test.ts
@@ -78,6 +78,95 @@ describe("sendNotification body — last_assistant_message isolation (#9)", () =
   });
 });
 
+// Step 5 of the agent-state attention rebuild (decision tmai-core@2026-05-07):
+// useIdleNotification now treats `attention.required` as the primary signal,
+// with the legacy `status` Processing → Idle transition as a compat
+// fallback. Mirror the hook's transition rule here as a pure function so
+// the trigger semantics are pinned down without dragging React in.
+describe("attention axis triggering — Step 5 transitions", () => {
+  // Mirrors the per-agent block in useIdleNotification.ts
+  // `justBecameNeedsHuman = attentionTrigger || statusTrigger`.
+  function justBecameNeedsHuman(args: {
+    prevAttention: boolean;
+    attentionRequired: boolean;
+    prevStatus: string | undefined;
+    status: string;
+  }): boolean {
+    const attentionTrigger = !args.prevAttention && args.attentionRequired;
+    const statusTrigger =
+      args.prevStatus === "Processing" && (args.status === "Idle" || args.status === "Offline");
+    return attentionTrigger || statusTrigger;
+  }
+
+  test("attention.required false → true fires (primary path)", () => {
+    expect(
+      justBecameNeedsHuman({
+        prevAttention: false,
+        attentionRequired: true,
+        prevStatus: undefined,
+        status: "Unknown",
+      }),
+    ).toBe(true);
+  });
+
+  test("attention.required held true → true does not retrigger", () => {
+    expect(
+      justBecameNeedsHuman({
+        prevAttention: true,
+        attentionRequired: true,
+        prevStatus: undefined,
+        status: "Unknown",
+      }),
+    ).toBe(false);
+  });
+
+  test("legacy status Processing → Idle fires when attention is undefined (fallback)", () => {
+    expect(
+      justBecameNeedsHuman({
+        prevAttention: false,
+        attentionRequired: false,
+        prevStatus: "Processing",
+        status: "Idle",
+      }),
+    ).toBe(true);
+  });
+
+  test("legacy status Processing → Offline also fires (fallback)", () => {
+    expect(
+      justBecameNeedsHuman({
+        prevAttention: false,
+        attentionRequired: false,
+        prevStatus: "Processing",
+        status: "Offline",
+      }),
+    ).toBe(true);
+  });
+
+  test("status Idle → Idle (no transition) does not retrigger", () => {
+    expect(
+      justBecameNeedsHuman({
+        prevAttention: false,
+        attentionRequired: false,
+        prevStatus: "Idle",
+        status: "Idle",
+      }),
+    ).toBe(false);
+  });
+
+  test("attention false → true wins even when legacy status is also transitioning", () => {
+    // Both signals fire on the same tick — still only one notification
+    // because the OR collapses to a single 'true'.
+    expect(
+      justBecameNeedsHuman({
+        prevAttention: false,
+        attentionRequired: true,
+        prevStatus: "Processing",
+        status: "Idle",
+      }),
+    ).toBe(true);
+  });
+});
+
 describe("notification trigger conditions", () => {
   // These tests document the expected behavior of status transitions
 

--- a/clients/react/src/hooks/useIdleNotification.ts
+++ b/clients/react/src/hooks/useIdleNotification.ts
@@ -67,11 +67,28 @@ function sendNotification(agent: AgentSnapshot, lastMessage?: string | null) {
 }
 
 // Hook: watch agent list for Processing → Idle transitions and fire browser notifications.
+//
+// Step 5 of the agent-state attention rebuild (decision tmai-core@2026-05-07):
+// the legacy state machine is dismantled, so the historical
+// "Processing → Idle" status transition no longer fires for new tmai-core
+// servers. The new `attention.required` axis (Step 4a / 4b) carries the
+// transition instead. The hook now triggers when **either** signal flips
+// "becomes attention-needed":
+//
+//   1. `attention.required` goes false / undefined → true
+//      (primary path; covers both CC hook fire and PTY-server fallback)
+//   2. legacy `status` goes Processing → Idle / Offline
+//      (compat fallback for snapshots from pre-Step 4 tmai-core)
+//
+// The two paths converge during the parallel-run period; Step 6 retires
+// the legacy path along with the rest of the status field.
 export function useIdleNotification(agents: AgentSnapshot[], config: IdleNotificationConfig) {
   // Track per-agent idle state
   const stateMap = useRef(new Map<string, AgentIdleState>());
-  // Track previous status per agent
+  // Track previous status per agent (legacy path)
   const prevStatusMap = useRef(new Map<string, string>());
+  // Track previous attention.required per agent (Step 5 primary path)
+  const prevAttentionMap = useRef(new Map<string, boolean>());
 
   // Request permission when enabled
   useEffect(() => {
@@ -89,6 +106,7 @@ export function useIdleNotification(agents: AgentSnapshot[], config: IdleNotific
       }
       stateMap.current.clear();
       prevStatusMap.current.clear();
+      prevAttentionMap.current.clear();
       return;
     }
 
@@ -102,13 +120,25 @@ export function useIdleNotification(agents: AgentSnapshot[], config: IdleNotific
       const status = statusName(agent.status);
       const prevStatus = prevStatusMap.current.get(agent.id);
       prevStatusMap.current.set(agent.id, status);
+      const attentionRequired = agent.attention?.required ?? false;
+      const prevAttention = prevAttentionMap.current.get(agent.id) ?? false;
+      prevAttentionMap.current.set(agent.id, attentionRequired);
 
       const idleState = stateMap.current.get(agent.id);
 
-      if (status === "Idle" || status === "Offline") {
-        // Agent is idle — was it previously processing?
-        if (prevStatus === "Processing" && !idleState?.notified) {
-          // Transition detected: Processing → Idle
+      // Step 5: "needs the human" condition is true when either the new
+      // attention axis says so or the legacy status is Idle / Offline.
+      const needsHuman = attentionRequired || status === "Idle" || status === "Offline";
+      // A *fresh* trigger requires a transition into the needs-human state
+      // on at least one of the two signals — otherwise re-renders would
+      // re-fire notifications for an agent that has been idle for hours.
+      const attentionTrigger = !prevAttention && attentionRequired;
+      const statusTrigger =
+        prevStatus === "Processing" && (status === "Idle" || status === "Offline");
+      const justBecameNeedsHuman = attentionTrigger || statusTrigger;
+
+      if (needsHuman) {
+        if (justBecameNeedsHuman && !idleState?.notified) {
           const delay = getDelay(agent.detection_source, config.thresholdSecs);
 
           // Clear any existing timer
@@ -138,7 +168,7 @@ export function useIdleNotification(agents: AgentSnapshot[], config: IdleNotific
             });
           }
         }
-        // If already idle and already notified (or no transition), do nothing
+        // If already needs-human and already notified (or no transition), do nothing
       } else {
         // Agent is processing or in another state — reset idle tracking
         if (idleState) {
@@ -154,6 +184,7 @@ export function useIdleNotification(agents: AgentSnapshot[], config: IdleNotific
         if (state.timerId) clearTimeout(state.timerId);
         stateMap.current.delete(id);
         prevStatusMap.current.delete(id);
+        prevAttentionMap.current.delete(id);
       }
     }
   }, [agents, config.enabled, config.thresholdSecs]);

--- a/clients/react/src/hooks/useIdleNotification.ts
+++ b/clients/react/src/hooks/useIdleNotification.ts
@@ -121,7 +121,7 @@ export function useIdleNotification(agents: AgentSnapshot[], config: IdleNotific
       const prevStatus = prevStatusMap.current.get(agent.id);
       prevStatusMap.current.set(agent.id, status);
       const attentionRequired = agent.attention?.required ?? false;
-      const prevAttention = prevAttentionMap.current.get(agent.id) ?? false;
+      const prevAttention = prevAttentionMap.current.get(agent.id);
       prevAttentionMap.current.set(agent.id, attentionRequired);
 
       const idleState = stateMap.current.get(agent.id);
@@ -132,7 +132,13 @@ export function useIdleNotification(agents: AgentSnapshot[], config: IdleNotific
       // A *fresh* trigger requires a transition into the needs-human state
       // on at least one of the two signals — otherwise re-renders would
       // re-fire notifications for an agent that has been idle for hours.
-      const attentionTrigger = !prevAttention && attentionRequired;
+      // The attention path explicitly compares against `false` (not `!prevAttention`)
+      // so the first observation of an agent (`prevAttention === undefined`)
+      // does NOT count as a transition: a freshly-loaded tab must not
+      // shower the user with notifications for agents that have been
+      // requiring attention since long before the tab opened. CodeRabbit
+      // tmai#618.
+      const attentionTrigger = prevAttention === false && attentionRequired;
       const statusTrigger =
         prevStatus === "Processing" && (status === "Idle" || status === "Offline");
       const justBecameNeedsHuman = attentionTrigger || statusTrigger;

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -115,6 +115,27 @@ export function statusName(status: AgentStatus): string {
 export type DetectionSource = "CapturePane" | "IpcSocket" | "HttpHook" | "WebSocket";
 export type SendCapability = "Ipc" | "Tmux" | "PtyInject" | "None";
 
+// ── Attention axis (decision tmai-core@2026-05-07) ──
+//
+// New dynamic-state axis introduced by the agent-state attention rebuild.
+// `required = true` ↔ the agent is waiting for the human; `required =
+// false` ↔ the agent is active. `reason` is an observability hint only
+// — never branched on by Core / PTY-server / Hub. Hand-written here
+// because the matching `clients/react/src/types/generated/AgentAttention.ts`
+// arrives via the next `gen-spec-pr` bot PR; this file unblocks the UI
+// migration meanwhile and survives as a re-export shim afterwards.
+//
+// Wire shape (`AgentSnapshot.attention`) is `Option<AgentAttention>`:
+// `null`/absent encodes "unknown" — the sampler bootstrap window per
+// decision Δ6 — and the UI renders an indeterminate badge there rather
+// than reusing a stale value.
+export type AttentionReason = "completed" | "halted";
+
+export interface AgentAttention {
+  required: boolean;
+  reason?: AttentionReason | null;
+}
+
 /// Which communication channels are currently available for this agent
 export interface ConnectionChannels {
   has_tmux: boolean;
@@ -196,6 +217,12 @@ export interface AgentSnapshot {
   model_id?: string | null;
   model_display_name?: string | null;
   is_orchestrator?: boolean;
+  /** New attention axis (decision tmai-core@2026-05-07 Step 4). `null` /
+   *  absent on the wire encodes "unknown" — the sampler bootstrap window
+   *  per Δ6. Step 5 of the rebuild teaches the Hub to prefer this over
+   *  the legacy `needs_attention` boolean below; Step 6 retires the
+   *  legacy field. */
+  attention?: AgentAttention | null;
   // Derived fields computed by tmai-core (tmai-core@c40e8b8aa5, Phase 1)
   needs_attention?: boolean;
   display_label?: string;

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -440,7 +440,12 @@ export function groupByProject(
       });
     }
 
-    const attentionCount = groupAgents.filter((a) => a.needs_attention ?? false).length;
+    // Step 5 of the agent-state attention rebuild (decision tmai-core@2026-05-07):
+    // prefer the new `attention.required` axis, fall back to the legacy
+    // `needs_attention` boolean for snapshots from pre-Step-4 servers.
+    const attentionCount = groupAgents.filter(
+      (a) => a.attention?.required ?? a.needs_attention ?? false,
+    ).length;
 
     projects.push({
       name: projectName(path),
@@ -902,7 +907,10 @@ export const api = {
   listAgents: () => apiFetch<AgentSnapshot[]>("/agents"),
   attentionCount: async () => {
     const agents = await apiFetch<AgentSnapshot[]>("/agents");
-    return agents.filter((a) => a.needs_attention ?? false).length;
+    // Step 5 of the agent-state attention rebuild: same fallback as
+    // useAgents and groupByProject above. Step 6 retires the legacy
+    // `needs_attention` field.
+    return agents.filter((a) => a.attention?.required ?? a.needs_attention ?? false).length;
   },
 
   // Agent actions


### PR DESCRIPTION
## Summary

Step 5 of the agent-state attention rebuild ([trust-delta/tmai-core#283](https://github.com/trust-delta/tmai-core/pull/283), decision tmai-core@2026-05-07). Migrates the React WebUI from the legacy `status` / `needs_attention` triple to the new `AgentSnapshot.attention` axis introduced by tmai-core Step 2. The legacy fields stay as a parallel-run fallback through Step 6 so older tmai-core servers still render correctly.

The ratatui client (`clients/ratatui/`) hand-defines `AgentStatus` in its own `types/mod.rs` and ships unchanged here — a follow-up mirrors the same migration there once this lands.

## Why this is human-authored on a non-bot path

The matching `clients/react/src/types/generated/AgentAttention.ts` will arrive via the next `gen-spec-pr` bot PR (after the tmai-core PR merges and the workflow runs). Step 5 hand-writes the same shapes inline in `src/lib/api-http.ts` (alongside the existing `AgentStatus` shim) so the UI migration is not blocked on the bot pipeline. Once the bot lands, a follow-up rewires the imports to the generated files and demotes the hand-written types to a thin re-export shim.

`clients/react/src/types/generated/` is **not** touched by this PR — types-drift CI stays green.

## What changes

- `src/lib/api-http.ts` — `AgentAttention { required, reason? }` + `AttentionReason` ('completed' | 'halted'); `AgentSnapshot.attention?` field
- `src/components/agent/AgentCard.tsx` — reason-aware right-hand pill: `Done` (sky) / `Halted` (rose) / `Wait` (amber for the fallback path); legacy `needs_attention` fallback retained
- `src/hooks/useAgents.ts` — `attentionCount` aggregates by `attention.required ?? needs_attention`
- `src/hooks/useIdleNotification.ts` — browser notifications fire on **either** `attention.required` `false → true` or legacy `status` `Processing → Idle/Offline` (the legacy path is now dormant for new tmai-core servers because Step 3 disconnected the status machine from CC hooks)

## Test plan

- [x] `pnpm test` — 318 vitest pass (+6 new attention-transition tests)
- [x] `pnpm exec tsc --noEmit` clean
- [ ] dogfood: send prompt to agent → `Wait`/`Done` pill flips correctly; browser notification fires when CC fires Stop hook
- [ ] dogfood: legacy fallback verified by pointing a fresh build at a pre-Step-4 tmai-core server (status path still triggers)

Pre-existing biome warnings in `PreviewPanel.tsx` + `useTerminal.test.ts` are unrelated and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エージェントの注意状態（Attention）機能を追加しました。エージェントカードに新しいステータス表示（完了/停止/待機）が追加され、視覚的にエージェントの優先度と注意状態が把握しやすくなりました。
  
* **テスト**
  * エージェント注意状態のトリガーロジックに関する包括的なテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->