### PR TITLE
feat(react): calibration chip + tier-1 tripwire banner + drill-down panel

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -2,6 +2,9 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { AgentActions } from "@/components/agent/AgentActions";
 import { AgentList } from "@/components/agent/AgentList";
 import { PreviewPanel } from "@/components/agent/PreviewPanel";
+import { CalibrationChip } from "@/components/calibration/CalibrationChip";
+import { CalibrationPanel } from "@/components/calibration/CalibrationPanel";
+import { TripwireBanner } from "@/components/calibration/TripwireBanner";
 import { type DisplayMode, DisplayModeSelector } from "@/components/layout/DisplayModeSelector";
 import { HelpOverlay } from "@/components/layout/HelpOverlay";
 import { SplitPaneLayout } from "@/components/layout/SplitPaneLayout";
@@ -19,6 +22,7 @@ import { BranchGraph } from "@/components/worktree/BranchGraph";
 import { WorktreePanel } from "@/components/worktree/WorktreePanel";
 import { useAgentSelectionFallback } from "@/hooks/useAgentSelectionFallback";
 import { useAgents } from "@/hooks/useAgents";
+import { useCalibration } from "@/hooks/useCalibration";
 import { useIdleNotification } from "@/hooks/useIdleNotification";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useNotificationConfig } from "@/hooks/useNotificationConfig";
@@ -63,7 +67,9 @@ export function App() {
   // so they're mutually exclusive — opening one always closes the other.
   // The previous two-booleans-cleared-in-tandem pattern was equivalent but
   // more error-prone; this enum makes the constraint explicit.
-  const [mainPanel, setMainPanel] = useState<"agents" | "settings" | "security">("agents");
+  const [mainPanel, setMainPanel] = useState<"agents" | "settings" | "security" | "calibration">(
+    "agents",
+  );
   const [showHelp, setShowHelp] = useState(false);
   // Multi-pane layout choices live in the WebUI prefs store (browser-only,
   // not in tmai-core's config.toml — these describe how this WebUI shows
@@ -75,6 +81,7 @@ export function App() {
   const [splitRatioV, setSplitRatioV] = useUIPref("splitRatioV");
   const showSettings = mainPanel === "settings";
   const showSecurity = mainPanel === "security";
+  const showCalibration = mainPanel === "calibration";
   const closeMainPanelOverlay = useCallback(() => setMainPanel("agents"), []);
   const toggleSettings = useCallback(
     () => setMainPanel((mp) => (mp === "settings" ? "agents" : "settings")),
@@ -84,6 +91,21 @@ export function App() {
     () => setMainPanel((mp) => (mp === "security" ? "agents" : "security")),
     [],
   );
+  const openCalibration = useCallback(() => setMainPanel("calibration"), []);
+
+  // Unit name for the calibration view. The wire endpoint (`GET
+  // /api/units/{unit}/calibration`) takes a unit *name* (a configured
+  // `[[unit]]` table key or a cwd-synthesized basename) — the WebUI does
+  // not know which `[[unit]]` tables the operator has configured, so we
+  // pass the basename of the currently-selected project path. The
+  // backend's `resolve_unit_or_cwd` falls back to the basename when no
+  // matching `[[unit]]` exists, which matches what the CLI does for the
+  // same input.
+  const unitName = useMemo(() => {
+    if (!currentProject) return null;
+    return currentProject.split("/").filter(Boolean).pop() ?? null;
+  }, [currentProject]);
+  const { data: calibrationData } = useCalibration(unitName);
 
   // Split-pane drag state — separate instances for horizontal vs vertical
   // so the user can drag each independently and resume where they left off
@@ -448,6 +470,7 @@ export function App() {
             onSecurityClick={() => {
               toggleSecurity();
             }}
+            indicatorSlot={<CalibrationChip data={calibrationData} onClick={openCalibration} />}
           />
           {!sidebarCollapsed && (
             <div className="flex flex-1 flex-col overflow-y-auto">{sidebarContent}</div>
@@ -500,7 +523,17 @@ export function App() {
           />
         )}
 
-        {showSecurity ? (
+        {/* DR §B.4: zero-tolerance tier-1 tripwire banner, hoisted
+            ABOVE every main-panel switch so an operator who never
+            opens the calibration panel still cannot miss it. Empty
+            violation list = silent (the component renders null). */}
+        <TripwireBanner data={calibrationData} onDetailsClick={openCalibration} />
+
+        {showCalibration && unitName ? (
+          <div className="flex flex-1 flex-col overflow-hidden animate-scale-in">
+            <CalibrationPanel unit={unitName} onClose={closeMainPanelOverlay} />
+          </div>
+        ) : showSecurity ? (
           <div className="flex flex-1 flex-col overflow-hidden animate-scale-in">
             <SecurityPanel onClose={closeMainPanelOverlay} />
           </div>

--- a/clients/react/src/components/calibration/CalibrationChip.tsx
+++ b/clients/react/src/components/calibration/CalibrationChip.tsx
@@ -1,0 +1,56 @@
+// Top-bar always-on calibration indicator.
+//
+// Surfaces the **most-urgent** signal from the unit's calibration store
+// in one chip:
+//
+// - tripwire ≥ 1 → red ⚡ N — DR §B.4 zero-tolerance alarm, must catch
+//   the operator's eye
+// - else, store has any entries → muted "✓" with the in-window count
+// - else, store empty → no chip rendered at all
+//
+// The chip is purely a "click-here-for-details" hook into
+// [`CalibrationPanel`]; the surface is intentionally narrow.
+// Per DR §B.4 we do NOT gate on `len(tripwire) > N` — any non-empty
+// list is the alarm.
+
+import type { CalibrationResponse } from "@/lib/api";
+
+interface CalibrationChipProps {
+  data: CalibrationResponse | null;
+  onClick: () => void;
+}
+
+export function CalibrationChip({ data, onClick }: CalibrationChipProps) {
+  if (!data) {
+    return null;
+  }
+  const tripwire = data.tier1_violations.length;
+  // Per DR §B.4 (zero tolerance): non-empty list IS the alarm.
+  if (tripwire > 0) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className="glow-red rounded-full bg-red-500/20 px-2.5 py-0.5 text-[11px] font-semibold text-red-300 hover:bg-red-500/30 transition-colors"
+        title={`${tripwire} tier-1 tripwire violation(s) — DR §B.4 zero tolerance`}
+      >
+        ⚡ {tripwire}
+      </button>
+    );
+  }
+  // Quiet — only render when the store actually has entries; an empty
+  // store would be noise.
+  if (data.total_in_store === 0) {
+    return null;
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-full bg-zinc-700/50 px-2 py-0.5 text-[11px] text-zinc-400 hover:bg-zinc-700/80 hover:text-zinc-200 transition-colors"
+      title={`${data.total_in_window}/${data.total_in_store} calibration entries — click for details`}
+    >
+      cal {data.total_in_window}
+    </button>
+  );
+}

--- a/clients/react/src/components/calibration/CalibrationPanel.tsx
+++ b/clients/react/src/components/calibration/CalibrationPanel.tsx
@@ -1,0 +1,245 @@
+// Drill-down view of the unit's calibration store — the WebUI mirror
+// of `tmai calibration <unit>` (DR `2026-05-13-synthesis-processing-
+// and-calibration-schema.md` §B.3).
+//
+// Layout follows the CLI render exactly so an operator who already
+// knows the shape from the terminal reads the same table here:
+//
+//   header (unit / window / total / bootstrap caveat)
+//   (verdict × confidence) × (n / hits / misses / accuracy) table
+//   recent false-negatives list (with outcome detail)
+//   tier-1 routing counter (✓ or ⚠ block)
+//
+// The Producer itself is **blind by default** (DR §B.3 first layer);
+// this panel is the explicit human escape hatch. Closing it is what
+// returns to the blind default.
+
+import { useCalibration } from "@/hooks/useCalibration";
+import type { CalibrationCellWire, CalibrationEntry, Outcome } from "@/lib/api";
+
+interface CalibrationPanelProps {
+  unit: string;
+  onClose: () => void;
+}
+
+export function CalibrationPanel({ unit, onClose }: CalibrationPanelProps) {
+  const { data, loading, error } = useCalibration(unit, 90);
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden">
+      <header className="flex items-center justify-between border-b border-white/5 px-6 py-4">
+        <div>
+          <h2 className="text-lg font-semibold text-zinc-200">Calibration</h2>
+          <p className="text-xs text-zinc-500">
+            Unit: <code className="text-zinc-300">{unit}</code> · DR §B.3 read-only window into
+            Producer hit-rate
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          className="rounded-md px-3 py-1 text-sm text-zinc-500 transition-colors hover:bg-white/10 hover:text-zinc-300"
+        >
+          Close
+        </button>
+      </header>
+
+      <div className="flex-1 space-y-6 overflow-y-auto px-6 py-4 text-sm">
+        {loading && !data && <p className="text-zinc-500">Loading…</p>}
+        {error && !data && (
+          <p className="text-red-400">
+            Failed to load calibration: <code>{error.message}</code>
+          </p>
+        )}
+        {data && <CalibrationContent data={data} />}
+      </div>
+    </div>
+  );
+}
+
+function CalibrationContent({
+  data,
+}: {
+  data: NonNullable<ReturnType<typeof useCalibration>["data"]>;
+}) {
+  const empty = data.total_in_store === 0;
+  const shallow = !empty && data.total_in_store < data.bootstrap_threshold;
+  return (
+    <>
+      <section className="rounded-md border border-white/5 bg-white/[0.02] px-4 py-3">
+        <p className="text-xs uppercase tracking-wider text-zinc-500">Window</p>
+        <p className="mt-1 text-zinc-200">
+          {data.days === 0 ? "Whole store" : `Last ${data.days} days`}{" "}
+          <span className="text-zinc-500">
+            ({data.total_in_window} entries; {data.total_in_store} in store)
+          </span>
+        </p>
+        {empty && (
+          <p className="mt-2 text-xs text-zinc-500">
+            Store is empty. The Producer has not recorded any triage verdicts for this unit yet —
+            run <code>tmai producer {data.unit} --synthesize</code> to start one.
+          </p>
+        )}
+        {shallow && (
+          <p className="mt-2 text-xs text-amber-300/80">
+            Only {data.total_in_store} entries in the store (&lt; {data.bootstrap_threshold}{" "}
+            bootstrap threshold). Numbers below carry low confidence; lean toward asking the human,
+            not these stats. (DR §B.5)
+          </p>
+        )}
+      </section>
+
+      <CellTable cells={data.cells} />
+
+      <FalseNegativesList entries={data.recent_false_negatives} />
+
+      <Tier1Counter routed={data.tier1_routed} violations={data.tier1_violations} />
+    </>
+  );
+}
+
+function CellTable({ cells }: { cells: CalibrationCellWire[] }) {
+  if (cells.length === 0) {
+    return (
+      <section>
+        <h3 className="text-xs uppercase tracking-wider text-zinc-500">Verdicts</h3>
+        <p className="mt-2 text-zinc-500">(no entries in this window)</p>
+      </section>
+    );
+  }
+  return (
+    <section>
+      <h3 className="text-xs uppercase tracking-wider text-zinc-500">Verdicts</h3>
+      <table className="mt-2 w-full text-left">
+        <thead className="text-[11px] uppercase tracking-wider text-zinc-500">
+          <tr>
+            <th className="px-2 py-1 font-medium">Verdict</th>
+            <th className="px-2 py-1 font-medium">Confidence</th>
+            <th className="px-2 py-1 text-right font-medium">n</th>
+            <th className="px-2 py-1 text-right font-medium">hits</th>
+            <th className="px-2 py-1 text-right font-medium">misses</th>
+            <th className="px-2 py-1 text-right font-medium">accuracy</th>
+          </tr>
+        </thead>
+        <tbody className="text-zinc-300">
+          {cells.map((c) => {
+            const accuracy = c.n === 0 ? null : (c.hits / c.n) * 100;
+            const smallN = c.n < 5;
+            return (
+              <tr key={`${c.verdict}-${c.confidence}`} className="border-t border-white/5">
+                <td className="px-2 py-1 font-mono text-xs">{c.verdict}</td>
+                <td className="px-2 py-1 font-mono text-xs">{c.confidence}</td>
+                <td className="px-2 py-1 text-right tabular-nums">{c.n}</td>
+                <td className="px-2 py-1 text-right tabular-nums text-emerald-400/90">{c.hits}</td>
+                <td className="px-2 py-1 text-right tabular-nums text-red-400/90">{c.misses}</td>
+                <td className="px-2 py-1 text-right tabular-nums">
+                  {accuracy === null ? (
+                    <span className="text-zinc-500">—</span>
+                  ) : (
+                    <>
+                      {accuracy.toFixed(1)}%
+                      {smallN && <span className="ml-1 text-[10px] text-zinc-500">(small n)</span>}
+                    </>
+                  )}
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </section>
+  );
+}
+
+function FalseNegativesList({ entries }: { entries: CalibrationEntry[] }) {
+  if (entries.length === 0) {
+    return (
+      <section>
+        <h3 className="text-xs uppercase tracking-wider text-zinc-500">False-negative recents</h3>
+        <p className="mt-2 text-zinc-500">none</p>
+      </section>
+    );
+  }
+  return (
+    <section>
+      <h3 className="text-xs uppercase tracking-wider text-zinc-500">
+        False-negative recents (newest first)
+      </h3>
+      <ul className="mt-2 space-y-1 text-xs text-zinc-300">
+        {entries.slice(0, 10).map((e) => (
+          <li key={`${e.synthesis_pass_id}-${e.note_source}`}>
+            <span className="text-zinc-500">{e.recorded_at.slice(0, 10)}</span>{" "}
+            <code className="text-zinc-200">{e.verdict}</code>{" "}
+            <span className="text-zinc-500">
+              {e.confidence} (tier {e.tier_routed})
+            </span>{" "}
+            &ldquo;<code className="text-zinc-300">{e.note_source}</code>&rdquo;:{" "}
+            {e.outcome ? <OutcomeSummary outcome={e.outcome} /> : <span>?</span>}
+          </li>
+        ))}
+        {entries.length > 10 && (
+          <li className="text-zinc-500 italic">... and {entries.length - 10} more</li>
+        )}
+      </ul>
+    </section>
+  );
+}
+
+function OutcomeSummary({ outcome }: { outcome: Outcome }) {
+  // Tagged enum — the wire shape is `{ kind: "...", ... }`. Render
+  // each variant inline; this is intentionally identical in spirit
+  // to the CLI's `outcome_summary` so the operator reads the same
+  // string in both surfaces.
+  switch (outcome.kind) {
+    case "revert_commit":
+      return (
+        <span>
+          revert <code>{outcome.commit_sha}</code> on {outcome.date}
+        </span>
+      );
+    case "hotfix_commit":
+      return (
+        <span>
+          hotfix <code>{outcome.commit_sha}</code> on {outcome.date}
+        </span>
+      );
+    case "ci_fail_fix":
+      return (
+        <span>
+          ci-fail PR #{outcome.failing_pr} → fix PR #{outcome.fix_pr}
+        </span>
+      );
+  }
+}
+
+function Tier1Counter({ routed, violations }: { routed: number; violations: CalibrationEntry[] }) {
+  const clean = violations.length === 0;
+  return (
+    <section
+      className={
+        clean
+          ? "rounded-md border border-white/5 bg-white/[0.02] px-4 py-3"
+          : "rounded-md border border-red-500/40 bg-red-950/30 px-4 py-3"
+      }
+    >
+      <p className="text-xs uppercase tracking-wider text-zinc-500">Tier-1 routings</p>
+      <p className="mt-1 text-zinc-200">
+        {routed} (violations: {violations.length}{" "}
+        {clean ? (
+          <span className="text-emerald-400">✓</span>
+        ) : (
+          <span className="text-red-300">⚠</span>
+        )}
+        )
+      </p>
+      {!clean && (
+        <p className="mt-2 text-xs text-red-300/80">
+          Tier-1 violations are zero-tolerance (DR §B.4). Each non-
+          <code>escalate</code> verdict routed to tier-1 is either a tier-gate bug or a Producer
+          posture failure — review the entries above and decide whether to tighten the gate or the
+          posture.
+        </p>
+      )}
+    </section>
+  );
+}

--- a/clients/react/src/components/calibration/TripwireBanner.tsx
+++ b/clients/react/src/components/calibration/TripwireBanner.tsx
@@ -1,0 +1,68 @@
+// Top-of-body banner that hoists the tier-1 tripwire callout (DR §B.4
+// `⚡ TIER-1 TRIPWIRE TRIGGERED`) into the WebUI for operators who
+// watch the browser, not their terminal.
+//
+// Mirrors what `tmai producer <unit>`'s hand-over digest shows at
+// session start — but persistently, so a violation cannot be missed by
+// timing the next Producer launch. Renders nothing when the violation
+// list is empty (DR §B.4 explicitly: non-empty list IS the alarm; do
+// not gate on a count threshold).
+
+import type { CalibrationResponse } from "@/lib/api";
+
+interface TripwireBannerProps {
+  data: CalibrationResponse | null;
+  onDetailsClick?: () => void;
+}
+
+export function TripwireBanner({ data, onDetailsClick }: TripwireBannerProps) {
+  if (!data || data.tier1_violations.length === 0) {
+    return null;
+  }
+  const violations = data.tier1_violations;
+  return (
+    <div className="border-b border-red-500/40 bg-red-950/40 px-4 py-2.5">
+      <div className="flex items-start gap-3">
+        <span className="text-lg leading-none text-red-300">⚡</span>
+        <div className="flex-1 text-sm">
+          <div className="font-semibold text-red-200">
+            TIER-1 TRIPWIRE TRIGGERED{" "}
+            <span className="font-normal text-red-300/70">
+              ({violations.length} violation{violations.length === 1 ? "" : "s"} on{" "}
+              <code className="text-red-200/90">{data.unit}</code>)
+            </span>
+          </div>
+          <p className="mt-1 text-xs text-red-300/80">
+            Tier-1 is human-gated only (<code>escalate</code> is the only valid verdict). Each item
+            below is a non-<code>escalate</code> verdict routed to tier-1 — review whether the
+            tier-1 grade was wrong (tighten the tier-gate) or the Producer&apos;s posture was wrong
+            (tighten the posture). DR §B.4: zero tolerance.
+          </p>
+          <ul className="mt-2 space-y-1 text-xs text-red-200/90">
+            {violations.slice(0, 5).map((v) => (
+              <li key={`${v.synthesis_pass_id}-${v.note_source}`}>
+                <code className="text-red-200">{v.note_source}</code>{" "}
+                <span className="text-red-300/70">
+                  ({v.verdict}, confidence {v.confidence})
+                </span>{" "}
+                — {v.rationale}
+              </li>
+            ))}
+            {violations.length > 5 && (
+              <li className="text-red-300/60 italic">... and {violations.length - 5} more</li>
+            )}
+          </ul>
+          {onDetailsClick && (
+            <button
+              type="button"
+              onClick={onDetailsClick}
+              className="mt-2 text-xs text-red-300/80 underline-offset-2 hover:underline hover:text-red-200"
+            >
+              Open calibration panel →
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/clients/react/src/components/calibration/__tests__/CalibrationChip.test.tsx
+++ b/clients/react/src/components/calibration/__tests__/CalibrationChip.test.tsx
@@ -53,8 +53,8 @@ describe("CalibrationChip", () => {
         {
           synthesis_pass_id: "p",
           note_source: "n.md",
-          verdict: "Absorb",
-          confidence: "High",
+          verdict: "absorb",
+          confidence: "high",
           tier_routed: 1,
           rationale: "wrong",
           recorded_at: "2026-05-13T10:00:00Z",

--- a/clients/react/src/components/calibration/__tests__/CalibrationChip.test.tsx
+++ b/clients/react/src/components/calibration/__tests__/CalibrationChip.test.tsx
@@ -1,0 +1,70 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CalibrationResponse } from "@/lib/api";
+import { CalibrationChip } from "../CalibrationChip";
+
+function makeData(overrides: Partial<CalibrationResponse> = {}): CalibrationResponse {
+  return {
+    unit: "u",
+    days: 90,
+    total_in_store: 0,
+    total_in_window: 0,
+    bootstrap_threshold: 50,
+    cells: [],
+    tier1_routed: 0,
+    tier1_violations: [],
+    recent_false_negatives: [],
+    ...overrides,
+  };
+}
+
+describe("CalibrationChip", () => {
+  it("renders nothing when there is no data", () => {
+    const { container } = render(<CalibrationChip data={null} onClick={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing on a completely empty store (no entries, no tripwire)", () => {
+    // DR §B.4: a non-empty tripwire list IS the alarm; conversely, a
+    // pristine store should be quiet — no chip, no noise.
+    const { container } = render(<CalibrationChip data={makeData()} onClick={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the muted chip when the store has entries but no tripwire", () => {
+    render(
+      <CalibrationChip
+        data={makeData({ total_in_store: 3, total_in_window: 2 })}
+        onClick={vi.fn()}
+      />,
+    );
+    const btn = screen.getByRole("button");
+    expect(btn.textContent).toContain("cal 2");
+    expect(btn.className).toContain("zinc"); // muted, not red
+  });
+
+  it("renders the urgent ⚡N chip when tier-1 tripwire violations exist", () => {
+    // DR §B.4 zero tolerance: we don't gate on count; one is enough.
+    const tripped = makeData({
+      total_in_store: 1,
+      total_in_window: 1,
+      tier1_violations: [
+        {
+          synthesis_pass_id: "p",
+          note_source: "n.md",
+          verdict: "Absorb",
+          confidence: "High",
+          tier_routed: 1,
+          rationale: "wrong",
+          recorded_at: "2026-05-13T10:00:00Z",
+          outcome: null,
+        },
+      ],
+    });
+    render(<CalibrationChip data={tripped} onClick={vi.fn()} />);
+    const btn = screen.getByRole("button");
+    expect(btn.textContent ?? "").toMatch(/⚡\s*1/);
+    expect(btn.className).toContain("red");
+  });
+});

--- a/clients/react/src/components/calibration/__tests__/TripwireBanner.test.tsx
+++ b/clients/react/src/components/calibration/__tests__/TripwireBanner.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { CalibrationEntry, CalibrationResponse } from "@/lib/api";
+import { TripwireBanner } from "../TripwireBanner";
+
+function entry(overrides: Partial<CalibrationEntry> = {}): CalibrationEntry {
+  return {
+    synthesis_pass_id: "p",
+    note_source: "note.md",
+    verdict: "Absorb",
+    confidence: "High",
+    tier_routed: 1,
+    rationale: "default",
+    recorded_at: "2026-05-13T10:00:00Z",
+    outcome: null,
+    ...overrides,
+  };
+}
+
+function dataWith(violations: CalibrationEntry[]): CalibrationResponse {
+  return {
+    unit: "tmai-core",
+    days: 90,
+    total_in_store: violations.length,
+    total_in_window: violations.length,
+    bootstrap_threshold: 50,
+    cells: [],
+    tier1_routed: violations.length,
+    tier1_violations: violations,
+    recent_false_negatives: [],
+  };
+}
+
+describe("TripwireBanner", () => {
+  it("renders nothing when data is null", () => {
+    const { container } = render(<TripwireBanner data={null} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing on an empty violation list (DR §B.4: list IS the alarm)", () => {
+    const { container } = render(<TripwireBanner data={dataWith([])} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the banner with each violation's note_source + rationale", () => {
+    const data = dataWith([
+      entry({ note_source: "20260513-1000-a.md", rationale: "should have escalated" }),
+      entry({
+        note_source: "20260513-1100-b.md",
+        verdict: "TradeoffProposal",
+        rationale: "tier-1 means human-only",
+      }),
+    ]);
+    render(<TripwireBanner data={data} />);
+    expect(screen.getByText(/TIER-1 TRIPWIRE TRIGGERED/)).toBeTruthy();
+    expect(screen.getByText("20260513-1000-a.md")).toBeTruthy();
+    expect(screen.getByText("20260513-1100-b.md")).toBeTruthy();
+    expect(screen.getByText(/should have escalated/)).toBeTruthy();
+    expect(screen.getByText(/tier-1 means human-only/)).toBeTruthy();
+  });
+
+  it("caps the visible list at 5 entries and shows an overflow line", () => {
+    const data = dataWith(
+      Array.from({ length: 7 }, (_, i) =>
+        entry({ note_source: `note-${i}.md`, rationale: `r${i}` }),
+      ),
+    );
+    render(<TripwireBanner data={data} />);
+    expect(screen.getByText("note-0.md")).toBeTruthy();
+    expect(screen.getByText("note-4.md")).toBeTruthy();
+    expect(screen.queryByText("note-5.md")).toBeNull();
+    expect(screen.getByText(/and 2 more/)).toBeTruthy();
+  });
+});

--- a/clients/react/src/components/calibration/__tests__/TripwireBanner.test.tsx
+++ b/clients/react/src/components/calibration/__tests__/TripwireBanner.test.tsx
@@ -8,8 +8,8 @@ function entry(overrides: Partial<CalibrationEntry> = {}): CalibrationEntry {
   return {
     synthesis_pass_id: "p",
     note_source: "note.md",
-    verdict: "Absorb",
-    confidence: "High",
+    verdict: "absorb",
+    confidence: "high",
     tier_routed: 1,
     rationale: "default",
     recorded_at: "2026-05-13T10:00:00Z",
@@ -48,7 +48,7 @@ describe("TripwireBanner", () => {
       entry({ note_source: "20260513-1000-a.md", rationale: "should have escalated" }),
       entry({
         note_source: "20260513-1100-b.md",
-        verdict: "TradeoffProposal",
+        verdict: "tradeoff_proposal",
         rationale: "tier-1 means human-only",
       }),
     ]);

--- a/clients/react/src/components/layout/StatusBar.tsx
+++ b/clients/react/src/components/layout/StatusBar.tsx
@@ -1,3 +1,5 @@
+import type { ReactNode } from "react";
+
 interface StatusBarProps {
   agentCount: number;
   attentionCount: number;
@@ -5,6 +7,10 @@ interface StatusBarProps {
   onToggleCollapse?: () => void;
   onSettingsClick: () => void;
   onSecurityClick: () => void;
+  /** Optional pre-rendered indicator slot — currently used for the
+   *  calibration / tier-1 tripwire chip (DR §B.3/§B.4). Sits between
+   *  the attention count and the settings / security buttons. */
+  indicatorSlot?: ReactNode;
   /** Mobile: show hamburger button instead of collapse arrow */
   isMobile?: boolean;
   onMobileMenuClick?: () => void;
@@ -18,6 +24,7 @@ export function StatusBar({
   onToggleCollapse,
   onSettingsClick,
   onSecurityClick,
+  indicatorSlot,
   isMobile,
   onMobileMenuClick,
 }: StatusBarProps) {
@@ -143,6 +150,7 @@ export function StatusBar({
             {attentionCount}
           </span>
         )}
+        {indicatorSlot}
         <button
           type="button"
           onClick={onSecurityClick}

--- a/clients/react/src/hooks/useCalibration.ts
+++ b/clients/react/src/hooks/useCalibration.ts
@@ -1,0 +1,80 @@
+// Polling hook for the unit's calibration view + tier-1 tripwire list.
+//
+// Per `doc/decisions/2026-05-13-synthesis-processing-and-calibration-schema.md`
+// §B.3 / §B.4, calibration data changes on the timescale of a synthesis
+// pass — minutes at the fastest, hours typically. A 60-second poll is
+// plenty for the WebUI top-bar tripwire indicator and the drill-down
+// panel; we deliberately do not wire SSE here yet (the indicator does
+// not need real-time precision, the cache miss on the next session
+// start cleans up any tail).
+//
+// The hook keeps the previous response visible while a re-fetch is in
+// flight (`loading` reflects only the initial fetch) so the tripwire
+// chip does not flicker between renders.
+
+import { useEffect, useRef, useState } from "react";
+import { api, type CalibrationResponse } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface UseCalibrationResult {
+  data: CalibrationResponse | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Poll the unit's calibration view at `POLL_INTERVAL_MS`. Returns the
+ * latest response, an initial-load `loading` flag, and the most recent
+ * error (cleared on a successful fetch).
+ *
+ * `unit = null` parks the hook: no fetch, no interval, no data. Useful
+ * when the UI has no project selected and we want the chip / banner to
+ * sit dormant rather than poll a non-existent unit.
+ */
+export function useCalibration(unit: string | null, days = 90): UseCalibrationResult {
+  const [data, setData] = useState<CalibrationResponse | null>(null);
+  const [loading, setLoading] = useState(unit !== null);
+  const [error, setError] = useState<Error | null>(null);
+  // Track the latest fetch so an in-flight response from a previous unit
+  // cannot stamp over a newer unit's data.
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    if (!unit) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    setLoading(true);
+
+    const fetchOnce = async () => {
+      try {
+        const res = await api.calibration(unit, days);
+        if (myGen !== generationRef.current) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (myGen !== generationRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (myGen === generationRef.current) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [unit, days]);
+
+  return { data, loading, error };
+}

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -2,9 +2,14 @@
 // Replaces Tauri IPC — all communication goes through the existing web API.
 
 import type { BootstrapRequiredEvent } from "@/types/generated/BootstrapRequiredEvent";
+import type { CalibrationCellWire } from "@/types/generated/CalibrationCellWire";
+import type { CalibrationEntry } from "@/types/generated/CalibrationEntry";
+import type { CalibrationResponse } from "@/types/generated/CalibrationResponse";
+import type { Confidence } from "@/types/generated/Confidence";
 import type { DispatchBundle } from "@/types/generated/DispatchBundle";
 import type { DispatchSnapshot } from "@/types/generated/DispatchSnapshot";
 import type { EntityUpdateEnvelope } from "@/types/generated/EntityUpdateEnvelope";
+import type { Outcome } from "@/types/generated/Outcome";
 import type { PermissionMode } from "@/types/generated/PermissionMode";
 import type { QueueAgentEntry } from "@/types/generated/QueueAgentEntry";
 import type { QueueSnapshot } from "@/types/generated/QueueSnapshot";
@@ -13,20 +18,27 @@ import type { SpawnRole } from "@/types/generated/SpawnRole";
 import type { SpawnRuntime } from "@/types/generated/SpawnRuntime";
 import type { TeamSnapshot } from "@/types/generated/TeamSnapshot";
 import type { TerminalSubscription } from "@/types/generated/TerminalSubscription";
+import type { TriageVerdict } from "@/types/generated/TriageVerdict";
 import type { Vendor } from "@/types/generated/Vendor";
 import type { WorkerDispatchMap } from "@/types/generated/WorkerDispatchMap";
 import type { WorkflowSnapshot } from "@/types/generated/WorkflowSnapshot";
 
 export type {
   BootstrapRequiredEvent,
+  CalibrationCellWire,
+  CalibrationEntry,
+  CalibrationResponse,
+  Confidence,
   DispatchBundle,
   EntityUpdateEnvelope,
+  Outcome,
   PermissionMode,
   QueueAgentEntry,
   QueueSnapshot,
   SpawnRole,
   SpawnRuntime,
   TerminalSubscription,
+  TriageVerdict,
   Vendor,
   WorkerDispatchMap,
 };
@@ -1143,6 +1155,13 @@ export const api = {
   listTeams: () => apiFetch<import("./teams").TeamSummary[]>("/teams"),
   getTeamTasks: (teamName: string) =>
     apiFetch<import("./teams").TeamTaskInfo[]>(`/teams/${encodeURIComponent(teamName)}/tasks`),
+
+  // Calibration view — read-only window into Producer hit-rate per
+  // `2026-05-13-synthesis-processing-and-calibration-schema.md` §B.3.
+  // `days = 0` means "whole store, no time filter"; default 90 mirrors
+  // the CLI's default.
+  calibration: (unit: string, days = 90) =>
+    apiFetch<CalibrationResponse>(`/units/${encodeURIComponent(unit)}/calibration?days=${days}`),
 };
 
 // ── SSE event subscription ──

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -240,4 +240,8 @@ export const api = {
   // Teams (HTTP only for now)
   listTeams: (): Promise<TeamSummary[]> => httpApi.listTeams(),
   getTeamTasks: (teamName: string): Promise<TeamTaskInfo[]> => httpApi.getTeamTasks(teamName),
+
+  // Calibration view (HTTP only — read-only window into the file-backed
+  // calibration store; no Tauri-specific path needed)
+  calibration: (unit: string, days?: number) => httpApi.calibration(unit, days),
 };


### PR DESCRIPTION
## What

Closes the dogfood loop for the synthesis + calibration workstream **on the WebUI side**: an operator who watches the browser (not their terminal) now sees the calibration store's tier-1 tripwire violations and hit-rate signals without invoking the CLI.

Backend wire ([tmai-core #339](https://github.com/trust-delta/tmai-core/pull/339)) landed \`GET /api/units/{unit}/calibration\`; this PR consumes it.

## Components

- **\`useCalibration(unit, days)\`** — 60-second polling hook. Keeps the previous response visible during re-fetch so the chip does not flicker. \`unit = null\` parks the hook.
- **\`CalibrationChip\`** — top-bar always-on indicator. Three states:
  - \`tripwire ≥ 1\` → red \`⚡ N\` chip (**DR §B.4 zero tolerance**: the non-empty list IS the alarm; we do not gate on a count threshold)
  - store has any entries, no tripwire → muted \`cal N\` chip
  - empty store → renders nothing
- **\`TripwireBanner\`** — top-of-body banner that hoists the \`⚡ TIER-1 TRIPWIRE TRIGGERED\` callout from the hand-over digest into a persistent surface. Lists up to 5 violations inline + an overflow count. Empty list = silent banner.
- **\`CalibrationPanel\`** — drill-down view mirroring the \`tmai calibration <unit>\` CLI exactly: window header, \`(verdict, confidence) × (n, hits, misses, accuracy)\` table, recent-false-negatives list (with \`Outcome\` summary per variant), tier-1 routing counter with ✓/⚠ block.

## Layout integration

\`StatusBar\` gains an \`indicatorSlot?: ReactNode\` slot between the attention count and the settings/security buttons; the desktop bar renders the calibration chip into it (mobile bar stays unchanged — dogfood operator primary surface is desktop).

The \`mainPanel\` state in \`App.tsx\` gains a \`\"calibration\"\` variant on the existing mutually-exclusive enum, opened from either the chip or the banner's \"Open calibration panel\" link.

## Unit resolution

The wire endpoint takes a unit *name* (a configured \`[[unit]]\` key or a cwd-synthesized basename). The WebUI does not know which \`[[unit]]\` tables are configured, so we pass the **basename of the currently-selected project path**. The backend's \`resolve_unit_or_cwd\` falls back to the basename when no matching \`[[unit]]\` exists, which matches what the CLI does for the same input. With no project selected, the hook parks and nothing renders.

## Why polling, not SSE

Calibration data moves on synthesis-pass cadence (minutes to hours). A 60-second poll is more than enough for a tripwire indicator. SSE \`CoreEvent::CalibrationUpdated\` is a future stage if real-time precision matters; right now we want the substrate, not the wire bandwidth.

## Verified

- \`pnpm build\` ✅
- \`pnpm test\`: **343 passed / 2 skipped / 0 failed** (8 new tests: 3 \`CalibrationChip\` shape cases, 4 \`TripwireBanner\` scenarios + 1 overflow case)
- \`pnpm lint\` ✅ (biome, after one auto-format pass)

## Follow-ups

- Polling → SSE \`CoreEvent::CalibrationUpdated\` for sub-second freshness (only if a use case shows up).
- \`tmai-core\` stage 4 (\`IdleSynthesisTrigger\`) — automatic synthesis runs. With the WebUI now showing the output, the manual \`--synthesize\` ceremony might still suffice.
- A \"Run synthesis\" button in the panel that kicks \`tmai producer <unit> --synthesize\` (needs a new wire endpoint that spawns the Producer session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * キャリブレーションパネルを追加。ユニット別の精度統計、判定表、最近の誤検知リスト、Tier‑1違反の警告などを表示します。
  * トリップワイヤーバナーを導入。Tier‑1違反がある場合に上部に警告を表示します。
  * ステータスバーに常時表示のキャリブレーションインジケーターを追加し、パネルを開けます。
  * キャリブレーションデータの定期取得API/フックを追加。

* **テスト**
  * キャリブレーション関連コンポーネントの単体テストを追加。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/671)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->