### PR TITLE
feat(react): dashboard return path + simulated-onboarded posture in code

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -97,6 +97,17 @@ export function App() {
   //   land them on the orchestrator-era controls directly.
   const [settingsOpenedFromOverride, setSettingsOpenedFromOverride] = useState(false);
   const closeMainPanelOverlay = useCallback(() => setMainPanel("agents"), []);
+  // Producer-console return path (dogfood feedback 2026-05-14):
+  // an operator talking to the Producer in the main pane had no way
+  // back to the hand-over digest without killing the session. Reset
+  // both selection and any overlay so the ProducerConsole branch (no
+  // `selectedAgent`, no overlay) renders again. The Producer agent
+  // itself stays alive in the sidebar — re-selecting it resumes the
+  // conversation.
+  const returnToConsole = useCallback(() => {
+    setSelection(null);
+    setMainPanel("agents");
+  }, []);
   const toggleSettings = useCallback(() => {
     setSettingsOpenedFromOverride(false);
     setMainPanel((mp) => (mp === "settings" ? "agents" : "settings"));
@@ -569,6 +580,9 @@ export function App() {
               toggleSecurity();
             }}
             indicatorSlot={<CalibrationChip data={calibrationData} onClick={openCalibration} />}
+            onReturnToConsole={
+              selection !== null || mainPanel !== "agents" ? returnToConsole : undefined
+            }
           />
           {!sidebarCollapsed && (
             <div className="flex flex-1 flex-col overflow-y-auto">{sidebarContent}</div>
@@ -618,6 +632,9 @@ export function App() {
             onSecurityClick={() => {
               toggleSecurity();
             }}
+            onReturnToConsole={
+              selection !== null || mainPanel !== "agents" ? returnToConsole : undefined
+            }
           />
         )}
 

--- a/clients/react/src/components/layout/StatusBar.tsx
+++ b/clients/react/src/components/layout/StatusBar.tsx
@@ -11,6 +11,16 @@ interface StatusBarProps {
    *  calibration / tier-1 tripwire chip (DR §B.3/§B.4). Sits between
    *  the attention count and the settings / security buttons. */
   indicatorSlot?: ReactNode;
+  /** Producer-console return affordance.
+   *  When defined, render a 🏠 button that clears the main-pane selection
+   *  and drops the operator back on the ProducerConsole hand-over digest.
+   *  Caller is responsible for the actual reset (e.g. `setSelection(null)`);
+   *  the Producer agent session itself stays alive in the sidebar so the
+   *  conversation can be resumed by re-selecting it.
+   *  Use case: dogfood feedback 2026-05-14 — operator was talking to the
+   *  Producer in the main pane with no obvious way to glance back at the
+   *  digest without closing the session. */
+  onReturnToConsole?: () => void;
   /** Mobile: show hamburger button instead of collapse arrow */
   isMobile?: boolean;
   onMobileMenuClick?: () => void;
@@ -25,6 +35,7 @@ export function StatusBar({
   onSettingsClick,
   onSecurityClick,
   indicatorSlot,
+  onReturnToConsole,
   isMobile,
   onMobileMenuClick,
 }: StatusBarProps) {
@@ -62,6 +73,17 @@ export function StatusBar({
           )}
         </div>
         <div className="flex items-center gap-1">
+          {onReturnToConsole && (
+            <button
+              type="button"
+              onClick={onReturnToConsole}
+              className="touch-target flex items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400"
+              title="Return to Producer console"
+              aria-label="Return to Producer console"
+            >
+              🏠
+            </button>
+          )}
           <button
             type="button"
             onClick={onSecurityClick}
@@ -107,6 +129,17 @@ export function StatusBar({
         <span className="bg-gradient-to-r from-cyan-400 to-blue-400 bg-clip-text text-xs font-bold text-transparent">
           tm
         </span>
+        {onReturnToConsole && (
+          <button
+            type="button"
+            onClick={onReturnToConsole}
+            className="rounded px-1.5 py-0.5 text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400"
+            title="Return to Producer console"
+            aria-label="Return to Producer console"
+          >
+            🏠
+          </button>
+        )}
         {attentionCount > 0 && (
           <span className="glow-amber rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] text-amber-400">
             {attentionCount}
@@ -151,6 +184,17 @@ export function StatusBar({
           </span>
         )}
         {indicatorSlot}
+        {onReturnToConsole && (
+          <button
+            type="button"
+            onClick={onReturnToConsole}
+            className="rounded px-1.5 py-0.5 text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400"
+            title="Return to Producer console"
+            aria-label="Return to Producer console"
+          >
+            🏠
+          </button>
+        )}
         <button
           type="button"
           onClick={onSecurityClick}

--- a/clients/react/src/components/layout/__tests__/StatusBar.test.tsx
+++ b/clients/react/src/components/layout/__tests__/StatusBar.test.tsx
@@ -1,0 +1,119 @@
+// @vitest-environment jsdom
+//
+// StatusBar — focused on the dashboard-return affordance added in
+// response to dogfood feedback 2026-05-14 ("Producer 会話中に dashboard
+// に戻る経路がない"). The other StatusBar slots (agent count,
+// attention pill, indicator slot, security / settings buttons) are
+// covered by integration tests via App.tsx; here we only assert the
+// new return-to-console button's presence / absence across the
+// desktop, collapsed-sidebar, and mobile variants.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { StatusBar } from "../StatusBar";
+
+describe("StatusBar — return-to-console button", () => {
+  describe("desktop variant", () => {
+    it("omits the button when onReturnToConsole is undefined", () => {
+      render(
+        <StatusBar
+          agentCount={0}
+          attentionCount={0}
+          onSettingsClick={vi.fn()}
+          onSecurityClick={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByRole("button", { name: /Return to Producer console/ })).toBeNull();
+    });
+
+    it("renders the button when onReturnToConsole is defined and fires it on click", () => {
+      const onReturn = vi.fn();
+      render(
+        <StatusBar
+          agentCount={1}
+          attentionCount={0}
+          onSettingsClick={vi.fn()}
+          onSecurityClick={vi.fn()}
+          onReturnToConsole={onReturn}
+        />,
+      );
+
+      const button = screen.getByRole("button", { name: /Return to Producer console/ });
+      fireEvent.click(button);
+      expect(onReturn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("collapsed-sidebar variant", () => {
+    it("omits the button when onReturnToConsole is undefined", () => {
+      render(
+        <StatusBar
+          agentCount={0}
+          attentionCount={0}
+          collapsed
+          onToggleCollapse={vi.fn()}
+          onSettingsClick={vi.fn()}
+          onSecurityClick={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByRole("button", { name: /Return to Producer console/ })).toBeNull();
+    });
+
+    it("renders the button when onReturnToConsole is defined and fires it on click", () => {
+      const onReturn = vi.fn();
+      render(
+        <StatusBar
+          agentCount={0}
+          attentionCount={0}
+          collapsed
+          onToggleCollapse={vi.fn()}
+          onSettingsClick={vi.fn()}
+          onSecurityClick={vi.fn()}
+          onReturnToConsole={onReturn}
+        />,
+      );
+
+      const button = screen.getByRole("button", { name: /Return to Producer console/ });
+      fireEvent.click(button);
+      expect(onReturn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("mobile variant", () => {
+    it("omits the button when onReturnToConsole is undefined", () => {
+      render(
+        <StatusBar
+          agentCount={0}
+          attentionCount={0}
+          isMobile
+          onMobileMenuClick={vi.fn()}
+          onSettingsClick={vi.fn()}
+          onSecurityClick={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByRole("button", { name: /Return to Producer console/ })).toBeNull();
+    });
+
+    it("renders the button when onReturnToConsole is defined and fires it on click", () => {
+      const onReturn = vi.fn();
+      render(
+        <StatusBar
+          agentCount={0}
+          attentionCount={0}
+          isMobile
+          onMobileMenuClick={vi.fn()}
+          onSettingsClick={vi.fn()}
+          onSecurityClick={vi.fn()}
+          onReturnToConsole={onReturn}
+        />,
+      );
+
+      const button = screen.getByRole("button", { name: /Return to Producer console/ });
+      fireEvent.click(button);
+      expect(onReturn).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -78,7 +78,7 @@ export function ProducerConsole({
   sidebarCollapsed,
   onOpenSettings,
 }: ProducerConsoleProps) {
-  const { whereYouLeftOff, crossUnit, settledDecisions, workingWithHuman } =
+  const { whereYouLeftOff, crossUnit, settledDecisions, workingWithHuman, missingPreconditions } =
     useHandover(currentProjectPath);
 
   return (
@@ -112,6 +112,7 @@ export function ProducerConsole({
           data={crossUnit}
           activePath={currentProjectPath}
           onSelectUnit={onSelectProjectByPath}
+          preconditions={missingPreconditions}
         />
         <SettledDecisionsSection data={settledDecisions} />
         <WorkingWithThisHumanSection data={workingWithHuman} />

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
@@ -34,6 +34,10 @@ function digest(overrides: Partial<HandoverDigest> = {}): HandoverDigest {
     crossUnit: overrides.crossUnit ?? { units: [] },
     settledDecisions: overrides.settledDecisions ?? { placeholder: true },
     workingWithHuman: overrides.workingWithHuman ?? { placeholder: true },
+    missingPreconditions: overrides.missingPreconditions ?? {
+      noLiveAgents: true,
+      singleUnitOnly: false,
+    },
   };
 }
 
@@ -173,5 +177,52 @@ describe("ProducerConsole", () => {
     expect(betaButton).toBeTruthy();
     betaButton?.click();
     expect(onSelect).toHaveBeenCalledWith("/p/beta", "beta");
+  });
+
+  it("shows the singleUnitOnly posture notice when missingPreconditions flags it", () => {
+    // Per the simulated-onboarded posture DR, the WebUI is honest
+    // about the multi-repo / dormant-unit wire gap (tmai-core#340)
+    // by surfacing this notice in the ⬢ Cross-unit status section
+    // whenever only one unit is derivable from live agents.
+    useHandoverMock.mockReturnValue(
+      digest({
+        crossUnit: {
+          units: [
+            {
+              path: "/p/alpha",
+              name: "alpha",
+              state: "in-progress",
+              agentCount: 1,
+              attentionCount: 0,
+            },
+          ],
+        },
+        missingPreconditions: { noLiveAgents: false, singleUnitOnly: true },
+      }),
+    );
+
+    render(
+      <ProducerConsole {...makeProps({ currentProjectPath: "/p/alpha", unitName: "alpha" })} />,
+    );
+
+    expect(screen.getByText(/Showing one unit only/i)).toBeTruthy();
+  });
+
+  it("omits the singleUnitOnly notice when more than one unit is derived", () => {
+    useHandoverMock.mockReturnValue(
+      digest({
+        crossUnit: {
+          units: [
+            { path: "/p/a", name: "a", state: "in-progress", agentCount: 1, attentionCount: 0 },
+            { path: "/p/b", name: "b", state: "quiet", agentCount: 0, attentionCount: 0 },
+          ],
+        },
+        missingPreconditions: { noLiveAgents: false, singleUnitOnly: false },
+      }),
+    );
+
+    render(<ProducerConsole {...makeProps()} />);
+
+    expect(screen.queryByText(/Showing one unit only/i)).toBeNull();
   });
 });

--- a/clients/react/src/components/producer-console/sections/CrossUnitStatusSection.tsx
+++ b/clients/react/src/components/producer-console/sections/CrossUnitStatusSection.tsx
@@ -11,19 +11,31 @@
 // from a `[[unit]]`-config endpoint, so units configured but currently
 // dormant are not visible here. Phase C will reconcile against a
 // `GET /api/units` endpoint and surface those too.
+//
+// TODO(tmai-core#340): when multi-repo / dormant-unit wire lands,
+// replace the live-agent derivation with a proper unit list. The
+// `singleUnitOnly` posture notice below is part of the
+// simulated-onboarded posture DR (`doc/decisions/2026-05-14-webui-
+// simulated-onboarded-posture.md`) and should be removed in the
+// same change.
 
-import type { CrossUnitStatus, UnitState } from "@/hooks/useHandover";
+import type { CrossUnitStatus, MissingPreconditions, UnitState } from "@/hooks/useHandover";
 
 interface CrossUnitStatusSectionProps {
   data: CrossUnitStatus;
   activePath: string | null;
   onSelectUnit: (path: string, name: string) => void;
+  /** Weak posture signals — see `MissingPreconditions` doc.
+   *  When omitted, no notice is rendered (back-compat for existing
+   *  tests / older callers). */
+  preconditions?: MissingPreconditions;
 }
 
 export function CrossUnitStatusSection({
   data,
   activePath,
   onSelectUnit,
+  preconditions,
 }: CrossUnitStatusSectionProps) {
   return (
     <section>
@@ -37,8 +49,8 @@ export function CrossUnitStatusSection({
 
       {data.units.length === 0 ? (
         <p className="pl-6 text-xs text-zinc-500">
-          No active units. Spawn an agent on any project to populate this list — Phase C will also
-          surface dormant configured units.
+          No active units. Spawn an agent on any project to populate this list — dormant configured
+          units aren't surfaced here yet.
         </p>
       ) : (
         <ul className="space-y-0.5 pl-6 text-xs text-zinc-300">
@@ -71,6 +83,15 @@ export function CrossUnitStatusSection({
             );
           })}
         </ul>
+      )}
+
+      {preconditions?.singleUnitOnly && (
+        // TODO(tmai-core#340): remove this notice once multi-repo /
+        // dormant-unit reconciliation lands.
+        <p className="mt-2 pl-6 text-[11px] text-zinc-600">
+          Showing one unit only — a tmai project can span multiple repos and have dormant configured
+          units, but that view isn't wired yet.
+        </p>
       )}
     </section>
   );

--- a/clients/react/src/components/producer-console/sections/SettledDecisionsSection.tsx
+++ b/clients/react/src/components/producer-console/sections/SettledDecisionsSection.tsx
@@ -9,6 +9,16 @@
 // jargon ("Phase C: `GET /api/units/...` is not yet wired") into the
 // user UI, which read as broken; this revision drops that and
 // addresses the operator directly.
+//
+// TODO(tmai-core#340): when multi-repo unit support lands, this
+// section will need to show decisions from every repo in
+// `UnitConfig.also[]`, not just the primary cwd. Per the
+// simulated-onboarded posture DR (`doc/decisions/2026-05-14-webui-
+// simulated-onboarded-posture.md`), the current copy is intentionally
+// honest about the single-repo limitation.
+// TODO(tmai-core#341): when `compose()` cold-start hardening lands,
+// surface the `meta.missing_preconditions` signal here so an operator
+// who hasn't run `tmai onboard <unit>` sees an actionable hint.
 
 import type { SettledDecisionsPlaceholder } from "@/hooks/useHandover";
 
@@ -34,7 +44,8 @@ export function SettledDecisionsSection({ data: _data }: SettledDecisionsSection
         </p>
         <p className="mt-2 text-zinc-600">
           When wired, this section will surface them bucketed by temperature: 📌 foundational · 🔴
-          in-play · 🟡 warm · ⚪ cold.
+          in-play · 🟡 warm · ⚪ cold — pulled from every repo this unit spans, not just the one you
+          launched against.
         </p>
       </div>
     </section>

--- a/clients/react/src/components/producer-console/sections/WorkingWithThisHumanSection.tsx
+++ b/clients/react/src/components/producer-console/sections/WorkingWithThisHumanSection.tsx
@@ -7,6 +7,13 @@
 // `CLAUDE.md` for the time being. (Earlier drafts surfaced phase-
 // tracking text into this UI which made the section read as broken;
 // this revision speaks to the operator directly instead.)
+//
+// TODO(tmai-core#341): the cold-start hardening issue is the natural
+// place to expose `compose()` output (including this baseline delta)
+// over the wire. Per the simulated-onboarded posture DR
+// (`doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md`),
+// the current "see CLAUDE.md for now" copy is honest about the gap
+// rather than fabricating a synthetic delta.
 
 import type { WorkingWithHumanPlaceholder } from "@/hooks/useHandover";
 

--- a/clients/react/src/hooks/__tests__/useHandover.test.ts
+++ b/clients/react/src/hooks/__tests__/useHandover.test.ts
@@ -221,3 +221,49 @@ describe("useHandover — crossUnit derivation", () => {
     expect(result.current.crossUnit.units[0]?.agentCount).toBe(2);
   });
 });
+
+describe("useHandover — missingPreconditions (simulated-onboarded posture)", () => {
+  it("flags noLiveAgents when the agent list is empty", () => {
+    const { result } = renderHook(() => useHandover(null));
+    expect(result.current.missingPreconditions.noLiveAgents).toBe(true);
+  });
+
+  it("clears noLiveAgents once any AI agent is observed", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [agent({ id: "a1", cwd: "/home/u/proj-a", git_common_dir: "/home/u/proj-a/.git" })],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useHandover(null));
+    expect(result.current.missingPreconditions.noLiveAgents).toBe(false);
+  });
+
+  it("flags singleUnitOnly when only one project group is derived", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [agent({ id: "a1", cwd: "/home/u/proj-a", git_common_dir: "/home/u/proj-a/.git" })],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useHandover(null));
+    expect(result.current.missingPreconditions.singleUnitOnly).toBe(true);
+  });
+
+  it("clears singleUnitOnly when two or more projects are present", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [
+        agent({ id: "a1", cwd: "/home/u/proj-a", git_common_dir: "/home/u/proj-a/.git" }),
+        agent({ id: "a2", cwd: "/home/u/proj-b", git_common_dir: "/home/u/proj-b/.git" }),
+      ],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useHandover(null));
+    expect(result.current.missingPreconditions.singleUnitOnly).toBe(false);
+  });
+});

--- a/clients/react/src/hooks/useHandover.ts
+++ b/clients/react/src/hooks/useHandover.ts
@@ -31,6 +31,14 @@
 // Both placeholders carry the exact wire-gap reason in the `reason`
 // field — the section components render that text directly so the
 // surface is self-documenting.
+//
+// Posture annotations (DR `doc/decisions/2026-05-14-webui-simulated-
+// onboarded-posture.md`): until tmai-core lands #340 (multi-repo) /
+// #341 (cold-start), this hook degrades gracefully and surfaces a
+// weak `missingPreconditions` signal so sections can render honest
+// notices instead of fabricating data. Anything tagged
+// `TODO(tmai-core#340)` / `TODO(tmai-core#341)` in this file is
+// scheduled for retirement once those ship.
 
 import { useMemo } from "react";
 import { useAgents } from "@/hooks/useAgents";
@@ -97,11 +105,40 @@ export interface WorkingWithHumanPlaceholder {
   placeholder: true;
 }
 
+/**
+ * Weak client-side signals that the unit might be incompletely onboarded
+ * or that we're only seeing a sliver of its real surface. Per the
+ * simulated-onboarded posture DR, the WebUI is not allowed to fabricate
+ * data when the underlying wire is absent — it has to be honest about
+ * which inferences are based on partial signals.
+ *
+ * These flags are *weak* by design: they come from the data we already
+ * have on the client (agent list, project grouping), not from a
+ * dedicated `compose().meta` payload (which is what tmai-core#341 will
+ * provide). Section components treat them as "may want to surface a
+ * notice", not as definitive state.
+ */
+export interface MissingPreconditions {
+  /** No live agents have been observed for this client session.
+   *  Weak signal — also true during the initial agents-fetch pre-load.
+   *  TODO(tmai-core#341): replace with `compose().meta` once the wire
+   *  endpoint reports actual missing preconditions (no
+   *  `doc/decisions/`, no `[[unit]]` config, etc.). */
+  noLiveAgents: boolean;
+  /** Only one unit derived from live agents. Because the wire side
+   *  doesn't yet expose dormant `[[unit]]` configs (#340) or a way
+   *  for a unit to span multiple repos (#340), the single-unit
+   *  view here is necessarily partial.
+   *  TODO(tmai-core#340): replace with `GET /api/units` reconciliation. */
+  singleUnitOnly: boolean;
+}
+
 export interface HandoverDigest {
   whereYouLeftOff: WhereYouLeftOff;
   crossUnit: CrossUnitStatus;
   settledDecisions: SettledDecisionsPlaceholder;
   workingWithHuman: WorkingWithHumanPlaceholder;
+  missingPreconditions: MissingPreconditions;
 }
 
 // Narrowing predicate — keeps the AttentionAgentBrief map free of the
@@ -184,5 +221,13 @@ export function useHandover(currentProjectPath: string | null): HandoverDigest {
   const settledDecisions: SettledDecisionsPlaceholder = { placeholder: true };
   const workingWithHuman: WorkingWithHumanPlaceholder = { placeholder: true };
 
-  return { whereYouLeftOff, crossUnit, settledDecisions, workingWithHuman };
+  // Weak posture-signal derivation. See `MissingPreconditions` doc for
+  // why these are tagged TODO(tmai-core#NNN) — they get retired once
+  // the wire side surfaces the real precondition data.
+  const missingPreconditions: MissingPreconditions = {
+    noLiveAgents: aiAgents.length === 0,
+    singleUnitOnly: projectGroups.length === 1,
+  };
+
+  return { whereYouLeftOff, crossUnit, settledDecisions, workingWithHuman, missingPreconditions };
 }


### PR DESCRIPTION
## Summary

Two threads from the 2026-05-14 dogfood-loop conversation, landing
together because they share the same ProducerConsole / useHandover /
StatusBar surface:

1. **Dashboard return path** — operator talking to the Producer had no
   obvious way back to the hand-over digest without killing the session.
2. **Simulated-onboarded posture in code** — codifies the foundational
   DR (tier:1) that the WebUI just adopted: graceful degradation +
   transparency over completeness + retirable compensation while
   tmai-core ships #340 (multi-repo) / #341 (cold-start).

DRs:

- `doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md`
  (foundational / tier:1)
- `doc/decisions/2026-05-14-react-producer-console-rebuild.md` (the
  PR #672 DR; this work continues its scope)

Companion issues (already filed): trust-delta/tmai-core#340,
trust-delta/tmai-core#341.

## A. Dashboard return path

- `StatusBar`: new optional `onReturnToConsole` prop. When defined,
  renders a 🏠 button on the desktop, collapsed-sidebar, and mobile
  variants, all titled `Return to Producer console`.
- `App.tsx`: new `returnToConsole` callback clears `selection` and
  resets the main-panel overlay flag. The Producer agent itself is
  not killed — re-selecting it from the sidebar resumes the
  conversation.
- Visibility condition: `selection !== null || mainPanel !== "agents"`,
  so the button stays out of the way when the console is already up.

## B. Simulated-onboarded posture in code

- `useHandover`: new `missingPreconditions: { noLiveAgents,
  singleUnitOnly }` weak-signal struct. Both flags are tagged
  `TODO(tmai-core#340)` / `TODO(tmai-core#341)` for grep-able
  retirement once `compose().meta` arrives on the wire.
- `CrossUnitStatusSection`: accepts `preconditions` and renders a
  one-line notice when only one unit is derivable from live agents:
  *"Showing one unit only — a tmai project can span multiple repos
  and have dormant configured units, but that view isn't wired yet."*
- `SettledDecisionsSection`: adds TODO markers for #340 / #341; copy
  tightened to explicit "pulled from every repo this unit spans, not
  just the one you launched against."
- `WorkingWithThisHumanSection`: adds TODO marker for #341.

Per the posture DR's "transparency over completeness" principle, no
section fabricates data when its wire is absent — the placeholders
explain what's missing and where to look in the meantime.

## What's NOT in this PR

- **Banner / dismissable notice at the top of ProducerConsole** —
  the posture DR's table mentions one as a possibility; held off
  because the per-section notices already convey the same info
  without a permanent header strip. Easy to add later if dogfood
  surfaces a need.
- **Phase C wire endpoints** — multi-repo decision reading,
  `compose().meta` exposure, SSE push. Cross-repo, tracked in
  tmai-core#340 / #341.

## Verified

- `pnpm lint` clean
- `pnpm test` — **389 tests pass + 2 skipped** (12 new: 6 StatusBar
  variants × omit/render/click + 4 useHandover preconditions + 2
  ProducerConsole posture-notice tests)
- `pnpm build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能
* プロデューサーコンソール画面に「コンソールに戻る」ボタンを追加しました。デスクトップおよびモバイル表示を含むすべてのUIモードで利用可能です。
* ユニット関連の状態を監視する機能を追加しました。ライブエージェントがない場合や単一ユニットのみの場合に、ユーザーに対して適切な状態表示を提供します。

## 改善
* UI表示メッセージを更新し、より正確でわかりやすい情報を表示するようにしました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/675)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->