### PR TITLE
chore(gen): sync generated spec + types from tmai-core@27d59af15e

### DIFF
--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -10,7 +10,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "3.0.0"
+    "version": "3.0.1"
   },
   "paths": {
     "/api/agents/{id}/subscribe-terminal": {

--- a/versions.toml
+++ b/versions.toml
@@ -6,7 +6,7 @@
 # release.yml refuses to bundle while any key is 0.0.0, so placeholders are
 # an active safety net rather than a pending TODO.
 
-core = "3.0.0"      # tmai-core private Release
+core = "3.0.1"      # tmai-core private Release
 react = "2.1.1"     # clients/react/package.json version
 ratatui = "0.2.0"   # clients/ratatui/Cargo.toml version
-api_spec = "3.0.0"  # api-spec/openapi.json info.version
+api_spec = "3.0.1"  # api-spec/openapi.json info.version


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@27d59af15edd28f7a39393ab0e706fea96dbddd6

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/openapi.json | 2 +-
 versions.toml         | 4 ++--
 2 files changed, 3 insertions(+), 3 deletions(-)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チャー（保守作業）**
  * コアコンポーネントとAPI仕様のバージョンを3.0.0から3.0.1に更新しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/639)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->