### PR TITLE
feat(ui): Step 6a — drop legacy AgentSnapshot pentad consumers

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -22,7 +22,7 @@ import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
 import { useShowAutoDiscovered } from "@/hooks/useShowAutoDiscovered";
 import { useSplitPane } from "@/hooks/useSplitPane";
 import { useWorktrees } from "@/hooks/useWorktrees";
-import { groupByProject, isAiAgent, type Selection, setCallerCwd, statusName } from "@/lib/api";
+import { groupByProject, isAiAgent, type Selection, setCallerCwd } from "@/lib/api";
 import { useSSE } from "@/lib/sse-provider";
 
 export function App() {
@@ -449,11 +449,15 @@ export function App() {
                   }`}
                   title={agent.target}
                 >
-                  {statusName(agent.status) === "Processing"
-                    ? "●"
-                    : statusName(agent.status) === "AwaitingApproval"
-                      ? "◐"
-                      : "○"}
+                  {/* Step 6a: status pentad removed — use the new
+                      attention axis. `required + halted` = AwaitingApproval
+                      analogue, `required + completed` / `required + null`
+                      = Wait, otherwise active dot. */}
+                  {agent.attention?.required && agent.attention.reason === "halted"
+                    ? "◐"
+                    : agent.attention?.required
+                      ? "○"
+                      : "●"}
                 </button>
               ))}
             </div>

--- a/clients/react/src/components/agent/AgentActions.tsx
+++ b/clients/react/src/components/agent/AgentActions.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect } from "react";
-import { type AgentSnapshot, api, statusName } from "@/lib/api";
+import { type AgentSnapshot, api } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 interface AgentActionsProps {
@@ -8,12 +8,34 @@ interface AgentActionsProps {
   passthrough?: boolean;
 }
 
-// Status bar displayed above the main panel for the selected agent
+// Status bar displayed above the main panel for the selected agent.
+//
+// Step 6a (decision tmai-core@2026-05-07): the legacy `AgentStatus`
+// enum is gone from the wire. Map the new `attention` axis onto the
+// same trio of UI states the existing layout relies on:
+//
+// - `needsPermission` ↔ attention.required && reason === "halted" —
+//   the `PermissionDenied` hook fired and auto-approve did not
+//   resolve it, so the agent is parked at a permission prompt.
+// - `isIdle` ↔ attention.required && reason !== "halted" — the
+//   agent finished a turn (`Stop` hook) or the sampler quiet signal
+//   fired; either way the agent is waiting for the next prompt.
+// - `isProcessing` ↔ attention is present but not required, i.e.
+//   the agent is actively working. Bootstrap window (attention ===
+//   undefined / null) collapses into the `isProcessing` lane so the
+//   badge never blanks during the sampler bootstrap.
 export function AgentActions({ agent, passthrough }: AgentActionsProps) {
-  const name = statusName(agent.status);
-  const needsPermission = name === "AwaitingApproval";
-  const isProcessing = name === "Processing";
-  const isIdle = name === "Idle";
+  const attention = agent.attention;
+  const needsPermission = attention?.required === true && attention.reason === "halted";
+  const isIdle = attention?.required === true && attention.reason !== "halted";
+  const isProcessing = !needsPermission && !isIdle;
+  const name = needsPermission
+    ? "Halted"
+    : isIdle
+      ? attention?.reason === "completed"
+        ? "Done"
+        : "Wait"
+      : "Active";
 
   const handleApprove = useCallback(async () => {
     try {

--- a/clients/react/src/components/agent/AgentCard.tsx
+++ b/clients/react/src/components/agent/AgentCard.tsx
@@ -7,23 +7,13 @@ import {
   type DetectionSource,
   isAiAgent,
   type SendCapability,
-  statusName,
 } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
-const statusColors: Record<string, string> = {
-  Processing: "bg-cyan-500/20 text-cyan-400 border-cyan-500/30",
-  AwaitingApproval: "bg-red-500/20 text-red-400 border-red-500/30",
-  Idle: "bg-zinc-500/20 text-zinc-400 border-zinc-500/30",
-  Error: "bg-red-500/20 text-red-300 border-red-500/30",
-  Offline: "bg-zinc-500/20 text-zinc-600 border-zinc-500/30",
-  Unknown: "bg-zinc-500/20 text-zinc-500 border-zinc-500/30",
-};
-
-const statusGlow: Record<string, string> = {
-  Processing: "glow-cyan",
-  AwaitingApproval: "glow-red",
-};
+// Step 6a (decision tmai-core@2026-05-07): `statusColors` /
+// `statusGlow` / `statusName` retired alongside the legacy
+// `AgentStatus` enum. The right-hand pill is now driven entirely
+// by the attention axis (`attentionPill` below).
 
 // Step 5 of the agent-state attention rebuild (decision tmai-core@2026-05-07).
 // Map the new `attention.reason` hint to a badge label / pill style.
@@ -148,13 +138,14 @@ interface AgentCardProps {
 
 // Card displaying a single agent's status and info
 export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
-  const name = statusName(agent.status);
-  // Step 5 of the rebuild: prefer the new `attention` axis when present;
-  // fall back to legacy `needs_attention` so a snapshot from an older
-  // tmai-core (pre-Step 4) still renders correctly through the parallel
-  // run period. Step 6 retires the fallback.
-  const attentionRequired = agent.attention?.required ?? agent.needs_attention ?? false;
+  // Step 6a: legacy `status` / `needs_attention` paths fully retired.
+  // The right-hand pill is now driven entirely by attention + auto-
+  // approve phase. `attention === null/undefined` (sampler bootstrap
+  // window per Δ6) renders an explicit "Bootstrap" placeholder so
+  // operators see the indeterminate state rather than a blank pill.
+  const attentionRequired = agent.attention?.required ?? false;
   const attentionReason = agent.attention?.reason ?? null;
+  const hasNewAttentionAxis = agent.attention !== null && agent.attention !== undefined;
   const typeInfo = agentTypeLabel(agent.agent_type);
   const isAi = isAiAgent(agent.agent_type);
   // Auto-approve state
@@ -162,47 +153,35 @@ export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
     agent.auto_approve_override !== null && agent.auto_approve_override !== undefined;
   const isAutoApproveOn = autoApproveEffective(agent);
 
-  // Display priority for the right-hand pill:
-  //   1. Auto-approve phase (Judging / Approved) — highest, drives the
-  //      orange / emerald accents that operator already trusts.
-  //   2. New attention axis when `required` — reason-aware label so the
-  //      operator can tell "agent finished, waiting for next prompt" from
-  //      "agent halted on a permission ask".
-  //   3. New attention axis when not required (i.e. wire field present
-  //      but `required: false`) — render an "Active" pill. This case
-  //      means the new tmai-core has affirmatively signaled "agent is
-  //      doing work or just ack'd input"; the legacy `status` field is
-  //      vestigial there and may still carry stale `Processing` from
-  //      the capture-pane detector that Step 3 of the rebuild did not
-  //      decommission. Showing the legacy name in that window misleads
-  //      operators (#618 dogfood report).
-  //   4. Legacy `status` name as the baseline (only when the new axis is
-  //      absent, e.g. talking to a pre-Step-4 tmai-core).
   const phase = agent.auto_approve_phase;
   const isJudging = phase === "Judging";
   const isAutoApproved = phase === "ApprovedByRule" || phase === "ApprovedByAi";
-  const hasNewAttentionAxis = agent.attention !== null && agent.attention !== undefined;
-  let attentionPillInfo: { label: string; style: string } | null = null;
+  let attentionPillInfo: { label: string; style: string };
   if (attentionRequired) {
     attentionPillInfo = attentionPill(attentionReason);
   } else if (hasNewAttentionAxis) {
-    // New axis explicitly says "not required" — show neutral Active pill.
+    // attention.required === false: agent is actively working.
     attentionPillInfo = {
       label: "Active",
       style: "bg-emerald-500/20 text-emerald-300 border-emerald-500/30",
     };
+  } else {
+    // Bootstrap window: sampler has not declared either way yet.
+    attentionPillInfo = {
+      label: "Bootstrap",
+      style: "bg-zinc-500/20 text-zinc-400 border-zinc-500/30",
+    };
   }
-  const displayName = isJudging
-    ? "Judging"
-    : isAutoApproved
-      ? "Approved"
-      : (attentionPillInfo?.label ?? name);
+  const displayName = isJudging ? "Judging" : isAutoApproved ? "Approved" : attentionPillInfo.label;
   const statusStyle = isJudging
     ? "bg-amber-500/20 text-amber-400 border-amber-500/30"
     : isAutoApproved
       ? "bg-emerald-500/20 text-emerald-400 border-emerald-500/30"
-      : (attentionPillInfo?.style ?? statusColors[name] ?? statusColors.Unknown);
-  const glow = isJudging || isAutoApproved ? "" : (statusGlow[name] ?? "");
+      : attentionPillInfo.style;
+  // Step 6a: glow is now reason-aware. `Halted` keeps the existing red
+  // accent, otherwise no special glow (the amber-glow-pulse on the
+  // outer card already conveys "needs attention" globally).
+  const glow = !isJudging && !isAutoApproved && attentionReason === "halted" ? "glow-red" : "";
 
   // Connection channels (with fallback for older API)
   const channels: ConnectionChannels = agent.connection_channels ?? {

--- a/clients/react/src/components/terminal/TerminalList.tsx
+++ b/clients/react/src/components/terminal/TerminalList.tsx
@@ -1,4 +1,4 @@
-import { type AgentSnapshot, statusName } from "@/lib/api";
+import type { AgentSnapshot } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 interface TerminalListProps {
@@ -20,7 +20,19 @@ export function TerminalList({ terminals, selectedTarget, onSelect }: TerminalLi
         {terminals.map((t) => {
           const selected = t.id === selectedTarget || t.target === selectedTarget;
           const name = commandLabel(t);
-          const status = statusName(t.status);
+          // Step 6a: replace legacy `status` with attention-derived label.
+          // Bootstrap (attention === undefined/null) renders "—" so the
+          // column never blanks during the sampler bootstrap window.
+          const att = t.attention;
+          const status: string = att?.required
+            ? att.reason === "halted"
+              ? "Halted"
+              : att.reason === "completed"
+                ? "Done"
+                : "Wait"
+            : att !== null && att !== undefined
+              ? "Active"
+              : "—";
           return (
             <button
               type="button"
@@ -40,7 +52,7 @@ export function TerminalList({ terminals, selectedTarget, onSelect }: TerminalLi
               <span
                 className={cn(
                   "shrink-0 text-[10px]",
-                  status === "Idle" ? "text-zinc-600" : "text-zinc-500",
+                  status === "Active" || status === "—" ? "text-zinc-600" : "text-zinc-500",
                 )}
               >
                 {status}

--- a/clients/react/src/components/worktree/BranchGraph.tsx
+++ b/clients/react/src/components/worktree/BranchGraph.tsx
@@ -7,9 +7,23 @@ import {
   type GraphData,
   type IssueInfo,
   type PrInfo,
-  statusName,
   type WorktreeSnapshot,
 } from "@/lib/api";
+
+// Step 6a (decision tmai-core@2026-05-07): the legacy `statusName`
+// helper retired with the `AgentStatus` enum. Map the new attention
+// axis onto the same single-word labels the LaneGraph rendering
+// already expects (Bootstrap → "—", Active → "Active", required
+// reasons → "Done" / "Halted" / "Wait").
+function attentionLabel(agent: AgentSnapshot | null | undefined): string {
+  const att = agent?.attention;
+  if (!att) return "—";
+  if (!att.required) return "Active";
+  if (att.reason === "completed") return "Done";
+  if (att.reason === "halted") return "Halted";
+  return "Wait";
+}
+
 import { useSSE } from "@/lib/sse-provider";
 import { ActionPanel } from "./ActionPanel";
 import { DetailPanel, type DetailView } from "./DetailPanel";
@@ -219,7 +233,7 @@ export function BranchGraph({
       agentStatus:
         mainWt?.agent_status ??
         (branchAgentMap.has(defaultBranch)
-          ? statusName(branchAgentMap.get(defaultBranch)?.status ?? "Unknown")
+          ? attentionLabel(branchAgentMap.get(defaultBranch))
           : null),
       diffSummary: null,
       worktree: mainWt ?? null,
@@ -269,7 +283,7 @@ export function BranchGraph({
             isDirty: false,
             hasAgent: !!matchedAgent,
             agentTarget: matchedAgent?.target ?? null,
-            agentStatus: matchedAgent ? statusName(matchedAgent.status) : null,
+            agentStatus: matchedAgent ? attentionLabel(matchedAgent) : null,
             diffSummary: null,
             worktree: null,
             ahead: ab?.[0] ?? 0,

--- a/clients/react/src/components/worktree/__tests__/git-panel-initial-load.test.tsx
+++ b/clients/react/src/components/worktree/__tests__/git-panel-initial-load.test.tsx
@@ -69,7 +69,8 @@ vi.mock("@/lib/api", async (importOriginal) => {
       // Fallback: any other api call hangs rather than throwing
       attentionCount: () => hanging,
     },
-    statusName: actual.statusName,
+    // Step 6a: `statusName` was retired alongside the `AgentStatus` enum.
+    // Nothing in this suite calls it, so the re-export is dropped.
   };
 });
 

--- a/clients/react/src/hooks/useAgents.ts
+++ b/clients/react/src/hooks/useAgents.ts
@@ -11,13 +11,10 @@ import { type CoreEvent, useTauriEvents } from "./useTauriEvents";
 export function useAgents() {
   const { cache, refreshCache } = useSSEContext();
   const { agents, loading } = cache;
-  // Step 5 of the agent-state attention rebuild (decision tmai-core@2026-05-07):
-  // prefer the new `attention.required` axis when present, fall back to the
-  // legacy `needs_attention` boolean (#521) so older tmai-core snapshots
-  // still aggregate. Step 6 retires the fallback.
-  const attentionCount = agents.filter(
-    (a) => a.attention?.required ?? a.needs_attention ?? false,
-  ).length;
+  // Step 6a (decision tmai-core@2026-05-07): legacy `needs_attention`
+  // fallback retired with the rest of the AgentSnapshot pentad. Count
+  // is driven entirely by `attention.required`.
+  const attentionCount = agents.filter((a) => a.attention?.required ?? false).length;
 
   // refreshCache triggers a full re-bootstrap; used by the Tauri event path
   // to pull a fresh snapshot when the desktop app signals an agent change.

--- a/clients/react/src/hooks/useIdleNotification.ts
+++ b/clients/react/src/hooks/useIdleNotification.ts
@@ -7,7 +7,7 @@
 // Uses the Notification API so notifications appear even when the tab is in the background.
 
 import { useCallback, useEffect, useRef } from "react";
-import { type AgentSnapshot, type DetectionSource, isAiAgent, statusName } from "@/lib/api";
+import { type AgentSnapshot, type DetectionSource, isAiAgent } from "@/lib/api";
 
 export interface IdleNotificationConfig {
   enabled: boolean;
@@ -85,9 +85,7 @@ function sendNotification(agent: AgentSnapshot, lastMessage?: string | null) {
 export function useIdleNotification(agents: AgentSnapshot[], config: IdleNotificationConfig) {
   // Track per-agent idle state
   const stateMap = useRef(new Map<string, AgentIdleState>());
-  // Track previous status per agent (legacy path)
-  const prevStatusMap = useRef(new Map<string, string>());
-  // Track previous attention.required per agent (Step 5 primary path)
+  // Track previous attention.required per agent (Step 6a: only signal)
   const prevAttentionMap = useRef(new Map<string, boolean>());
 
   // Request permission when enabled
@@ -105,7 +103,6 @@ export function useIdleNotification(agents: AgentSnapshot[], config: IdleNotific
         if (state.timerId) clearTimeout(state.timerId);
       }
       stateMap.current.clear();
-      prevStatusMap.current.clear();
       prevAttentionMap.current.clear();
       return;
     }
@@ -117,33 +114,21 @@ export function useIdleNotification(agents: AgentSnapshot[], config: IdleNotific
       if (!isAiAgent(agent.agent_type)) continue;
 
       currentIds.add(agent.id);
-      const status = statusName(agent.status);
-      const prevStatus = prevStatusMap.current.get(agent.id);
-      prevStatusMap.current.set(agent.id, status);
       const attentionRequired = agent.attention?.required ?? false;
       const prevAttention = prevAttentionMap.current.get(agent.id);
       prevAttentionMap.current.set(agent.id, attentionRequired);
 
       const idleState = stateMap.current.get(agent.id);
 
-      // Step 5: "needs the human" condition is true when either the new
-      // attention axis says so or the legacy status is Idle / Offline.
-      const needsHuman = attentionRequired || status === "Idle" || status === "Offline";
-      // A *fresh* trigger requires a transition into the needs-human state
-      // on at least one of the two signals — otherwise re-renders would
-      // re-fire notifications for an agent that has been idle for hours.
-      // The attention path explicitly compares against `false` (not `!prevAttention`)
-      // so the first observation of an agent (`prevAttention === undefined`)
-      // does NOT count as a transition: a freshly-loaded tab must not
-      // shower the user with notifications for agents that have been
-      // requiring attention since long before the tab opened. CodeRabbit
-      // tmai#618.
-      const attentionTrigger = prevAttention === false && attentionRequired;
-      const statusTrigger =
-        prevStatus === "Processing" && (status === "Idle" || status === "Offline");
-      const justBecameNeedsHuman = attentionTrigger || statusTrigger;
+      // Step 6a: legacy `status` Processing → Idle path retired with the
+      // `AgentStatus` enum. Trigger entirely on the attention axis.
+      // First observation (`prevAttention === undefined`) does NOT count
+      // as a transition so a freshly-loaded tab does not shower the user
+      // with stale notifications for agents that have been requiring
+      // attention since long before the tab opened.
+      const justBecameNeedsHuman = prevAttention === false && attentionRequired;
 
-      if (needsHuman) {
+      if (attentionRequired) {
         if (justBecameNeedsHuman && !idleState?.notified) {
           const delay = getDelay(agent.detection_source, config.thresholdSecs);
 
@@ -189,7 +174,6 @@ export function useIdleNotification(agents: AgentSnapshot[], config: IdleNotific
       if (!currentIds.has(id)) {
         if (state.timerId) clearTimeout(state.timerId);
         stateMap.current.delete(id);
-        prevStatusMap.current.delete(id);
         prevAttentionMap.current.delete(id);
       }
     }

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -90,27 +90,12 @@ async function apiFetch<T>(path: string, options: RequestInit = {}): Promise<T> 
 
 // ── Types ──
 
-// Agent status (serde externally tagged)
-export type AgentStatus =
-  | "Idle"
-  | "Offline"
-  | "Unknown"
-  | { Processing: { activity: string } }
-  | { AwaitingApproval: { approval_type: string; details: string } }
-  | { Error: { message: string } };
-
-export function statusName(status: AgentStatus): string {
-  if (typeof status === "string") return status;
-  if (status == null) return "Unknown";
-  // Externally tagged: { "Processing": { "activity": "..." } }
-  const keys = Object.keys(status).filter((k) => k !== "type");
-  if (keys.length > 0) return keys[0];
-  // Internally tagged fallback: { "type": "Processing", ... }
-  if ("type" in status && typeof (status as Record<string, unknown>).type === "string") {
-    return (status as Record<string, unknown>).type as string;
-  }
-  return "Unknown";
-}
+// Step 6a (decision tmai-core@2026-05-07): the legacy `AgentStatus`
+// shim, the matching `statusName` helper, and the `Phase` / `Detail`
+// types are retired alongside the wire fields. Only the new
+// `AgentAttention` axis below survives. Use
+// `attention?.required` + `attention?.reason` to drive UI semantics
+// (see `AgentCard.tsx::attentionPill`).
 
 export type DetectionSource = "CapturePane" | "IpcSocket" | "HttpHook" | "WebSocket";
 export type SendCapability = "Ipc" | "Tmux" | "PtyInject" | "None";
@@ -147,28 +132,9 @@ export interface ConnectionChannels {
 export type AgentType = "ClaudeCode" | "OpenCode" | "CodexCli" | "GeminiCli" | { Custom: string };
 export type EffortLevel = "Low" | "Medium" | "High";
 
-/// Coarse-grained phase for orchestrator consumption
-export type Phase = "Working" | "Blocked" | "Idle" | "Offline";
-
-/// Fine-grained detail for UI display (serde externally tagged)
-export type Detail =
-  | "Idle"
-  | "Offline"
-  | "Unknown"
-  | "Compacting"
-  | "Thinking"
-  | { ToolExecution: { tool_name: string } }
-  | { AwaitingApproval: { approval_type: string; details: string } }
-  | { Error: { message: string } };
-
-/// Extract a human-readable label from a Detail value
-export function detailLabel(detail: Detail): string {
-  if (typeof detail === "string") return detail;
-  if ("ToolExecution" in detail) return `Tool: ${detail.ToolExecution.tool_name}`;
-  if ("AwaitingApproval" in detail) return `Awaiting: ${detail.AwaitingApproval.approval_type}`;
-  if ("Error" in detail) return `Error: ${detail.Error.message}`;
-  return "Unknown";
-}
+// Phase / Detail / detailLabel retired in Step 6a (decision
+// tmai-core@2026-05-07) alongside the AgentStatus pentad. Use the
+// `AgentAttention` axis above for dynamic state.
 
 /// Whether this agent type is an AI coding agent (not a plain terminal)
 export function isAiAgent(agentType: AgentType): boolean {
@@ -184,9 +150,6 @@ export interface AgentSnapshot {
   id: string;
   target: string;
   agent_type: AgentType;
-  status: AgentStatus;
-  phase: Phase;
-  detail: Detail;
   title: string;
   cwd: string;
   display_cwd: string;
@@ -217,18 +180,17 @@ export interface AgentSnapshot {
   model_id?: string | null;
   model_display_name?: string | null;
   is_orchestrator?: boolean;
-  /** New attention axis (decision tmai-core@2026-05-07 Step 4). `null` /
-   *  absent on the wire encodes "unknown" — the sampler bootstrap window
-   *  per Δ6. Step 5 of the rebuild teaches the Hub to prefer this over
-   *  the legacy `needs_attention` boolean below; Step 6 retires the
-   *  legacy field. */
+  /** Attention axis introduced by Step 4 of the agent-state attention
+   *  rebuild (decision tmai-core@2026-05-07). `null` / absent on the
+   *  wire encodes "unknown" — the sampler bootstrap window per Δ6.
+   *  Step 6a (this PR) made this the **only** dynamic-state surface
+   *  on the wire; the legacy `status` / `phase` / `detail` /
+   *  `needs_attention` / `has_pending_approval` pentad is gone. */
   attention?: AgentAttention | null;
-  // Derived fields computed by tmai-core (tmai-core@c40e8b8aa5, Phase 1)
-  needs_attention?: boolean;
+  // Other derived fields computed by tmai-core
   display_label?: string;
   has_queued_prompt?: boolean;
   queued_prompt_count?: number;
-  has_pending_approval?: boolean;
   primary_worktree_path?: string | null;
   current_dispatch_id?: string | null;
   /** True when tmai did NOT spawn this agent — the Claude Code session
@@ -440,12 +402,9 @@ export function groupByProject(
       });
     }
 
-    // Step 5 of the agent-state attention rebuild (decision tmai-core@2026-05-07):
-    // prefer the new `attention.required` axis, fall back to the legacy
-    // `needs_attention` boolean for snapshots from pre-Step-4 servers.
-    const attentionCount = groupAgents.filter(
-      (a) => a.attention?.required ?? a.needs_attention ?? false,
-    ).length;
+    // Step 6a (decision tmai-core@2026-05-07): legacy `needs_attention`
+    // fallback retired with the rest of the AgentSnapshot pentad.
+    const attentionCount = groupAgents.filter((a) => a.attention?.required ?? false).length;
 
     projects.push({
       name: projectName(path),
@@ -907,10 +866,9 @@ export const api = {
   listAgents: () => apiFetch<AgentSnapshot[]>("/agents"),
   attentionCount: async () => {
     const agents = await apiFetch<AgentSnapshot[]>("/agents");
-    // Step 5 of the agent-state attention rebuild: same fallback as
-    // useAgents and groupByProject above. Step 6 retires the legacy
-    // `needs_attention` field.
-    return agents.filter((a) => a.attention?.required ?? a.needs_attention ?? false).length;
+    // Step 6a (decision tmai-core@2026-05-07): legacy `needs_attention`
+    // fallback retired with the rest of the AgentSnapshot pentad.
+    return agents.filter((a) => a.attention?.required ?? false).length;
   },
 
   // Agent actions

--- a/clients/react/src/lib/tauri.ts
+++ b/clients/react/src/lib/tauri.ts
@@ -21,60 +21,21 @@ interface TauriAgentInfo {
   team_name: string | null;
 }
 
-// Convert Tauri AgentInfo to API AgentSnapshot
+// Convert Tauri AgentInfo to API AgentSnapshot.
+//
+// Step 6a (decision tmai-core@2026-05-07): the legacy `status` /
+// `phase` / `detail` triple was retired from the wire surface. The
+// Tauri bridge therefore drops the parser block — `info.status`
+// continues to flow from the Tauri side (older Tauri builds may still
+// emit it) but is not surfaced into the React snapshot. The new
+// `attention` axis is left as `null` here because the Tauri bridge
+// has no separate signal for it; downstream UI renders the bootstrap
+// indeterminate badge until the SSE / HTTP path takes over.
 function convertTauriAgent(info: TauriAgentInfo): AgentSnapshot {
-  // Parse status enum string from Tauri
-  let status: AgentSnapshot["status"];
-  if (info.status === "Idle") {
-    status = "Idle";
-  } else if (info.status === "Offline") {
-    status = "Offline";
-  } else if (info.status === "Unknown") {
-    status = "Unknown";
-  } else if (info.status.startsWith("Processing")) {
-    status = { Processing: { activity: info.status.substring(11) } };
-  } else if (info.status.startsWith("AwaitingApproval")) {
-    status = { AwaitingApproval: { approval_type: "unknown", details: "" } };
-  } else if (info.status.startsWith("Error")) {
-    status = { Error: { message: info.status.substring(7) } };
-  } else {
-    status = "Unknown";
-  }
-
-  // Derive phase and detail from status for Tauri compatibility
-  let phase: import("./api-http").Phase = "Idle";
-  let detail: import("./api-http").Detail = "Idle";
-  if (typeof status === "string") {
-    if (status === "Idle") {
-      phase = "Idle";
-      detail = "Idle";
-    } else if (status === "Offline") {
-      phase = "Offline";
-      detail = "Offline";
-    } else {
-      phase = "Idle";
-      detail = "Unknown";
-    }
-  } else if ("Processing" in status) {
-    phase = "Working";
-    detail = status.Processing.activity
-      ? { ToolExecution: { tool_name: status.Processing.activity } }
-      : "Thinking";
-  } else if ("AwaitingApproval" in status) {
-    phase = "Blocked";
-    detail = { AwaitingApproval: status.AwaitingApproval };
-  } else if ("Error" in status) {
-    phase = "Blocked";
-    detail = { Error: status.Error };
-  }
-
   return {
     id: info.id,
     target: info.target,
     agent_type: info.type as AgentType,
-    status,
-    phase,
-    detail,
     title: info.title,
     cwd: info.cwd,
     display_cwd: info.display_cwd,


### PR DESCRIPTION
## Summary

Step 6a follow-up on tmai (public). Mirrors trust-delta/tmai-core#284 which retired the wire fields \`status\`, \`phase\`, \`detail\`, \`needs_attention\`, and \`has_pending_approval\` from \`AgentSnapshot\`. This patch deletes every consumer of those fields in the React client, dropping the parallel-run fallback chain Step 5 left behind.

The dogfood-blocking artifact (spawn-time \"Processing\" pill from the capture-pane detector) cannot recur because the wire field is gone and the React fallback chain to \`statusName(agent.status)\` is gone with it.

## Wire shape after this PR

\`AgentSnapshot.attention?: AgentAttention | null\` is now the **only** dynamic-state surface. UI mapping:

| attention shape | pill label | style |
|---|---|---|
| \`{ required: true, reason: 'completed' }\` | Done | sky |
| \`{ required: true, reason: 'halted' }\` | Halted | rose + glow-red |
| \`{ required: true, reason: null }\` | Wait | amber |
| \`{ required: false, reason: any }\` | Active | emerald |
| \`null\` / \`undefined\` (bootstrap window) | Bootstrap | zinc |

## File-by-file

- \`src/lib/api-http.ts\` — drop \`AgentStatus\` / \`Phase\` / \`Detail\` types + \`statusName\` / \`detailLabel\` helpers; AgentSnapshot loses 5 fields.
- \`src/lib/tauri.ts\` — drop the Tauri-side \`info.status\` parser block; bridge surfaces no \`status\` to React.
- \`src/components/agent/AgentCard.tsx\` — pill logic collapses to attention. \`statusColors\` / \`statusGlow\` retired.
- \`src/components/agent/AgentActions.tsx\` — \`needsPermission\` / \`isProcessing\` / \`isIdle\` / pill label all derived from attention.
- \`src/components/terminal/TerminalList.tsx\` — terminal status column attention-driven.
- \`src/components/worktree/BranchGraph.tsx\` — small \`attentionLabel\` helper emitting the LaneGraph vocabulary (Done / Halted / Wait / Active / —).
- \`src/App.tsx\` — mobile sidebar agent dot maps to attention reasons.
- \`src/hooks/useAgents.ts\` + \`useIdleNotification.ts\` — drop \`prevStatusMap\` + Processing→Idle fallback path. Browser notifications fire purely on \`attention.required\` false → true transitions (first observation suppressed per CodeRabbit invariant on tmai#618).
- \`src/components/worktree/__tests__/git-panel-initial-load.test.tsx\` — mock drops the retired \`statusName\` re-export.

## Test plan

- [x] \`pnpm test\` — 320 vitest pass
- [x] \`pnpm exec tsc -b --force\` clean
- [x] \`pnpm lint\` — same 6 pre-existing warnings (biome suppression + non-null assertions in unrelated files)
- [ ] dogfood: spawn agent — pill flips Bootstrap → Active (emerald) when CC starts producing output → Done (sky) when CC fires Stop → cleared by sending the next prompt; no transient \"Processing\" badge.

## Out of scope

- Capture-pane detector (\`detectors/default.rs\`) and the auto-approve subsystem still produce \`MonitoredAgent.status\` internally on tmai-core. Step 7 / 8 retire those internal references along with the legacy enums.
- ratatui client mirror — a follow-up PR mirrors the same migration there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)