### PR TITLE
fix(react): replace polynomial regex in normalizeGitDir (CodeQL alert #1)

### DIFF
--- a/clients/react/src/lib/__tests__/normalize-git-dir.test.ts
+++ b/clients/react/src/lib/__tests__/normalize-git-dir.test.ts
@@ -1,0 +1,43 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { normalizeGitDir } from "../api-http";
+
+describe("normalizeGitDir", () => {
+  it("strips a trailing /.git", () => {
+    expect(normalizeGitDir("/home/user/repo/.git")).toBe("/home/user/repo");
+  });
+
+  it("strips a trailing /.git/", () => {
+    expect(normalizeGitDir("/home/user/repo/.git/")).toBe("/home/user/repo");
+  });
+
+  it("trims trailing slashes when there is no /.git suffix", () => {
+    expect(normalizeGitDir("/home/user/repo/")).toBe("/home/user/repo");
+    expect(normalizeGitDir("/home/user/repo///")).toBe("/home/user/repo");
+  });
+
+  it("returns the path unchanged when no trailing artefacts exist", () => {
+    expect(normalizeGitDir("/home/user/repo")).toBe("/home/user/repo");
+  });
+
+  it("handles long runs of trailing slashes in linear time (CodeQL alert #1)", () => {
+    // The previous `/+$` regex backtracked super-linearly on inputs like
+    // this; the linear scan finishes in microseconds. We assert a generous
+    // wall-clock budget rather than a tight one so the test stays stable
+    // under CI noise — the polynomial version would have blown past
+    // seconds, not the 250 ms allowance.
+    const path = `/home/user/repo${"/".repeat(50_000)}`;
+    const start = performance.now();
+    expect(normalizeGitDir(path)).toBe("/home/user/repo");
+    expect(performance.now() - start).toBeLessThan(250);
+  });
+
+  it("matches the previous behaviour when /.git is followed by multiple slashes", () => {
+    // Both old and new implementations strip the trailing slash run but
+    // leave `/.git` in place — the first regex only matches when there's
+    // either nothing or a single slash between `.git` and end-of-string.
+    // Documenting the parity here so a future "tighten the regex" pass
+    // doesn't silently change semantics.
+    expect(normalizeGitDir("/home/user/repo/.git///")).toBe("/home/user/repo/.git");
+  });
+});

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -246,9 +246,20 @@ function projectName(path: string): string {
   return cleaned.split("/").filter(Boolean).pop() || path;
 }
 
-// Normalize git_common_dir: strip trailing /.git and slashes
-function normalizeGitDir(dir: string): string {
-  return dir.replace(/\/\.git\/?$/, "").replace(/\/+$/, "");
+// Normalize git_common_dir: strip trailing /.git and slashes.
+//
+// Exported for unit tests. The trailing-slash trimmer used to be
+// `.replace(/\/+$/, "")` but the `+` quantifier triggered CodeQL's
+// `js/polynomial-redos` rule (alert #1) — `dir` flows in from
+// `AgentSnapshot.git_common_dir` / `WorktreeSnapshot.repo_path` which
+// counts as untrusted wire input, and a long run of `/` would burn
+// quadratic time backtracking. A linear right-to-left scan finishes
+// in O(n) regardless of input shape.
+export function normalizeGitDir(dir: string): string {
+  const cleaned = dir.replace(/\/\.git\/?$/, "");
+  let end = cleaned.length;
+  while (end > 0 && cleaned[end - 1] === "/") end--;
+  return cleaned.slice(0, end);
 }
 
 // Group agents by project (git_common_dir) and worktree.


### PR DESCRIPTION
## Summary

Resolves CodeQL alert #1 (\`js/polynomial-redos\`, warning) on \`clients/react/src/lib/api-http.ts:251\`.

The trailing-slash trimmer was \`.replace(/\/+$/, "")\`. The \`+\` quantifier backtracks super-linearly on long runs of \`/\`, and \`dir\` enters from \`AgentSnapshot.git_common_dir\` / \`WorktreeSnapshot.repo_path\` — wire data treated as untrusted by CodeQL — so a malformed or hostile payload could chew CPU.

Swapped that regex for a linear right-to-left scan (\`while (end > 0 && cleaned[end - 1] === "/") end--\`). The first \`/.git/?$\` regex stays as-is because \`?\` is bounded and doesn't backtrack. Behaviour is byte-for-byte identical for every input both versions accept.

Exported \`normalizeGitDir\` so the new test suite can hit it directly, including a 50,000-slash stress test that proves O(n) instead of O(n²).

## Test plan

- [x] \`pnpm test\` — 345 pass / 2 skipped (+6 new normalize-git-dir cases)
- [x] \`pnpm exec tsc -b\`
- [x] \`pnpm lint\`
- [x] \`pnpm build\`
- [ ] CodeQL re-scan on merge confirms alert #1 closes
- [ ] CodeRabbit review

Targeted for v3.2.1 (or whichever the next release is).

🤖 Generated with [Claude Code](https://claude.com/claude-code)