### PR TITLE
fix(app): retire 500ms last-good-agent cache, rely on wire reorder

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { AgentActions } from "@/components/agent/AgentActions";
 import { AgentList } from "@/components/agent/AgentList";
 import { PreviewPanel } from "@/components/agent/PreviewPanel";
@@ -22,13 +22,7 @@ import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
 import { useShowAutoDiscovered } from "@/hooks/useShowAutoDiscovered";
 import { useSplitPane } from "@/hooks/useSplitPane";
 import { useWorktrees } from "@/hooks/useWorktrees";
-import {
-  type AgentSnapshot,
-  groupByProject,
-  isAiAgent,
-  type Selection,
-  setCallerCwd,
-} from "@/lib/api";
+import { groupByProject, isAiAgent, type Selection, setCallerCwd } from "@/lib/api";
 import { useSSE } from "@/lib/sse-provider";
 
 export function App() {
@@ -156,36 +150,16 @@ export function App() {
   //
   // tmai-core's L2 upgrade (decision 2026-05-09 Phase 1: hook payload
   // binds CC's session_id → pane_id) re-keys the agent's wire `id` from
-  // `provisional:UUID` to `claude:UUID`. The wire emits `Removed`
-  // (provisional id) BEFORE the follow-up `Upserted` (canonical id), so
-  // for one render tick `agents.find` returns undefined → panels using
-  // `selectedAgent` would unmount, dropping the xterm WS connection.
-  //
-  // Defend against that race with a short-lived cache (500 ms): if the
-  // live lookup misses but a recent successful lookup is still warm,
-  // surface the cached snapshot so the panel stays mounted across the
-  // re-key. Real disappearances (kill) fall through after the window.
-  const liveSelectedAgent =
+  // `provisional:UUID` to `claude:UUID`. The follow-up wire fix (commit
+  // landing alongside this one) reorders the emit to `Upserted(new) →
+  // Removed(old)`, so both keys are simultaneously present in the
+  // entity cache during the swap — `agents.find` resolves by `target`
+  // (stable across the re-key) and panels stay mounted. The earlier
+  // 500 ms last-good cache fallback retired with the wire reorder.
+  const selectedAgent =
     selection?.type === "agent"
       ? agents.find((a) => a.id === selection.id || a.target === selection.id)
       : undefined;
-  const lastGoodAgentRef = useRef<{ agent: AgentSnapshot; at: number } | undefined>(undefined);
-  if (liveSelectedAgent !== undefined) {
-    lastGoodAgentRef.current = { agent: liveSelectedAgent, at: Date.now() };
-  } else if (selection?.type !== "agent") {
-    lastGoodAgentRef.current = undefined;
-  } else if (
-    lastGoodAgentRef.current !== undefined &&
-    lastGoodAgentRef.current.agent.target !== selection.id &&
-    lastGoodAgentRef.current.agent.id !== selection.id
-  ) {
-    // Selection now points at a different agent — drop the stale cache.
-    lastGoodAgentRef.current = undefined;
-  }
-  const cacheStillFresh =
-    lastGoodAgentRef.current !== undefined && Date.now() - lastGoodAgentRef.current.at < 500;
-  const selectedAgent =
-    liveSelectedAgent ?? (cacheStillFresh ? lastGoodAgentRef.current?.agent : undefined);
   const sessionId = selectedAgent?.pty_session_id ?? null;
 
   // Derive selected worktree from selection


### PR DESCRIPTION
## Summary

Companion to tmai-core PR #307 (`refactor/promotion-emit-upserted-first`). With the wire reorder landing — `Upserted(new id)` now fires BEFORE `Removed(old id)` during the L2 promotion — the React entity cache holds both keys through the swap. The 500 ms `lastGoodAgentRef` band-aid added in commit 8418ab7 is no longer needed.

## Changes

- App.tsx: remove `lastGoodAgentRef` + timestamp logic; restore the simple direct `agents.find` derivation. Drop unused `useRef` / `AgentSnapshot` imports.

## Behavior

- L2 upgrade: target-based `agents.find` never misses (both keys live during the swap) → panel stays mounted.
- Real disappearance (kill / removed for real): `agents.find` returns undefined immediately → `selectedAgent = undefined` → "no agent selected" branch renders. Same as pre-cache behaviour.

## Test

- pnpm test: 312/312
- pnpm build: TS strict, clean

## Order of operations

1. Merge tmai-core #307 first.
2. Merge this PR (clients update).
3. Dogfood: spawn → first prompt → preview persists. Without the cache (this PR retires it) and with the wire reorder (companion), the L2 race is closed at the source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * エージェント選択ロジックを簡略化し、安定性とパフォーマンスを向上させました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/634)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->