### PR TITLE
feat(react): visible focus ring on both panels, hide xterm scrollbar gutter

### DIFF
--- a/clients/react/src/components/agent/PreviewPanel.tsx
+++ b/clients/react/src/components/agent/PreviewPanel.tsx
@@ -204,8 +204,10 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
   return (
     <div
       ref={containerRef}
-      className={`relative flex flex-1 flex-col overflow-hidden bg-[#0c0c0c] outline-none ${
-        focused && hasDomFocus ? "ring-1 ring-cyan-500/30 ring-inset" : ""
+      className={`relative flex flex-1 flex-col overflow-hidden bg-[#0c0c0c] outline-none transition-shadow ${
+        focused && hasDomFocus
+          ? "shadow-[inset_0_0_0_2px_rgba(34,211,238,0.55),inset_0_0_24px_rgba(34,211,238,0.06)]"
+          : "shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)]"
       }`}
     >
       {/* Live tab — xterm canvas. Stays mounted across tab toggles so

--- a/clients/react/src/components/terminal/TerminalPanel.tsx
+++ b/clients/react/src/components/terminal/TerminalPanel.tsx
@@ -23,11 +23,34 @@ interface TerminalPanelProps {
 // terminal plane (#174 Phase 3a).
 // Shares the same Input/Select + Auto-scroll footer pattern as PreviewPanel.
 export function TerminalPanel({ agentId }: TerminalPanelProps) {
+  const sectionRef = useRef<HTMLElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [inputMode, setInputMode] = useState(true);
+  const [hasFocus, setHasFocus] = useState(false);
   const [autoScroll, setAutoScroll] = useAutoScrollPerAgent(agentId);
 
   const { setAttachable } = useTerminal({ agentId, containerRef, autoScroll });
+
+  // Surface "this panel is the active surface" — without it, after
+  // spawning or switching agents users couldn't tell at a glance whether
+  // their next keystroke would land here or get eaten by the body.
+  // Track focus on the section wrapper so xterm's helper textarea
+  // (mounted inside `containerRef`, a descendant of the section) bubbles
+  // focusin/focusout naturally.
+  useEffect(() => {
+    const el = sectionRef.current;
+    if (!el) return;
+    const onFocusIn = () => setHasFocus(true);
+    const onFocusOut = (e: FocusEvent) => {
+      if (!el.contains(e.relatedTarget as Node)) setHasFocus(false);
+    };
+    el.addEventListener("focusin", onFocusIn);
+    el.addEventListener("focusout", onFocusOut);
+    return () => {
+      el.removeEventListener("focusin", onFocusIn);
+      el.removeEventListener("focusout", onFocusOut);
+    };
+  }, []);
 
   // Switch to input mode (xterm captures keyboard)
   const enterInputMode = useCallback(() => {
@@ -57,7 +80,14 @@ export function TerminalPanel({ agentId }: TerminalPanelProps) {
   }, [inputMode, enterInputMode]);
 
   return (
-    <section className="relative flex h-full w-full flex-col">
+    <section
+      ref={sectionRef}
+      className={`relative flex h-full w-full flex-col transition-shadow ${
+        hasFocus
+          ? "shadow-[inset_0_0_0_2px_rgba(34,211,238,0.55),inset_0_0_24px_rgba(34,211,238,0.06)]"
+          : "shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)]"
+      }`}
+    >
       <div className="flex items-center justify-between border-b border-zinc-800 px-3 py-1.5">
         <span className="text-xs text-zinc-500">{agentIdShort(agentId)}</span>
       </div>

--- a/clients/react/src/styles/globals.css
+++ b/clients/react/src/styles/globals.css
@@ -256,3 +256,20 @@ html {
   scrollbar-width: thin;
   scrollbar-color: rgba(255, 255, 255, 0.08) transparent;
 }
+
+/* xterm-viewport ships `overflow-y: scroll`, which reserves a 6 px scrollbar
+   gutter even on a fresh empty terminal — and against the dark canvas the
+   permanently-visible track reads as a noisy seam. Switch to `auto` so the
+   gutter only appears when scrollback actually overflows the viewport, and
+   blend the resting thumb into the terminal background so it doesn't stand
+   out as a contrasting strip. */
+.xterm .xterm-viewport {
+  overflow-y: auto !important;
+  scrollbar-color: rgba(255, 255, 255, 0.06) transparent;
+}
+.xterm .xterm-viewport::-webkit-scrollbar-thumb {
+  background: rgba(255, 255, 255, 0.06);
+}
+.xterm .xterm-viewport::-webkit-scrollbar-thumb:hover {
+  background: rgba(255, 255, 255, 0.18);
+}


### PR DESCRIPTION
## Summary

Two dogfood papercuts on the active-pane surface:

- **Focus ring is visible now**. TerminalPanel had no focus indicator at all — after spawn / agent switch the cyan ring on PreviewPanel was the only signal, and that panel only renders during the brief pre-PTY window. Both panels now share an inset-shadow recipe: 2px / 55%-cyan + faint inner glow when the panel has DOM focus, faint 1px / 4%-white otherwise. Tracked via `focusin` / `focusout` on the panel's wrapper element, so xterm's hidden helper textarea (PreviewPanel's hidden IME input) bubbles up naturally. PreviewPanel's old `ring-1 ring-cyan-500/30` whisper retires.
- **xterm scrollbar gutter retires when empty**. xterm's stylesheet pins `.xterm-viewport` to `overflow-y: scroll`, reserving a 6 px gutter on every terminal even when there is nothing to scroll yet. Override to `auto` and recolor the thumb to match the dark canvas (white/6%, hover white/18%) so the gutter only appears when scrollback overflows.

## Test plan

- [x] `pnpm test` — 322 pass / 2 skipped (no test changes needed; styling-only)
- [x] `pnpm lint` — clean
- [x] `pnpm exec tsc -b` — clean
- [ ] Dogfood: spawn an agent → cyan ring visible on TerminalPanel without clicking
- [ ] Dogfood: click off the panel → ring fades; click back → ring returns
- [ ] Dogfood: brand-new agent (empty terminal) → no scrollbar gutter visible; once scrollback fills the viewport, scrollbar appears thin and tinted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * フォーカスインジケーターのスタイルを更新し、視覚的なフィードバックを改善しました
  * ターミナルパネルがフォーカス状態で強調表示されるようになりました
  * ターミナルのスクロールバーのスタイルを最適化し、ダークテーマとの調和を向上させました

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/637)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->