### PR TITLE
feat(react): rebuild WebUI around Producer console (Phase A+B)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -30,7 +30,7 @@ import { useNotificationConfig } from "@/hooks/useNotificationConfig";
 import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
 import { useSplitPane } from "@/hooks/useSplitPane";
 import { useWorktrees } from "@/hooks/useWorktrees";
-import { groupByProject, isAiAgent, type Selection, setCallerCwd } from "@/lib/api";
+import { api, groupByProject, isAiAgent, type Selection, setCallerCwd } from "@/lib/api";
 import { useSSE } from "@/lib/sse-provider";
 import { useUIPref } from "@/lib/ui-prefs-provider";
 
@@ -138,31 +138,31 @@ export function App() {
   // `localhost` qualifies, so it works in dev. When the API isn't
   // available (or rejects) we still surface the command in a toast
   // so the operator can copy it by hand — no silent failure.
-  const openProducerTerminal = useCallback(() => {
+  const openProducerTerminal = useCallback(async () => {
     if (!unitName) return;
-    const cmd = `tmai producer ${unitName}`;
-    // The Producer is a real CC session running on a terminal substrate
-    // (tmux / wezTerm / native). The WebUI's job here is to make the
-    // launch command trivially copy-pasteable + tell the operator what
-    // happens next — earlier drafts only surfaced `Copied: <cmd>`,
-    // which left first-time users stranded ("copied… and then?").
-    const successMsg =
-      `Copied: ${cmd}\n` +
-      `Paste it in your terminal — the Producer will read your context ` +
-      `(decisions / memory) and brief you on what to look at first.`;
-    const fallbackMsg =
-      `Run in your terminal: ${cmd}\n` +
-      `The Producer will read your context and brief you on what to look at first.`;
-    const clipboard = typeof navigator !== "undefined" ? navigator.clipboard : undefined;
-    if (clipboard?.writeText) {
-      clipboard.writeText(cmd).then(
-        () => toastSuccess(successMsg),
-        () => toastInfo(fallbackMsg),
-      );
-    } else {
-      toastInfo(fallbackMsg);
+    // `tmai producer <unit>` is implemented as an `exec`-style command
+    // (`tmai-core/src/producer_cli.rs::launch_producer`) — the tmai
+    // subprocess composes the hand-over, then replaces itself with a
+    // Claude session seeded with that hand-over as the initial prompt.
+    // From the PTY-server's perspective this is just a normal spawn,
+    // so we treat it as one: `spawnPty` returns a session id, we point
+    // selection at it, and the PreviewPanel shows the Producer session
+    // immediately. No clipboard / external-terminal round-trip.
+    try {
+      const res = await api.spawnPty({
+        command: "tmai",
+        args: ["producer", unitName],
+        cwd: currentProject ?? undefined,
+      });
+      setSelection({ type: "agent", id: res.session_id });
+      closeMainPanelOverlay();
+      refresh();
+      toastSuccess(`Producer launched for ${unitName}`);
+    } catch (e) {
+      const reason = e instanceof Error ? e.message : String(e);
+      toastInfo(`Failed to launch Producer: ${reason}`);
     }
-  }, [unitName, toastSuccess, toastInfo]);
+  }, [unitName, currentProject, closeMainPanelOverlay, refresh, toastSuccess, toastInfo]);
 
   // Split-pane drag state — separate instances for horizontal vs vertical
   // so the user can drag each independently and resume where they left off

--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -138,31 +138,57 @@ export function App() {
   // `localhost` qualifies, so it works in dev. When the API isn't
   // available (or rejects) we still surface the command in a toast
   // so the operator can copy it by hand — no silent failure.
-  const openProducerTerminal = useCallback(async () => {
-    if (!unitName) return;
-    // `tmai producer <unit>` is implemented as an `exec`-style command
-    // (`tmai-core/src/producer_cli.rs::launch_producer`) — the tmai
-    // subprocess composes the hand-over, then replaces itself with a
-    // Claude session seeded with that hand-over as the initial prompt.
-    // From the PTY-server's perspective this is just a normal spawn,
-    // so we treat it as one: `spawnPty` returns a session id, we point
-    // selection at it, and the PreviewPanel shows the Producer session
-    // immediately. No clipboard / external-terminal round-trip.
-    try {
-      const res = await api.spawnPty({
-        command: "tmai",
-        args: ["producer", unitName],
-        cwd: currentProject ?? undefined,
-      });
-      setSelection({ type: "agent", id: res.session_id });
-      closeMainPanelOverlay();
-      refresh();
-      toastSuccess(`Producer launched for ${unitName}`);
-    } catch (e) {
-      const reason = e instanceof Error ? e.message : String(e);
-      toastInfo(`Failed to launch Producer: ${reason}`);
-    }
-  }, [unitName, currentProject, closeMainPanelOverlay, refresh, toastSuccess, toastInfo]);
+  // `tmai producer <unit>` is implemented as an `exec`-style command
+  // (`tmai-core/src/producer_cli.rs::launch_producer`) — the tmai
+  // subprocess composes the hand-over, then replaces itself with a
+  // Claude session seeded with that hand-over as the initial prompt.
+  // From the PTY-server's perspective this is a normal spawn, so we
+  // treat it as one.
+  //
+  // Caveat that bit on first dogfood: the WebUI derives `unitName`
+  // from the *currently-selected* project, which itself comes from
+  // *currently-running* agents. On a clean start with no agents,
+  // there's no project, so no unit — the Producer launch button used
+  // to disable itself there (chicken-and-egg). We now split the path:
+  //
+  //   - `launchProducerAt(path)` is the actual spawn — takes a repo
+  //     root path explicitly, derives the unit name from its basename,
+  //     and `setCurrentProject`s it so the next click skips the dir
+  //     picker.
+  //   - `openProducerTerminal` is the "hot path" callable when
+  //     `currentProject` is already set; it delegates to the above.
+  //     When nothing is set, ProducerConsoleActions opens a DirBrowser
+  //     instead and calls `launchProducerAt` with the picked path.
+  const launchProducerAt = useCallback(
+    async (path: string) => {
+      const derivedUnit = path.split("/").filter(Boolean).pop();
+      if (!derivedUnit) {
+        toastInfo("Could not derive a unit name from the chosen path.");
+        return;
+      }
+      try {
+        const res = await api.spawnPty({
+          command: "tmai",
+          args: ["producer", derivedUnit],
+          cwd: path,
+        });
+        setSelection({ type: "agent", id: res.session_id });
+        setCurrentProject(path);
+        closeMainPanelOverlay();
+        refresh();
+        toastSuccess(`Producer launched for ${derivedUnit}`);
+      } catch (e) {
+        const reason = e instanceof Error ? e.message : String(e);
+        toastInfo(`Failed to launch Producer: ${reason}`);
+      }
+    },
+    [closeMainPanelOverlay, refresh, toastSuccess, toastInfo],
+  );
+
+  const openProducerTerminal = useCallback(() => {
+    if (!currentProject) return; // ProducerConsoleActions opens DirBrowser in this case
+    void launchProducerAt(currentProject);
+  }, [currentProject, launchProducerAt]);
 
   // Split-pane drag state — separate instances for horizontal vs vertical
   // so the user can drag each independently and resume where they left off
@@ -732,6 +758,7 @@ export function App() {
                 onOpenProducerTerminal={openProducerTerminal}
                 onOpenCalibration={openCalibration}
                 onSelectProjectByPath={handleSelectProject}
+                onLaunchProducerAt={launchProducerAt}
                 onOverrideSpawned={handleSpawned}
                 onOpenSidebar={toggleSidebar}
                 sidebarCollapsed={sidebarCollapsed}

--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -141,14 +141,26 @@ export function App() {
   const openProducerTerminal = useCallback(() => {
     if (!unitName) return;
     const cmd = `tmai producer ${unitName}`;
+    // The Producer is a real CC session running on a terminal substrate
+    // (tmux / wezTerm / native). The WebUI's job here is to make the
+    // launch command trivially copy-pasteable + tell the operator what
+    // happens next — earlier drafts only surfaced `Copied: <cmd>`,
+    // which left first-time users stranded ("copied… and then?").
+    const successMsg =
+      `Copied: ${cmd}\n` +
+      `Paste it in your terminal — the Producer will read your context ` +
+      `(decisions / memory) and brief you on what to look at first.`;
+    const fallbackMsg =
+      `Run in your terminal: ${cmd}\n` +
+      `The Producer will read your context and brief you on what to look at first.`;
     const clipboard = typeof navigator !== "undefined" ? navigator.clipboard : undefined;
     if (clipboard?.writeText) {
       clipboard.writeText(cmd).then(
-        () => toastSuccess(`Copied: ${cmd}`),
-        () => toastInfo(`Run in terminal: ${cmd}`),
+        () => toastSuccess(successMsg),
+        () => toastInfo(fallbackMsg),
       );
     } else {
-      toastInfo(`Run in terminal: ${cmd}`);
+      toastInfo(fallbackMsg);
     }
   }, [unitName, toastSuccess, toastInfo]);
 

--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -700,6 +700,10 @@ export function App() {
                 onOpenProducerTerminal={openProducerTerminal}
                 onOpenCalibration={openCalibration}
                 onSelectProjectByPath={handleSelectProject}
+                onOverrideSpawned={handleSpawned}
+                onOpenSidebar={toggleSidebar}
+                sidebarCollapsed={sidebarCollapsed}
+                onOpenSettings={toggleSettings}
               />
             )}
           </div>

--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -83,11 +83,28 @@ export function App() {
   const showSettings = mainPanel === "settings";
   const showSecurity = mainPanel === "security";
   const showCalibration = mainPanel === "calibration";
+  // Phase B of the Producer-console rebuild
+  // (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`)
+  // routes orchestrator-era controls behind a `<details>` section
+  // inside SettingsPanel. The flag below distinguishes:
+  //
+  // - regular Settings entry (StatusBar button / Ctrl+,) → Advanced
+  //   stays collapsed; the Producer-relevant sections are what you
+  //   see first.
+  // - "Open Settings" deep-link from `ProducerConsoleActions`'
+  //   Operator override panel → Advanced opens by default; the
+  //   operator deliberately asked to bypass the Producer, so we
+  //   land them on the orchestrator-era controls directly.
+  const [settingsOpenedFromOverride, setSettingsOpenedFromOverride] = useState(false);
   const closeMainPanelOverlay = useCallback(() => setMainPanel("agents"), []);
-  const toggleSettings = useCallback(
-    () => setMainPanel((mp) => (mp === "settings" ? "agents" : "settings")),
-    [],
-  );
+  const toggleSettings = useCallback(() => {
+    setSettingsOpenedFromOverride(false);
+    setMainPanel((mp) => (mp === "settings" ? "agents" : "settings"));
+  }, []);
+  const openSettingsFromOverride = useCallback(() => {
+    setSettingsOpenedFromOverride(true);
+    setMainPanel("settings");
+  }, []);
   const toggleSecurity = useCallback(
     () => setMainPanel((mp) => (mp === "security" ? "agents" : "security")),
     [],
@@ -567,7 +584,10 @@ export function App() {
           </div>
         ) : showSettings ? (
           <div className="flex flex-1 flex-col overflow-hidden animate-scale-in">
-            <SettingsPanel onClose={closeMainPanelOverlay} />
+            <SettingsPanel
+              onClose={closeMainPanelOverlay}
+              defaultOpenAdvanced={settingsOpenedFromOverride}
+            />
           </div>
         ) : selection?.type === "project" ? (
           <div className="flex flex-1 flex-col overflow-hidden animate-fade-in">
@@ -703,7 +723,7 @@ export function App() {
                 onOverrideSpawned={handleSpawned}
                 onOpenSidebar={toggleSidebar}
                 sidebarCollapsed={sidebarCollapsed}
-                onOpenSettings={toggleSettings}
+                onOpenSettings={openSettingsFromOverride}
               />
             )}
           </div>

--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -167,9 +167,24 @@ export function App() {
         return;
       }
       try {
+        // tmai-core's `/api/spawn` only allows a tight set of commands
+        // (`claude / codex / gemini / bash / sh / zsh`) — see
+        // `tmai-core/src/server/spawn.rs`. `tmai` itself isn't on the
+        // allow-list, so we wrap the launch in a `bash -c "exec …"`.
+        //
+        // The unit name flows through `$0` so shell metacharacters in
+        // the basename (a real concern: it's a user-picked directory)
+        // can't break out of the argument. `exec` collapses the bash
+        // wrapper into the tmai process; `tmai producer` itself execs
+        // into the Claude session — net result is a clean PTY with no
+        // bash / tmai shim left on the process tree.
+        //
+        // The right long-term fix is a Producer-specific spawn
+        // endpoint (or extending the allow-list) on the tmai-core
+        // side; tracked as Phase C / D work.
         const res = await api.spawnPty({
-          command: "tmai",
-          args: ["producer", derivedUnit],
+          command: "bash",
+          args: ["-c", 'exec tmai producer "$0"', derivedUnit],
           cwd: path,
         });
         setSelection({ type: "agent", id: res.session_id });

--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -13,6 +13,7 @@ import { TabbedPaneLayout } from "@/components/layout/TabbedPaneLayout";
 import { ToastContainer, useToast } from "@/components/layout/ToastContainer";
 import { TriplePaneLayout } from "@/components/layout/TriplePaneLayout";
 import { MarkdownPanel } from "@/components/markdown/MarkdownPanel";
+import { ProducerConsole } from "@/components/producer-console/ProducerConsole";
 import { SecurityPanel } from "@/components/settings/SecurityPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import { TerminalList } from "@/components/terminal/TerminalList";
@@ -106,6 +107,33 @@ export function App() {
     return currentProject.split("/").filter(Boolean).pop() ?? null;
   }, [currentProject]);
   const { data: calibrationData } = useCalibration(unitName);
+
+  // "Open Producer terminal" affordance from <ProducerConsole>.
+  //
+  // Decision `doc/decisions/2026-05-14-react-producer-console-rebuild.md`
+  // §Producer chat: the Producer conversation stays on the terminal
+  // substrate (substrate swap is rejected per cross-ref
+  // `tmai-core@2026-05-13-agent-view-does-not-replace-multiplexer-
+  // substrate`). The WebUI's job is just to make the canonical
+  // command trivially copy-pasteable.
+  //
+  // `navigator.clipboard.writeText` requires a secure context;
+  // `localhost` qualifies, so it works in dev. When the API isn't
+  // available (or rejects) we still surface the command in a toast
+  // so the operator can copy it by hand — no silent failure.
+  const openProducerTerminal = useCallback(() => {
+    if (!unitName) return;
+    const cmd = `tmai producer ${unitName}`;
+    const clipboard = typeof navigator !== "undefined" ? navigator.clipboard : undefined;
+    if (clipboard?.writeText) {
+      clipboard.writeText(cmd).then(
+        () => toastSuccess(`Copied: ${cmd}`),
+        () => toastInfo(`Run in terminal: ${cmd}`),
+      );
+    } else {
+      toastInfo(`Run in terminal: ${cmd}`);
+    }
+  }, [unitName, toastSuccess, toastInfo]);
 
   // Split-pane drag state — separate instances for horizontal vs vertical
   // so the user can drag each independently and resume where they left off
@@ -660,22 +688,19 @@ export function App() {
                 <PreviewPanel agentId={selectedAgent.target} />
               </div>
             ) : (
-              <div className="flex flex-1 items-center justify-center animate-fade-in">
-                <div className="glass-light rounded-2xl px-8 py-8 text-center transition-subtle hover:glass mx-4">
-                  <h1 className="bg-gradient-to-r from-cyan-400 to-blue-500 bg-clip-text text-3xl font-bold tracking-tight text-transparent">
-                    tmai
-                  </h1>
-                  <p className="mt-2 text-sm text-zinc-500">
-                    {agents.length > 0
-                      ? isMobileScreen
-                        ? "Tap ☰ to select an agent"
-                        : "Select an agent to view • Press ? for shortcuts"
-                      : isMobileScreen
-                        ? "Tap ☰ then + on a project to spawn an agent"
-                        : "Click + on a project to spawn an agent • Press ? for shortcuts"}
-                  </p>
-                </div>
-              </div>
+              // Decision `doc/decisions/2026-05-14-react-producer-
+              // console-rebuild.md` Phase A: default view becomes the
+              // Producer console (hand-over digest). Selecting an
+              // agent in the sidebar still drops into the agent view
+              // above; this is the empty / between-selections home.
+              <ProducerConsole
+                currentProjectPath={currentProject}
+                unitName={unitName}
+                calibrationData={calibrationData}
+                onOpenProducerTerminal={openProducerTerminal}
+                onOpenCalibration={openCalibration}
+                onSelectProjectByPath={handleSelectProject}
+              />
             )}
           </div>
         )}

--- a/clients/react/src/components/agent/AgentList.tsx
+++ b/clients/react/src/components/agent/AgentList.tsx
@@ -46,6 +46,22 @@ export function AgentList({
 
   return (
     <div className="flex flex-1 flex-col overflow-y-auto p-2">
+      {/* Phase B of the Producer-console rebuild
+          (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`)
+          moved the main flow to the Producer console (the empty
+          main-pane view). This sidebar still exists — defaults to
+          collapsed, opt-in via the Operator override panel or the
+          sidebar toggle — so the operator has a direct-agent
+          escape hatch. The label below makes that intent visible. */}
+      <div className="mb-2 border-b border-white/5 pb-2">
+        <p className="text-[11px] uppercase tracking-wider text-amber-400/70">
+          Operator view (legacy)
+        </p>
+        <p className="mt-0.5 text-[10px] leading-tight text-zinc-600">
+          Direct agent / project access. The new main flow is the Producer console — use this
+          sidebar only when you need to bypass the Producer.
+        </p>
+      </div>
       <NewAgentLauncher onSpawned={onSpawned} />
       {projects.length === 0 ? (
         <p className="px-2 py-6 text-center text-xs text-zinc-600">

--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -1,0 +1,89 @@
+// Producer console — the default main view per
+// `doc/decisions/2026-05-14-react-producer-console-rebuild.md`.
+//
+// Composition mirrors the Producer's session-start hand-over digest:
+//
+//   ▶ Where you left off
+//   ⬢ Cross-unit status
+//   ⬡ Settled decisions      (Phase A placeholder)
+//   ◐ Working with this human (Phase A placeholder)
+//
+// Bottom row offers two real actions and one Phase-B stub. The
+// tier-1 tripwire banner is hoisted by `App.tsx` above the entire
+// main-pane swap (so it persists across Settings / Calibration /
+// agent views too) — this component intentionally does NOT render
+// its own tripwire band to avoid a duplicate alarm.
+//
+// Producer conversation itself stays on the terminal substrate;
+// the "Open Producer terminal" action copies the canonical command
+// to the clipboard (Phase A fallback — see ProducerConsoleActions).
+
+import { useHandover } from "@/hooks/useHandover";
+import type { CalibrationResponse } from "@/lib/api";
+import { ProducerConsoleActions } from "./ProducerConsoleActions";
+import { CrossUnitStatusSection } from "./sections/CrossUnitStatusSection";
+import { SettledDecisionsSection } from "./sections/SettledDecisionsSection";
+import { WhereYouLeftOffSection } from "./sections/WhereYouLeftOffSection";
+import { WorkingWithThisHumanSection } from "./sections/WorkingWithThisHumanSection";
+
+interface ProducerConsoleProps {
+  /** Currently focused project (from App.tsx's `currentProject` state).
+   *  Drives the ▶ Where-you-left-off section and the unit for the
+   *  Producer-terminal command. */
+  currentProjectPath: string | null;
+  /** Unit name — basename of `currentProjectPath`. The backend's
+   *  `resolve_unit_or_cwd` accepts this and falls back to the cwd
+   *  if no matching `[[unit]]` is configured. */
+  unitName: string | null;
+  /** Calibration response from the parent (App.tsx already polls);
+   *  reused here for the footer's calibration-jump badge. */
+  calibrationData: CalibrationResponse | null;
+  onOpenProducerTerminal: () => void;
+  onOpenCalibration: () => void;
+  /** Click handler for the cross-unit list — wired to App.tsx's
+   *  `handleSelectProject` so unit selection here matches sidebar
+   *  selection there. */
+  onSelectProjectByPath: (path: string, name: string) => void;
+}
+
+export function ProducerConsole({
+  currentProjectPath,
+  unitName,
+  calibrationData,
+  onOpenProducerTerminal,
+  onOpenCalibration,
+  onSelectProjectByPath,
+}: ProducerConsoleProps) {
+  const { whereYouLeftOff, crossUnit, settledDecisions, workingWithHuman } =
+    useHandover(currentProjectPath);
+
+  return (
+    <div className="flex flex-1 flex-col overflow-hidden animate-fade-in">
+      <header className="border-b border-white/5 px-6 py-4">
+        <h2 className="text-lg font-semibold text-zinc-200">Producer console</h2>
+        <p className="text-xs text-zinc-500">
+          Hand-over digest. The Producer conversation itself lives on your terminal substrate (tmux
+          / wezTerm / native) — see the actions below to launch it.
+        </p>
+      </header>
+
+      <div className="flex-1 space-y-6 overflow-y-auto px-6 py-5 text-sm">
+        <WhereYouLeftOffSection data={whereYouLeftOff} />
+        <CrossUnitStatusSection
+          data={crossUnit}
+          activePath={currentProjectPath}
+          onSelectUnit={onSelectProjectByPath}
+        />
+        <SettledDecisionsSection data={settledDecisions} />
+        <WorkingWithThisHumanSection data={workingWithHuman} />
+      </div>
+
+      <ProducerConsoleActions
+        unitName={unitName}
+        calibrationData={calibrationData}
+        onOpenProducerTerminal={onOpenProducerTerminal}
+        onOpenCalibration={onOpenCalibration}
+      />
+    </div>
+  );
+}

--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -74,10 +74,25 @@ export function ProducerConsole({
   return (
     <div className="flex flex-1 flex-col overflow-hidden animate-fade-in">
       <header className="border-b border-white/5 px-6 py-4">
-        <h2 className="text-lg font-semibold text-zinc-200">Producer console</h2>
-        <p className="text-xs text-zinc-500">
-          Hand-over digest. The Producer conversation itself lives on your terminal substrate (tmux
-          / wezTerm / native) — see the actions below to launch it.
+        <h2 className="text-lg font-semibold text-zinc-200">Welcome to tmai</h2>
+        <p className="mt-1 text-xs text-zinc-400">
+          tmai routes your work through a <strong className="text-cyan-300">Producer</strong> — one
+          CC session per project that reads your decisions / memory, briefs you on what needs
+          attention, and dispatches workers. You talk to the Producer, not to individual agents.
+        </p>
+        <p className="mt-2 text-xs text-zinc-500">
+          <span className="text-zinc-400">Quick start:</span>{" "}
+          <strong className="text-zinc-300">①</strong> Read the digest below.{" "}
+          <strong className="text-zinc-300">②</strong> Click{" "}
+          <span className="text-cyan-300">Open Producer terminal</span> at the bottom — it copies
+          the launch command, paste it in your terminal (tmux / wezTerm / native).{" "}
+          <strong className="text-zinc-300">③</strong> The Producer reads your context and briefs
+          you on what to look at first.
+        </p>
+        <p className="mt-1.5 text-[11px] text-zinc-600">
+          Need direct agent control (legacy)?{" "}
+          <span className="text-zinc-500">Operator override</span> at the bottom · expandable
+          sidebar on the left.
         </p>
       </header>
 

--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -44,6 +44,16 @@ interface ProducerConsoleProps {
    *  `handleSelectProject` so unit selection here matches sidebar
    *  selection there. */
   onSelectProjectByPath: (path: string, name: string) => void;
+  /** Phase B: operator-override callbacks. The override expandable
+   *  in the footer needs to spawn agents (re-using `NewAgentLauncher`),
+   *  re-expand the (now default-collapsed) sidebar, and deep-link
+   *  into the Settings page where orchestration / dispatch-bundle
+   *  config still lives. All three are pass-through to App.tsx
+   *  handlers — the console is purely a routing surface. */
+  onOverrideSpawned: (sessionId: string) => void;
+  onOpenSidebar: () => void;
+  sidebarCollapsed: boolean;
+  onOpenSettings: () => void;
 }
 
 export function ProducerConsole({
@@ -53,6 +63,10 @@ export function ProducerConsole({
   onOpenProducerTerminal,
   onOpenCalibration,
   onSelectProjectByPath,
+  onOverrideSpawned,
+  onOpenSidebar,
+  sidebarCollapsed,
+  onOpenSettings,
 }: ProducerConsoleProps) {
   const { whereYouLeftOff, crossUnit, settledDecisions, workingWithHuman } =
     useHandover(currentProjectPath);
@@ -83,6 +97,10 @@ export function ProducerConsole({
         calibrationData={calibrationData}
         onOpenProducerTerminal={onOpenProducerTerminal}
         onOpenCalibration={onOpenCalibration}
+        onOverrideSpawned={onOverrideSpawned}
+        onOpenSidebar={onOpenSidebar}
+        sidebarCollapsed={sidebarCollapsed}
+        onOpenSettings={onOpenSettings}
       />
     </div>
   );

--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -43,6 +43,11 @@ interface ProducerConsoleProps {
    *  reused here for the footer's calibration-jump badge. */
   calibrationData: CalibrationResponse | null;
   onOpenProducerTerminal: () => void;
+  /** Phase B polish v3: invoked from the DirBrowser path when the
+   *  operator hasn't selected a project yet. `path` is a repo root;
+   *  App.tsx derives the unit name from its basename and spawns
+   *  `tmai producer` there. */
+  onLaunchProducerAt: (path: string) => void;
   onOpenCalibration: () => void;
   /** Click handler for the cross-unit list — wired to App.tsx's
    *  `handleSelectProject` so unit selection here matches sidebar
@@ -65,6 +70,7 @@ export function ProducerConsole({
   unitName,
   calibrationData,
   onOpenProducerTerminal,
+  onLaunchProducerAt,
   onOpenCalibration,
   onSelectProjectByPath,
   onOverrideSpawned,
@@ -115,6 +121,7 @@ export function ProducerConsole({
         unitName={unitName}
         calibrationData={calibrationData}
         onOpenProducerTerminal={onOpenProducerTerminal}
+        onLaunchProducerAt={onLaunchProducerAt}
         onOpenCalibration={onOpenCalibration}
         onOverrideSpawned={onOverrideSpawned}
         onOpenSidebar={onOpenSidebar}

--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -14,9 +14,13 @@
 // agent views too) — this component intentionally does NOT render
 // its own tripwire band to avoid a duplicate alarm.
 //
-// Producer conversation itself stays on the terminal substrate;
-// the "Open Producer terminal" action copies the canonical command
-// to the clipboard (Phase A fallback — see ProducerConsoleActions).
+// Producer conversation runs in-tmai via `spawnPty("tmai", ["producer",
+// unit])` — `tmai producer` `exec`s into a Claude session seeded with
+// the unit's hand-over (`tmai-core/src/producer_cli.rs::launch_producer`),
+// so from the PTY-server's perspective the Producer is just a normal
+// agent spawn. After spawn, App.tsx's `openProducerTerminal` selects
+// the new session and the main pane switches to its PreviewPanel — no
+// external-terminal round-trip.
 
 import { useHandover } from "@/hooks/useHandover";
 import type { CalibrationResponse } from "@/lib/api";
@@ -84,10 +88,10 @@ export function ProducerConsole({
           <span className="text-zinc-400">Quick start:</span>{" "}
           <strong className="text-zinc-300">①</strong> Read the digest below.{" "}
           <strong className="text-zinc-300">②</strong> Click{" "}
-          <span className="text-cyan-300">Open Producer terminal</span> at the bottom — it copies
-          the launch command, paste it in your terminal (tmux / wezTerm / native).{" "}
+          <span className="text-cyan-300">Open Producer terminal</span> at the bottom — tmai spawns
+          the Producer session and switches this pane to it.{" "}
           <strong className="text-zinc-300">③</strong> The Producer reads your context and briefs
-          you on what to look at first.
+          you on what to look at first; you converse with it right here.
         </p>
         <p className="mt-1.5 text-[11px] text-zinc-600">
           Need direct agent control (legacy)?{" "}

--- a/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
@@ -2,51 +2,51 @@
 //
 // Three affordances, left-to-right:
 //
-// 1. **Open Producer terminal ▸** — clipboard copy of
-//    `tmai producer <unit>` (Phase A fallback). Decision
-//    `doc/decisions/2026-05-14-react-producer-console-rebuild.md` §
-//    "Producer chat" defers an in-WebUI launch endpoint to Phase D —
-//    the substrate swap is explicitly rejected per cross-ref
-//    `tmai-core@2026-05-13-agent-view-does-not-replace-multiplexer-
-//    substrate`, so the WebUI's role here is to make the command
-//    trivially copy-pasteable, nothing more.
+// 1. **Open Producer terminal ▸** — spawns `tmai producer <unit>` via
+//    `api.spawnPty` (`tmai-core/src/producer_cli.rs::launch_producer`
+//    exec-style replaces tmai with a seeded Claude session). The
+//    button is **always enabled**:
+//    - If `unitName` is already resolved (operator has a focused
+//      project), it delegates to `onOpenProducerTerminal`, which
+//      spawns immediately.
+//    - If not (first launch / no live agents), it opens an inline
+//      DirBrowser so the operator can pick a repo root. The picked
+//      path is forwarded to `onLaunchProducerAt`, which derives the
+//      unit name from its basename and spawns there — App.tsx also
+//      sets `currentProject` so the next click skips the picker.
+//    First-dogfood blocker: the button used to disable itself when
+//    `unitName === null`, but `unitName` derives from the *active
+//    agents*' projects — chicken-and-egg on a clean start. This
+//    revision unblocks it.
 //
 // 2. **Calibration ▸** — jumps into the existing `<CalibrationPanel>`
-//    full-screen view (PR #671). Disabled when no unit is resolvable
-//    (`unitName === null`) so the user doesn't open a panel that
-//    can't fetch anything.
+//    (PR #671). Disabled when `unitName === null` because the
+//    calibration endpoint needs an explicit unit.
 //
-// 3. **Operator override ▾** — expandable. Phase B (this revision):
-//    real surface for the post-inversion "bypass the Producer"
-//    escape hatch. Hosts the legacy spawn path (NewAgentLauncher),
-//    a sidebar-expand affordance when the sidebar is collapsed
-//    (default per `useResponsiveLayout`), and a deep-link into the
-//    Settings page where orchestration / dispatch-bundle config
-//    lives. Per `feedback_pty_emergency_terminal_access` we keep
-//    the override path — we just route it off the main flow.
+// 3. **Operator override ▾** — expandable panel hosting the legacy
+//    spawn path (`NewAgentLauncher`), a Show-sidebar affordance when
+//    the sidebar is collapsed, and an Open-Settings deep-link into
+//    the Advanced section. Per `feedback_pty_emergency_terminal_
+//    access` we keep this path — just route it off the main flow.
 
-import { useState } from "react";
+import { useCallback, useEffect, useState } from "react";
+import { DirBrowser } from "@/components/project/DirBrowser";
 import { NewAgentLauncher } from "@/components/project/NewAgentLauncher";
-import type { CalibrationResponse } from "@/lib/api";
+import { api, type CalibrationResponse } from "@/lib/api";
 
 interface ProducerConsoleActionsProps {
   unitName: string | null;
   calibrationData: CalibrationResponse | null;
+  /** Spawn the Producer using the already-selected project. */
   onOpenProducerTerminal: () => void;
+  /** Spawn the Producer at an explicit repo root — used after the
+   *  DirBrowser picks a path. */
+  onLaunchProducerAt: (path: string) => void;
   onOpenCalibration: () => void;
-  /** Spawn callback for the operator-override NewAgentLauncher. Wired
-   *  to App.tsx's `handleSpawned` so legacy spawns from inside the
-   *  console still propagate selection + toast + cache refresh. */
+  /** Spawn callback for the operator-override NewAgentLauncher. */
   onOverrideSpawned: (sessionId: string) => void;
-  /** Re-expand the sidebar when the operator wants to see the raw
-   *  AgentList. The button is only shown when the sidebar is
-   *  currently collapsed. */
   onOpenSidebar: () => void;
   sidebarCollapsed: boolean;
-  /** Open Settings (where orchestration / dispatch-bundle editors
-   *  still live). The override panel deep-links there as the
-   *  Phase-B compromise until Settings tabs themselves are
-   *  reorganized in a follow-up. */
   onOpenSettings: () => void;
 }
 
@@ -54,6 +54,7 @@ export function ProducerConsoleActions({
   unitName,
   calibrationData,
   onOpenProducerTerminal,
+  onLaunchProducerAt,
   onOpenCalibration,
   onOverrideSpawned,
   onOpenSidebar,
@@ -61,20 +62,55 @@ export function ProducerConsoleActions({
   onOpenSettings,
 }: ProducerConsoleActionsProps) {
   const [overrideOpen, setOverrideOpen] = useState(false);
+  const [browsing, setBrowsing] = useState(false);
+  const [defaultRoot, setDefaultRoot] = useState<string | null>(null);
   const tripwireCount = calibrationData?.tier1_violations.length ?? 0;
   const calCount = calibrationData?.total_in_window ?? 0;
+
+  // Same pattern as NewAgentLauncher: pull `[general] default_project_
+  // root` lazily on open so an edit in GeneralSection flips the picker
+  // on the next launch without a reload. Read-only here, so a transient
+  // fetch failure just leaves `defaultRoot = null` and DirBrowser falls
+  // back to `~`.
+  const refreshDefaultRoot = useCallback(async () => {
+    try {
+      const g = await api.getGeneralSettings();
+      setDefaultRoot(g.default_project_root);
+    } catch {
+      // intentional no-op — see comment above.
+    }
+  }, []);
+  useEffect(() => {
+    void refreshDefaultRoot();
+  }, [refreshDefaultRoot]);
+
+  const handleProducerClick = useCallback(() => {
+    if (unitName !== null) {
+      onOpenProducerTerminal();
+      return;
+    }
+    void refreshDefaultRoot();
+    setBrowsing(true);
+  }, [unitName, onOpenProducerTerminal, refreshDefaultRoot]);
+
+  const handlePickPath = useCallback(
+    (path: string) => {
+      setBrowsing(false);
+      onLaunchProducerAt(path);
+    },
+    [onLaunchProducerAt],
+  );
 
   return (
     <div className="border-t border-white/5">
       <div className="flex items-center gap-2 px-6 py-3">
         <button
           type="button"
-          onClick={onOpenProducerTerminal}
-          disabled={unitName === null}
-          className="rounded-md bg-cyan-500/10 px-3 py-1.5 text-xs text-cyan-300 transition-colors hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+          onClick={handleProducerClick}
+          className="rounded-md bg-cyan-500/10 px-3 py-1.5 text-xs text-cyan-300 transition-colors hover:bg-cyan-500/20"
           title={
             unitName === null
-              ? "No unit resolvable yet — select a project first"
+              ? "Pick a repo root and launch the Producer there"
               : `Launch the Producer for ${unitName} — tmai spawns it in-place and this pane switches to the conversation`
           }
         >
@@ -88,7 +124,7 @@ export function ProducerConsoleActions({
           className="rounded-md bg-white/[0.04] px-3 py-1.5 text-xs text-zinc-300 transition-colors hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-50"
           title={
             unitName === null
-              ? "No unit resolvable yet — select a project first"
+              ? "No unit resolvable yet — launch the Producer (or pick a project) first"
               : "Open the calibration drill-down"
           }
         >
@@ -155,6 +191,30 @@ export function ProducerConsoleActions({
             </button>
           </div>
         </div>
+      )}
+
+      {browsing && (
+        <DirBrowser
+          startPath={defaultRoot ?? undefined}
+          onCancel={() => setBrowsing(false)}
+          actionSlot={(currentPath) => (
+            <div className="flex w-full flex-col gap-1.5">
+              <button
+                type="button"
+                onClick={() => handlePickPath(currentPath)}
+                disabled={!currentPath}
+                className="w-full rounded bg-cyan-500/10 px-3 py-1.5 text-center text-xs text-cyan-300 transition-colors hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+              >
+                Launch Producer here ▸
+              </button>
+              <p className="text-[10px] text-zinc-600">
+                tmai will spawn{" "}
+                <code className="text-zinc-500">tmai producer &lt;basename&gt;</code> in this
+                directory.
+              </p>
+            </div>
+          )}
+        />
       )}
     </div>
   );

--- a/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
@@ -75,7 +75,7 @@ export function ProducerConsoleActions({
           title={
             unitName === null
               ? "No unit resolvable yet — select a project first"
-              : `Copy "tmai producer ${unitName}" to clipboard`
+              : `Launch the Producer for ${unitName} — tmai spawns it in-place and this pane switches to the conversation`
           }
         >
           Open Producer terminal ▸

--- a/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
@@ -1,0 +1,90 @@
+// Bottom action row of the Producer console.
+//
+// Three affordances, left-to-right:
+//
+// 1. **Open Producer terminal ▸** — clipboard copy of
+//    `tmai producer <unit>` (Phase A fallback). Decision
+//    `doc/decisions/2026-05-14-react-producer-console-rebuild.md` §
+//    "Producer chat" defers an in-WebUI launch endpoint to Phase D —
+//    the substrate swap is explicitly rejected per cross-ref
+//    `tmai-core@2026-05-13-agent-view-does-not-replace-multiplexer-
+//    substrate`, so the WebUI's role here is to make the command
+//    trivially copy-pasteable, nothing more.
+//
+// 2. **Calibration ▸** — jumps into the existing `<CalibrationPanel>`
+//    full-screen view (PR #671). Disabled when no unit is resolvable
+//    (`unitName === null`) so the user doesn't open a panel that
+//    can't fetch anything.
+//
+// 3. **Operator override ▾** — Phase A stub. Phase B will demote the
+//    legacy orchestrator-era controls (NewAgentLauncher, manual
+//    dispatch buttons, direct prompt input, OrchestrationSection)
+//    behind this expandable. For now it tells the operator the move
+//    is planned but not yet built — keeps the slot visible without
+//    promising a feature that doesn't exist.
+
+import type { CalibrationResponse } from "@/lib/api";
+
+interface ProducerConsoleActionsProps {
+  unitName: string | null;
+  calibrationData: CalibrationResponse | null;
+  onOpenProducerTerminal: () => void;
+  onOpenCalibration: () => void;
+}
+
+export function ProducerConsoleActions({
+  unitName,
+  calibrationData,
+  onOpenProducerTerminal,
+  onOpenCalibration,
+}: ProducerConsoleActionsProps) {
+  const tripwireCount = calibrationData?.tier1_violations.length ?? 0;
+  const calCount = calibrationData?.total_in_window ?? 0;
+
+  return (
+    <div className="flex items-center gap-2 border-t border-white/5 px-6 py-3">
+      <button
+        type="button"
+        onClick={onOpenProducerTerminal}
+        disabled={unitName === null}
+        className="rounded-md bg-cyan-500/10 px-3 py-1.5 text-xs text-cyan-300 transition-colors hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+        title={
+          unitName === null
+            ? "No unit resolvable yet — select a project first"
+            : `Copy "tmai producer ${unitName}" to clipboard`
+        }
+      >
+        Open Producer terminal ▸
+      </button>
+
+      <button
+        type="button"
+        onClick={onOpenCalibration}
+        disabled={unitName === null}
+        className="rounded-md bg-white/[0.04] px-3 py-1.5 text-xs text-zinc-300 transition-colors hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-50"
+        title={
+          unitName === null
+            ? "No unit resolvable yet — select a project first"
+            : "Open the calibration drill-down"
+        }
+      >
+        Calibration ▸
+        {tripwireCount > 0 && (
+          <span className="ml-1.5 rounded-full bg-red-500/30 px-1.5 py-0.5 text-[10px] text-red-200">
+            ⚡ {tripwireCount}
+          </span>
+        )}
+        {tripwireCount === 0 && calCount > 0 && (
+          <span className="ml-1.5 text-[10px] text-zinc-500">{calCount}</span>
+        )}
+      </button>
+
+      <span
+        className="ml-auto cursor-not-allowed rounded-md bg-white/[0.02] px-3 py-1.5 text-xs text-zinc-500"
+        title="Phase B will demote legacy orchestrator-era controls (manual spawn, dispatch buttons, direct prompt input) behind this expandable."
+      >
+        Operator override ▾ <span className="text-[10px] uppercase tracking-wider">phase B</span>
+      </span>
+    </div>
+  );
+}

--- a/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
@@ -16,13 +16,17 @@
 //    (`unitName === null`) so the user doesn't open a panel that
 //    can't fetch anything.
 //
-// 3. **Operator override ▾** — Phase A stub. Phase B will demote the
-//    legacy orchestrator-era controls (NewAgentLauncher, manual
-//    dispatch buttons, direct prompt input, OrchestrationSection)
-//    behind this expandable. For now it tells the operator the move
-//    is planned but not yet built — keeps the slot visible without
-//    promising a feature that doesn't exist.
+// 3. **Operator override ▾** — expandable. Phase B (this revision):
+//    real surface for the post-inversion "bypass the Producer"
+//    escape hatch. Hosts the legacy spawn path (NewAgentLauncher),
+//    a sidebar-expand affordance when the sidebar is collapsed
+//    (default per `useResponsiveLayout`), and a deep-link into the
+//    Settings page where orchestration / dispatch-bundle config
+//    lives. Per `feedback_pty_emergency_terminal_access` we keep
+//    the override path — we just route it off the main flow.
 
+import { useState } from "react";
+import { NewAgentLauncher } from "@/components/project/NewAgentLauncher";
 import type { CalibrationResponse } from "@/lib/api";
 
 interface ProducerConsoleActionsProps {
@@ -30,6 +34,20 @@ interface ProducerConsoleActionsProps {
   calibrationData: CalibrationResponse | null;
   onOpenProducerTerminal: () => void;
   onOpenCalibration: () => void;
+  /** Spawn callback for the operator-override NewAgentLauncher. Wired
+   *  to App.tsx's `handleSpawned` so legacy spawns from inside the
+   *  console still propagate selection + toast + cache refresh. */
+  onOverrideSpawned: (sessionId: string) => void;
+  /** Re-expand the sidebar when the operator wants to see the raw
+   *  AgentList. The button is only shown when the sidebar is
+   *  currently collapsed. */
+  onOpenSidebar: () => void;
+  sidebarCollapsed: boolean;
+  /** Open Settings (where orchestration / dispatch-bundle editors
+   *  still live). The override panel deep-links there as the
+   *  Phase-B compromise until Settings tabs themselves are
+   *  reorganized in a follow-up. */
+  onOpenSettings: () => void;
 }
 
 export function ProducerConsoleActions({
@@ -37,54 +55,107 @@ export function ProducerConsoleActions({
   calibrationData,
   onOpenProducerTerminal,
   onOpenCalibration,
+  onOverrideSpawned,
+  onOpenSidebar,
+  sidebarCollapsed,
+  onOpenSettings,
 }: ProducerConsoleActionsProps) {
+  const [overrideOpen, setOverrideOpen] = useState(false);
   const tripwireCount = calibrationData?.tier1_violations.length ?? 0;
   const calCount = calibrationData?.total_in_window ?? 0;
 
   return (
-    <div className="flex items-center gap-2 border-t border-white/5 px-6 py-3">
-      <button
-        type="button"
-        onClick={onOpenProducerTerminal}
-        disabled={unitName === null}
-        className="rounded-md bg-cyan-500/10 px-3 py-1.5 text-xs text-cyan-300 transition-colors hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:opacity-50"
-        title={
-          unitName === null
-            ? "No unit resolvable yet — select a project first"
-            : `Copy "tmai producer ${unitName}" to clipboard`
-        }
-      >
-        Open Producer terminal ▸
-      </button>
+    <div className="border-t border-white/5">
+      <div className="flex items-center gap-2 px-6 py-3">
+        <button
+          type="button"
+          onClick={onOpenProducerTerminal}
+          disabled={unitName === null}
+          className="rounded-md bg-cyan-500/10 px-3 py-1.5 text-xs text-cyan-300 transition-colors hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+          title={
+            unitName === null
+              ? "No unit resolvable yet — select a project first"
+              : `Copy "tmai producer ${unitName}" to clipboard`
+          }
+        >
+          Open Producer terminal ▸
+        </button>
 
-      <button
-        type="button"
-        onClick={onOpenCalibration}
-        disabled={unitName === null}
-        className="rounded-md bg-white/[0.04] px-3 py-1.5 text-xs text-zinc-300 transition-colors hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-50"
-        title={
-          unitName === null
-            ? "No unit resolvable yet — select a project first"
-            : "Open the calibration drill-down"
-        }
-      >
-        Calibration ▸
-        {tripwireCount > 0 && (
-          <span className="ml-1.5 rounded-full bg-red-500/30 px-1.5 py-0.5 text-[10px] text-red-200">
-            ⚡ {tripwireCount}
-          </span>
-        )}
-        {tripwireCount === 0 && calCount > 0 && (
-          <span className="ml-1.5 text-[10px] text-zinc-500">{calCount}</span>
-        )}
-      </button>
+        <button
+          type="button"
+          onClick={onOpenCalibration}
+          disabled={unitName === null}
+          className="rounded-md bg-white/[0.04] px-3 py-1.5 text-xs text-zinc-300 transition-colors hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-50"
+          title={
+            unitName === null
+              ? "No unit resolvable yet — select a project first"
+              : "Open the calibration drill-down"
+          }
+        >
+          Calibration ▸
+          {tripwireCount > 0 && (
+            <span className="ml-1.5 rounded-full bg-red-500/30 px-1.5 py-0.5 text-[10px] text-red-200">
+              ⚡ {tripwireCount}
+            </span>
+          )}
+          {tripwireCount === 0 && calCount > 0 && (
+            <span className="ml-1.5 text-[10px] text-zinc-500">{calCount}</span>
+          )}
+        </button>
 
-      <span
-        className="ml-auto cursor-not-allowed rounded-md bg-white/[0.02] px-3 py-1.5 text-xs text-zinc-500"
-        title="Phase B will demote legacy orchestrator-era controls (manual spawn, dispatch buttons, direct prompt input) behind this expandable."
-      >
-        Operator override ▾ <span className="text-[10px] uppercase tracking-wider">phase B</span>
-      </span>
+        <button
+          type="button"
+          onClick={() => setOverrideOpen((o) => !o)}
+          aria-expanded={overrideOpen}
+          aria-controls="operator-override-panel"
+          className="ml-auto rounded-md bg-white/[0.02] px-3 py-1.5 text-xs text-zinc-400 transition-colors hover:bg-white/[0.06] hover:text-zinc-200"
+          title="Bypass the Producer — for emergency / debug use only"
+        >
+          Operator override {overrideOpen ? "▴" : "▾"}
+        </button>
+      </div>
+
+      {overrideOpen && (
+        <div
+          id="operator-override-panel"
+          className="border-t border-white/5 bg-white/[0.02] px-6 py-3"
+        >
+          <p className="text-[11px] uppercase tracking-wider text-zinc-500">Operator override</p>
+          <p className="mt-1 text-xs text-zinc-500">
+            These shortcuts bypass the Producer. The post-inversion default is to let the Producer
+            route work — use these only when the Producer isn't running, you need to intervene
+            directly, or you're debugging.
+          </p>
+
+          <div className="mt-3 space-y-2">
+            <NewAgentLauncher onSpawned={onOverrideSpawned} />
+
+            {sidebarCollapsed && (
+              <button
+                type="button"
+                onClick={onOpenSidebar}
+                className="block w-full rounded-md border border-white/5 bg-white/[0.02] px-3 py-2 text-left text-xs text-zinc-300 transition-colors hover:bg-white/[0.06]"
+                title="Re-expand the sidebar and show the raw agent list"
+              >
+                Show sidebar ▸{" "}
+                <span className="text-zinc-500">(legacy agent list / per-project shortcuts)</span>
+              </button>
+            )}
+
+            <button
+              type="button"
+              onClick={onOpenSettings}
+              className="block w-full rounded-md border border-white/5 bg-white/[0.02] px-3 py-2 text-left text-xs text-zinc-300 transition-colors hover:bg-white/[0.06]"
+              title="Open Settings — orchestration / dispatch bundles still live here"
+            >
+              Open Settings ▸{" "}
+              <span className="text-zinc-500">
+                (orchestration rules, dispatch bundles, guardrails, …)
+              </span>
+            </button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
@@ -32,14 +32,8 @@ function digest(overrides: Partial<HandoverDigest> = {}): HandoverDigest {
       attentionAgents: [],
     },
     crossUnit: overrides.crossUnit ?? { units: [] },
-    settledDecisions: overrides.settledDecisions ?? {
-      placeholder: true,
-      reason: "PLACEHOLDER_DECISIONS_REASON",
-    },
-    workingWithHuman: overrides.workingWithHuman ?? {
-      placeholder: true,
-      reason: "PLACEHOLDER_HUMAN_REASON",
-    },
+    settledDecisions: overrides.settledDecisions ?? { placeholder: true },
+    workingWithHuman: overrides.workingWithHuman ?? { placeholder: true },
   };
 }
 
@@ -73,7 +67,7 @@ describe("ProducerConsole", () => {
 
     render(<ProducerConsole {...makeProps()} />);
 
-    expect(screen.getByRole("heading", { name: /Producer console/ })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Welcome to tmai/ })).toBeTruthy();
     expect(screen.getByRole("heading", { name: /Where you left off/ })).toBeTruthy();
     expect(screen.getByRole("heading", { name: /Cross-unit status/ })).toBeTruthy();
     expect(screen.getByRole("heading", { name: /Settled decisions/ })).toBeTruthy();
@@ -123,13 +117,17 @@ describe("ProducerConsole", () => {
     expect(screen.getByText("main")).toBeTruthy();
   });
 
-  it("surfaces the explicit Phase-C placeholder reason in both placeholder sections", () => {
+  it("renders the user-facing copy in the not-yet-wired sections", () => {
     useHandoverMock.mockReturnValue(digest());
 
     render(<ProducerConsole {...makeProps()} />);
 
-    expect(screen.getByText("PLACEHOLDER_DECISIONS_REASON")).toBeTruthy();
-    expect(screen.getByText("PLACEHOLDER_HUMAN_REASON")).toBeTruthy();
+    // Section components own these strings (not the hook); they should
+    // point the operator at the repo-side fallbacks rather than leak
+    // phase-tracking jargon ("Phase C: ... not yet wired") which read
+    // as broken on first contact.
+    expect(screen.getByText(/doc\/decisions/)).toBeTruthy();
+    expect(screen.getByText(/CLAUDE\.md/)).toBeTruthy();
   });
 
   it("renders cross-unit rows and routes click to onSelectProjectByPath", () => {

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
@@ -4,9 +4,11 @@
 //
 // We mock `useHandover` so each render can present a deterministic
 // digest shape and we can assert on what the four sections actually
-// surface (headers, placeholders, attention rows).
+// surface (headers, placeholders, attention rows). NewAgentLauncher
+// is also mocked because the operator-override panel embeds it.
 
 import { render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { HandoverDigest } from "@/hooks/useHandover";
 import { ProducerConsole } from "../ProducerConsole";
@@ -15,6 +17,10 @@ const useHandoverMock = vi.fn();
 
 vi.mock("@/hooks/useHandover", () => ({
   useHandover: (path: string | null) => useHandoverMock(path),
+}));
+
+vi.mock("@/components/project/NewAgentLauncher", () => ({
+  NewAgentLauncher: () => <div data-testid="mock-new-agent-launcher">[mocked]</div>,
 }));
 
 function digest(overrides: Partial<HandoverDigest> = {}): HandoverDigest {
@@ -37,6 +43,26 @@ function digest(overrides: Partial<HandoverDigest> = {}): HandoverDigest {
   };
 }
 
+// Common prop bag — keeps each render() call short and lets us
+// override only the fields a given test cares about.
+function makeProps(
+  overrides: Partial<ComponentProps<typeof ProducerConsole>> = {},
+): ComponentProps<typeof ProducerConsole> {
+  return {
+    currentProjectPath: null,
+    unitName: null,
+    calibrationData: null,
+    onOpenProducerTerminal: vi.fn(),
+    onOpenCalibration: vi.fn(),
+    onSelectProjectByPath: vi.fn(),
+    onOverrideSpawned: vi.fn(),
+    onOpenSidebar: vi.fn(),
+    sidebarCollapsed: false,
+    onOpenSettings: vi.fn(),
+    ...overrides,
+  };
+}
+
 beforeEach(() => {
   useHandoverMock.mockReset();
 });
@@ -45,16 +71,7 @@ describe("ProducerConsole", () => {
   it("renders the four hand-over section headers", () => {
     useHandoverMock.mockReturnValue(digest());
 
-    render(
-      <ProducerConsole
-        currentProjectPath={null}
-        unitName={null}
-        calibrationData={null}
-        onOpenProducerTerminal={vi.fn()}
-        onOpenCalibration={vi.fn()}
-        onSelectProjectByPath={vi.fn()}
-      />,
-    );
+    render(<ProducerConsole {...makeProps()} />);
 
     expect(screen.getByRole("heading", { name: /Producer console/ })).toBeTruthy();
     expect(screen.getByRole("heading", { name: /Where you left off/ })).toBeTruthy();
@@ -66,16 +83,7 @@ describe("ProducerConsole", () => {
   it("shows the no-project hint when nothing is scoped", () => {
     useHandoverMock.mockReturnValue(digest());
 
-    render(
-      <ProducerConsole
-        currentProjectPath={null}
-        unitName={null}
-        calibrationData={null}
-        onOpenProducerTerminal={vi.fn()}
-        onOpenCalibration={vi.fn()}
-        onSelectProjectByPath={vi.fn()}
-      />,
-    );
+    render(<ProducerConsole {...makeProps()} />);
 
     expect(screen.getByText(/No project scoped yet/i)).toBeTruthy();
   });
@@ -109,35 +117,16 @@ describe("ProducerConsole", () => {
       }),
     );
 
-    render(
-      <ProducerConsole
-        currentProjectPath="/p/a"
-        unitName="a"
-        calibrationData={null}
-        onOpenProducerTerminal={vi.fn()}
-        onOpenCalibration={vi.fn()}
-        onSelectProjectByPath={vi.fn()}
-      />,
-    );
+    render(<ProducerConsole {...makeProps({ currentProjectPath: "/p/a", unitName: "a" })} />);
 
     expect(screen.getByText("halted-agent")).toBeTruthy();
-    // Worktree row
     expect(screen.getByText("main")).toBeTruthy();
   });
 
   it("surfaces the explicit Phase-C placeholder reason in both placeholder sections", () => {
     useHandoverMock.mockReturnValue(digest());
 
-    render(
-      <ProducerConsole
-        currentProjectPath={null}
-        unitName={null}
-        calibrationData={null}
-        onOpenProducerTerminal={vi.fn()}
-        onOpenCalibration={vi.fn()}
-        onSelectProjectByPath={vi.fn()}
-      />,
-    );
+    render(<ProducerConsole {...makeProps()} />);
 
     expect(screen.getByText("PLACEHOLDER_DECISIONS_REASON")).toBeTruthy();
     expect(screen.getByText("PLACEHOLDER_HUMAN_REASON")).toBeTruthy();
@@ -170,18 +159,15 @@ describe("ProducerConsole", () => {
 
     const { container } = render(
       <ProducerConsole
-        currentProjectPath="/p/alpha"
-        unitName="alpha"
-        calibrationData={null}
-        onOpenProducerTerminal={vi.fn()}
-        onOpenCalibration={vi.fn()}
-        onSelectProjectByPath={onSelect}
+        {...makeProps({
+          currentProjectPath: "/p/alpha",
+          unitName: "alpha",
+          onSelectProjectByPath: onSelect,
+        })}
       />,
     );
-    // Sanity: rows render
     expect(screen.getByText("alpha")).toBeTruthy();
     expect(screen.getByText("beta")).toBeTruthy();
-    // Click the beta row — find the button containing the text.
     const betaButton = Array.from(container.querySelectorAll("button")).find((b) =>
       b.textContent?.includes("beta"),
     );

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+//
+// ProducerConsole composition tests.
+//
+// We mock `useHandover` so each render can present a deterministic
+// digest shape and we can assert on what the four sections actually
+// surface (headers, placeholders, attention rows).
+
+import { render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HandoverDigest } from "@/hooks/useHandover";
+import { ProducerConsole } from "../ProducerConsole";
+
+const useHandoverMock = vi.fn();
+
+vi.mock("@/hooks/useHandover", () => ({
+  useHandover: (path: string | null) => useHandoverMock(path),
+}));
+
+function digest(overrides: Partial<HandoverDigest> = {}): HandoverDigest {
+  return {
+    whereYouLeftOff: overrides.whereYouLeftOff ?? {
+      activeProjectPath: null,
+      activeProjectName: null,
+      worktrees: [],
+      attentionAgents: [],
+    },
+    crossUnit: overrides.crossUnit ?? { units: [] },
+    settledDecisions: overrides.settledDecisions ?? {
+      placeholder: true,
+      reason: "PLACEHOLDER_DECISIONS_REASON",
+    },
+    workingWithHuman: overrides.workingWithHuman ?? {
+      placeholder: true,
+      reason: "PLACEHOLDER_HUMAN_REASON",
+    },
+  };
+}
+
+beforeEach(() => {
+  useHandoverMock.mockReset();
+});
+
+describe("ProducerConsole", () => {
+  it("renders the four hand-over section headers", () => {
+    useHandoverMock.mockReturnValue(digest());
+
+    render(
+      <ProducerConsole
+        currentProjectPath={null}
+        unitName={null}
+        calibrationData={null}
+        onOpenProducerTerminal={vi.fn()}
+        onOpenCalibration={vi.fn()}
+        onSelectProjectByPath={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByRole("heading", { name: /Producer console/ })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Where you left off/ })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Cross-unit status/ })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Settled decisions/ })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Working with this human/ })).toBeTruthy();
+  });
+
+  it("shows the no-project hint when nothing is scoped", () => {
+    useHandoverMock.mockReturnValue(digest());
+
+    render(
+      <ProducerConsole
+        currentProjectPath={null}
+        unitName={null}
+        calibrationData={null}
+        onOpenProducerTerminal={vi.fn()}
+        onOpenCalibration={vi.fn()}
+        onSelectProjectByPath={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/No project scoped yet/i)).toBeTruthy();
+  });
+
+  it("renders attention agents when present on the scoped project", () => {
+    useHandoverMock.mockReturnValue(
+      digest({
+        whereYouLeftOff: {
+          activeProjectPath: "/p/a",
+          activeProjectName: "a",
+          worktrees: [
+            {
+              name: "main",
+              branch: "main",
+              path: "/p/a",
+              isMain: true,
+              dirty: false,
+              agentCount: 1,
+            },
+          ],
+          attentionAgents: [
+            {
+              target: "claude:1",
+              displayName: "halted-agent",
+              attention: "halted",
+              cwd: "/p/a",
+              isOrchestrator: false,
+            },
+          ],
+        },
+      }),
+    );
+
+    render(
+      <ProducerConsole
+        currentProjectPath="/p/a"
+        unitName="a"
+        calibrationData={null}
+        onOpenProducerTerminal={vi.fn()}
+        onOpenCalibration={vi.fn()}
+        onSelectProjectByPath={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("halted-agent")).toBeTruthy();
+    // Worktree row
+    expect(screen.getByText("main")).toBeTruthy();
+  });
+
+  it("surfaces the explicit Phase-C placeholder reason in both placeholder sections", () => {
+    useHandoverMock.mockReturnValue(digest());
+
+    render(
+      <ProducerConsole
+        currentProjectPath={null}
+        unitName={null}
+        calibrationData={null}
+        onOpenProducerTerminal={vi.fn()}
+        onOpenCalibration={vi.fn()}
+        onSelectProjectByPath={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("PLACEHOLDER_DECISIONS_REASON")).toBeTruthy();
+    expect(screen.getByText("PLACEHOLDER_HUMAN_REASON")).toBeTruthy();
+  });
+
+  it("renders cross-unit rows and routes click to onSelectProjectByPath", () => {
+    const onSelect = vi.fn();
+    useHandoverMock.mockReturnValue(
+      digest({
+        crossUnit: {
+          units: [
+            {
+              path: "/p/alpha",
+              name: "alpha",
+              state: "needs-you",
+              agentCount: 2,
+              attentionCount: 1,
+            },
+            {
+              path: "/p/beta",
+              name: "beta",
+              state: "quiet",
+              agentCount: 0,
+              attentionCount: 0,
+            },
+          ],
+        },
+      }),
+    );
+
+    const { container } = render(
+      <ProducerConsole
+        currentProjectPath="/p/alpha"
+        unitName="alpha"
+        calibrationData={null}
+        onOpenProducerTerminal={vi.fn()}
+        onOpenCalibration={vi.fn()}
+        onSelectProjectByPath={onSelect}
+      />,
+    );
+    // Sanity: rows render
+    expect(screen.getByText("alpha")).toBeTruthy();
+    expect(screen.getByText("beta")).toBeTruthy();
+    // Click the beta row — find the button containing the text.
+    const betaButton = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("beta"),
+    );
+    expect(betaButton).toBeTruthy();
+    betaButton?.click();
+    expect(onSelect).toHaveBeenCalledWith("/p/beta", "beta");
+  });
+});

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
@@ -47,6 +47,7 @@ function makeProps(
     unitName: null,
     calibrationData: null,
     onOpenProducerTerminal: vi.fn(),
+    onLaunchProducerAt: vi.fn(),
     onOpenCalibration: vi.fn(),
     onSelectProjectByPath: vi.fn(),
     onOverrideSpawned: vi.fn(),

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+//
+// ProducerConsoleActions — clipboard copy, calibration jump, and
+// the Phase-B operator-override stub.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CalibrationResponse } from "@/lib/api";
+import { ProducerConsoleActions } from "../ProducerConsoleActions";
+
+function calibrationFixture(overrides: Partial<CalibrationResponse> = {}): CalibrationResponse {
+  return {
+    unit: overrides.unit ?? "test-unit",
+    days: overrides.days ?? 90,
+    total_in_store: overrides.total_in_store ?? 5,
+    total_in_window: overrides.total_in_window ?? 5,
+    bootstrap_threshold: overrides.bootstrap_threshold ?? 10,
+    cells: overrides.cells ?? [],
+    tier1_routed: overrides.tier1_routed ?? 0,
+    tier1_violations: overrides.tier1_violations ?? [],
+    recent_false_negatives: overrides.recent_false_negatives ?? [],
+  };
+}
+
+describe("ProducerConsoleActions", () => {
+  it("disables both real-action buttons when unitName is null", () => {
+    render(
+      <ProducerConsoleActions
+        unitName={null}
+        calibrationData={null}
+        onOpenProducerTerminal={vi.fn()}
+        onOpenCalibration={vi.fn()}
+      />,
+    );
+
+    const openTerm = screen.getByRole("button", { name: /Open Producer terminal/ });
+    const openCal = screen.getByRole("button", { name: /Calibration/ });
+    expect(openTerm).toHaveProperty("disabled", true);
+    expect(openCal).toHaveProperty("disabled", true);
+  });
+
+  it("invokes onOpenProducerTerminal when the terminal button is clicked", () => {
+    const onOpenTerm = vi.fn();
+    render(
+      <ProducerConsoleActions
+        unitName="my-unit"
+        calibrationData={null}
+        onOpenProducerTerminal={onOpenTerm}
+        onOpenCalibration={vi.fn()}
+      />,
+    );
+
+    screen.getByRole("button", { name: /Open Producer terminal/ }).click();
+    expect(onOpenTerm).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onOpenCalibration when the calibration button is clicked", () => {
+    const onOpenCal = vi.fn();
+    render(
+      <ProducerConsoleActions
+        unitName="my-unit"
+        calibrationData={null}
+        onOpenProducerTerminal={vi.fn()}
+        onOpenCalibration={onOpenCal}
+      />,
+    );
+
+    screen.getByRole("button", { name: /Calibration/ }).click();
+    expect(onOpenCal).toHaveBeenCalledTimes(1);
+  });
+
+  it("badges the calibration button with the tripwire count when non-empty", () => {
+    render(
+      <ProducerConsoleActions
+        unitName="my-unit"
+        calibrationData={calibrationFixture({
+          tier1_violations: [
+            {
+              verdict: "absorb",
+              note_source: "x",
+              confidence: "high",
+              synthesis_pass_id: "p1",
+              tier_routed: 1,
+              rationale: "r",
+              recorded_at: "2026-05-13",
+              outcome: null,
+            },
+          ],
+        })}
+        onOpenProducerTerminal={vi.fn()}
+        onOpenCalibration={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/⚡ 1/)).toBeTruthy();
+  });
+
+  it("shows the cal count when tripwire is empty but store has entries", () => {
+    render(
+      <ProducerConsoleActions
+        unitName="my-unit"
+        calibrationData={calibrationFixture({
+          total_in_window: 7,
+          tier1_violations: [],
+        })}
+        onOpenProducerTerminal={vi.fn()}
+        onOpenCalibration={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("7")).toBeTruthy();
+  });
+
+  it("renders the Phase-B operator override as a non-interactive stub", () => {
+    render(
+      <ProducerConsoleActions
+        unitName="my-unit"
+        calibrationData={null}
+        onOpenProducerTerminal={vi.fn()}
+        onOpenCalibration={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/Operator override/)).toBeTruthy();
+    expect(screen.getByText(/phase B/i)).toBeTruthy();
+  });
+});

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
@@ -1,12 +1,36 @@
 // @vitest-environment jsdom
 //
 // ProducerConsoleActions — clipboard copy, calibration jump, and
-// the Phase-B operator-override stub.
+// the operator-override expandable (Phase B). NewAgentLauncher is
+// mocked so we don't pull in api.getGeneralSettings during render.
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen } from "@testing-library/react";
+import type { ComponentProps } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CalibrationResponse } from "@/lib/api";
 import { ProducerConsoleActions } from "../ProducerConsoleActions";
+
+vi.mock("@/components/project/NewAgentLauncher", () => ({
+  NewAgentLauncher: () => (
+    <div data-testid="mock-new-agent-launcher">[mocked NewAgentLauncher]</div>
+  ),
+}));
+
+function makeProps(
+  overrides: Partial<ComponentProps<typeof ProducerConsoleActions>> = {},
+): ComponentProps<typeof ProducerConsoleActions> {
+  return {
+    unitName: "u",
+    calibrationData: null,
+    onOpenProducerTerminal: vi.fn(),
+    onOpenCalibration: vi.fn(),
+    onOverrideSpawned: vi.fn(),
+    onOpenSidebar: vi.fn(),
+    sidebarCollapsed: false,
+    onOpenSettings: vi.fn(),
+    ...overrides,
+  };
+}
 
 function calibrationFixture(overrides: Partial<CalibrationResponse> = {}): CalibrationResponse {
   return {
@@ -22,16 +46,13 @@ function calibrationFixture(overrides: Partial<CalibrationResponse> = {}): Calib
   };
 }
 
-describe("ProducerConsoleActions", () => {
+describe("ProducerConsoleActions — top row", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it("disables both real-action buttons when unitName is null", () => {
-    render(
-      <ProducerConsoleActions
-        unitName={null}
-        calibrationData={null}
-        onOpenProducerTerminal={vi.fn()}
-        onOpenCalibration={vi.fn()}
-      />,
-    );
+    render(<ProducerConsoleActions {...makeProps({ unitName: null })} />);
 
     const openTerm = screen.getByRole("button", { name: /Open Producer terminal/ });
     const openCal = screen.getByRole("button", { name: /Calibration/ });
@@ -43,14 +64,11 @@ describe("ProducerConsoleActions", () => {
     const onOpenTerm = vi.fn();
     render(
       <ProducerConsoleActions
-        unitName="my-unit"
-        calibrationData={null}
-        onOpenProducerTerminal={onOpenTerm}
-        onOpenCalibration={vi.fn()}
+        {...makeProps({ unitName: "my-unit", onOpenProducerTerminal: onOpenTerm })}
       />,
     );
 
-    screen.getByRole("button", { name: /Open Producer terminal/ }).click();
+    fireEvent.click(screen.getByRole("button", { name: /Open Producer terminal/ }));
     expect(onOpenTerm).toHaveBeenCalledTimes(1);
   });
 
@@ -58,37 +76,34 @@ describe("ProducerConsoleActions", () => {
     const onOpenCal = vi.fn();
     render(
       <ProducerConsoleActions
-        unitName="my-unit"
-        calibrationData={null}
-        onOpenProducerTerminal={vi.fn()}
-        onOpenCalibration={onOpenCal}
+        {...makeProps({ unitName: "my-unit", onOpenCalibration: onOpenCal })}
       />,
     );
 
-    screen.getByRole("button", { name: /Calibration/ }).click();
+    fireEvent.click(screen.getByRole("button", { name: /Calibration/ }));
     expect(onOpenCal).toHaveBeenCalledTimes(1);
   });
 
   it("badges the calibration button with the tripwire count when non-empty", () => {
     render(
       <ProducerConsoleActions
-        unitName="my-unit"
-        calibrationData={calibrationFixture({
-          tier1_violations: [
-            {
-              verdict: "absorb",
-              note_source: "x",
-              confidence: "high",
-              synthesis_pass_id: "p1",
-              tier_routed: 1,
-              rationale: "r",
-              recorded_at: "2026-05-13",
-              outcome: null,
-            },
-          ],
+        {...makeProps({
+          unitName: "my-unit",
+          calibrationData: calibrationFixture({
+            tier1_violations: [
+              {
+                verdict: "absorb",
+                note_source: "x",
+                confidence: "high",
+                synthesis_pass_id: "p1",
+                tier_routed: 1,
+                rationale: "r",
+                recorded_at: "2026-05-13",
+                outcome: null,
+              },
+            ],
+          }),
         })}
-        onOpenProducerTerminal={vi.fn()}
-        onOpenCalibration={vi.fn()}
       />,
     );
 
@@ -98,29 +113,86 @@ describe("ProducerConsoleActions", () => {
   it("shows the cal count when tripwire is empty but store has entries", () => {
     render(
       <ProducerConsoleActions
-        unitName="my-unit"
-        calibrationData={calibrationFixture({
-          total_in_window: 7,
-          tier1_violations: [],
+        {...makeProps({
+          unitName: "my-unit",
+          calibrationData: calibrationFixture({
+            total_in_window: 7,
+            tier1_violations: [],
+          }),
         })}
-        onOpenProducerTerminal={vi.fn()}
-        onOpenCalibration={vi.fn()}
       />,
     );
 
     expect(screen.getByText("7")).toBeTruthy();
   });
+});
 
-  it("renders the Phase-B operator override as a non-interactive stub", () => {
-    render(
-      <ProducerConsoleActions
-        unitName="my-unit"
-        calibrationData={null}
-        onOpenProducerTerminal={vi.fn()}
-        onOpenCalibration={vi.fn()}
-      />,
-    );
-    expect(screen.getByText(/Operator override/)).toBeTruthy();
-    expect(screen.getByText(/phase B/i)).toBeTruthy();
+describe("ProducerConsoleActions — operator override (Phase B)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the override toggle button collapsed by default", () => {
+    render(<ProducerConsoleActions {...makeProps()} />);
+
+    const toggle = screen.getByRole("button", { name: /Operator override/ });
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByTestId("mock-new-agent-launcher")).toBeNull();
+  });
+
+  it("expands the override panel and reveals NewAgentLauncher on toggle click", () => {
+    render(<ProducerConsoleActions {...makeProps()} />);
+
+    const toggle = screen.getByRole("button", { name: /Operator override/ });
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("true");
+    expect(screen.getByTestId("mock-new-agent-launcher")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Open Settings/ })).toBeTruthy();
+  });
+
+  it("collapses the override panel on a second click", () => {
+    render(<ProducerConsoleActions {...makeProps()} />);
+
+    const toggle = screen.getByRole("button", { name: /Operator override/ });
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+
+    expect(toggle.getAttribute("aria-expanded")).toBe("false");
+    expect(screen.queryByTestId("mock-new-agent-launcher")).toBeNull();
+  });
+
+  it("hides the Show-sidebar button when sidebarCollapsed is false", () => {
+    render(<ProducerConsoleActions {...makeProps({ sidebarCollapsed: false })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Operator override/ }));
+    expect(screen.queryByRole("button", { name: /Show sidebar/ })).toBeNull();
+  });
+
+  it("shows the Show-sidebar button when sidebarCollapsed is true", () => {
+    render(<ProducerConsoleActions {...makeProps({ sidebarCollapsed: true })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Operator override/ }));
+    expect(screen.getByRole("button", { name: /Show sidebar/ })).toBeTruthy();
+  });
+
+  it("invokes onOpenSidebar when the Show-sidebar button is clicked", () => {
+    const onOpenSidebar = vi.fn();
+    render(<ProducerConsoleActions {...makeProps({ sidebarCollapsed: true, onOpenSidebar })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Operator override/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Show sidebar/ }));
+
+    expect(onOpenSidebar).toHaveBeenCalledTimes(1);
+  });
+
+  it("invokes onOpenSettings when the Open-Settings button is clicked", () => {
+    const onOpenSettings = vi.fn();
+    render(<ProducerConsoleActions {...makeProps({ onOpenSettings })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Operator override/ }));
+    fireEvent.click(screen.getByRole("button", { name: /Open Settings/ }));
+
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 //
-// ProducerConsoleActions — clipboard copy, calibration jump, and
-// the operator-override expandable (Phase B). NewAgentLauncher is
-// mocked so we don't pull in api.getGeneralSettings during render.
+// ProducerConsoleActions — top row, operator-override expandable
+// (Phase B), and DirBrowser-backed Producer launch when unit is
+// unresolved (Phase B polish v3). NewAgentLauncher + DirBrowser
+// + `api.getGeneralSettings` are mocked so we don't pull live
+// network calls into render.
 
 import { fireEvent, render, screen } from "@testing-library/react";
-import type { ComponentProps } from "react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { CalibrationResponse } from "@/lib/api";
 import { ProducerConsoleActions } from "../ProducerConsoleActions";
@@ -16,6 +18,29 @@ vi.mock("@/components/project/NewAgentLauncher", () => ({
   ),
 }));
 
+vi.mock("@/components/project/DirBrowser", () => ({
+  DirBrowser: (props: {
+    onCancel: () => void;
+    actionSlot?: (currentPath: string) => ReactNode;
+    startPath?: string | null;
+  }) => (
+    <div data-testid="mock-dirbrowser" data-start-path={props.startPath ?? ""}>
+      <button type="button" data-testid="mock-dirbrowser-cancel" onClick={props.onCancel}>
+        cancel
+      </button>
+      {props.actionSlot?.("/picked/path")}
+    </div>
+  ),
+}));
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getGeneralSettings: vi.fn().mockResolvedValue({ default_project_root: null }),
+  },
+}));
+
+import type { ComponentProps } from "react";
+
 function makeProps(
   overrides: Partial<ComponentProps<typeof ProducerConsoleActions>> = {},
 ): ComponentProps<typeof ProducerConsoleActions> {
@@ -23,6 +48,7 @@ function makeProps(
     unitName: "u",
     calibrationData: null,
     onOpenProducerTerminal: vi.fn(),
+    onLaunchProducerAt: vi.fn(),
     onOpenCalibration: vi.fn(),
     onOverrideSpawned: vi.fn(),
     onOpenSidebar: vi.fn(),
@@ -51,25 +77,67 @@ describe("ProducerConsoleActions — top row", () => {
     vi.clearAllMocks();
   });
 
-  it("disables both real-action buttons when unitName is null", () => {
+  it("keeps Open-Producer-terminal enabled even when unitName is null", () => {
+    // Phase B polish v3 fix: when no project is selected yet, the
+    // button should still be clickable and route to the DirBrowser
+    // path (not disabled). Calibration stays disabled because it
+    // needs an explicit unit.
     render(<ProducerConsoleActions {...makeProps({ unitName: null })} />);
 
     const openTerm = screen.getByRole("button", { name: /Open Producer terminal/ });
     const openCal = screen.getByRole("button", { name: /Calibration/ });
-    expect(openTerm).toHaveProperty("disabled", true);
+    expect(openTerm).toHaveProperty("disabled", false);
     expect(openCal).toHaveProperty("disabled", true);
   });
 
-  it("invokes onOpenProducerTerminal when the terminal button is clicked", () => {
+  it("invokes onOpenProducerTerminal when unitName is resolved and the button is clicked", () => {
     const onOpenTerm = vi.fn();
+    const onLaunchAt = vi.fn();
     render(
       <ProducerConsoleActions
-        {...makeProps({ unitName: "my-unit", onOpenProducerTerminal: onOpenTerm })}
+        {...makeProps({
+          unitName: "my-unit",
+          onOpenProducerTerminal: onOpenTerm,
+          onLaunchProducerAt: onLaunchAt,
+        })}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: /Open Producer terminal/ }));
     expect(onOpenTerm).toHaveBeenCalledTimes(1);
+    expect(onLaunchAt).not.toHaveBeenCalled();
+    // No DirBrowser when we have a unit already.
+    expect(screen.queryByTestId("mock-dirbrowser")).toBeNull();
+  });
+
+  it("opens DirBrowser when unitName is null and the button is clicked", () => {
+    const onOpenTerm = vi.fn();
+    render(
+      <ProducerConsoleActions
+        {...makeProps({ unitName: null, onOpenProducerTerminal: onOpenTerm })}
+      />,
+    );
+
+    expect(screen.queryByTestId("mock-dirbrowser")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Open Producer terminal/ }));
+    expect(screen.getByTestId("mock-dirbrowser")).toBeTruthy();
+    // The hot-path callback should NOT have been fired — we routed to
+    // the picker instead.
+    expect(onOpenTerm).not.toHaveBeenCalled();
+  });
+
+  it("forwards the picked path to onLaunchProducerAt and closes the browser", () => {
+    const onLaunchAt = vi.fn();
+    render(
+      <ProducerConsoleActions {...makeProps({ unitName: null, onLaunchProducerAt: onLaunchAt })} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Open Producer terminal/ }));
+    // Mock DirBrowser renders the actionSlot with `"/picked/path"`.
+    fireEvent.click(screen.getByRole("button", { name: /Launch Producer here/ }));
+    expect(onLaunchAt).toHaveBeenCalledWith("/picked/path");
+    // Modal should close after the pick.
+    expect(screen.queryByTestId("mock-dirbrowser")).toBeNull();
   });
 
   it("invokes onOpenCalibration when the calibration button is clicked", () => {

--- a/clients/react/src/components/producer-console/sections/CrossUnitStatusSection.tsx
+++ b/clients/react/src/components/producer-console/sections/CrossUnitStatusSection.tsx
@@ -1,0 +1,100 @@
+// ⬢ Cross-unit status — second hand-over section.
+//
+// One line per unit (= project derived from active agents). State pill
+// is read off `useHandover`'s `UnitStatus.state`:
+//
+// - 🔴 needs-you   — at least one agent has non-null `attention`
+// - 🟡 in-progress — agents present, none on the attention axis
+// - ⚪ quiet       — no agents (but the unit is known)
+//
+// Phase A note: the unit list is *derived* from live agents, not read
+// from a `[[unit]]`-config endpoint, so units configured but currently
+// dormant are not visible here. Phase C will reconcile against a
+// `GET /api/units` endpoint and surface those too.
+
+import type { CrossUnitStatus, UnitState } from "@/hooks/useHandover";
+
+interface CrossUnitStatusSectionProps {
+  data: CrossUnitStatus;
+  activePath: string | null;
+  onSelectUnit: (path: string, name: string) => void;
+}
+
+export function CrossUnitStatusSection({
+  data,
+  activePath,
+  onSelectUnit,
+}: CrossUnitStatusSectionProps) {
+  return (
+    <section>
+      <header className="mb-2 flex items-baseline gap-2">
+        <span className="text-base text-cyan-400">⬢</span>
+        <h3 className="text-sm font-semibold text-zinc-200">Cross-unit status</h3>
+        <span className="text-xs text-zinc-500">
+          {data.units.length} unit{data.units.length === 1 ? "" : "s"} derived from live agents
+        </span>
+      </header>
+
+      {data.units.length === 0 ? (
+        <p className="pl-6 text-xs text-zinc-500">
+          No active units. Spawn an agent on any project to populate this list — Phase C will also
+          surface dormant configured units.
+        </p>
+      ) : (
+        <ul className="space-y-0.5 pl-6 text-xs text-zinc-300">
+          {data.units.map((u) => {
+            const isActive = u.path === activePath;
+            return (
+              <li key={u.path}>
+                <button
+                  type="button"
+                  onClick={() => onSelectUnit(u.path, u.name)}
+                  className={`flex w-full items-baseline gap-2 rounded px-2 py-1 text-left transition-colors hover:bg-white/[0.04] ${
+                    isActive ? "bg-white/[0.04]" : ""
+                  }`}
+                >
+                  <StatePill state={u.state} />
+                  <code className="text-zinc-200">{u.name}</code>
+                  <span className="text-zinc-600">
+                    {u.attentionCount > 0 && (
+                      <span className="text-amber-400">{u.attentionCount}↑ </span>
+                    )}
+                    {u.agentCount} agent{u.agentCount === 1 ? "" : "s"}
+                  </span>
+                  {isActive && (
+                    <span className="ml-auto text-[10px] uppercase tracking-wider text-cyan-400">
+                      active
+                    </span>
+                  )}
+                </button>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function StatePill({ state }: { state: UnitState }) {
+  switch (state) {
+    case "needs-you":
+      return (
+        <span className="text-red-400" title="agent(s) on the attention axis">
+          🔴
+        </span>
+      );
+    case "in-progress":
+      return (
+        <span className="text-amber-300" title="agents present, none waiting on you">
+          🟡
+        </span>
+      );
+    case "quiet":
+      return (
+        <span className="text-zinc-500" title="no agents">
+          ⚪
+        </span>
+      );
+  }
+}

--- a/clients/react/src/components/producer-console/sections/SettledDecisionsSection.tsx
+++ b/clients/react/src/components/producer-console/sections/SettledDecisionsSection.tsx
@@ -1,0 +1,36 @@
+// ⬡ Settled decisions — third hand-over section (Phase A placeholder).
+//
+// The hand-over composer on the Producer side renders decisions
+// bucketed by temperature: 📌 Foundational / 🔴 In-play / 🟡 Warm /
+// ⚪ Cold. The wire endpoint (`GET /api/units/{unit}/decisions`) is
+// not yet wired, so this section explicitly tells the operator that
+// the placeholder is intentional, what's missing, and where to read
+// the records in the meantime.
+
+import type { SettledDecisionsPlaceholder } from "@/hooks/useHandover";
+
+interface SettledDecisionsSectionProps {
+  data: SettledDecisionsPlaceholder;
+}
+
+export function SettledDecisionsSection({ data }: SettledDecisionsSectionProps) {
+  return (
+    <section>
+      <header className="mb-2 flex items-baseline gap-2">
+        <span className="text-base text-cyan-400">⬡</span>
+        <h3 className="text-sm font-semibold text-zinc-200">Settled decisions</h3>
+        <span className="rounded bg-zinc-700/50 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-zinc-400">
+          phase C
+        </span>
+      </header>
+
+      <div className="pl-6">
+        <p className="text-xs text-zinc-500">{data.reason}</p>
+        <p className="mt-2 text-xs text-zinc-600">
+          Once wired, this section will surface DRs bucketed by temperature: 📌 foundational · 🔴
+          in-play · 🟡 warm · ⚪ cold.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/clients/react/src/components/producer-console/sections/SettledDecisionsSection.tsx
+++ b/clients/react/src/components/producer-console/sections/SettledDecisionsSection.tsx
@@ -3,9 +3,12 @@
 // The hand-over composer on the Producer side renders decisions
 // bucketed by temperature: 📌 Foundational / 🔴 In-play / 🟡 Warm /
 // ⚪ Cold. The wire endpoint (`GET /api/units/{unit}/decisions`) is
-// not yet wired, so this section explicitly tells the operator that
-// the placeholder is intentional, what's missing, and where to read
-// the records in the meantime.
+// not yet wired, so this section displays a user-readable "not yet
+// automated" notice pointing at the repo's `doc/decisions/` for the
+// time being. Earlier drafts of this string leaked phase-tracking
+// jargon ("Phase C: `GET /api/units/...` is not yet wired") into the
+// user UI, which read as broken; this revision drops that and
+// addresses the operator directly.
 
 import type { SettledDecisionsPlaceholder } from "@/hooks/useHandover";
 
@@ -13,21 +16,24 @@ interface SettledDecisionsSectionProps {
   data: SettledDecisionsPlaceholder;
 }
 
-export function SettledDecisionsSection({ data }: SettledDecisionsSectionProps) {
+export function SettledDecisionsSection({ data: _data }: SettledDecisionsSectionProps) {
   return (
     <section>
       <header className="mb-2 flex items-baseline gap-2">
         <span className="text-base text-cyan-400">⬡</span>
         <h3 className="text-sm font-semibold text-zinc-200">Settled decisions</h3>
         <span className="rounded bg-zinc-700/50 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-zinc-400">
-          phase C
+          not automated yet
         </span>
       </header>
 
-      <div className="pl-6">
-        <p className="text-xs text-zinc-500">{data.reason}</p>
-        <p className="mt-2 text-xs text-zinc-600">
-          Once wired, this section will surface DRs bucketed by temperature: 📌 foundational · 🔴
+      <div className="pl-6 text-xs text-zinc-500">
+        <p>
+          Browse your repo's <code className="text-zinc-300">doc/decisions/</code> directly to see
+          settled decisions for now — the Producer reads them on session-start.
+        </p>
+        <p className="mt-2 text-zinc-600">
+          When wired, this section will surface them bucketed by temperature: 📌 foundational · 🔴
           in-play · 🟡 warm · ⚪ cold.
         </p>
       </div>

--- a/clients/react/src/components/producer-console/sections/WhereYouLeftOffSection.tsx
+++ b/clients/react/src/components/producer-console/sections/WhereYouLeftOffSection.tsx
@@ -1,0 +1,129 @@
+// ▶ Where you left off — first hand-over section.
+//
+// Surfaces the operator's currently-scoped project: its worktrees (with
+// branch + dirty + agent count) and any agents waiting on the user.
+// Empty states are explicit — a blank section reads as "no project
+// selected yet" rather than as a broken render.
+
+import type { AttentionAgentBrief, WhereYouLeftOff, WorktreeBrief } from "@/hooks/useHandover";
+
+interface WhereYouLeftOffSectionProps {
+  data: WhereYouLeftOff;
+}
+
+export function WhereYouLeftOffSection({ data }: WhereYouLeftOffSectionProps) {
+  const { activeProjectName, worktrees, attentionAgents } = data;
+
+  return (
+    <section>
+      <header className="mb-2 flex items-baseline gap-2">
+        <span className="text-base text-cyan-400">▶</span>
+        <h3 className="text-sm font-semibold text-zinc-200">Where you left off</h3>
+        {activeProjectName && (
+          <span className="text-xs text-zinc-500">
+            on <code className="text-zinc-300">{activeProjectName}</code>
+          </span>
+        )}
+      </header>
+
+      {!activeProjectName ? (
+        <EmptyProject />
+      ) : (
+        <div className="space-y-3 pl-6">
+          <WorktreeList worktrees={worktrees} />
+          <AttentionAgentsList agents={attentionAgents} />
+        </div>
+      )}
+    </section>
+  );
+}
+
+function EmptyProject() {
+  return (
+    <p className="pl-6 text-xs text-zinc-500">
+      No project scoped yet. Click + on a project in the sidebar to spawn an agent, or pick an
+      existing project to focus this view.
+    </p>
+  );
+}
+
+function WorktreeList({ worktrees }: { worktrees: WorktreeBrief[] }) {
+  if (worktrees.length === 0) {
+    return <p className="text-xs text-zinc-500">No worktrees discovered yet.</p>;
+  }
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-wider text-zinc-500">Worktrees</p>
+      <ul className="mt-1 space-y-0.5 text-xs text-zinc-300">
+        {worktrees.map((wt) => (
+          <li key={`${wt.path}-${wt.name}`} className="flex items-baseline gap-2">
+            <code className="text-zinc-200">
+              {wt.isMain ? "main" : wt.name}
+              {wt.dirty && <span className="ml-1 text-amber-400">●</span>}
+            </code>
+            {wt.branch && <span className="text-zinc-500">({wt.branch})</span>}
+            <span className="text-zinc-600">
+              {wt.agentCount} agent{wt.agentCount === 1 ? "" : "s"}
+            </span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function AttentionAgentsList({ agents }: { agents: AttentionAgentBrief[] }) {
+  if (agents.length === 0) {
+    return (
+      <div>
+        <p className="text-[11px] uppercase tracking-wider text-zinc-500">Attention</p>
+        <p className="mt-1 text-xs text-zinc-500">
+          No agent is waiting on you on this project. <span className="text-zinc-600">✓</span>
+        </p>
+      </div>
+    );
+  }
+  return (
+    <div>
+      <p className="text-[11px] uppercase tracking-wider text-zinc-500">Attention</p>
+      <ul className="mt-1 space-y-0.5 text-xs text-zinc-300">
+        {agents.map((a) => (
+          <li key={a.target} className="flex items-baseline gap-2">
+            <AttentionGlyph kind={a.attention} />
+            <code className="text-zinc-200">{a.displayName}</code>
+            {a.isOrchestrator && (
+              <span className="rounded bg-cyan-500/10 px-1 text-[10px] text-cyan-300">orch</span>
+            )}
+            <span className="text-zinc-600">{a.cwd}</span>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// Decision tmai-core@2026-05-09 Phase 4: flat attention enum on the
+// wire. Glyphs match the sidebar-collapsed pill set so the operator
+// reads the same shape in both surfaces.
+function AttentionGlyph({ kind }: { kind: AttentionAgentBrief["attention"] }) {
+  switch (kind) {
+    case "halted":
+      return (
+        <span className="text-amber-400" title="permission/selection prompt">
+          ◐
+        </span>
+      );
+    case "started":
+      return (
+        <span className="text-cyan-300" title="just spawned, awaiting first prompt">
+          ○
+        </span>
+      );
+    case "completed":
+      return (
+        <span className="text-zinc-300" title="turn finished, awaiting your next move">
+          ○
+        </span>
+      );
+  }
+}

--- a/clients/react/src/components/producer-console/sections/WorkingWithThisHumanSection.tsx
+++ b/clients/react/src/components/producer-console/sections/WorkingWithThisHumanSection.tsx
@@ -1,0 +1,35 @@
+// ◐ Working with this human — fourth hand-over section (Phase A placeholder).
+//
+// The Producer's `compose()` baseline builder emits a "working-norms
+// delta" — process rules that diverge from the baseline `CLAUDE.md`,
+// computed at session-start. The read endpoint is not yet wired, so
+// this section displays an explicit placeholder pointing at the
+// baseline `CLAUDE.md` as the fallback.
+
+import type { WorkingWithHumanPlaceholder } from "@/hooks/useHandover";
+
+interface WorkingWithThisHumanSectionProps {
+  data: WorkingWithHumanPlaceholder;
+}
+
+export function WorkingWithThisHumanSection({ data }: WorkingWithThisHumanSectionProps) {
+  return (
+    <section>
+      <header className="mb-2 flex items-baseline gap-2">
+        <span className="text-base text-cyan-400">◐</span>
+        <h3 className="text-sm font-semibold text-zinc-200">Working with this human</h3>
+        <span className="rounded bg-zinc-700/50 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-zinc-400">
+          phase C
+        </span>
+      </header>
+
+      <div className="pl-6">
+        <p className="text-xs text-zinc-500">{data.reason}</p>
+        <p className="mt-2 text-xs text-zinc-600">
+          Once wired, this section will list deltas from the baseline norms (language preference,
+          review rituals, branch conventions, etc.) computed by the Producer's hand-over composer.
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/clients/react/src/components/producer-console/sections/WorkingWithThisHumanSection.tsx
+++ b/clients/react/src/components/producer-console/sections/WorkingWithThisHumanSection.tsx
@@ -3,8 +3,10 @@
 // The Producer's `compose()` baseline builder emits a "working-norms
 // delta" — process rules that diverge from the baseline `CLAUDE.md`,
 // computed at session-start. The read endpoint is not yet wired, so
-// this section displays an explicit placeholder pointing at the
-// baseline `CLAUDE.md` as the fallback.
+// this section displays a user-readable pointer at the baseline
+// `CLAUDE.md` for the time being. (Earlier drafts surfaced phase-
+// tracking text into this UI which made the section read as broken;
+// this revision speaks to the operator directly instead.)
 
 import type { WorkingWithHumanPlaceholder } from "@/hooks/useHandover";
 
@@ -12,22 +14,26 @@ interface WorkingWithThisHumanSectionProps {
   data: WorkingWithHumanPlaceholder;
 }
 
-export function WorkingWithThisHumanSection({ data }: WorkingWithThisHumanSectionProps) {
+export function WorkingWithThisHumanSection({ data: _data }: WorkingWithThisHumanSectionProps) {
   return (
     <section>
       <header className="mb-2 flex items-baseline gap-2">
         <span className="text-base text-cyan-400">◐</span>
         <h3 className="text-sm font-semibold text-zinc-200">Working with this human</h3>
         <span className="rounded bg-zinc-700/50 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-zinc-400">
-          phase C
+          not automated yet
         </span>
       </header>
 
-      <div className="pl-6">
-        <p className="text-xs text-zinc-500">{data.reason}</p>
-        <p className="mt-2 text-xs text-zinc-600">
-          Once wired, this section will list deltas from the baseline norms (language preference,
-          review rituals, branch conventions, etc.) computed by the Producer's hand-over composer.
+      <div className="pl-6 text-xs text-zinc-500">
+        <p>
+          See your repo's <code className="text-zinc-300">CLAUDE.md</code> for the baseline norms
+          (language, review rituals, branch conventions, …) — the Producer reads it on
+          session-start.
+        </p>
+        <p className="mt-2 text-zinc-600">
+          When wired, this section will surface deltas from the baseline computed by the Producer's
+          hand-over composer.
         </p>
       </div>
     </section>

--- a/clients/react/src/components/settings/SettingsPanel.tsx
+++ b/clients/react/src/components/settings/SettingsPanel.tsx
@@ -12,6 +12,15 @@ import { WorktreeSection } from "./WorktreeSection";
 
 interface SettingsPanelProps {
   onClose: () => void;
+  /** Phase B of the Producer-console rebuild
+   *  (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`)
+   *  collapses orchestrator-era controls behind an Advanced section.
+   *  When the operator arrives here from `ProducerConsoleActions`'
+   *  Operator-override panel, we want Advanced open by default so
+   *  the deep-link lands on the controls the operator was after.
+   *  Otherwise default-closed: the post-inversion default is to
+   *  let the Producer route work. */
+  defaultOpenAdvanced?: boolean;
 }
 
 // Visual divider between "Core" (tmai-core config.toml) and "WebUI" (this
@@ -33,8 +42,13 @@ function GroupHeader({ label, description }: { label: string; description: strin
  * save tracker, and load. The shell only sources the project list — derived
  * from currently active agents — used by `OrchestrationSection`'s per-project
  * override scope selector.
+ *
+ * Phase B layout: Producer-relevant sections sit at the top of the Core
+ * group; orchestrator-era controls (spawn defaults, orchestration rules,
+ * dispatch bundles, workflow engine, worktree ops) fall behind a
+ * `<details>`-backed Advanced expandable. The WebUI group is unchanged.
  */
-export function SettingsPanel({ onClose }: SettingsPanelProps) {
+export function SettingsPanel({ onClose, defaultOpenAdvanced = false }: SettingsPanelProps) {
   const [agents, setAgents] = useState<AgentSnapshot[]>([]);
 
   // Pre-registered projects were retired in favour of deriving the scope
@@ -63,17 +77,41 @@ export function SettingsPanel({ onClose }: SettingsPanelProps) {
 
       <div className="flex-1 overflow-y-auto px-6 py-4 space-y-6">
         <GroupHeader
-          label="tmai (core)"
-          description="Server-side settings persisted to ~/.config/tmai/config.toml. Shared across CLI, TUI, and WebUI."
+          label="Producer"
+          description="Settings the Producer and the human console both read. Stored in ~/.config/tmai/config.toml; shared across CLI, TUI, and WebUI."
         />
         <GeneralSection />
-        <SpawnSection />
-        <OrchestrationSection projects={projects} />
-        <OrchestrationDispatchSection />
-        <UsageSection />
         <NotificationSection />
-        <WorkflowSection />
-        <WorktreeSection />
+        <UsageSection />
+
+        {/* Advanced — Phase B: orchestrator-era controls live here, off
+            the main flow but reachable. `<details>` is native /
+            keyboard-accessible; `open={defaultOpenAdvanced}` makes
+            the override-deep-link land with the section already
+            expanded so the operator doesn't have to click twice. */}
+        <details
+          className="rounded-md border border-white/5 bg-white/[0.02]"
+          open={defaultOpenAdvanced}
+        >
+          <summary className="cursor-pointer select-none px-4 py-3 text-sm text-zinc-300 hover:bg-white/[0.04]">
+            <span className="text-[11px] font-semibold uppercase tracking-wider text-amber-400/80">
+              Advanced
+            </span>{" "}
+            — orchestrator-era controls
+            <p className="mt-1 text-xs font-normal normal-case tracking-normal text-zinc-500">
+              These bypass the Producer (manual spawn defaults, orchestration rules, dispatch
+              bundles, workflow engine, worktree ops). The post-inversion default is to let the
+              Producer route work — open this only when you need to override directly.
+            </p>
+          </summary>
+          <div className="space-y-6 border-t border-white/5 px-4 py-4">
+            <SpawnSection />
+            <OrchestrationSection projects={projects} />
+            <OrchestrationDispatchSection />
+            <WorkflowSection />
+            <WorktreeSection />
+          </div>
+        </details>
 
         <GroupHeader
           label="WebUI (this browser)"

--- a/clients/react/src/components/settings/__tests__/SettingsPanel.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel.test.tsx
@@ -1,0 +1,111 @@
+// @vitest-environment jsdom
+//
+// SettingsPanel layout tests — Phase B reorg.
+//
+// We mock every sub-section so the test exercises only the shell:
+// section ordering, the new Advanced expandable, and the
+// `defaultOpenAdvanced` prop wired by App.tsx when the operator
+// deep-links from the ProducerConsole override panel.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { SettingsPanel } from "../SettingsPanel";
+
+vi.mock("@/lib/api", () => ({
+  api: { listAgents: vi.fn().mockResolvedValue([]) },
+  groupByProject: vi.fn().mockReturnValue([]),
+}));
+
+vi.mock("../GeneralSection", () => ({
+  GeneralSection: () => <div data-testid="section-general">General</div>,
+}));
+vi.mock("../NotificationSection", () => ({
+  NotificationSection: () => <div data-testid="section-notification">Notification</div>,
+}));
+vi.mock("../UsageSection", () => ({
+  UsageSection: () => <div data-testid="section-usage">Usage</div>,
+}));
+vi.mock("../SpawnSection", () => ({
+  SpawnSection: () => <div data-testid="section-spawn">Spawn</div>,
+}));
+vi.mock("../OrchestrationSection", () => ({
+  OrchestrationSection: () => <div data-testid="section-orchestration">Orchestration</div>,
+}));
+vi.mock("../OrchestrationDispatchSection", () => ({
+  OrchestrationDispatchSection: () => <div data-testid="section-dispatch">Dispatch</div>,
+}));
+vi.mock("../WorkflowSection", () => ({
+  WorkflowSection: () => <div data-testid="section-workflow">Workflow</div>,
+}));
+vi.mock("../WorktreeSection", () => ({
+  WorktreeSection: () => <div data-testid="section-worktree">Worktree</div>,
+}));
+vi.mock("../DisplayLayoutSection", () => ({
+  DisplayLayoutSection: () => <div data-testid="section-display">Display</div>,
+}));
+
+const ADVANCED_TESTIDS = [
+  "section-spawn",
+  "section-orchestration",
+  "section-dispatch",
+  "section-workflow",
+  "section-worktree",
+];
+
+describe("SettingsPanel — Phase B layout", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders the Producer-group sections directly (not behind an expandable)", () => {
+    render(<SettingsPanel onClose={vi.fn()} />);
+
+    expect(screen.getByTestId("section-general")).toBeTruthy();
+    expect(screen.getByTestId("section-notification")).toBeTruthy();
+    expect(screen.getByTestId("section-usage")).toBeTruthy();
+  });
+
+  it("renders the WebUI-group section directly", () => {
+    render(<SettingsPanel onClose={vi.fn()} />);
+
+    expect(screen.getByTestId("section-display")).toBeTruthy();
+  });
+
+  it("keeps the Advanced sections hidden by default", () => {
+    render(<SettingsPanel onClose={vi.fn()} />);
+
+    const details = screen.getByText(/Advanced/).closest("details");
+    expect(details).toBeTruthy();
+    expect((details as HTMLDetailsElement).open).toBe(false);
+    // jsdom collapses <details> content visually via the open attr;
+    // mocked sections still mount in the DOM, so assert on the
+    // `open` attribute rather than visibility.
+  });
+
+  it("opens the Advanced section when defaultOpenAdvanced is true", () => {
+    render(<SettingsPanel onClose={vi.fn()} defaultOpenAdvanced={true} />);
+
+    const details = screen.getByText(/Advanced/).closest("details");
+    expect((details as HTMLDetailsElement).open).toBe(true);
+  });
+
+  it("mounts all advanced sub-sections inside the Advanced details", () => {
+    render(<SettingsPanel onClose={vi.fn()} defaultOpenAdvanced={true} />);
+
+    const details = screen.getByText(/Advanced/).closest("details");
+    expect(details).toBeTruthy();
+    for (const testId of ADVANCED_TESTIDS) {
+      const node = screen.getByTestId(testId);
+      // Every advanced section should be inside the <details> subtree.
+      expect(details?.contains(node)).toBe(true);
+    }
+  });
+
+  it("invokes onClose when the close button is clicked", () => {
+    const onClose = vi.fn();
+    render(<SettingsPanel onClose={onClose} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Close/ }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/react/src/hooks/__tests__/useHandover.test.ts
+++ b/clients/react/src/hooks/__tests__/useHandover.test.ts
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+//
+// Aggregation tests for the Producer console's hand-over digest.
+//
+// We mock `useAgents` and `useWorktrees` directly so the test exercises
+// `useHandover`'s composition logic (project grouping, attention
+// filtering, state-pill derivation) without spinning up SSEProvider.
+
+import { renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentSnapshot, WorktreeSnapshot } from "@/lib/api";
+import { useHandover } from "../useHandover";
+
+const useAgentsMock = vi.fn();
+const useWorktreesMock = vi.fn();
+
+vi.mock("@/hooks/useAgents", () => ({
+  useAgents: () => useAgentsMock(),
+}));
+
+vi.mock("@/hooks/useWorktrees", () => ({
+  useWorktrees: () => useWorktreesMock(),
+}));
+
+function agent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot {
+  return {
+    id: partial.id,
+    target: partial.target ?? partial.id,
+    agent_type: partial.agent_type ?? "ClaudeCode",
+    title: partial.title ?? partial.id,
+    cwd: partial.cwd ?? "/home/u/proj",
+    display_cwd: partial.display_cwd ?? "proj",
+    display_name: partial.display_name ?? partial.id,
+    detection_source: partial.detection_source ?? "IpcSocket",
+    git_branch: partial.git_branch ?? "main",
+    git_dirty: partial.git_dirty ?? false,
+    is_worktree: partial.is_worktree ?? false,
+    git_common_dir: partial.git_common_dir ?? "/home/u/proj/.git",
+    worktree_name: partial.worktree_name ?? null,
+    worktree_base_branch: partial.worktree_base_branch ?? null,
+    effort_level: partial.effort_level ?? null,
+    active_subagents: partial.active_subagents ?? 0,
+    compaction_count: partial.compaction_count ?? 0,
+    pty_session_id: partial.pty_session_id ?? null,
+    send_capability: partial.send_capability ?? "Ipc",
+    is_virtual: partial.is_virtual ?? false,
+    team_info: partial.team_info ?? null,
+    attention: partial.attention ?? null,
+    is_orchestrator: partial.is_orchestrator,
+  };
+}
+
+beforeEach(() => {
+  useAgentsMock.mockReset();
+  useWorktreesMock.mockReset();
+  useAgentsMock.mockReturnValue({
+    agents: [],
+    attentionCount: 0,
+    loading: false,
+    refresh: vi.fn(),
+  });
+  useWorktreesMock.mockReturnValue({
+    worktrees: [] as WorktreeSnapshot[],
+    loading: false,
+    refresh: vi.fn(),
+  });
+});
+
+describe("useHandover — empty state", () => {
+  it("returns empty WhereYouLeftOff when no project is scoped", () => {
+    const { result } = renderHook(() => useHandover(null));
+    expect(result.current.whereYouLeftOff.activeProjectPath).toBeNull();
+    expect(result.current.whereYouLeftOff.activeProjectName).toBeNull();
+    expect(result.current.whereYouLeftOff.worktrees).toEqual([]);
+    expect(result.current.whereYouLeftOff.attentionAgents).toEqual([]);
+  });
+
+  it("returns empty crossUnit list when no agents are running", () => {
+    const { result } = renderHook(() => useHandover(null));
+    expect(result.current.crossUnit.units).toEqual([]);
+  });
+
+  it("always exposes the two Phase-C placeholders", () => {
+    const { result } = renderHook(() => useHandover(null));
+    expect(result.current.settledDecisions.placeholder).toBe(true);
+    expect(result.current.settledDecisions.reason).toMatch(/Phase C/);
+    expect(result.current.workingWithHuman.placeholder).toBe(true);
+    expect(result.current.workingWithHuman.reason).toMatch(/Phase C/);
+  });
+});
+
+describe("useHandover — WhereYouLeftOff scoping", () => {
+  it("returns the active project's name and its worktrees when scoped", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [
+        agent({ id: "a1", cwd: "/home/u/proj-a", git_common_dir: "/home/u/proj-a/.git" }),
+        agent({ id: "a2", cwd: "/home/u/proj-b", git_common_dir: "/home/u/proj-b/.git" }),
+      ],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useHandover("/home/u/proj-a"));
+    expect(result.current.whereYouLeftOff.activeProjectName).toBe("proj-a");
+    expect(result.current.whereYouLeftOff.worktrees).toHaveLength(1);
+    expect(result.current.whereYouLeftOff.worktrees[0]?.isMain).toBe(true);
+  });
+
+  it("only surfaces attention agents on the scoped project", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [
+        agent({
+          id: "a-need",
+          cwd: "/home/u/proj-a",
+          git_common_dir: "/home/u/proj-a/.git",
+          attention: "halted",
+          display_name: "needs-attention",
+        }),
+        agent({
+          id: "b-need",
+          cwd: "/home/u/proj-b",
+          git_common_dir: "/home/u/proj-b/.git",
+          attention: "halted",
+          display_name: "other-needs",
+        }),
+        agent({
+          id: "a-quiet",
+          cwd: "/home/u/proj-a",
+          git_common_dir: "/home/u/proj-a/.git",
+        }),
+      ],
+      attentionCount: 2,
+      loading: false,
+      refresh: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useHandover("/home/u/proj-a"));
+    const names = result.current.whereYouLeftOff.attentionAgents.map((a) => a.displayName);
+    expect(names).toContain("needs-attention");
+    expect(names).not.toContain("other-needs");
+  });
+
+  it("falls back to all attention agents when no project is scoped", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [
+        agent({
+          id: "a-need",
+          cwd: "/home/u/proj-a",
+          git_common_dir: "/home/u/proj-a/.git",
+          attention: "halted",
+          display_name: "alpha",
+        }),
+        agent({
+          id: "b-need",
+          cwd: "/home/u/proj-b",
+          git_common_dir: "/home/u/proj-b/.git",
+          attention: "halted",
+          display_name: "beta",
+        }),
+      ],
+      attentionCount: 2,
+      loading: false,
+      refresh: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useHandover(null));
+    const names = result.current.whereYouLeftOff.attentionAgents.map((a) => a.displayName);
+    expect(names).toEqual(expect.arrayContaining(["alpha", "beta"]));
+  });
+});
+
+describe("useHandover — crossUnit derivation", () => {
+  it("flags a unit as needs-you when any agent has non-null attention", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [
+        agent({
+          id: "a1",
+          cwd: "/home/u/proj-a",
+          git_common_dir: "/home/u/proj-a/.git",
+          attention: "halted",
+        }),
+      ],
+      attentionCount: 1,
+      loading: false,
+      refresh: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useHandover(null));
+    expect(result.current.crossUnit.units).toHaveLength(1);
+    expect(result.current.crossUnit.units[0]?.state).toBe("needs-you");
+    expect(result.current.crossUnit.units[0]?.attentionCount).toBe(1);
+  });
+
+  it("flags a unit as in-progress when agents present but none attention", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [agent({ id: "a1", cwd: "/home/u/proj-a", git_common_dir: "/home/u/proj-a/.git" })],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useHandover(null));
+    expect(result.current.crossUnit.units[0]?.state).toBe("in-progress");
+  });
+
+  it("dedupes units by git_common_dir so siblings sharing a repo collapse", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [
+        agent({ id: "a1", cwd: "/home/u/proj-a", git_common_dir: "/home/u/proj-a/.git" }),
+        agent({ id: "a2", cwd: "/home/u/proj-a", git_common_dir: "/home/u/proj-a/.git" }),
+      ],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useHandover(null));
+    expect(result.current.crossUnit.units).toHaveLength(1);
+    expect(result.current.crossUnit.units[0]?.agentCount).toBe(2);
+  });
+});

--- a/clients/react/src/hooks/__tests__/useHandover.test.ts
+++ b/clients/react/src/hooks/__tests__/useHandover.test.ts
@@ -80,12 +80,13 @@ describe("useHandover — empty state", () => {
     expect(result.current.crossUnit.units).toEqual([]);
   });
 
-  it("always exposes the two Phase-C placeholders", () => {
+  it("always exposes the two not-yet-wired placeholders as plain signals", () => {
     const { result } = renderHook(() => useHandover(null));
+    // The placeholder shape is intentionally just `{ placeholder: true }`
+    // — the section components own the user-facing copy so the hook
+    // stays free of UI strings.
     expect(result.current.settledDecisions.placeholder).toBe(true);
-    expect(result.current.settledDecisions.reason).toMatch(/Phase C/);
     expect(result.current.workingWithHuman.placeholder).toBe(true);
-    expect(result.current.workingWithHuman.reason).toMatch(/Phase C/);
   });
 });
 

--- a/clients/react/src/hooks/useHandover.ts
+++ b/clients/react/src/hooks/useHandover.ts
@@ -84,14 +84,17 @@ export interface CrossUnitStatus {
   units: UnitStatus[];
 }
 
+// Placeholder shapes are intentionally tiny — the section components
+// hard-code the user-facing copy so the hook stays free of UI strings.
+// (Earlier drafts inlined a `reason` field with "Phase C: <endpoint>
+// not yet wired" technical text, which leaked through to the user UI
+// and read as broken. Lesson: keep technical reasons out of UI hooks.)
 export interface SettledDecisionsPlaceholder {
   placeholder: true;
-  reason: string;
 }
 
 export interface WorkingWithHumanPlaceholder {
   placeholder: true;
-  reason: string;
 }
 
 export interface HandoverDigest {
@@ -174,22 +177,12 @@ export function useHandover(currentProjectPath: string | null): HandoverDigest {
     [projectGroups],
   );
 
-  // Plain object — does not need `useMemo`; the section component
-  // does not depend on identity stability.
-  const settledDecisions: SettledDecisionsPlaceholder = {
-    placeholder: true,
-    reason:
-      "Phase C: `GET /api/units/{unit}/decisions` is not yet wired. " +
-      "Decision records live in this repo under `doc/decisions/`; " +
-      "for now, browse them directly from the file tree.",
-  };
-
-  const workingWithHuman: WorkingWithHumanPlaceholder = {
-    placeholder: true,
-    reason:
-      "Phase C: working-norms delta from the Producer's hand-over composer is not yet wired. " +
-      "Baseline norms live in this repo's `CLAUDE.md`.",
-  };
+  // Plain signal objects — the section components own the user-facing
+  // copy. Section identity is stable across renders since the literal
+  // is structurally identical, but we still allocate fresh objects to
+  // keep the type literal `true` exact.
+  const settledDecisions: SettledDecisionsPlaceholder = { placeholder: true };
+  const workingWithHuman: WorkingWithHumanPlaceholder = { placeholder: true };
 
   return { whereYouLeftOff, crossUnit, settledDecisions, workingWithHuman };
 }

--- a/clients/react/src/hooks/useHandover.ts
+++ b/clients/react/src/hooks/useHandover.ts
@@ -1,0 +1,195 @@
+// Hand-over digest aggregator for the Producer console.
+//
+// Background — `doc/decisions/2026-05-14-react-producer-console-rebuild.md`
+// (cross-refs `tmai-core@doc/decisions/2026-05-13-producer-feedback-loop-
+// and-decision-tiers.md`): the Producer's session-start hand-over is
+// composed from four sections — ▶ Where-you-left-off, ⬢ Cross-unit
+// status, ⬡ Settled decisions, ◐ Working-with-this-human.
+//
+// Phase A scope (this file): wire what we already have on the client.
+//
+// - `whereYouLeftOff` — derived from `useAgents` + `useWorktrees`
+//   scoped to `currentProjectPath`. Reuses `groupByProject` so the
+//   sidebar's worktree shape matches the console's worktree shape
+//   exactly (single source of truth for project grouping).
+// - `crossUnit` — every project derived from active agents, with a
+//   state pill (needs-you / in-progress / quiet). The "unit" here is
+//   the *derived* project — not yet read from a `[[unit]]`-config
+//   wire endpoint. Phase C will reconcile against
+//   `GET /api/units` and surface units that have no live agents.
+//
+// Placeholders for Phase C wire:
+//
+// - `settledDecisions` — decision records live in this repo's
+//   `doc/decisions/`, but there is no wire endpoint yet to expose
+//   their frontmatter (status / tier / temperature) to the WebUI.
+//   The section renders an explicit "not yet wired" notice so the
+//   operator knows the placeholder is intentional, not a bug.
+// - `workingWithHuman` — same shape, same reason. Composed by the
+//   Producer's `compose()` baseline builder; needs a read endpoint.
+//
+// Both placeholders carry the exact wire-gap reason in the `reason`
+// field — the section components render that text directly so the
+// surface is self-documenting.
+
+import { useMemo } from "react";
+import { useAgents } from "@/hooks/useAgents";
+import { useWorktrees } from "@/hooks/useWorktrees";
+import {
+  type AgentAttention,
+  type AgentSnapshot,
+  groupByProject,
+  isAiAgent,
+  type ProjectGroup,
+} from "@/lib/api";
+
+export interface WorktreeBrief {
+  name: string;
+  branch: string | null;
+  path: string;
+  isMain: boolean;
+  dirty: boolean;
+  agentCount: number;
+}
+
+export interface AttentionAgentBrief {
+  target: string;
+  displayName: string;
+  attention: AgentAttention;
+  cwd: string;
+  isOrchestrator: boolean;
+}
+
+export interface WhereYouLeftOff {
+  activeProjectPath: string | null;
+  activeProjectName: string | null;
+  worktrees: WorktreeBrief[];
+  /** Agents waiting on the user, scoped to the active project when one is
+   *  selected; falls back to all AI agents otherwise so the operator still
+   *  sees what's blocked even with no project selected. */
+  attentionAgents: AttentionAgentBrief[];
+}
+
+export type UnitState = "needs-you" | "in-progress" | "quiet";
+
+export interface UnitStatus {
+  path: string;
+  name: string;
+  state: UnitState;
+  agentCount: number;
+  attentionCount: number;
+}
+
+export interface CrossUnitStatus {
+  units: UnitStatus[];
+}
+
+export interface SettledDecisionsPlaceholder {
+  placeholder: true;
+  reason: string;
+}
+
+export interface WorkingWithHumanPlaceholder {
+  placeholder: true;
+  reason: string;
+}
+
+export interface HandoverDigest {
+  whereYouLeftOff: WhereYouLeftOff;
+  crossUnit: CrossUnitStatus;
+  settledDecisions: SettledDecisionsPlaceholder;
+  workingWithHuman: WorkingWithHumanPlaceholder;
+}
+
+// Narrowing predicate — keeps the AttentionAgentBrief map free of the
+// `attention!` non-null-assertion (would survive `noUncheckedIndexedAccess`
+// but reads as a code smell against the project's `any`-banned rule).
+function isAttentionAgent(a: AgentSnapshot): a is AgentSnapshot & { attention: AgentAttention } {
+  return a.attention != null;
+}
+
+function deriveUnitState(group: ProjectGroup): UnitState {
+  if (group.attentionAgents > 0) return "needs-you";
+  if (group.totalAgents > 0) return "in-progress";
+  return "quiet";
+}
+
+/**
+ * Aggregate client-side data into the hand-over digest's four sections.
+ *
+ * Phase A: `settledDecisions` and `workingWithHuman` are placeholders;
+ * see file header for the wire endpoints Phase C will introduce.
+ */
+export function useHandover(currentProjectPath: string | null): HandoverDigest {
+  const { agents } = useAgents();
+  const { worktrees } = useWorktrees();
+
+  const aiAgents = useMemo(() => agents.filter((a) => isAiAgent(a.agent_type)), [agents]);
+
+  const projectGroups = useMemo<ProjectGroup[]>(
+    () => groupByProject(aiAgents, worktrees),
+    [aiAgents, worktrees],
+  );
+
+  const whereYouLeftOff = useMemo<WhereYouLeftOff>(() => {
+    const active = currentProjectPath
+      ? (projectGroups.find((g) => g.path === currentProjectPath) ?? null)
+      : null;
+
+    const activeAgents = active ? active.worktrees.flatMap((wt) => wt.agents) : aiAgents;
+
+    return {
+      activeProjectPath: active?.path ?? null,
+      activeProjectName: active?.name ?? null,
+      worktrees: active
+        ? active.worktrees.map((wt) => ({
+            name: wt.name,
+            branch: wt.branch,
+            path: wt.path,
+            isMain: !wt.isWorktree,
+            dirty: wt.dirty,
+            agentCount: wt.agents.length,
+          }))
+        : [],
+      attentionAgents: activeAgents.filter(isAttentionAgent).map((a) => ({
+        target: a.target,
+        displayName: a.display_name,
+        attention: a.attention,
+        cwd: a.cwd,
+        isOrchestrator: a.is_orchestrator === true,
+      })),
+    };
+  }, [currentProjectPath, projectGroups, aiAgents]);
+
+  const crossUnit = useMemo<CrossUnitStatus>(
+    () => ({
+      units: projectGroups.map((g) => ({
+        path: g.path,
+        name: g.name,
+        state: deriveUnitState(g),
+        agentCount: g.totalAgents,
+        attentionCount: g.attentionAgents,
+      })),
+    }),
+    [projectGroups],
+  );
+
+  // Plain object — does not need `useMemo`; the section component
+  // does not depend on identity stability.
+  const settledDecisions: SettledDecisionsPlaceholder = {
+    placeholder: true,
+    reason:
+      "Phase C: `GET /api/units/{unit}/decisions` is not yet wired. " +
+      "Decision records live in this repo under `doc/decisions/`; " +
+      "for now, browse them directly from the file tree.",
+  };
+
+  const workingWithHuman: WorkingWithHumanPlaceholder = {
+    placeholder: true,
+    reason:
+      "Phase C: working-norms delta from the Producer's hand-over composer is not yet wired. " +
+      "Baseline norms live in this repo's `CLAUDE.md`.",
+  };
+
+  return { whereYouLeftOff, crossUnit, settledDecisions, workingWithHuman };
+}

--- a/clients/react/src/hooks/useResponsiveLayout.ts
+++ b/clients/react/src/hooks/useResponsiveLayout.ts
@@ -46,7 +46,14 @@ export function useResponsiveLayout(): UseResponsiveLayoutResult {
     if (typeof window !== "undefined" && !window.matchMedia(NARROW_BREAKPOINT).matches) {
       return true; // Auto-collapse on narrow screens
     }
-    return readStoredBool(STORAGE_KEY_SIDEBAR, false);
+    // Phase B of the Producer-console rebuild
+    // (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`)
+    // flips the default to *collapsed* so the legacy AgentList stops
+    // being on the main flow. Existing operators are unaffected — their
+    // localStorage value (set by `toggleSidebar` on first use) keeps
+    // overriding the default. New / clean-state users land on the
+    // Producer console directly.
+    return readStoredBool(STORAGE_KEY_SIDEBAR, true);
   });
 
   const [actionPanelCollapsed, setActionPanelCollapsed] = useState(() => {

--- a/doc/decisions/2026-05-14-react-producer-console-rebuild.md
+++ b/doc/decisions/2026-05-14-react-producer-console-rebuild.md
@@ -1,0 +1,125 @@
+# React WebUI を Producer console に再構築する（段階差し替え）
+
+**Date:** 2026-05-14
+**Status:** Proposed
+**Tier:** 2 (methodology — tier 付与は Producer↔人間 合意で確定)
+**Governs:** `clients/react/`
+**Cross-repo refs (tmai-core, private):**
+- `doc/decisions/2026-05-11-orchestration-locus-inversion.md`
+- `doc/decisions/2026-05-11-producer-only-operator-interface.md`
+- `doc/decisions/2026-05-11-producer-conversation-workbench.md`
+- `doc/decisions/2026-05-12-producer-layer-topology.md`
+- `doc/decisions/2026-05-13-tmai-is-a-producer-exoskeleton.md`
+- `doc/decisions/2026-05-13-agent-view-does-not-replace-multiplexer-substrate.md`
+- `doc/decisions/2026-05-13-producer-feedback-loop-and-decision-tiers.md`
+
+## Context
+
+`clients/react/` の WebUI は 2026-05 反転前の「人間が N agent を直接捌く orchestrator cockpit」前提で組まれている:
+
+- `AgentList`（左サイドバー）が primary navigation。人間が agent を選んで `PreviewPanel` (xterm + 直接 prompt 入力) で会話する
+- `NewAgentLauncher` で人間が DirBrowser + runtime picker から manual spawn
+- `SettingsPanel` の `OrchestrationSection` + `DispatchBundleEditor` で人間が orchestrator config を編集
+- `WorktreePanel` / `IssueActionView` に「Dispatch Issue」「Create Worktree」ボタン
+- `AgentCard` の `attention: started/halted/completed` pill = 人間が状態を読んで動く前提
+
+しかし tmai-core で landed した反転（cross-refs 参照）はこれを supersede している:
+
+> tmai is a Producer's exoskeleton + a human console. Orchestration logic lives in
+> the Producer's reasoning, not in tmai code. Workers are invisible to the
+> operator; their output routes through the Producer. The substrate for the
+> Producer conversation is the existing terminal multiplexer (tmux/wezTerm/native),
+> not a WebUI-internal Agent View.
+
+PR #671 で「Producer console」の入口は既に立ち上がっている: `CalibrationChip`（StatusBar の ⚡N）/ `TripwireBanner`（ホイスト、ゼロ寛容アラート）/ `CalibrationPanel`（read-only な Producer hit-rate）/ `useCalibration`（90s polling `/api/units/{unit}/calibration`）。これらは新モデルに整合していて、起点として活きる。
+
+## Decision
+
+`clients/react/` を **Producer console** として再構築する。方針は以下の 4 軸で確定（2026-05-14 セッション）:
+
+| 軸 | 決定 |
+|---|---|
+| Scope | **段階差し替え** — dogfood を切らずに PR #671 surface を主役に昇格させ、orchestrator-era UI を順次降格 |
+| Main view | **Hand-over digest 中心** — `▶ Where you left off / ⬢ Cross-unit status / ⬡ Settled decisions / ◐ Working with this human` の 4 セクション構成（tmai-core `2026-05-13-producer-feedback-loop-and-decision-tiers` の hand-over 仕様に準拠） |
+| Legacy controls | **Advanced 奥に退避して保持** — 撤去はしない（`feedback_pty_emergency_terminal_access` の精神で human override 経路は残す）。ただしメイン動線からは外す |
+| Producer chat | **terminal substrate のまま** — WebUI は「Open Producer terminal」launch affordance のみ持つ。Producer 会話用の panel を WebUI 内に持つことは substrate swap になるので却下（cross-ref `2026-05-13-agent-view-does-not-replace-multiplexer-substrate`） |
+
+### Target composition (text mock)
+
+```
+┌─ ⚡ Tier-1 Tripwire (N)  ──────────────── Details ▸ ┐
+│   (only shown when tier1_violations is non-empty)   │
+└─────────────────────────────────────────────────────┘
+
+▶ Where you left off
+  - active worktree (branch, dispatched briefs)
+  - open briefs awaiting human
+
+⬢ Cross-unit status
+  - 1 line per unit (🔴 needs-you / 🟡 in-progress / ⚪ quiet)
+
+⬡ Settled decisions     [📌 foundational] [🔴 in-play] [🟡 warm] [⚪ cold]
+  - top N by temperature; click → DR view
+
+◐ Working with this human
+  - deltas from baseline CLAUDE.md / norm reminders
+
+[ Open Producer terminal ▸ ]  [ Calibration ▸ ]  [ Operator override ▾ ]
+```
+
+### Phase plan
+
+**Phase A — WebUI 内完結（既存 wire のみ）**
+- `components/producer-console/ProducerConsole.tsx` + 4 セクション sub-components を新設
+- App.tsx の default を `ProducerConsole` に切替（既存 routing は壊さない）
+- セクション wire-up:
+  - `⚡ Tripwire` band → 既存 `useCalibration` の `tier1_violations`
+  - `▶ Where you left off` → `useAgents` から active worktree / queued briefs を導出
+  - `⬢ Cross-unit status` → 既存 `GET /api/projects` + `[[unit]]` 設定から導出
+  - `⬡ Settled decisions` → **Phase A は client-side placeholder**（wire が後追い）
+  - `◐ Working with this human` → 同上 placeholder
+- `[Open Producer terminal ▸]` ボタン → v1 は clipboard copy fallback（`tmai producer <unit>` を clipboard へ）。専用 endpoint は Phase C で検討
+- AgentList は subsidiary に降格（折りたたみで残す、default 閉じる）
+
+**Phase B — Legacy demote**
+- `NewAgentLauncher` / `PreviewPanel` の直接 prompt 入力 / `OrchestrationSection` / `DispatchBundleEditor` / `WorktreePanel`-`IssueActionView` の dispatch ボタンを「Operator override」expandable に集約
+- `SettingsPanel` のタブ並び替え: Producer 関連（calibration / unit / general）が primary、orchestration bundles は Advanced タブへ
+- `AgentCard` 状態 pill は Operator override 内のみ表示。Producer console 本体には raw agent state を出さない
+
+**Phase C — Wire 拡張（tmai-core 連携、cross-repo work）**
+- `GET /api/units/{unit}/hand-over` — composed `▶⬢⬡◐` payload を返す（Producer は session-start で内部 compose しているので endpoint 化が gap）
+- `GET /api/units` — units 列挙 + cross-unit summary
+- `GET /api/units/{unit}/decisions` — decision-record frontmatter + temperature
+- SSE: `CoreEvent::HandOverUpdated` / `CalibrationUpdated`（polling → push）
+- これらは tmai-core 側の作業を伴う。Phase B 完了後に DR を private 側で別途起こす
+
+**Phase D — Polish**
+- Cross-unit ナビゲーション ergonomics
+- 「Open Producer terminal」の実 launch 経路（clipboard fallback から専用 endpoint or MCP に移行検討）
+- Visual: tripwire severity ramp / decision temperature glyph / `▶⬢⬡◐` typography 整え
+
+## 非範囲（NOT 構築するもの）
+
+- **WebUI 内 Producer chat panel**: substrate swap になるので却下（cross-ref `2026-05-13-agent-view-does-not-replace-multiplexer-substrate`）
+- **Worker queue / per-worker dashboard / parallel task timeline**: 「workers are invisible to operator」原則違反
+- **Legacy orchestrator-era UI の物理削除**: Advanced 奥に退避するのみ、削除はしない（emergency override 経路として温存）
+- **`useTerminal.ts` / `globals.css` への変更**: 別作業者の active workpiece (xterm v6 scrollbar 統一)、独立して進行中
+
+## 帰結 / Open questions
+
+- **Tier**: Tier 2 (methodology) で提案。Producer↔人間で確定（memory 慣行）
+- **`is_orchestrator` agent flag**: Phase B で WebUI 側は読まなくなる方向だが、wire 上の field は tmai-core 側で残る可能性あり。Phase C で要 cross-repo 議論
+- **「Open Producer terminal」launch 方式**: Phase A は clipboard fallback、Phase D で再評価
+- **Multi-unit (cross-unit) navigation の primary affordance**: top bar の unit picker vs sidebar の unit list、Phase A 実装中に decide
+
+## Implementation order (Phase A)
+
+Branch: `feat/react-producer-console`（既に切り出し済 2026-05-14）
+
+1. `components/producer-console/` 新設、`ProducerConsole.tsx` + section sub-components
+2. `hooks/useHandover.ts` 新設（既存 wire 集約 + placeholder セクション）
+3. `App.tsx` の routing 変更（default = ProducerConsole、AgentList を subsidiary に）
+4. Sidebar 構造調整（AgentList を折りたたみに、Operator override panel の足場を仮置き）
+5. Test: ProducerConsole composition / 各 section の rendering / placeholder 切替
+6. Lint / typecheck / build (`pnpm` 系) を pass
+7. PR を `fix/...` ではなく `feat/...` で出す（CLAUDE.md の慣行）。本 DR を PR description で参照

--- a/doc/decisions/2026-05-14-react-producer-console-rebuild.md
+++ b/doc/decisions/2026-05-14-react-producer-console-rebuild.md
@@ -1,17 +1,28 @@
+---
+status: accepted
+category: scoped
+tier: 2
+governs:
+  - clients/react/
+cross-repo-refs:
+  - "tmai-core:doc/decisions/2026-05-11-orchestration-locus-inversion.md"
+  - "tmai-core:doc/decisions/2026-05-11-producer-only-operator-interface.md"
+  - "tmai-core:doc/decisions/2026-05-11-producer-conversation-workbench.md"
+  - "tmai-core:doc/decisions/2026-05-12-producer-layer-topology.md"
+  - "tmai-core:doc/decisions/2026-05-13-tmai-is-a-producer-exoskeleton.md"
+  - "tmai-core:doc/decisions/2026-05-13-agent-view-does-not-replace-multiplexer-substrate.md"
+  - "tmai-core:doc/decisions/2026-05-13-producer-feedback-loop-and-decision-tiers.md"
+last-verified: 2026-05-14
+contract-surface: false
+related:
+  - "2026-04-21-monorepo-reconsolidation"
+  - "2026-04-24-snapshot-contract"
+---
+
 # React WebUI を Producer console に再構築する（段階差し替え）
 
 **Date:** 2026-05-14
-**Status:** Proposed
 **Tier:** 2 (methodology — tier 付与は Producer↔人間 合意で確定)
-**Governs:** `clients/react/`
-**Cross-repo refs (tmai-core, private):**
-- `doc/decisions/2026-05-11-orchestration-locus-inversion.md`
-- `doc/decisions/2026-05-11-producer-only-operator-interface.md`
-- `doc/decisions/2026-05-11-producer-conversation-workbench.md`
-- `doc/decisions/2026-05-12-producer-layer-topology.md`
-- `doc/decisions/2026-05-13-tmai-is-a-producer-exoskeleton.md`
-- `doc/decisions/2026-05-13-agent-view-does-not-replace-multiplexer-substrate.md`
-- `doc/decisions/2026-05-13-producer-feedback-loop-and-decision-tiers.md`
 
 ## Context
 
@@ -78,7 +89,7 @@ PR #671 で「Producer console」の入口は既に立ち上がっている: `Ca
   - `⬢ Cross-unit status` → 既存 `GET /api/projects` + `[[unit]]` 設定から導出
   - `⬡ Settled decisions` → **Phase A は client-side placeholder**（wire が後追い）
   - `◐ Working with this human` → 同上 placeholder
-- `[Open Producer terminal ▸]` ボタン → v1 は clipboard copy fallback（`tmai producer <unit>` を clipboard へ）。専用 endpoint は Phase C で検討
+- `[Open Producer terminal ▸]` ボタン → v1 は clipboard copy fallback。専用 endpoint は Phase D で検討
 - AgentList は subsidiary に降格（折りたたみで残す、default 閉じる）
 
 **Phase B — Legacy demote**
@@ -97,6 +108,7 @@ PR #671 で「Producer console」の入口は既に立ち上がっている: `Ca
 - Cross-unit ナビゲーション ergonomics
 - 「Open Producer terminal」の実 launch 経路（clipboard fallback から専用 endpoint or MCP に移行検討）
 - Visual: tripwire severity ramp / decision temperature glyph / `▶⬢⬡◐` typography 整え
+- Idempotent Producer launch（既存 Producer に attach する tmai-core-side ensure endpoint）
 
 ## 非範囲（NOT 構築するもの）
 
@@ -107,14 +119,14 @@ PR #671 で「Producer console」の入口は既に立ち上がっている: `Ca
 
 ## 帰結 / Open questions
 
-- **Tier**: Tier 2 (methodology) で提案。Producer↔人間で確定（memory 慣行）
+- **Tier**: Tier 2 (methodology) で確定（2026-05-14 セッション、ユーザー承認済）
 - **`is_orchestrator` agent flag**: Phase B で WebUI 側は読まなくなる方向だが、wire 上の field は tmai-core 側で残る可能性あり。Phase C で要 cross-repo 議論
-- **「Open Producer terminal」launch 方式**: Phase A は clipboard fallback、Phase D で再評価
-- **Multi-unit (cross-unit) navigation の primary affordance**: top bar の unit picker vs sidebar の unit list、Phase A 実装中に decide
+- **「Open Producer terminal」launch 方式**: Phase A は clipboard fallback → Phase B polish v2 で `api.spawnPty` 経由の in-tmai launch に移行 → Phase B polish v4 で tmai-core spawn allow-list を回避するため `bash -c 'exec tmai producer "$0"' unit` で wrap。長期的には tmai-core 側で Producer 専用 endpoint or allow-list 拡張（Phase D）
+- **Multi-unit (cross-unit) navigation の primary affordance**: top bar の unit picker vs sidebar の unit list、Phase D で decide
 
 ## Implementation order (Phase A)
 
-Branch: `feat/react-producer-console`（既に切り出し済 2026-05-14）
+Branch: `feat/react-producer-console`（2026-05-14 切り出し、PR #672）
 
 1. `components/producer-console/` 新設、`ProducerConsole.tsx` + section sub-components
 2. `hooks/useHandover.ts` 新設（既存 wire 集約 + placeholder セクション）
@@ -123,3 +135,9 @@ Branch: `feat/react-producer-console`（既に切り出し済 2026-05-14）
 5. Test: ProducerConsole composition / 各 section の rendering / placeholder 切替
 6. Lint / typecheck / build (`pnpm` 系) を pass
 7. PR を `fix/...` ではなく `feat/...` で出す（CLAUDE.md の慣行）。本 DR を PR description で参照
+
+## Update history
+
+- 2026-05-14 (initial): Proposed, Markdown-bold frontmatter
+- 2026-05-14 (PR #672 progress): Phase A + Phase B legacy demote + Phase B Settings reorg + Phase B onboarding polish + Phase B polish v2 (in-tmai spawn) + Phase B polish v3 (DirBrowser flow) + Phase B polish v4 (bash wrap)
+- 2026-05-14 (this revision): frontmatter migrated from Markdown-bold to YAML — `tmai-core/workbench/decision.rs::parse` requires a real YAML frontmatter block delimited by `---` lines (the post-#326 convention), and the hand-over composer was erroring out on the old shape. Status flipped to `accepted` since Phase A+B+polish all landed.


### PR DESCRIPTION
## Summary

Rebuild of the React WebUI around the **Producer exoskeleton + human console** model — graduating PR #671's calibration / tripwire surface from a side panel to the main view, routing the legacy "human-orchestrator-era" controls off the main flow, grouping the orchestrator-era settings behind an Advanced expandable, rewriting main-view copy after first-dogfood feedback, and unblocking the clean-start chicken-and-egg so the Producer can be launched even with zero live agents.

DR: `doc/decisions/2026-05-14-react-producer-console-rebuild.md` (public-side, tier:2; cross-refs the tmai-core inversion DRs).

## Phase A — Producer console as the default main view

- **`useHandover` hook** aggregates existing wire (`useAgents` + `useWorktrees` + `groupByProject`) into the hand-over digest's four sections (▶ Where you left off / ⬢ Cross-unit status / ⬡ Settled decisions / ◐ Working with this human). `Settled decisions` and `Working with this human` are explicit placeholders until the read endpoints land tmai-core side.
- **`<ProducerConsole>`** composes the four sections + a footer action row.
- **`App.tsx`** switches the empty (`selection === null`) main view from a generic "Select an agent" card to the new console. The tier-1 `<TripwireBanner>` hoist (PR #671) stays as-is — above every main-pane swap so the alarm is never hidden.

## Phase B — demote legacy UI behind Operator override + sidebar default collapsed

- **`ProducerConsoleActions` "Operator override ▾"** is now expandable. The panel hosts `NewAgentLauncher` (existing DirBrowser + runtime picker), a `Show sidebar ▸` affordance (only when collapsed), and `Open Settings ▸` (deep-links into the new Advanced section).
- **`useResponsiveLayout`**: sidebar default flips from expanded to **collapsed**. Existing operators' `localStorage` values keep overriding the default — their experience is unchanged. New / clean-state users land on the Producer console directly with no `AgentList` visible until they explicitly open the override panel or expand the sidebar.

## Phase B reorg — group orchestrator-era controls behind Advanced in Settings

- **`SettingsPanel`** layout: **Producer** group (primary, immediately visible) = `GeneralSection` / `NotificationSection` / `UsageSection`. **Advanced** expandable (`<details>`, collapsed by default) = `SpawnSection` / `OrchestrationSection` / `OrchestrationDispatchSection` / `WorkflowSection` / `WorktreeSection`. **WebUI** group (unchanged) = `DisplayLayoutSection`.
- New `defaultOpenAdvanced?: boolean` prop wired so the ProducerConsole footer's "Open Settings" deep-link lands with Advanced already expanded. Regular Settings entry leaves Advanced collapsed.

Per the DR's non-scope, **no orchestrator-era UI is physically deleted**; everything stays accessible (override panel + Advanced) as an emergency override path (`feedback_pty_emergency_terminal_access`).

## Phase B polish — onboarding copy after first-dogfood feedback

Dogfooder reported "起動しました。少し使い方が不明瞭です" — the new vocabulary (Producer / hand-over digest / exoskeleton / unit / tripwire) didn't connect for first-time users, and phase-tracking jargon (`Phase C: GET /api/units/{unit}/decisions is not yet wired`) was leaking into placeholder copy where it read as broken.

- **ProducerConsole header** rewritten: drops `"Producer console"` / `"Hand-over digest"` for `"Welcome to tmai"` + a Quick-start 3-step. A secondary line points at the Operator override / sidebar as the legacy escape hatch.
- **Placeholder copy** in `SettledDecisionsSection` / `WorkingWithThisHumanSection` now speaks to the operator (*"browse `doc/decisions/` directly for now"*, *"see `CLAUDE.md` for the baseline norms"*) instead of leaking phase tracking jargon. `useHandover`'s placeholder shape simplified to `{ placeholder: true }`; section components own the user-facing copy.
- **AgentList sidebar** gets an explicit *"Operator view (legacy)"* label.

## Phase B polish v2 — launch Producer in-tmai (no clipboard)

Dogfooder follow-up: "ターミナルに直接貼り付けてください、はダメです。tmai内でproducerを立ち上げてください" — the clipboard fallback wasn't actually the WebUI doing the work, it was punting to the operator's terminal.

- `tmai producer <unit>` is implemented as `exec`-style in tmai-core (`producer_cli.rs::launch_producer`): the tmai subprocess composes the hand-over, then `exec`s into a Claude session seeded with that hand-over as the initial prompt. From the PTY-server's perspective this is a normal spawn.
- **`App.tsx::openProducerTerminal`** switched from `navigator.clipboard.writeText(...)` to `api.spawnPty({ command: "tmai", args: ["producer", unitName], cwd })`. On success: select the new session, close any overlay, toast `Producer launched for <unit>`. The main pane swaps to the new agent's PreviewPanel automatically.

## Phase B polish v3 — DirBrowser-backed launch when no project is selected

Dogfooder follow-up: "Open Producer terminal が押せません" — the button was disabled when `unitName === null`, but `unitName` derives from the *active agents*' projects, so on a clean start (no agents yet) there's no project, no unit, no clickable button. **Chicken-and-egg blocker on the first-launch path.**

- **`App.tsx::launchProducerAt(path)`** new callback: takes a repo root explicitly, derives the unit name from its basename, spawns `tmai producer <unit>` with `cwd=path`, sets `currentProject = path` (so subsequent clicks skip the picker), selects the new session, toasts.
- The old `openProducerTerminal` is now a thin wrapper that delegates to `launchProducerAt(currentProject)` when one is set.
- **`ProducerConsoleActions`**: Open Producer terminal is no longer disabled. When `unitName === null`, click opens an inline `DirBrowser` (lazily loaded with `[general] default_project_root` for the start path). Picking a path forwards to `onLaunchProducerAt`. Calibration stays disabled while `unitName === null` because its endpoint needs an explicit unit.

## What's NOT in this PR

- **Phase C** — wire endpoints for `Settled decisions` (`GET /api/units/{unit}/decisions`) and `Working with this human` (read endpoint for the Producer's hand-over composer). Plus `GET /api/units` to surface dormant configured units and SSE `CoreEvent::HandOverUpdated` / `CalibrationUpdated` (polling → push). Cross-repo with tmai-core.
- **Phase D (polish)** — cross-unit navigation ergonomics, idempotent Producer launch (current naive `spawnPty` will spawn a fresh Producer each click; a tmai-core-side "ensure" endpoint would attach an existing session instead), visual ramps for tripwire severity / decision temperature glyphs / `▶⬢⬡◐` typography.

## Verified

- `pnpm lint` — clean
- `pnpm test` — **377 tests pass + 2 skipped** (Phase A scaffolding + Phase B legacy demote / Settings reorg / onboarding polish / v2 in-tmai launch / v3 DirBrowser flow)
- `pnpm build` — clean (existing tauri chunk-size warning is unrelated)

## Notes

- This branch holds six commits; squash-merge gives the same surface as a single rebuild commit.
- The unrelated workpiece on `useTerminal.ts` / `globals.css` (xterm v6 scrollbar globals) is **not** in this branch — see DR §"非範囲".
- This is the first DR placed under `doc/decisions/` on the public hub (matches the post-#326 tmai-core convention). Migrating the remaining `.claude/decisions/*` is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
