### PR TITLE
chore(release): v3.0.0 — bundle bump + spec sync from tmai-core@a015389d1e

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,68 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 > jumped again to v2.0.0 at the 2026-04-21 monorepo re-consolidation.
 > For the TUI-era changelog (v0.0.1–v0.20.0), see [Legacy Changelog](#legacy-tui-era-v001v0200).
 
+## [3.0.0] - 2026-05-10 — agent detection canonicalization
+
+Major release closing the agent detection / state-model rebuild chain (Step 6
+through 2026-05-09 detection canonicalization, decision
+`tmai-core/.claude/decisions/2026-05-09-agent-detection-canonicalization.md`).
+**Wire shape is breaking** — the `attention` axis collapses from a
+`{required, reason?}` struct to a flat string enum
+(`"started" | "halted" | "completed" | null`); `AttentionReason` is removed.
+Mixing a v2.x client with a v3 engine (or vice-versa) is not supported.
+
+### Bundled
+
+- tmai-core 3.0.0 (`core-v3.0.0`)
+- clients/react 2.0.0
+- clients/ratatui 0.2.0
+- api-spec 3.0.0
+
+### Changed
+
+- **`AgentSnapshot.attention` is now a string enum** — three variants flag
+  user-blocked states; `null` means "running normally". Replaces the
+  `{ required: bool, reason?: "completed" | "halted" }` struct shape that
+  shipped in 2.x. UIs no longer branch on a `required` boolean — they switch
+  on the discriminator (or check `attention === null`).
+- **Three pills retire** — `Active`, `Wait`, `Bootstrap`. New pills:
+  - `Started` (cyan) — agent just spawned; awaiting first prompt.
+  - `Halted` (red) — at a permission/selection prompt.
+  - `Done` (sky blue) — turn finished; awaiting next decision.
+  - `Running` (muted gray, ambient) — `attention === null`; no UI action
+    needed.
+- **`PreToolUse` hook retired** — `tmai init` only configures `Stop`,
+  `Notification`, `UserPromptSubmit`. Existing CC settings.json files keep
+  working; on next `tmai init --force` the `PreToolUse` entry is dropped.
+- **Auto-discovery retired** — tmai exclusively manages tmai-spawned agents.
+  Manually-launched CCs no longer surface in the WebUI even with the dev
+  toggle on. Restart picks live agents back up because the PTY-server
+  dispatch ledger is the single canonical source.
+- **PTY-server attention sampler retired** — the subtree CPU/IO/PTY-write
+  quiet-signal aggregator is gone (~890 LOC). Attention is hook-driven
+  exclusively (`Stop` → Completed, `Notification[PermissionPrompt]` →
+  Halted, spawn → Started).
+
+### Fixed
+
+- L2-upgrade race that blanked the WebUI preview during the first hook —
+  wire emit reordered to `Upserted(canonical) → Removed(provisional)` so
+  the entity cache holds both keys through the swap.
+- Steady-state preview-disappear after re-selecting a hook-resolved agent —
+  `resolve_agent_key_in_state` falls through to target-based lookup when
+  the parsed canonical id doesn't match the L2-upgraded state map.
+- Terminal subscription tickets resolve via `agent.target` (PTY-server's
+  spawn-time identity, stable across L2 upgrade) instead of Core's
+  canonical id, which PTY-server doesn't track.
+
+### Migration
+
+- Re-run `tmai init --force` after upgrading to refresh `~/.claude/settings.json`
+  with the new hook set (`PreToolUse` removed, `X-Tmai-Agent-Id: $TMAI_AGENT_ID`
+  header added so spawned CCs route deterministically without cwd inference).
+- Previous `~/.claude/settings.json.before-attention-rebuild-cleanup` backup
+  remains the rollback path.
+
 ## [2.0.0] - 2026-04-22 — monorepo re-consolidation
 
 First release under the two-repo structure adopted on 2026-04-21: a public

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "2.4.0"
+    "version": "3.0.0"
   },
   "paths": {
     "/api/agents/{id}/subscribe-terminal": {

--- a/clients/ratatui/Cargo.lock
+++ b/clients/ratatui/Cargo.lock
@@ -2297,7 +2297,7 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tmai-ratatui"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/clients/ratatui/Cargo.toml
+++ b/clients/ratatui/Cargo.toml
@@ -6,7 +6,7 @@
 
 [package]
 name = "tmai-ratatui"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 rust-version = "1.91"
 authors = ["TrustDelta"]

--- a/clients/react/package.json
+++ b/clients/react/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tmai-react",
   "private": true,
-  "version": "1.2.0",
+  "version": "2.0.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/versions.toml
+++ b/versions.toml
@@ -7,6 +7,6 @@
 # an active safety net rather than a pending TODO.
 
 core = "3.0.0"      # tmai-core private Release
-react = "1.2.0"     # clients/react/package.json version
-ratatui = "0.1.0"   # clients/ratatui/Cargo.toml version
+react = "2.0.0"     # clients/react/package.json version
+ratatui = "0.2.0"   # clients/ratatui/Cargo.toml version
 api_spec = "3.0.0"  # api-spec/openapi.json info.version

--- a/versions.toml
+++ b/versions.toml
@@ -6,7 +6,7 @@
 # release.yml refuses to bundle while any key is 0.0.0, so placeholders are
 # an active safety net rather than a pending TODO.
 
-core = "2.4.0"      # tmai-core private Release
+core = "3.0.0"      # tmai-core private Release
 react = "1.2.0"     # clients/react/package.json version
 ratatui = "0.1.0"   # clients/ratatui/Cargo.toml version
-api_spec = "2.4.0"  # api-spec/openapi.json info.version
+api_spec = "3.0.0"  # api-spec/openapi.json info.version


### PR DESCRIPTION
## Summary

Bundle release v3.0.0 — closes the agent detection / state-model rebuild chain. Wire shape **breaking** (the `attention` axis collapses from a struct to a string enum); clients consume the new shape.

## Bundled

| Component | Version |
|---|---|
| tmai-core | **3.0.0** (`core-v3.0.0`) |
| clients/react | **2.0.0** |
| clients/ratatui | **0.2.0** |
| api-spec | **3.0.0** |

## What's in the cycle

The bot's initial commit (`ab0fbf9`) re-syncs api-spec + generated types from tmai-core@a015389d1e (which is the post-3.0.0-bump tip), so this PR carries:
- `api-spec/openapi.json` info.version: 2.4.0 → 3.0.0
- `versions.toml`: core / api_spec → 3.0.0 (auto by bot)

The hand-stacked commit `16b79b8` adds the rest of the bump:
- `clients/react/package.json`: 1.2.0 → 2.0.0
- `clients/ratatui/Cargo.toml`: 0.1.0 → 0.2.0
- `clients/ratatui/Cargo.lock`: regenerated for 0.2.0
- `versions.toml`: react / ratatui pins
- `CHANGELOG.md`: 3.0.0 entry (Bundled / Changed / Fixed / Migration sections)

`bot/` branch exempts the `no-hand-edits` guard so generated artefacts and their consumers can ship together (same flow as #633).

## After merge

Tag `v3.0.0` from main → `release.yml` fetches the bundled tarball.

## Test plan

- [x] `pnpm build` (clients/react) — TS strict, clean
- [x] `cargo build` (clients/ratatui) — clean
- [x] `no-hand-edits` skipped (bot branch)
- [x] `validate` / `ts-drift` / `rust-drift` / `CodeQL` — all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)