### PR TITLE
feat(ratatui): mirror Step 6 — drop AgentStatus + Phase, render attention

### DIFF
--- a/clients/ratatui/src/types/mod.rs
+++ b/clients/ratatui/src/types/mod.rs
@@ -2,8 +2,8 @@
 pub mod generated;
 
 pub use generated::{
-    ApprovalSnapshot, DispatchSnapshot, Phase, QueueSnapshot, RuntimeSnapshot, TaskMetaSnapshot,
-    TeamSnapshot, WorkflowSnapshot, WorktreeSnapshot,
+    AgentAttention, ApprovalSnapshot, AttentionReason, DispatchSnapshot, QueueSnapshot,
+    RuntimeSnapshot, TaskMetaSnapshot, TeamSnapshot, WorkflowSnapshot, WorktreeSnapshot,
 };
 
 use serde::Deserialize;
@@ -11,7 +11,12 @@ use serde::Deserialize;
 /// Agent snapshot returned by `GET /api/agents` and the `agents` SSE event.
 ///
 /// `display_label` is pre-computed by tmai-core (mirrors `QueueAgentEntry.agent_display_label`).
-/// `phase` captures the agent's operational state; UI styling reads from this field directly.
+///
+/// Step 6 of the agent-state attention rebuild (decision tmai-core@2026-05-07):
+/// the legacy `status` (`AgentStatus` enum) and `phase` fields were retired
+/// from the wire surface. The new `attention?: AgentAttention | null`
+/// axis (decision Step 4 / 6b) is the only dynamic-state field. UI styling
+/// reads from it via [`attention_label`].
 #[derive(Debug, Clone, Deserialize)]
 pub struct AgentSnapshot {
     pub id: String,
@@ -22,33 +27,27 @@ pub struct AgentSnapshot {
     pub is_virtual: bool,
     #[serde(default)]
     pub is_orchestrator: bool,
+    /// New attention axis (decision tmai-core@2026-05-07 Steps 4 / 6).
+    /// `None` / absent on the wire encodes the sampler bootstrap window
+    /// per Δ6 (UI renders "Bootstrap" / "—").
     #[serde(default)]
-    pub phase: Option<Phase>,
-    pub status: AgentStatus,
+    pub attention: Option<AgentAttention>,
 }
 
-/// Forward-compat agent status — tolerates unknown variants from newer tmai-core.
-#[derive(Debug, Clone, Deserialize)]
-#[serde(tag = "type")]
-pub enum AgentStatus {
-    Idle,
-    Processing {
-        #[serde(default)]
-        activity: serde_json::Value,
-    },
-    AwaitingApproval {
-        #[serde(default)]
-        approval_type: serde_json::Value,
-        #[serde(default)]
-        details: String,
-    },
-    Error {
-        #[serde(default)]
-        message: String,
-    },
-    Offline,
-    #[serde(other)]
-    Unknown,
+/// Map an [`AgentAttention`] reading to a single-word label matching the
+/// React WebUI badge vocabulary (`Done` / `Halted` / `Wait` / `Active`).
+/// `None` (sampler bootstrap window per Δ6) renders as `"—"` so the
+/// status column never blanks during the brief bootstrap interval.
+pub fn attention_label(a: Option<&AgentAttention>) -> &'static str {
+    match a {
+        Some(att) if att.required => match att.reason {
+            Some(AttentionReason::completed) => "Done",
+            Some(AttentionReason::halted) => "Halted",
+            None => "Wait",
+        },
+        Some(_) => "Active",
+        None => "—",
+    }
 }
 
 /// Payload for `POST /api/agents/{id}/input`.
@@ -72,51 +71,88 @@ mod tests {
         let json = r#"{
             "id": "main:0.0",
             "target": "main:0.0",
-            "agent_type": "ClaudeCode",
-            "status": {"type": "Idle"}
+            "agent_type": "ClaudeCode"
         }"#;
         let a: AgentSnapshot = serde_json::from_str(json).unwrap();
         assert_eq!(a.id, "main:0.0");
-        assert!(matches!(a.status, AgentStatus::Idle));
+        // Bootstrap state — no attention emitted yet.
+        assert!(a.attention.is_none());
     }
 
     #[test]
     fn display_label_defaults_to_empty_when_absent() {
-        let json = r#"{"id":"x","target":"x","status":{"type":"Idle"}}"#;
+        let json = r#"{"id":"x","target":"x"}"#;
         let a: AgentSnapshot = serde_json::from_str(json).unwrap();
         assert_eq!(a.display_label, "");
     }
 
     #[test]
     fn display_label_populated_when_present() {
-        let json = r#"{"id":"x","target":"x","display_label":"my-agent","status":{"type":"Idle"}}"#;
+        let json = r#"{"id":"x","target":"x","display_label":"my-agent"}"#;
         let a: AgentSnapshot = serde_json::from_str(json).unwrap();
         assert_eq!(a.display_label, "my-agent");
     }
 
     #[test]
-    fn unknown_status_variant_does_not_fail() {
-        // Forward-compat: tmai-core adds a new AgentStatus variant.
-        let json = r#"{
-            "id": "x",
-            "target": "x",
-            "status": {"type": "WatchingPaint", "details": "."}
-        }"#;
-        let a: AgentSnapshot = serde_json::from_str(json).unwrap();
-        assert!(matches!(a.status, AgentStatus::Unknown));
-    }
-
-    #[test]
     fn extra_fields_are_tolerated() {
         // Forward-compat: future snapshot fields must not crash the client.
+        // Also tolerates legacy `status` / `phase` from older tmai-core that
+        // hasn't merged the Step 6a wire-pentad drop yet — they're ignored.
         let json = r#"{
             "id": "x",
             "target": "x",
-            "status": {"type": "Idle"},
             "agent_type": "ClaudeCode",
+            "status": {"type": "Idle"},
+            "phase": "Idle",
             "some_future_field": 42,
             "another_one": {"nested": true}
         }"#;
         let _: AgentSnapshot = serde_json::from_str(json).unwrap();
+    }
+
+    #[test]
+    fn attention_label_maps_variants() {
+        assert_eq!(attention_label(None), "—");
+        assert_eq!(
+            attention_label(Some(&AgentAttention {
+                required: false,
+                reason: None
+            })),
+            "Active"
+        );
+        assert_eq!(
+            attention_label(Some(&AgentAttention {
+                required: true,
+                reason: Some(AttentionReason::completed)
+            })),
+            "Done"
+        );
+        assert_eq!(
+            attention_label(Some(&AgentAttention {
+                required: true,
+                reason: Some(AttentionReason::halted)
+            })),
+            "Halted"
+        );
+        assert_eq!(
+            attention_label(Some(&AgentAttention {
+                required: true,
+                reason: None
+            })),
+            "Wait"
+        );
+    }
+
+    #[test]
+    fn attention_field_round_trips_with_reason() {
+        let json = r#"{
+            "id": "x",
+            "target": "x",
+            "attention": {"required": true, "reason": "completed"}
+        }"#;
+        let a: AgentSnapshot = serde_json::from_str(json).unwrap();
+        let att = a.attention.expect("attention populated");
+        assert!(att.required);
+        assert!(matches!(att.reason, Some(AttentionReason::completed)));
     }
 }

--- a/clients/ratatui/src/ui/session_list.rs
+++ b/clients/ratatui/src/ui/session_list.rs
@@ -14,7 +14,7 @@ use ratatui::{
     Frame,
 };
 
-use crate::types::{AgentSnapshot, Phase};
+use crate::types::{attention_label, AgentSnapshot, AttentionReason};
 
 pub struct SessionListView<'a> {
     pub agents: &'a [AgentSnapshot],
@@ -137,26 +137,35 @@ fn render_status(frame: &mut Frame, area: Rect, text: &str) {
     frame.render_widget(para, area);
 }
 
-/// Phase tag label read directly from the core-provided `phase` field.
+/// Tag label derived from the new attention axis (decision tmai-core@2026-05-07
+/// Steps 4 / 6). Replaces the legacy `phase` enum that was retired by
+/// Step 6a. Lower-case to match the existing UI vocabulary; the explicit
+/// values match the React WebUI badge labels (`Done` / `Halted` / `Wait` /
+/// `Active` / `—`) lower-cased.
 fn phase_label(agent: &AgentSnapshot) -> &'static str {
-    match &agent.phase {
-        Some(Phase::Working) => "working",
-        Some(Phase::Blocked) => "blocked",
-        Some(Phase::Idle) => "idle",
-        Some(Phase::Offline) => "offline",
-        None => "?",
+    match attention_label(agent.attention.as_ref()) {
+        "Done" => "done",
+        "Halted" => "halted",
+        "Wait" => "wait",
+        "Active" => "active",
+        _ => "—",
     }
 }
 
-/// UI color for the phase tag, reading from the core-provided `phase` field.
+/// UI color for the phase tag. Maps attention states onto the same
+/// blocked / working / idle palette the legacy `phase` field used to
+/// drive — Halted keeps the urgent yellow accent, Done / Wait stay
+/// muted, Active mirrors the working cyan, bootstrap stays gray.
 fn phase_color(agent: &AgentSnapshot) -> Style {
     let base = Style::default();
-    match &agent.phase {
-        Some(Phase::Working) => base.fg(Color::Cyan),
-        Some(Phase::Blocked) => base.fg(Color::Yellow),
-        Some(Phase::Idle) => base.fg(Color::Green),
-        Some(Phase::Offline) => base.fg(Color::DarkGray),
-        None => base,
+    match agent.attention.as_ref() {
+        Some(att) if att.required => match att.reason {
+            Some(AttentionReason::halted) => base.fg(Color::Yellow),
+            Some(AttentionReason::completed) => base.fg(Color::Green),
+            None => base.fg(Color::Yellow),
+        },
+        Some(_) => base.fg(Color::Cyan),
+        None => base.fg(Color::DarkGray),
     }
 }
 


### PR DESCRIPTION
## Summary

Mirrors the React Step 5 + 6a migration on the ratatui client. Brings the TUI in line with the post-rebuild wire surface: the legacy \`AgentStatus\` enum and \`phase: Option<Phase>\` field are gone from \`AgentSnapshot\`, and the new \`attention?: AgentAttention\` axis (Step 4 / 6b) drives the status column.

## Wire shape after this PR

ratatui's \`AgentSnapshot\` now matches the new wire contract — only \`attention\` carries dynamic state. Single-word labels match the React WebUI badge vocabulary lower-cased:

| attention shape | label | color |
|---|---|---|
| \`{ required: true, reason: 'completed' }\` | done | green |
| \`{ required: true, reason: 'halted' }\` | halted | yellow |
| \`{ required: true, reason: null }\` | wait | yellow |
| \`{ required: false }\` | active | cyan |
| \`null\` (bootstrap) | — | dark gray |

## Files

- \`clients/ratatui/src/types/mod.rs\` — drop hand-written \`AgentStatus\` enum + \`phase\` field, add \`attention\` field, new \`attention_label\` helper, retire migration tests + add fresh attention round-trip / label-mapping tests.
- \`clients/ratatui/src/ui/session_list.rs\` — \`phase_label\` / \`phase_color\` rewritten on the attention axis. Halted preserves the urgent yellow accent that AwaitingApproval used to drive.

## Test plan

- [x] \`cargo test -p tmai-ratatui --lib\` — 9 pass (5 types tests + api tests)
- [x] \`cargo clippy -p tmai-ratatui --all-targets -- -D warnings\` clean
- [ ] dogfood: launch ratatui TUI against the new tmai-core; confirm session list shows the attention-derived label and color (Halted yellow on permission prompt, Done green on Stop, Active cyan during processing, — gray during sampler bootstrap).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * エージェント状態表示がアップデートされました。ステータスバッジが、Done（完了）、Halted（停止）、Wait（待機）、Active（実行中）の各状態をより正確に反映するようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->