### PR TITLE
fix(react): classify bash-wrapped Producer as AI agent in handover digest

### DIFF
--- a/clients/react/src/hooks/__tests__/useHandover.test.ts
+++ b/clients/react/src/hooks/__tests__/useHandover.test.ts
@@ -266,4 +266,55 @@ describe("useHandover — missingPreconditions (simulated-onboarded posture)", (
     const { result } = renderHook(() => useHandover(null));
     expect(result.current.missingPreconditions.singleUnitOnly).toBe(false);
   });
+
+  // The Producer launch wraps `tmai producer <unit>` under `bash -c` to
+  // satisfy tmai-core's `/api/spawn` allow-list (DR polish v4). The
+  // resulting agent has `agent_type: Custom("bash")` but its canonical
+  // `id` is already `claude:UUID` — `useHandover` must classify it as
+  // an AI coding agent via the id-scheme fallback, otherwise the
+  // Producer's own unit drops out of `projectGroups` and the posture
+  // notices ("no live agents" / "showing one unit only") all misfire
+  // even though the Producer is plainly running.
+  it("classifies a bash-wrapped Producer as an AI agent via canonical id scheme", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [
+        agent({
+          id: "claude:8b762cf8-b5e1-48f1-a828-af6411d58e96",
+          agent_type: { Custom: "bash" },
+          title: "bash",
+          cwd: "/home/u/proj-a",
+          git_common_dir: "/home/u/proj-a/.git",
+        }),
+      ],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useHandover(null));
+    expect(result.current.missingPreconditions.noLiveAgents).toBe(false);
+    expect(result.current.missingPreconditions.singleUnitOnly).toBe(true);
+    expect(result.current.crossUnit.units).toHaveLength(1);
+  });
+
+  it("does not classify a plain Custom-type agent without an AI id scheme", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [
+        agent({
+          id: "pty:00000000-0000-0000-0000-000000000001",
+          agent_type: { Custom: "bash" },
+          title: "bash",
+          cwd: "/home/u/proj-a",
+          git_common_dir: "/home/u/proj-a/.git",
+        }),
+      ],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useHandover(null));
+    expect(result.current.missingPreconditions.noLiveAgents).toBe(true);
+    expect(result.current.crossUnit.units).toEqual([]);
+  });
 });

--- a/clients/react/src/hooks/useHandover.ts
+++ b/clients/react/src/hooks/useHandover.ts
@@ -51,6 +51,27 @@ import {
   type ProjectGroup,
 } from "@/lib/api";
 
+// Canonical AgentId schemes that mark a snapshot as an AI coding agent
+// regardless of `agent_type`. Post-2026-05-09 detection canonicalization,
+// `id` carries the canonical scheme (`claude:` / `codex:` / `gemini:` /
+// `opencode:`) even when the spawn command was wrapped (e.g. the
+// Producer launch wraps `tmai producer <unit>` under `bash -c` to
+// satisfy tmai-core's `/api/spawn` allow-list — see
+// `doc/decisions/2026-05-14-react-producer-console-rebuild.md` polish v4).
+// In that wrapped case `agent_type` stays `Custom("bash")` and the
+// plain `isAiAgent(agent_type)` check misses the Producer.
+//
+// TODO(tmai-core spawn-allow-list): when tmai-core's allow-list adds
+// `tmai` as a first-class command, the bash wrap goes away and
+// `agent_type` will reflect reality — this id-scheme fallback can
+// then retire.
+const AI_ID_SCHEMES = ["claude:", "codex:", "gemini:", "opencode:"] as const;
+
+function isHandoverAgent(a: AgentSnapshot): boolean {
+  if (isAiAgent(a.agent_type)) return true;
+  return AI_ID_SCHEMES.some((scheme) => a.id.startsWith(scheme));
+}
+
 export interface WorktreeBrief {
   name: string;
   branch: string | null;
@@ -164,7 +185,7 @@ export function useHandover(currentProjectPath: string | null): HandoverDigest {
   const { agents } = useAgents();
   const { worktrees } = useWorktrees();
 
-  const aiAgents = useMemo(() => agents.filter((a) => isAiAgent(a.agent_type)), [agents]);
+  const aiAgents = useMemo(() => agents.filter(isHandoverAgent), [agents]);
 
   const projectGroups = useMemo<ProjectGroup[]>(
     () => groupByProject(aiAgents, worktrees),


### PR DESCRIPTION
## Summary

The Producer launch wraps `tmai producer <unit>` under `bash -c` to satisfy tmai-core's `/api/spawn` allow-list (per PR #672 polish v4). On the wire the resulting agent shows:

- `agent_type: { Custom: "bash" }` — what tmai launched
- `id: "claude:UUID"` — what tmai-core's L2 resolver canonicalized to

`useHandover`'s `isAiAgent(a.agent_type)` filter only checks the legacy spawn-time type, so the Producer drops out of `aiAgents` → `projectGroups` is empty → `singleUnitOnly` / `noLiveAgents` both misfire. The `⬢ Cross-unit status` posture notice ("Showing one unit only — multi-repo / dormant-unit view isn't wired yet") never renders, even though the Producer is plainly running.

## Fix

Add an id-scheme fallback (`claude:` / `codex:` / `gemini:` / `opencode:`) so canonical AI agents are classified correctly regardless of how spawn was wrapped. Scoped to `useHandover` only — sidebar AI/terminal split (`App.tsx`), idle notifications, and `AgentCard` styling untouched.

`TODO(tmai-core spawn-allow-list)` marker added so the fallback retires once tmai-core's `/api/spawn` allow-list adds `tmai` as a first-class command (the wrap goes away and `agent_type` becomes accurate).

## Test plan

- [x] `pnpm test` — 391 passing / 2 skipped (15 in `useHandover.test.ts`, +2 new)
- [x] `pnpm exec tsc -b` clean
- [x] `pnpm lint` (biome) clean
- [ ] Hot-reload in running `pnpm run dev` — Producer alone in unit `tmai` should now surface the "Showing one unit only" notice in `⬢ Cross-unit status`

## Cross-refs

- DR `doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md` — the foundational posture this notice serves
- DR `doc/decisions/2026-05-14-react-producer-console-rebuild.md` — polish v4 = the bash-wrap that caused this misclassification

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **バグ修正**
  * Handover AI エージェントの検出ロジックを改善しました。標準的なID形式によるフォールバック検出が追加され、より正確なエージェント識別と分類が可能になります。

* **テスト**
  * Handover エージェント分類の動作を検証するテストケースを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/676)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->