### PR TITLE
fix(react): align xterm v6 scrollbar with global thin-overlay (6px)

### DIFF
--- a/clients/react/src/hooks/useTerminal.ts
+++ b/clients/react/src/hooks/useTerminal.ts
@@ -92,6 +92,12 @@ export function useTerminal({
         foreground: "#fafafa",
         cursor: "#a1a1aa",
         selectionBackground: "#3f3f46",
+        // Match the global thin-overlay scrollbar (rgba white/8 → 15 → 18).
+        // xterm v6 paints its own VSCode-style scrollbar; only the colors are
+        // theme-driven, the 6 px width is pinned in globals.css.
+        scrollbarSliderBackground: "rgba(255, 255, 255, 0.08)",
+        scrollbarSliderHoverBackground: "rgba(255, 255, 255, 0.15)",
+        scrollbarSliderActiveBackground: "rgba(255, 255, 255, 0.18)",
       },
       cursorBlink: true,
     });

--- a/clients/react/src/styles/globals.css
+++ b/clients/react/src/styles/globals.css
@@ -257,19 +257,28 @@ html {
   scrollbar-color: rgba(255, 255, 255, 0.08) transparent;
 }
 
-/* xterm-viewport ships `overflow-y: scroll`, which reserves a 6 px scrollbar
-   gutter even on a fresh empty terminal — and against the dark canvas the
-   permanently-visible track reads as a noisy seam. Switch to `auto` so the
-   gutter only appears when scrollback actually overflows the viewport, and
-   blend the resting thumb into the terminal background so it doesn't stand
-   out as a contrasting strip. */
+/* xterm v6 paints its own VSCode-derived scrollbar (`.xterm-scrollable-element
+   > .scrollbar`) instead of the native browser scrollbar, and JS pins both the
+   bar and the inner slider to an inline `width: 14px`. The native viewport
+   underneath also ships `overflow-y: scroll` which reserves a redundant gutter
+   on every empty terminal.
+
+   Force the inline 14 px down to the global thin-overlay 6 px so the preview
+   pane reads at the same scale as every other scrollable surface (git pane,
+   transcript, sidebars). Slider thumb colors come from the Terminal theme
+   (`scrollbarSliderBackground` + hover/active) so they stay in lockstep with
+   the global thumb without an `!important` color war. */
 .xterm .xterm-viewport {
   overflow-y: auto !important;
-  scrollbar-color: rgba(255, 255, 255, 0.06) transparent;
 }
-.xterm .xterm-viewport::-webkit-scrollbar-thumb {
-  background: rgba(255, 255, 255, 0.06);
+.xterm .xterm-scrollable-element > .scrollbar.vertical,
+.xterm .xterm-scrollable-element > .scrollbar.vertical > .slider {
+  width: 6px !important;
 }
-.xterm .xterm-viewport::-webkit-scrollbar-thumb:hover {
-  background: rgba(255, 255, 255, 0.18);
+.xterm .xterm-scrollable-element > .scrollbar.horizontal,
+.xterm .xterm-scrollable-element > .scrollbar.horizontal > .slider {
+  height: 6px !important;
+}
+.xterm .xterm-scrollable-element > .scrollbar > .slider {
+  border-radius: 3px;
 }


### PR DESCRIPTION
## Summary

Pin xterm v6's self-painted scrollbar down to the **6 px global thin-overlay** so PreviewPanel / TerminalPanel scrollbars match every other scrollable surface in the WebUI (git pane, transcript, sidebars). Carved out of PR #672 (Producer console rebuild) as it's an independent visual polish.

## What's happening

xterm v6 (the version pinned in `package.json`) paints its own VSCode-derived scrollbar at `.xterm-scrollable-element > .scrollbar` instead of using the native browser scrollbar. JS pins both the bar and the inner slider to an inline `width: 14px`, so the terminal pane ends up with a fat scrollbar that doesn't match the rest of the WebUI.

The native viewport underneath (`xterm-viewport`) also ships `overflow-y: scroll`, reserving a redundant gutter on every empty terminal.

## What changed

- **`globals.css`** — Override xterm's inline `14px` with `6px !important` on `.xterm-scrollable-element > .scrollbar.vertical` (and `> .slider`), plus horizontal mirror. The old `.xterm-viewport::-webkit-scrollbar-thumb` shim is gone (xterm now owns the paint, not the native scrollbar). `overflow-y: auto` on `.xterm-viewport` so the redundant gutter only appears when scrollback actually overflows.
- **`useTerminal.ts`** — Pass the thumb colors to xterm via the Terminal theme (`scrollbarSliderBackground` + `scrollbarSliderHoverBackground` + `scrollbarSliderActiveBackground`), keyed to the same `rgba(white, 0.08 → 0.15 → 0.18)` ramp the global thin-overlay uses. Slider colors are now theme-driven, so no `!important` color war is needed.

## Why a separate PR

PR #672 (Producer console rebuild) explicitly carved this work out of scope — see its DR §"非範囲". Keeping each PR focused so reviewers don't have to disentangle "console rebuild" from "scrollbar polish".

## Verified

- `pnpm lint` — clean
- `pnpm test` — 377 tests pass + 2 skipped (no scrollbar-specific test; the test suite doesn't exercise xterm's paint)
- `pnpm build` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## スタイル
* ターミナルのスクロールバースタイルをアプリケーション全体の設定に統一しました。スクロールバースライダーの色（デフォルト状態、ホバー状態、アクティブ状態）、寸法、およびボーダー半径を標準化し、一貫性のあるビジュアルデザインを実現しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/673)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->