### PR TITLE
feat(react): tighter spawn flow — inline runtime pick, auto-focus, kill handoff

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -14,6 +14,7 @@ import { TerminalPanel } from "@/components/terminal/TerminalPanel";
 import { UsagePanel } from "@/components/usage/UsagePanel";
 import { BranchGraph } from "@/components/worktree/BranchGraph";
 import { WorktreePanel } from "@/components/worktree/WorktreePanel";
+import { useAgentSelectionFallback } from "@/hooks/useAgentSelectionFallback";
 import { useAgents } from "@/hooks/useAgents";
 import { useIdleNotification } from "@/hooks/useIdleNotification";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -161,6 +162,12 @@ export function App() {
       ? agents.find((a) => a.id === selection.id || a.target === selection.id)
       : undefined;
   const sessionId = selectedAgent?.pty_session_id ?? null;
+
+  // When the agent we were looking at disappears (kill button, CC quit,
+  // dispatch unwind …) auto-pick a sibling in the same cwd so the user
+  // doesn't drop into an empty pane. Same-cwd preferred (orchestrator
+  // first, matching the sidebar order); else any agent; else clear.
+  useAgentSelectionFallback({ selection, selectedAgent, agents, setSelection });
 
   // Derive selected worktree from selection
   const selectedWorktree =

--- a/clients/react/src/components/agent/PreviewPanel.tsx
+++ b/clients/react/src/components/agent/PreviewPanel.tsx
@@ -215,7 +215,6 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
         style={{ display: activeTab === "live" ? undefined : "none" }}
         className="flex-1 overflow-hidden"
       >
-        {/* biome-ignore lint/a11y/noStaticElementInteractions: terminal container needs pointer events for selection mode */}
         <div
           ref={xtermContainerRef}
           role="log"

--- a/clients/react/src/components/project/DirBrowser.tsx
+++ b/clients/react/src/components/project/DirBrowser.tsx
@@ -1,18 +1,27 @@
+import type { ReactNode } from "react";
 import { useCallback, useEffect, useState } from "react";
 import { api, type DirEntry } from "@/lib/api";
 import { cn } from "@/lib/utils";
 
 interface DirBrowserProps {
-  onSelect: (path: string) => void;
+  /** Default confirm-and-close handler bound to "Select this" + entry
+   *  double-click. Required for the picker mode (GeneralSection /
+   *  OrchestrationSection); ignored when `actionSlot` is provided. */
+  onSelect?: (path: string) => void;
   onCancel: () => void;
   /** Initial directory to load. When unset, the backend picks a default
    *  (typically the user's home). Phase 3 passes `default_project_root`
    *  here so users don't have to navigate from `~` every time. */
   startPath?: string | null;
+  /** Replaces the single "Select this" button with caller-rendered actions
+   *  for the currently-browsed path. NewAgentLauncher uses this to inline
+   *  claude/codex/bash spawn buttons so the user picks a runtime in one
+   *  click instead of "Select this" → secondary runtime menu. */
+  actionSlot?: (currentPath: string) => ReactNode;
 }
 
 // Modal directory tree browser for selecting a project folder
-export function DirBrowser({ onSelect, onCancel, startPath }: DirBrowserProps) {
+export function DirBrowser({ onSelect, onCancel, startPath, actionSlot }: DirBrowserProps) {
   const [currentPath, setCurrentPath] = useState("");
   const [entries, setEntries] = useState<DirEntry[]>([]);
   const [loading, setLoading] = useState(true);
@@ -90,14 +99,20 @@ export function DirBrowser({ onSelect, onCancel, startPath }: DirBrowserProps) {
           <span className="flex-1 truncate text-xs text-zinc-500" title={currentPath}>
             {currentPath || "~"}
           </span>
-          <button
-            type="button"
-            onClick={() => onSelect(currentPath)}
-            className="shrink-0 rounded-md bg-cyan-500/20 px-3 py-1 text-xs text-cyan-400 transition-colors hover:bg-cyan-500/30"
-          >
-            Select this
-          </button>
+          {!actionSlot && (
+            <button
+              type="button"
+              onClick={() => onSelect?.(currentPath)}
+              className="shrink-0 rounded-md bg-cyan-500/20 px-3 py-1 text-xs text-cyan-400 transition-colors hover:bg-cyan-500/30"
+            >
+              Select this
+            </button>
+          )}
         </div>
+
+        {actionSlot && (
+          <div className="border-b border-white/5 px-5 py-2">{actionSlot(currentPath)}</div>
+        )}
 
         {/* Directory listing */}
         <div className="max-h-80 overflow-y-auto">
@@ -113,7 +128,7 @@ export function DirBrowser({ onSelect, onCancel, startPath }: DirBrowserProps) {
                 type="button"
                 key={entry.path}
                 onClick={() => loadDir(entry.path)}
-                onDoubleClick={() => onSelect(entry.path)}
+                onDoubleClick={actionSlot ? undefined : () => onSelect?.(entry.path)}
                 className={cn(
                   "flex w-full items-center gap-2 px-5 py-1.5 text-left text-xs transition-colors hover:bg-white/5",
                   entry.is_git ? "text-cyan-400" : "text-zinc-400",
@@ -128,7 +143,11 @@ export function DirBrowser({ onSelect, onCancel, startPath }: DirBrowserProps) {
 
         {/* Footer hint */}
         <div className="border-t border-white/5 px-5 py-2">
-          <p className="text-[10px] text-zinc-600">Click to navigate, double-click to select</p>
+          <p className="text-[10px] text-zinc-600">
+            {actionSlot
+              ? "Click to navigate, then pick a runtime to spawn here"
+              : "Click to navigate, double-click to select"}
+          </p>
         </div>
       </div>
     </div>

--- a/clients/react/src/components/project/NewAgentLauncher.tsx
+++ b/clients/react/src/components/project/NewAgentLauncher.tsx
@@ -11,15 +11,16 @@ const RUNTIMES = ["claude", "codex", "bash"] as const;
 type Runtime = (typeof RUNTIMES)[number];
 
 /**
- * Top-of-sidebar launcher: pick a directory via DirBrowser, then choose a
- * runtime (claude / codex / bash) to spawn.  Replaces the per-project `+`
- * menu as the entry point for brand-new project work — the per-project `+`
- * inside `ProjectGroup` stays for adding agents to projects already shown
- * in the sidebar.
+ * Top-of-sidebar launcher: open DirBrowser, navigate to the desired folder,
+ * and pick a runtime (claude / codex / bash) inline to spawn there.  The
+ * runtime buttons live inside the DirBrowser via its `actionSlot` prop —
+ * earlier versions split this across "Select this" + a secondary runtime
+ * picker, which made every spawn a two-step round trip through a closing
+ * modal.  The per-project `+` inside `ProjectGroup` stays for adding agents
+ * to projects already shown in the sidebar.
  */
 export function NewAgentLauncher({ onSpawned }: NewAgentLauncherProps) {
   const [browsing, setBrowsing] = useState(false);
-  const [pickedDir, setPickedDir] = useState<string | null>(null);
   const [spawning, setSpawning] = useState(false);
   const [error, setError] = useState("");
   const [defaultRoot, setDefaultRoot] = useState<string | null>(null);
@@ -47,24 +48,19 @@ export function NewAgentLauncher({ onSpawned }: NewAgentLauncherProps) {
     // startPath in one shot — opening first and updating on the next render
     // would briefly flash the previous root's listing.
     await refreshDefaultRoot();
+    setError("");
     setBrowsing(true);
   }, [refreshDefaultRoot]);
 
-  const handleDirSelected = useCallback((path: string) => {
-    setPickedDir(path);
-    setBrowsing(false);
-    setError("");
-  }, []);
-
   const handleSpawn = useCallback(
-    async (runtime: Runtime) => {
-      if (!pickedDir || spawning) return;
+    async (runtime: Runtime, cwd: string) => {
+      if (!cwd || spawning) return;
       setSpawning(true);
       setError("");
       try {
-        const res = await api.spawnPty({ command: runtime, cwd: pickedDir });
+        const res = await api.spawnPty({ command: runtime, cwd });
         onSpawned(res.session_id);
-        setPickedDir(null);
+        setBrowsing(false);
       } catch (e) {
         // Surface which runtime was tried so users can tell apart
         // "claude is mis-installed" from "this directory can't host
@@ -75,7 +71,7 @@ export function NewAgentLauncher({ onSpawned }: NewAgentLauncherProps) {
         setSpawning(false);
       }
     },
-    [pickedDir, spawning, onSpawned],
+    [spawning, onSpawned],
   );
 
   return (
@@ -90,49 +86,35 @@ export function NewAgentLauncher({ onSpawned }: NewAgentLauncherProps) {
         <span>New agent</span>
       </button>
 
-      {pickedDir && (
-        <div className="mt-2 rounded-lg border border-white/10 bg-white/[0.03] p-2">
-          <div className="flex items-center gap-2 text-[11px] text-zinc-500">
-            <span className="truncate" title={pickedDir}>
-              {pickedDir}
-            </span>
-            <button
-              type="button"
-              onClick={() => setPickedDir(null)}
-              className="ml-auto shrink-0 rounded px-1.5 py-0.5 text-zinc-600 transition-colors hover:bg-white/10 hover:text-zinc-300"
-            >
-              Cancel
-            </button>
-          </div>
-          <div className="mt-1.5 flex gap-1">
-            {RUNTIMES.map((rt) => (
-              <button
-                key={rt}
-                type="button"
-                onClick={() => void handleSpawn(rt)}
-                disabled={spawning}
-                className={cn(
-                  "flex-1 rounded px-2 py-1 text-center text-[11px] transition-colors",
-                  "text-zinc-300 hover:bg-cyan-500/10 hover:text-cyan-400 disabled:opacity-50",
-                )}
-              >
-                {rt}
-              </button>
-            ))}
-          </div>
-          {error && (
-            <p role="alert" aria-live="assertive" className="mt-1.5 text-[11px] text-red-400">
-              {error}
-            </p>
-          )}
-        </div>
-      )}
-
       {browsing && (
         <DirBrowser
           startPath={defaultRoot ?? undefined}
-          onSelect={handleDirSelected}
           onCancel={() => setBrowsing(false)}
+          actionSlot={(currentPath) => (
+            <div className="flex w-full flex-col gap-1.5">
+              <div className="flex gap-1">
+                {RUNTIMES.map((rt) => (
+                  <button
+                    key={rt}
+                    type="button"
+                    onClick={() => void handleSpawn(rt, currentPath)}
+                    disabled={spawning || !currentPath}
+                    className={cn(
+                      "flex-1 rounded px-2 py-1 text-center text-[11px] transition-colors",
+                      "text-zinc-300 hover:bg-cyan-500/10 hover:text-cyan-400 disabled:opacity-50",
+                    )}
+                  >
+                    {rt}
+                  </button>
+                ))}
+              </div>
+              {error && (
+                <p role="alert" aria-live="assertive" className="text-[11px] text-red-400">
+                  {error}
+                </p>
+              )}
+            </div>
+          )}
         />
       )}
     </div>

--- a/clients/react/src/components/project/__tests__/NewAgentLauncher.test.tsx
+++ b/clients/react/src/components/project/__tests__/NewAgentLauncher.test.tsx
@@ -49,4 +49,40 @@ describe("NewAgentLauncher", () => {
       expect(vi.mocked(api.listDirectories)).toHaveBeenNthCalledWith(1, "/new");
     });
   });
+
+  it("spawns the chosen runtime against DirBrowser's currentPath without an intermediate confirm", async () => {
+    // Regression for the redundant "Select this" → close → re-open runtime
+    // menu flow. The fix inlines the runtime buttons into DirBrowser via
+    // `actionSlot`, so clicking `claude` while browsing in `/projects`
+    // fires `spawnPty({ command: "claude", cwd: "/projects" })` directly.
+    vi.mocked(api.getGeneralSettings).mockResolvedValue({ default_project_root: "/projects" });
+    vi.mocked(api.listDirectories).mockResolvedValue([]);
+    vi.mocked(api.spawnPty).mockResolvedValue({
+      session_id: "sess-1",
+      pid: 42,
+      command: "claude",
+    });
+
+    const onSpawned = vi.fn();
+    render(<NewAgentLauncher onSpawned={onSpawned} />);
+    await waitFor(() => expect(vi.mocked(api.getGeneralSettings)).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("button", { name: /new agent/i }));
+
+    // The runtime buttons mount with DirBrowser, but they're disabled until
+    // `currentPath` is hydrated from listDirectories — wait for the path to
+    // surface in the path bar before clicking, otherwise the click lands on
+    // a disabled button and silently no-ops.
+    await screen.findByText("/projects");
+    const claudeBtn = await screen.findByRole("button", { name: /^claude$/i });
+    fireEvent.click(claudeBtn);
+
+    await waitFor(() => {
+      expect(vi.mocked(api.spawnPty)).toHaveBeenCalledWith({
+        command: "claude",
+        cwd: "/projects",
+      });
+      expect(onSpawned).toHaveBeenCalledWith("sess-1");
+    });
+  });
 });

--- a/clients/react/src/hooks/__tests__/useAgentSelectionFallback.test.ts
+++ b/clients/react/src/hooks/__tests__/useAgentSelectionFallback.test.ts
@@ -1,0 +1,217 @@
+// @vitest-environment jsdom
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentSnapshot, Selection } from "@/lib/api-http";
+import { useAgentSelectionFallback } from "../useAgentSelectionFallback";
+
+// renderHook infers `initialProps`'s shape from the literal we pass in,
+// so a concrete `selectedAgent: agent(...)` narrows it to `AgentSnapshot`
+// and rejects the `selectedAgent: undefined` we pass to the death-case
+// `rerender`. Annotating both `initialProps` and the callback param with
+// these aliases keeps the death cases type-checkable without `as` casts.
+type FallbackProps = {
+  selectedAgent: AgentSnapshot | undefined;
+  agents: AgentSnapshot[];
+};
+type FullFallbackProps = FallbackProps & { selection: Selection | null };
+
+function agent(
+  spec: Pick<AgentSnapshot, "target" | "cwd"> & Partial<Omit<AgentSnapshot, "target" | "cwd">>,
+): AgentSnapshot {
+  const { target, cwd, ...rest } = spec;
+  return {
+    id: target,
+    target,
+    agent_type: "Claude",
+    title: target,
+    cwd,
+    display_cwd: cwd,
+    display_name: target,
+    detection_source: "Adopted",
+    git_branch: null,
+    git_dirty: null,
+    is_worktree: null,
+    git_common_dir: null,
+    worktree_name: null,
+    worktree_base_branch: null,
+    effort_level: null,
+    active_subagents: 0,
+    compaction_count: 0,
+    pty_session_id: null,
+    send_capability: "Unknown",
+    is_virtual: false,
+    team_info: null,
+    is_orchestrator: false,
+    attention: null,
+    ...rest,
+  } as AgentSnapshot;
+}
+
+describe("useAgentSelectionFallback", () => {
+  it("does nothing while the selected agent is still in the list", () => {
+    const setSelection = vi.fn();
+    const a = agent({ target: "a", cwd: "/foo" });
+    const selection: Selection = { type: "agent", id: "a" };
+    renderHook(() =>
+      useAgentSelectionFallback({
+        selection,
+        selectedAgent: a,
+        agents: [a],
+        setSelection,
+      }),
+    );
+    expect(setSelection).not.toHaveBeenCalled();
+  });
+
+  it("hands selection to a same-cwd sibling when the resolved agent disappears", () => {
+    // Render once with the agent resolved so the hook captures its
+    // (target, cwd) into refs. Then re-render with the agent gone — that's
+    // the death signal we want to react to.
+    const setSelection = vi.fn();
+    const a = agent({ target: "a", cwd: "/foo" });
+    const b = agent({ target: "b", cwd: "/foo" });
+    const c = agent({ target: "c", cwd: "/bar" });
+    const selection: Selection = { type: "agent", id: "a" };
+    const { rerender } = renderHook(
+      ({ selectedAgent, agents }: FallbackProps) =>
+        useAgentSelectionFallback({ selection, selectedAgent, agents, setSelection }),
+      { initialProps: { selectedAgent: a, agents: [a, b, c] } as FallbackProps },
+    );
+
+    rerender({ selectedAgent: undefined, agents: [b, c] });
+
+    expect(setSelection).toHaveBeenCalledTimes(1);
+    expect(setSelection).toHaveBeenCalledWith({ type: "agent", id: "b" });
+  });
+
+  it("prefers orchestrator within the same cwd group", () => {
+    // Mirrors the sidebar's "orchestrator on top" sort — the killed
+    // agent's neighbour is the orchestrator if one is present, even when
+    // a non-orchestrator was inserted earlier.
+    const setSelection = vi.fn();
+    const a = agent({ target: "a", cwd: "/foo" });
+    const worker = agent({ target: "worker", cwd: "/foo" });
+    const orch = agent({ target: "orch", cwd: "/foo", is_orchestrator: true });
+    const { rerender } = renderHook(
+      ({ selectedAgent, agents }: FallbackProps) =>
+        useAgentSelectionFallback({
+          selection: { type: "agent", id: "a" },
+          selectedAgent,
+          agents,
+          setSelection,
+        }),
+      { initialProps: { selectedAgent: a, agents: [a, worker, orch] } as FallbackProps },
+    );
+
+    rerender({ selectedAgent: undefined, agents: [worker, orch] });
+
+    expect(setSelection).toHaveBeenCalledWith({ type: "agent", id: "orch" });
+  });
+
+  it("falls back to any agent when no same-cwd sibling exists", () => {
+    const setSelection = vi.fn();
+    const a = agent({ target: "a", cwd: "/foo" });
+    const c = agent({ target: "c", cwd: "/bar" });
+    const { rerender } = renderHook(
+      ({ selectedAgent, agents }: FallbackProps) =>
+        useAgentSelectionFallback({
+          selection: { type: "agent", id: "a" },
+          selectedAgent,
+          agents,
+          setSelection,
+        }),
+      { initialProps: { selectedAgent: a, agents: [a, c] } as FallbackProps },
+    );
+
+    rerender({ selectedAgent: undefined, agents: [c] });
+
+    expect(setSelection).toHaveBeenCalledWith({ type: "agent", id: "c" });
+  });
+
+  it("clears selection when the entity list becomes empty", () => {
+    const setSelection = vi.fn();
+    const a = agent({ target: "a", cwd: "/foo" });
+    const { rerender } = renderHook(
+      ({ selectedAgent, agents }: FallbackProps) =>
+        useAgentSelectionFallback({
+          selection: { type: "agent", id: "a" },
+          selectedAgent,
+          agents,
+          setSelection,
+        }),
+      { initialProps: { selectedAgent: a, agents: [a] } as FallbackProps },
+    );
+
+    rerender({ selectedAgent: undefined, agents: [] });
+
+    expect(setSelection).toHaveBeenCalledWith(null);
+  });
+
+  it("does not yank focus during a spawn-time pre-resolution gap", () => {
+    // The user has an agent selected. A spawn flips selection.id to the
+    // new session id; the wire round-trip hasn't landed yet, so
+    // selectedAgent goes briefly undefined while the OLD agent is still
+    // in `agents`. Reacting to that gap as a death would re-select the
+    // old agent and stomp on the spawn intent — the hook must hold off.
+    const setSelection = vi.fn();
+    const oldAgent = agent({ target: "old", cwd: "/foo" });
+    const { rerender } = renderHook(
+      ({ selection, selectedAgent, agents }: FullFallbackProps) =>
+        useAgentSelectionFallback({ selection, selectedAgent, agents, setSelection }),
+      {
+        initialProps: {
+          selection: { type: "agent", id: "old" },
+          selectedAgent: oldAgent,
+          agents: [oldAgent],
+        } as FullFallbackProps,
+      },
+    );
+
+    rerender({
+      selection: { type: "agent", id: "new-session" },
+      selectedAgent: undefined,
+      agents: [oldAgent],
+    });
+
+    expect(setSelection).not.toHaveBeenCalled();
+  });
+
+  it("does not interfere when the user navigated to a non-agent selection", () => {
+    // User had an agent selected, then clicked a worktree. selectedAgent
+    // becomes undefined because the selection type changed, not because
+    // the agent died. Hook should leave selection alone.
+    const setSelection = vi.fn();
+    const a = agent({ target: "a", cwd: "/foo" });
+    type WorktreeNavProps = {
+      selection: Selection | null;
+      selectedAgent: AgentSnapshot | undefined;
+    };
+    const { rerender } = renderHook(
+      ({ selection, selectedAgent }: WorktreeNavProps) =>
+        useAgentSelectionFallback({
+          selection,
+          selectedAgent,
+          agents: [a],
+          setSelection,
+        }),
+      {
+        initialProps: {
+          selection: { type: "agent", id: "a" },
+          selectedAgent: a,
+        } as WorktreeNavProps,
+      },
+    );
+
+    rerender({
+      selection: {
+        type: "worktree",
+        repoPath: "/foo",
+        name: "wt",
+        worktreePath: "/foo/wt",
+      } as Selection,
+      selectedAgent: undefined,
+    });
+
+    expect(setSelection).not.toHaveBeenCalled();
+  });
+});

--- a/clients/react/src/hooks/__tests__/useTerminal.test.ts
+++ b/clients/react/src/hooks/__tests__/useTerminal.test.ts
@@ -30,6 +30,8 @@ interface FakeTerminalInstance {
   onWriteParsed: ReturnType<typeof vi.fn>;
   reset: ReturnType<typeof vi.fn>;
   scrollToBottom: ReturnType<typeof vi.fn>;
+  focus: ReturnType<typeof vi.fn>;
+  blur: ReturnType<typeof vi.fn>;
   dispose: ReturnType<typeof vi.fn>;
   _triggerResize: (dims: { rows: number; cols: number }) => void;
 }
@@ -57,6 +59,8 @@ vi.mock("@xterm/xterm", () => {
       onWriteParsed: vi.fn(() => makeDisposable()),
       reset: vi.fn(),
       scrollToBottom: vi.fn(),
+      focus: vi.fn(),
+      blur: vi.fn(),
       dispose: vi.fn(),
       _triggerResize(dims) {
         for (const cb of resizeCallbacks) cb(dims);
@@ -91,6 +95,18 @@ function makeContainerRef(): React.RefObject<HTMLDivElement> {
   return { current: div } as React.RefObject<HTMLDivElement>;
 }
 
+// Narrow `lastTermInstance` to non-null at call sites without a `!`
+// assertion — biome's noNonNullAssertion would auto-rewrite that to `?.`,
+// which silently no-ops when the mock failed to register and hides the
+// real failure (the resize-event assertion afterwards would then "pass"
+// for the wrong reason).
+function term(): FakeTerminalInstance {
+  if (lastTermInstance === null) {
+    throw new Error("Expected fake xterm Terminal to have been constructed");
+  }
+  return lastTermInstance;
+}
+
 describe("useTerminal resize wiring", () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -122,7 +138,7 @@ describe("useTerminal resize wiring", () => {
     vi.mocked(api.resizeAgentTerminal).mockClear();
 
     act(() => {
-      lastTermInstance!._triggerResize({ rows: 40, cols: 200 });
+      term()._triggerResize({ rows: 40, cols: 200 });
     });
 
     // Should not have fired yet — debounce window is 75 ms.
@@ -143,9 +159,10 @@ describe("useTerminal resize wiring", () => {
     vi.mocked(api.resizeAgentTerminal).mockClear();
 
     act(() => {
-      lastTermInstance!._triggerResize({ rows: 20, cols: 80 });
-      lastTermInstance!._triggerResize({ rows: 25, cols: 100 });
-      lastTermInstance!._triggerResize({ rows: 35, cols: 150 });
+      const t = term();
+      t._triggerResize({ rows: 20, cols: 80 });
+      t._triggerResize({ rows: 25, cols: 100 });
+      t._triggerResize({ rows: 35, cols: 150 });
     });
 
     await act(async () => {
@@ -157,6 +174,29 @@ describe("useTerminal resize wiring", () => {
     expect(api.resizeAgentTerminal).toHaveBeenCalledWith("cc:agent-3", 35, 150);
   });
 
+  it("auto-focuses xterm on mount when the hook owns the keyboard", () => {
+    // Spawn-then-type relies on this: on every fresh mount of TerminalPanel
+    // (forced by the `key={sessionId}` wrapper in App.tsx) the xterm
+    // textarea must grab focus so the user doesn't have to click into the
+    // panel to start typing.
+    const containerRef = makeContainerRef();
+    renderHook(() => useTerminal({ agentId: "cc:agent-focus", containerRef }));
+
+    expect(lastTermInstance?.focus).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not auto-focus xterm when keys are handled externally", () => {
+    // PreviewPanel drives keyboard through its own hidden IME input — if
+    // useTerminal also focused xterm, the two would fight over caret
+    // ownership and IME composition would land in the wrong target.
+    const containerRef = makeContainerRef();
+    renderHook(() =>
+      useTerminal({ agentId: "cc:agent-preview", containerRef, keysHandledExternally: true }),
+    );
+
+    expect(lastTermInstance?.focus).not.toHaveBeenCalled();
+  });
+
   it("cancels pending debounce timer on unmount", async () => {
     const containerRef = makeContainerRef();
 
@@ -165,7 +205,7 @@ describe("useTerminal resize wiring", () => {
     vi.mocked(api.resizeAgentTerminal).mockClear();
 
     act(() => {
-      lastTermInstance!._triggerResize({ rows: 50, cols: 200 });
+      term()._triggerResize({ rows: 50, cols: 200 });
     });
 
     // Unmount before the debounce fires.

--- a/clients/react/src/hooks/useAgentSelectionFallback.ts
+++ b/clients/react/src/hooks/useAgentSelectionFallback.ts
@@ -1,0 +1,84 @@
+import { useEffect, useRef } from "react";
+import type { AgentSnapshot, Selection } from "@/lib/api-http";
+
+interface UseAgentSelectionFallbackArgs {
+  selection: Selection | null;
+  selectedAgent: AgentSnapshot | undefined;
+  agents: AgentSnapshot[];
+  setSelection: (next: Selection | null) => void;
+}
+
+// Sort key for "first agent in this group": orchestrator wins, then
+// insertion order. Mirrors `WorktreeSection` in ProjectGroup so the
+// fallback target matches what the sidebar renders at the top of the
+// group the user was already looking at.
+function sortByOrchestratorFirst(agents: AgentSnapshot[]): AgentSnapshot[] {
+  return [...agents].sort((a, b) => {
+    if (a.is_orchestrator && !b.is_orchestrator) return -1;
+    if (!a.is_orchestrator && b.is_orchestrator) return 1;
+    return 0;
+  });
+}
+
+function pickSibling(agents: AgentSnapshot[], prevCwd: string | null): AgentSnapshot | undefined {
+  if (prevCwd) {
+    const sameCwd = agents.filter((a) => a.cwd === prevCwd);
+    const pick = sortByOrchestratorFirst(sameCwd)[0];
+    if (pick) return pick;
+  }
+  return sortByOrchestratorFirst(agents)[0];
+}
+
+/**
+ * Move selection to a sibling agent when the previously-resolved one
+ * disappears from `agents` (kill button, CC quit, dispatch unwind, …).
+ * Prefers "same cwd, orchestrator first" so the user lands in the same
+ * project group; falls back to any first agent; clears selection only
+ * when the entity list is empty.
+ *
+ * Why key off the *resolved* target rather than `selection.id`: a fresh
+ * spawn updates `selection.id` to the spawn-time session id well before
+ * the wire round-trip lands an `AgentSnapshot`, and during that gap
+ * `selectedAgent` is briefly `undefined`. Reacting to that gap as if the
+ * old agent had died would yank focus away from the freshly-spawned
+ * agent before it ever became visible.
+ *
+ * Why a hook instead of inline in App.tsx: the "previously resolved"
+ * state needs ref-tracking across renders, and the death-detection
+ * branches (same-cwd / any-cwd / none) are easier to unit-test as a
+ * pure module than nested under App's render path.
+ */
+export function useAgentSelectionFallback({
+  selection,
+  selectedAgent,
+  agents,
+  setSelection,
+}: UseAgentSelectionFallbackArgs): void {
+  const prevTargetRef = useRef<string | null>(null);
+  const prevCwdRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (selectedAgent) {
+      prevTargetRef.current = selectedAgent.target;
+      prevCwdRef.current = selectedAgent.cwd;
+      return;
+    }
+    const prevTarget = prevTargetRef.current;
+    const prevCwd = prevCwdRef.current;
+    if (!prevTarget) return;
+    // Pre-resolution gap (e.g. just-spawned id not yet wire-delivered).
+    // Leave selection alone — wire arrival will resolve it momentarily.
+    if (agents.some((a) => a.target === prevTarget)) return;
+
+    prevTargetRef.current = null;
+    prevCwdRef.current = null;
+    const sibling = pickSibling(agents, prevCwd);
+    if (sibling) {
+      setSelection({ type: "agent", id: sibling.target });
+    } else if (selection?.type === "agent") {
+      // Only clear when the dead selection was an agent — if the user
+      // moved on to a worktree/project view themselves, preserve that.
+      setSelection(null);
+    }
+  }, [selectedAgent, agents, selection, setSelection]);
+}

--- a/clients/react/src/hooks/useTerminal.ts
+++ b/clients/react/src/hooks/useTerminal.ts
@@ -107,6 +107,20 @@ export function useTerminal({
     termRef.current = term;
     fitAddonRef.current = fitAddon;
 
+    // Auto-focus the xterm textarea on every fresh mount so users can
+    // type immediately after spawn or agent switch — the wrapping `key`
+    // in App.tsx forces a fresh `useTerminal` run on each agent change,
+    // so this also covers the spawn case where wire delivery flips the
+    // panel from PreviewPanel → TerminalPanel mid-flight (the hidden
+    // IME input PreviewPanel briefly held focus on goes away with that
+    // unmount, leaving keystrokes nowhere to land without this call).
+    // PreviewPanel passes `keysHandledExternally: true` and drives focus
+    // through its own hidden input, so skip xterm focus there to avoid
+    // fighting that path.
+    if (!keysHandledExternally) {
+      term.focus();
+    }
+
     // Re-attach replay is handled by the PTY-server: the first frames
     // delivered by `useAgentTerminalStream` are the agent's scrollback
     // (tmai-core PR #227) and xterm renders them as soon as they


### PR DESCRIPTION
## Summary

Three dogfood UX papercuts on the spawn → use → kill loop in the WebUI:

- **One-click runtime pick**: `DirBrowser` gains an optional `actionSlot` render-prop. `NewAgentLauncher` uses it to render the `claude` / `codex` / `bash` buttons inline on the currently-browsed path, replacing the old "Select this → close modal → pick runtime in a secondary panel" two-step. The picker stays open until spawn succeeds (or surfaces an error). Other DirBrowser callers (`GeneralSection`, `OrchestrationSection`) keep the existing "Select this" mode untouched.
- **Type-ready on spawn / agent switch**: `useTerminal` calls `term.focus()` after `term.open()` when it owns the keyboard, so the xterm textarea is always focused on a fresh mount. The `key={sessionId}` / `key={selectedAgent.target}` wrappers in `App.tsx` already force a fresh mount on agent switch and on the spawn-time PreviewPanel→TerminalPanel flip, so this also covers the race where wire-delivered `pty_session_id` swaps the panel out from under PreviewPanel's hidden-input focus. Skipped when `keysHandledExternally: true` (PreviewPanel) to avoid fighting the IME input there.
- **Kill hands focus to a neighbour**: new `useAgentSelectionFallback` hook moves selection to a sibling when the resolved agent disappears (kill button, CC quit, dispatch unwind, …). Prefers same cwd, orchestrator first (matching sidebar ordering); falls back to any agent; clears selection only when no agents remain. Reacts to the *resolved* target rather than `selection.id` so the spawn-time pre-resolution gap (where `selection.id` is the new session id but the wire round-trip hasn't landed) isn't mistaken for a death.

Also clears the 6 pre-existing biome warnings (unused `noStaticElementInteractions` suppression on PreviewPanel's `role="log"` container; `lastTermInstance!` non-null assertions in `useTerminal` tests, replaced by a `term()` narrow helper that throws explicitly so a broken mock fails loudly instead of silently passing).

## Test plan

- [x] `pnpm test` — 322 pass / 2 skipped (8 new tests: `useAgentSelectionFallback` covering same-cwd / orchestrator-first / cross-cwd / empty / spawn-gap / worktree-nav, `useTerminal` mount focus + keysHandledExternally skip, `NewAgentLauncher` direct-spawn from inline runtime button)
- [x] `pnpm lint` — clean (was 6 warnings, now 0)
- [x] `pnpm exec tsc -b` — clean
- [ ] Dogfood: spawn from sidebar → runtime button click → land in TerminalPanel typing-ready
- [ ] Dogfood: with two agents in `~/works/foo`, kill the active one → focus jumps to the sibling, not an empty pane
- [ ] Dogfood: with one agent in `~/works/foo` and one in `~/works/bar`, kill `foo`'s → focus jumps to the `bar` agent
- [ ] Dogfood: kill the only agent → pane goes empty (no stale selection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **新機能**
  * エージェント選択の自動復旧機能を追加。削除されたエージェントの場合、同じディレクトリ内の別のエージェントに自動的に切り替わります。
  * ターミナルの自動フォーカス機能を追加。マウント時にキーボード入力を即座に受け付けられるようになりました。

* **改善**
  * 新規エージェント起動フローを簡素化。ディレクトリ選択と実行時の選択が1ステップで完了するようになりました。

* **テスト**
  * 選択復旧機能、新しいランチャーフロー、ターミナル動作に関する包括的なテストを追加。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/636)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->