### PR TITLE
fix(ui): Active pill when new attention axis is present-but-not-required

### DIFF
--- a/clients/react/src/components/agent/AgentCard.tsx
+++ b/clients/react/src/components/agent/AgentCard.tsx
@@ -168,11 +168,30 @@ export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
   //   2. New attention axis when `required` — reason-aware label so the
   //      operator can tell "agent finished, waiting for next prompt" from
   //      "agent halted on a permission ask".
-  //   3. Legacy `status` name as the baseline.
+  //   3. New attention axis when not required (i.e. wire field present
+  //      but `required: false`) — render an "Active" pill. This case
+  //      means the new tmai-core has affirmatively signaled "agent is
+  //      doing work or just ack'd input"; the legacy `status` field is
+  //      vestigial there and may still carry stale `Processing` from
+  //      the capture-pane detector that Step 3 of the rebuild did not
+  //      decommission. Showing the legacy name in that window misleads
+  //      operators (#618 dogfood report).
+  //   4. Legacy `status` name as the baseline (only when the new axis is
+  //      absent, e.g. talking to a pre-Step-4 tmai-core).
   const phase = agent.auto_approve_phase;
   const isJudging = phase === "Judging";
   const isAutoApproved = phase === "ApprovedByRule" || phase === "ApprovedByAi";
-  const attentionPillInfo = attentionRequired ? attentionPill(attentionReason) : null;
+  const hasNewAttentionAxis = agent.attention !== null && agent.attention !== undefined;
+  let attentionPillInfo: { label: string; style: string } | null = null;
+  if (attentionRequired) {
+    attentionPillInfo = attentionPill(attentionReason);
+  } else if (hasNewAttentionAxis) {
+    // New axis explicitly says "not required" — show neutral Active pill.
+    attentionPillInfo = {
+      label: "Active",
+      style: "bg-emerald-500/20 text-emerald-300 border-emerald-500/30",
+    };
+  }
   const displayName = isJudging
     ? "Judging"
     : isAutoApproved


### PR DESCRIPTION
## Summary

Step 5 follow-up surfaced by dogfood verification on tmai-core@f132c40 + tmai@5c68391. Symptom: spawned agent shows a stuck `Processing` pill even though the new attention axis correctly reads `{ required: false }`.

## Root cause

- `crates/tmai-core/src/detectors/default.rs:99` (capture-pane title heuristic) still sets `agent.status = AgentStatus::Processing { ... }` on every poll cycle when the pane title contains \"working\" / \"processing\" / \"running\". Step 3 of the rebuild disconnected hooks from the state machine but did **not** touch the poller / capture-pane parser path — proposal §9 lists that for removal under Step 6 / 7.
- `AgentCard.tsx` fell through to `statusName(agent.status)` whenever `attention.required === false`, surfacing the now-stale legacy value.

## Fix

The right-hand pill renders an **Active** (emerald) pill whenever the new axis is **present but not required** (`agent.attention !== null && agent.attention !== undefined && !attentionRequired`). The pre-Step-4 fallback path (no new axis at all) still surfaces the legacy `statusName` so older tmai-core servers render unchanged.

Step 6 / 7 tears out the capture-pane detector outright; this patch unblocks dogfood meanwhile.

## Test plan

- [x] `pnpm exec tsc --noEmit` clean
- [x] `pnpm lint` — same 6 pre-existing warnings, no new errors
- [ ] dogfood: spawn agent — pill flips from \"Active\" (emerald) when working to \"Done\" (sky) when CC `Stop` fires; no more stale \"Processing\" badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * エージェントカードの状態表示ロジックを改善し、注意が必要な場合とそうでない場合の表示をより明確に区別できるようにしました。ステータス情報の表示精度が向上し、ユーザーがエージェントの状態をより正確に把握できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->