### PR TITLE
feat(react): ctx% header display + auto-handoff threshold setting (handoff-lifecycle DR §E) (#681)

### DIFF
--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -26,6 +26,7 @@ import { useAgents } from "@/hooks/useAgents";
 import { useHandover } from "@/hooks/useHandover";
 import type { CalibrationResponse } from "@/lib/api";
 import { ProducerConsoleActions } from "./ProducerConsoleActions";
+import { ProducerCtxHeader } from "./ProducerCtxHeader";
 import { CrossUnitStatusSection } from "./sections/CrossUnitStatusSection";
 import { SettledDecisionsSection } from "./sections/SettledDecisionsSection";
 import { WhereYouLeftOffSection } from "./sections/WhereYouLeftOffSection";
@@ -85,6 +86,11 @@ export function ProducerConsole({
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden animate-fade-in">
+      <ProducerCtxHeader
+        agents={agents}
+        currentProjectPath={currentProjectPath}
+        onOpenSettings={onOpenSettings}
+      />
       <header className="border-b border-white/5 px-6 py-4">
         <h2 className="text-lg font-semibold text-zinc-200">Welcome to tmai</h2>
         <p className="mt-1 text-xs text-zinc-400">

--- a/clients/react/src/components/producer-console/ProducerCtxHeader.tsx
+++ b/clients/react/src/components/producer-console/ProducerCtxHeader.tsx
@@ -1,0 +1,164 @@
+// ProducerCtxHeader — context-window usage strip for the active Producer.
+//
+// Renders the live ctx% / auto-handoff threshold readout from
+// handoff-lifecycle DR §E:
+//
+//   ctx: 142k / 200k (71%) ▮▮▮▮▮▮▮░░░ │ auto-handoff at 75% ⚙
+//
+// Surfaces the same wire data the auto-handoff trigger fires on
+// (`AgentSnapshot.ctx_usage.pct` vs `OrchestratorSettings
+// .auto_handoff_threshold_pct`), so the operator can predict
+// the trigger instead of being surprised by it.
+//
+// Producer scoping matches the `Handoff & restart` button
+// (`ProducerConsoleActions.findProducerForUnit`): `claude:` id-scheme
+// + `!is_worktree` + cwd resolves to the unit's repo path. The header
+// always renders (fixed-height row) so swapping projects / waiting
+// for the first statusline payload doesn't make the layout jump.
+
+import { useEffect, useState } from "react";
+import { type AgentSnapshot, api, normalizeGitDir } from "@/lib/api";
+
+interface ProducerCtxHeaderProps {
+  agents: AgentSnapshot[];
+  /** Repo root for the currently focused unit. When null, no Producer
+   *  can be resolved and the row renders its placeholder. */
+  currentProjectPath: string | null;
+  onOpenSettings: () => void;
+}
+
+const PRODUCER_ID_SCHEME = "claude:";
+
+// Same filter rules as `ProducerConsoleActions.findProducerForUnit`,
+// kept inline to avoid widening that module's export surface for what
+// is essentially a one-call helper.
+function findProducerForUnit(
+  agents: AgentSnapshot[],
+  unitRepoPath: string | null,
+): AgentSnapshot | null {
+  if (unitRepoPath === null) return null;
+  const targetPath = normalizeGitDir(unitRepoPath);
+  const candidates = agents.filter((a) => {
+    if (!a.id.startsWith(PRODUCER_ID_SCHEME)) return false;
+    if (a.is_worktree === true) return false;
+    const agentRepo = a.git_common_dir ? normalizeGitDir(a.git_common_dir) : a.cwd;
+    return agentRepo === targetPath;
+  });
+  return candidates.length === 1 ? (candidates[0] ?? null) : null;
+}
+
+// CC's statusline reports `total` and `used` as bigints (200_000-ish);
+// `Nk` rounding keeps the row scannable. `Math.round` on bigint→number
+// is safe here — context-window totals fit in `Number.MAX_SAFE_INTEGER`
+// by orders of magnitude.
+export function formatThousands(n: bigint): string {
+  const k = Math.round(Number(n) / 1000);
+  return `${k}k`;
+}
+
+// 10-segment bar where `pct=71` → 7 filled (▮) + 3 empty (░).
+// `Math.round` chosen over `floor` so 65% reads as 7 segments and 64%
+// reads as 6 — operator's eye expects "more than half" of the bar to
+// flip near the visual midpoint.
+export function renderBar(pct: number): { filled: number; empty: number; chars: string } {
+  const clamped = Math.max(0, Math.min(100, pct));
+  const filled = Math.max(0, Math.min(10, Math.round(clamped / 10)));
+  const empty = 10 - filled;
+  return {
+    filled,
+    empty,
+    chars: "▮".repeat(filled) + "░".repeat(empty),
+  };
+}
+
+// Threshold readout colour bands per the issue:
+//   pct >= threshold        → red    (will trigger / has triggered)
+//   threshold - 10 ≤ pct    → amber  ("within 10% of threshold")
+//   else                    → zinc
+// Threshold == 0 means auto-handoff is disabled — never colour the
+// readout in that mode; the row instead labels it "disabled".
+export function thresholdColorClass(pct: number | null, threshold: number): string {
+  if (threshold <= 0) return "text-zinc-500";
+  if (pct === null) return "text-zinc-500";
+  if (pct >= threshold) return "text-red-300";
+  if (pct >= threshold - 10) return "text-amber-300";
+  return "text-zinc-400";
+}
+
+export function ProducerCtxHeader({
+  agents,
+  currentProjectPath,
+  onOpenSettings,
+}: ProducerCtxHeaderProps) {
+  const producer = findProducerForUnit(agents, currentProjectPath);
+  const ctx = producer?.ctx_usage ?? null;
+
+  const [threshold, setThreshold] = useState<number | null>(null);
+
+  // One-shot fetch on mount. The threshold rarely changes — when the
+  // operator edits it in Settings, SettingsPanel persists via PUT
+  // and the next mount picks up the new value. (Threshold edits are
+  // not on the SSE entity-update fanout; a 30s reload window is fine.)
+  // Re-fetch on currentProjectPath change so per-project overrides
+  // (if landed later) flow through without a hard reload.
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getOrchestratorSettings(currentProjectPath ?? undefined)
+      .then((s) => {
+        if (!cancelled) setThreshold(s.auto_handoff_threshold_pct);
+      })
+      .catch(() => {
+        if (!cancelled) setThreshold(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentProjectPath]);
+
+  const effectiveThreshold = threshold ?? 0;
+  const thresholdLabel =
+    threshold === null
+      ? "auto-handoff threshold: —"
+      : effectiveThreshold === 0
+        ? "auto-handoff: disabled"
+        : `auto-handoff at ${effectiveThreshold}%`;
+  const readoutColor = thresholdColorClass(ctx?.pct ?? null, effectiveThreshold);
+
+  return (
+    <div className="border-b border-white/5 bg-white/[0.02] px-6 py-2 text-xs">
+      <div className="flex items-center gap-3 text-zinc-400">
+        {ctx ? (
+          <>
+            <span className="font-mono text-zinc-300">
+              ctx: <span className="text-zinc-200">{formatThousands(ctx.used)}</span>
+              {" / "}
+              <span className="text-zinc-200">{formatThousands(ctx.total)}</span>
+              {" ("}
+              <span className="text-zinc-200">{ctx.pct}%</span>
+              {")"}
+            </span>
+            <span className="font-mono text-zinc-500" aria-hidden="true">
+              {renderBar(ctx.pct).chars}
+            </span>
+          </>
+        ) : (
+          <span className="font-mono text-zinc-600">ctx: — / —</span>
+        )}
+        <span className="text-zinc-700" aria-hidden="true">
+          │
+        </span>
+        <span className={`font-mono ${readoutColor}`}>{thresholdLabel}</span>
+        <button
+          type="button"
+          onClick={onOpenSettings}
+          aria-label="Open settings — auto-handoff threshold"
+          title="Open settings — auto-handoff threshold"
+          className="ml-0 rounded text-zinc-500 transition-colors hover:text-zinc-200"
+        >
+          ⚙
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/clients/react/src/components/producer-console/__tests__/ProducerCtxHeader.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerCtxHeader.test.tsx
@@ -1,0 +1,235 @@
+// @vitest-environment jsdom
+//
+// ProducerCtxHeader — ctx% display strip + auto-handoff threshold
+// readout. Mocks the orchestrator-settings fetch so each test can
+// drive a deterministic threshold value, and constructs minimal
+// AgentSnapshot fixtures that match the Handoff & restart filter
+// (claude: id-scheme + !is_worktree + cwd resolves to the unit).
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentSnapshot } from "@/lib/api";
+import {
+  formatThousands,
+  ProducerCtxHeader,
+  renderBar,
+  thresholdColorClass,
+} from "../ProducerCtxHeader";
+
+const getOrchestratorSettingsMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getOrchestratorSettings: (project?: string) => getOrchestratorSettingsMock(project),
+    },
+  };
+});
+
+function agent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot {
+  return {
+    id: partial.id,
+    target: partial.target ?? partial.id,
+    agent_type: partial.agent_type ?? "ClaudeCode",
+    title: partial.title ?? partial.id,
+    cwd: partial.cwd ?? "/home/u/proj",
+    display_cwd: partial.display_cwd ?? "proj",
+    display_name: partial.display_name ?? partial.id,
+    detection_source: partial.detection_source ?? "IpcSocket",
+    git_branch: partial.git_branch ?? "main",
+    git_dirty: partial.git_dirty ?? false,
+    is_worktree: partial.is_worktree ?? false,
+    git_common_dir: partial.git_common_dir ?? "/home/u/proj/.git",
+    worktree_name: partial.worktree_name ?? null,
+    worktree_base_branch: partial.worktree_base_branch ?? null,
+    effort_level: partial.effort_level ?? null,
+    active_subagents: partial.active_subagents ?? 0,
+    compaction_count: partial.compaction_count ?? 0,
+    pty_session_id: partial.pty_session_id ?? null,
+    send_capability: partial.send_capability ?? "Ipc",
+    is_virtual: partial.is_virtual ?? false,
+    team_info: partial.team_info ?? null,
+    attention: partial.attention ?? null,
+    is_orchestrator: partial.is_orchestrator,
+    ctx_usage: partial.ctx_usage,
+  };
+}
+
+function orchestratorFixture(threshold: number) {
+  return {
+    enabled: true,
+    role: "",
+    rules: { branch: "", merge: "", review: "", custom: "" },
+    notify: {},
+    guardrails: { max_ci_retries: 0, max_review_loops: 0, escalate_to_human_after: 0 },
+    auto_action_templates: {},
+    pr_monitor_enabled: false,
+    pr_monitor_interval_secs: 60,
+    pr_monitor_exclude_authors: [],
+    pr_monitor_scope: "current_project",
+    inject_state_snapshot: false,
+    auto_handoff_threshold_pct: threshold,
+    is_project_override: false,
+    dispatch: {},
+  };
+}
+
+describe("ProducerCtxHeader — pure helpers", () => {
+  it("formatThousands rounds bigint to nearest thousand with k suffix", () => {
+    expect(formatThousands(142_000n)).toBe("142k");
+    expect(formatThousands(199_500n)).toBe("200k");
+    expect(formatThousands(0n)).toBe("0k");
+  });
+
+  it("renderBar gives proportional 10-wide segments rounded to nearest tenth", () => {
+    expect(renderBar(0)).toEqual({ filled: 0, empty: 10, chars: "░░░░░░░░░░" });
+    expect(renderBar(71)).toEqual({ filled: 7, empty: 3, chars: "▮▮▮▮▮▮▮░░░" });
+    expect(renderBar(100)).toEqual({ filled: 10, empty: 0, chars: "▮▮▮▮▮▮▮▮▮▮" });
+    // Clamp out-of-range
+    expect(renderBar(-10).filled).toBe(0);
+    expect(renderBar(150).filled).toBe(10);
+  });
+
+  it("thresholdColorClass flips zinc / amber / red across the boundary", () => {
+    expect(thresholdColorClass(50, 75)).toMatch(/zinc/);
+    expect(thresholdColorClass(66, 75)).toMatch(/amber/);
+    expect(thresholdColorClass(74, 75)).toMatch(/amber/);
+    expect(thresholdColorClass(75, 75)).toMatch(/red/);
+    expect(thresholdColorClass(95, 75)).toMatch(/red/);
+    // Disabled threshold keeps the readout zinc regardless of pct
+    expect(thresholdColorClass(99, 0)).toMatch(/zinc/);
+    // null pct (no ctx_usage yet) → zinc
+    expect(thresholdColorClass(null, 75)).toMatch(/zinc/);
+  });
+});
+
+describe("ProducerCtxHeader — rendering", () => {
+  beforeEach(() => {
+    getOrchestratorSettingsMock.mockReset();
+  });
+
+  it("renders ctx Nk / Nk (pct%) from fixture ctx_usage", async () => {
+    getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+    const producer = agent({
+      id: "claude:abc",
+      cwd: "/home/u/proj",
+      git_common_dir: "/home/u/proj/.git",
+      ctx_usage: {
+        used: 142_000n,
+        total: 200_000n,
+        pct: 71,
+        updated_at: "2026-05-15T00:00:00Z",
+      },
+    });
+    render(
+      <ProducerCtxHeader
+        agents={[producer]}
+        currentProjectPath="/home/u/proj"
+        onOpenSettings={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/ctx:/)).toBeTruthy();
+    expect(screen.getByText("142k")).toBeTruthy();
+    expect(screen.getByText("200k")).toBeTruthy();
+    expect(screen.getByText("71%")).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText(/auto-handoff at 75%/)).toBeTruthy();
+    });
+  });
+
+  it("renders the 10-segment bar matching the pct", () => {
+    getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+    const producer = agent({
+      id: "claude:abc",
+      ctx_usage: {
+        used: 60_000n,
+        total: 200_000n,
+        pct: 30,
+        updated_at: "2026-05-15T00:00:00Z",
+      },
+    });
+    render(
+      <ProducerCtxHeader
+        agents={[producer]}
+        currentProjectPath="/home/u/proj"
+        onOpenSettings={vi.fn()}
+      />,
+    );
+    // 30% → 3 filled + 7 empty
+    expect(screen.getByText("▮▮▮░░░░░░░")).toBeTruthy();
+  });
+
+  it("shows placeholder when no Producer matches the unit", async () => {
+    getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+    render(
+      <ProducerCtxHeader agents={[]} currentProjectPath="/home/u/proj" onOpenSettings={vi.fn()} />,
+    );
+    expect(screen.getByText(/ctx: — \/ —/)).toBeTruthy();
+    // Threshold still appears so the row keeps fixed height
+    await waitFor(() => {
+      expect(screen.getByText(/auto-handoff at 75%/)).toBeTruthy();
+    });
+  });
+
+  it("shows placeholder when Producer exists but ctx_usage is absent", async () => {
+    getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+    const producer = agent({ id: "claude:abc", ctx_usage: null });
+    render(
+      <ProducerCtxHeader
+        agents={[producer]}
+        currentProjectPath="/home/u/proj"
+        onOpenSettings={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/ctx: — \/ —/)).toBeTruthy();
+  });
+
+  it("labels the threshold as 'disabled' when set to 0", async () => {
+    getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(0));
+    render(
+      <ProducerCtxHeader agents={[]} currentProjectPath="/home/u/proj" onOpenSettings={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/auto-handoff: disabled/)).toBeTruthy();
+    });
+  });
+
+  it("⚙ click invokes onOpenSettings", async () => {
+    getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+    const onOpenSettings = vi.fn();
+    render(
+      <ProducerCtxHeader
+        agents={[]}
+        currentProjectPath="/home/u/proj"
+        onOpenSettings={onOpenSettings}
+      />,
+    );
+    fireEvent.click(screen.getByLabelText(/Open settings/));
+    expect(onOpenSettings).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not pick a worktree-Producer (is_worktree gate)", () => {
+    getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+    const worktreeProducer = agent({
+      id: "claude:wt",
+      is_worktree: true,
+      ctx_usage: {
+        used: 100_000n,
+        total: 200_000n,
+        pct: 50,
+        updated_at: "2026-05-15T00:00:00Z",
+      },
+    });
+    render(
+      <ProducerCtxHeader
+        agents={[worktreeProducer]}
+        currentProjectPath="/home/u/proj"
+        onOpenSettings={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/ctx: — \/ —/)).toBeTruthy();
+  });
+});

--- a/clients/react/src/components/settings/HandoffThresholdSection.tsx
+++ b/clients/react/src/components/settings/HandoffThresholdSection.tsx
@@ -1,0 +1,125 @@
+// Auto-handoff threshold control.
+//
+// Operators routinely tune this (handoff-lifecycle DR §E says "primary,
+// not Advanced"), so the control sits in the top Producer group rather
+// than inside `OrchestrationSection` which is collapsed behind the
+// Advanced expandable.
+//
+// Persists `auto_handoff_threshold_pct` on the (global) OrchestratorSettings
+// object via the same PUT helper calibration / orchestration rules use.
+// `0` is a sentinel that disables the auto-trigger entirely; the manual
+// `Handoff & restart` button still works.
+
+import { useEffect, useState } from "react";
+import { useSaveTracker } from "@/hooks/useSaveTracker";
+import { api, type OrchestratorSettings } from "@/lib/api";
+import { SaveStatus } from "./SaveStatus";
+
+const INPUT_CLS =
+  "w-20 rounded-md border border-white/10 bg-white/5 px-2.5 py-1.5 text-xs text-zinc-200 placeholder-zinc-600 outline-none focus:border-cyan-500/30";
+
+const MIN_PCT = 0;
+const MAX_PCT = 100;
+
+function validate(value: string): { ok: true; pct: number } | { ok: false; error: string } {
+  const trimmed = value.trim();
+  if (trimmed === "") return { ok: false, error: "Enter a value between 0 and 100" };
+  const n = Number(trimmed);
+  if (!Number.isFinite(n) || !Number.isInteger(n)) {
+    return { ok: false, error: "Must be a whole number" };
+  }
+  if (n < MIN_PCT || n > MAX_PCT) {
+    return { ok: false, error: `Must be between ${MIN_PCT} and ${MAX_PCT}` };
+  }
+  return { ok: true, pct: n };
+}
+
+export function HandoffThresholdSection() {
+  const [orchestrator, setOrchestrator] = useState<OrchestratorSettings | null>(null);
+  const [draft, setDraft] = useState("");
+  const [localError, setLocalError] = useState<string | null>(null);
+  const save = useSaveTracker();
+
+  useEffect(() => {
+    api
+      .getOrchestratorSettings()
+      .then((s) => {
+        setOrchestrator(s);
+        setDraft(String(s.auto_handoff_threshold_pct));
+      })
+      .catch(() => {});
+  }, []);
+
+  if (!orchestrator) return null;
+
+  const commit = (value: string) => {
+    setLocalError(null);
+    const result = validate(value);
+    if (!result.ok) {
+      setLocalError(result.error);
+      return;
+    }
+    const next = result.pct;
+    if (next === orchestrator.auto_handoff_threshold_pct) return;
+    const prev = orchestrator;
+    setOrchestrator({ ...orchestrator, auto_handoff_threshold_pct: next });
+    setDraft(String(next));
+    void save.track(() => api.updateOrchestratorSettings({ auto_handoff_threshold_pct: next }), {
+      onError: () => {
+        setOrchestrator(prev);
+        setDraft(String(prev.auto_handoff_threshold_pct));
+      },
+    });
+  };
+
+  const currentPct = orchestrator.auto_handoff_threshold_pct;
+  const disabled = currentPct === 0;
+  const statusLabel = disabled ? "Disabled" : `Triggers at ${currentPct}%`;
+
+  return (
+    <section>
+      <div className="flex items-center gap-2">
+        <h3 className="text-sm font-medium text-zinc-300">Auto-handoff threshold (%)</h3>
+        <SaveStatus status={save.status} error={save.error} variant="section" />
+      </div>
+      <p className="mt-1 text-xs text-zinc-600">
+        Producer ritual auto-fires when context usage crosses this percent. Set to 0 to disable;
+        manual <code className="text-zinc-500">Handoff &amp; restart</code> still works.
+      </p>
+
+      <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3 space-y-2">
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            min={MIN_PCT}
+            max={MAX_PCT}
+            step={1}
+            value={draft}
+            onChange={(e) => {
+              setLocalError(null);
+              save.clearError();
+              setDraft(e.target.value);
+            }}
+            onBlur={() => commit(draft)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter") {
+                e.preventDefault();
+                (e.currentTarget as HTMLInputElement).blur();
+              }
+            }}
+            className={INPUT_CLS}
+            aria-label="Auto-handoff threshold percent"
+          />
+          <span className={`text-xs ${disabled ? "text-zinc-500" : "text-zinc-400"}`}>
+            {statusLabel}
+          </span>
+        </div>
+        {localError && (
+          <p role="alert" className="text-[11px] text-red-400">
+            {localError}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/clients/react/src/components/settings/SettingsPanel.tsx
+++ b/clients/react/src/components/settings/SettingsPanel.tsx
@@ -2,6 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { type AgentSnapshot, api, groupByProject } from "@/lib/api";
 import { DisplayLayoutSection } from "./DisplayLayoutSection";
 import { GeneralSection } from "./GeneralSection";
+import { HandoffThresholdSection } from "./HandoffThresholdSection";
 import { NotificationSection } from "./NotificationSection";
 import { OrchestrationDispatchSection } from "./OrchestrationDispatchSection";
 import { OrchestrationSection } from "./OrchestrationSection";
@@ -81,6 +82,7 @@ export function SettingsPanel({ onClose, defaultOpenAdvanced = false }: Settings
           description="Settings the Producer and the human console both read. Stored in ~/.config/tmai/config.toml; shared across CLI, TUI, and WebUI."
         />
         <GeneralSection />
+        <HandoffThresholdSection />
         <NotificationSection />
         <UsageSection />
 

--- a/clients/react/src/components/settings/__tests__/HandoffThresholdSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/HandoffThresholdSection.test.tsx
@@ -1,0 +1,167 @@
+// @vitest-environment jsdom
+//
+// HandoffThresholdSection — auto-handoff threshold control. Verifies:
+//   - reads current value from `api.getOrchestratorSettings()`
+//   - PUT round-trip via `api.updateOrchestratorSettings`
+//   - 0 ⇒ "Disabled" label
+//   - out-of-range values surface inline validation error and skip PUT
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { OrchestratorSettings } from "@/lib/api";
+import { HandoffThresholdSection } from "../HandoffThresholdSection";
+
+const getMock = vi.fn();
+const updateMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getOrchestratorSettings: () => getMock(),
+      updateOrchestratorSettings: (params: unknown) => updateMock(params),
+    },
+  };
+});
+
+function orchestrator(threshold: number): OrchestratorSettings {
+  return {
+    enabled: true,
+    role: "",
+    rules: { branch: "", merge: "", review: "", custom: "" },
+    notify: {
+      on_agent_stopped: "off",
+      on_agent_error: "off",
+      on_rebase_conflict: "off",
+      on_ci_passed: "off",
+      on_ci_failed: "off",
+      on_pr_created: "off",
+      on_pr_comment: "off",
+      on_pr_closed: "off",
+      on_guardrail_exceeded: "off",
+      templates: {
+        agent_stopped: "",
+        agent_error: "",
+        ci_passed: "",
+        ci_failed: "",
+        pr_created: "",
+        pr_comment: "",
+        rebase_conflict: "",
+        pr_closed: "",
+        guardrail_exceeded: "",
+      },
+      default_templates: {
+        agent_stopped: "",
+        agent_error: "",
+        ci_passed: "",
+        ci_failed: "",
+        pr_created: "",
+        pr_comment: "",
+        rebase_conflict: "",
+        pr_closed: "",
+        guardrail_exceeded: "",
+      },
+      suppress_self: false,
+      notify_on_human_action: false,
+      notify_on_agent_action: false,
+      notify_on_system_action: false,
+    },
+    guardrails: { max_ci_retries: 3, max_review_loops: 3, escalate_to_human_after: 3 },
+    auto_action_templates: { ci_failed_implementer: "", review_feedback_implementer: "" },
+    pr_monitor_enabled: false,
+    pr_monitor_interval_secs: 60,
+    pr_monitor_exclude_authors: [],
+    pr_monitor_scope: "current_project",
+    inject_state_snapshot: false,
+    auto_handoff_threshold_pct: threshold,
+    is_project_override: false,
+    orchestrator: null,
+    dispatch: { implementer: null, reviewer: null },
+  };
+}
+
+describe("HandoffThresholdSection", () => {
+  beforeEach(() => {
+    getMock.mockReset();
+    updateMock.mockReset();
+  });
+
+  it("renders the current value once loaded", async () => {
+    getMock.mockResolvedValue(orchestrator(80));
+    render(<HandoffThresholdSection />);
+    await waitFor(() => {
+      const input = screen.getByLabelText(/Auto-handoff threshold percent/i) as HTMLInputElement;
+      expect(input.value).toBe("80");
+    });
+    expect(screen.getByText(/Triggers at 80%/)).toBeTruthy();
+  });
+
+  it("0 renders as Disabled and does not show a percent", async () => {
+    getMock.mockResolvedValue(orchestrator(0));
+    render(<HandoffThresholdSection />);
+    await waitFor(() => {
+      expect(screen.getByText(/Disabled/i)).toBeTruthy();
+    });
+    expect(screen.queryByText(/Triggers at/)).toBeNull();
+  });
+
+  it("blur commits a valid edit via PUT round-trip", async () => {
+    getMock.mockResolvedValue(orchestrator(75));
+    updateMock.mockResolvedValue(undefined);
+    render(<HandoffThresholdSection />);
+    const input = await waitFor(() => {
+      return screen.getByLabelText(/Auto-handoff threshold percent/i) as HTMLInputElement;
+    });
+    fireEvent.change(input, { target: { value: "60" } });
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(updateMock).toHaveBeenCalledTimes(1);
+    });
+    expect(updateMock).toHaveBeenCalledWith({ auto_handoff_threshold_pct: 60 });
+    expect(screen.getByText(/Triggers at 60%/)).toBeTruthy();
+  });
+
+  it("out-of-range (>100) shows validation error and skips PUT", async () => {
+    getMock.mockResolvedValue(orchestrator(75));
+    render(<HandoffThresholdSection />);
+    const input = await waitFor(() => {
+      return screen.getByLabelText(/Auto-handoff threshold percent/i) as HTMLInputElement;
+    });
+    fireEvent.change(input, { target: { value: "150" } });
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(/between 0 and 100/);
+    });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("negative value is rejected and PUT is skipped", async () => {
+    getMock.mockResolvedValue(orchestrator(75));
+    render(<HandoffThresholdSection />);
+    const input = await waitFor(() => {
+      return screen.getByLabelText(/Auto-handoff threshold percent/i) as HTMLInputElement;
+    });
+    fireEvent.change(input, { target: { value: "-5" } });
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(/between 0 and 100/);
+    });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  it("non-integer value is rejected", async () => {
+    getMock.mockResolvedValue(orchestrator(75));
+    render(<HandoffThresholdSection />);
+    const input = await waitFor(() => {
+      return screen.getByLabelText(/Auto-handoff threshold percent/i) as HTMLInputElement;
+    });
+    fireEvent.change(input, { target: { value: "72.5" } });
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toMatch(/whole number/);
+    });
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/react/src/components/settings/__tests__/SettingsPanel-autosave.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel-autosave.test.tsx
@@ -109,6 +109,7 @@ function makeOrchestrator(): OrchestratorSettings {
     pr_monitor_exclude_authors: [],
     pr_monitor_scope: "current_project",
     inject_state_snapshot: false,
+    auto_handoff_threshold_pct: 75,
     is_project_override: false,
     orchestrator: null,
     dispatch: { implementer: null, reviewer: null },

--- a/clients/react/src/components/settings/__tests__/SettingsPanel-orchestration.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel-orchestration.test.tsx
@@ -79,6 +79,7 @@ function makeSettings(overrides: Partial<OrchestratorSettings>): OrchestratorSet
     pr_monitor_exclude_authors: [],
     pr_monitor_scope: "current_project",
     inject_state_snapshot: false,
+    auto_handoff_threshold_pct: 75,
     is_project_override: false,
     orchestrator: null,
     dispatch: { implementer: null, reviewer: null },

--- a/clients/react/src/components/settings/__tests__/SettingsPanel.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel.test.tsx
@@ -19,6 +19,9 @@ vi.mock("@/lib/api", () => ({
 vi.mock("../GeneralSection", () => ({
   GeneralSection: () => <div data-testid="section-general">General</div>,
 }));
+vi.mock("../HandoffThresholdSection", () => ({
+  HandoffThresholdSection: () => <div data-testid="section-handoff-threshold">Handoff</div>,
+}));
 vi.mock("../NotificationSection", () => ({
   NotificationSection: () => <div data-testid="section-notification">Notification</div>,
 }));
@@ -61,6 +64,7 @@ describe("SettingsPanel — Phase B layout", () => {
     render(<SettingsPanel onClose={vi.fn()} />);
 
     expect(screen.getByTestId("section-general")).toBeTruthy();
+    expect(screen.getByTestId("section-handoff-threshold")).toBeTruthy();
     expect(screen.getByTestId("section-notification")).toBeTruthy();
     expect(screen.getByTestId("section-usage")).toBeTruthy();
   });

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -1,6 +1,7 @@
 // HTTP/SSE/WebSocket API layer for tmai axum backend.
 // Replaces Tauri IPC — all communication goes through the existing web API.
 
+import type { AgentCtxUsage } from "@/types/generated/AgentCtxUsage";
 import type { BootstrapRequiredEvent } from "@/types/generated/BootstrapRequiredEvent";
 import type { CalibrationCellWire } from "@/types/generated/CalibrationCellWire";
 import type { CalibrationEntry } from "@/types/generated/CalibrationEntry";
@@ -25,6 +26,7 @@ import type { WorkerDispatchMap } from "@/types/generated/WorkerDispatchMap";
 import type { WorkflowSnapshot } from "@/types/generated/WorkflowSnapshot";
 
 export type {
+  AgentCtxUsage,
   BootstrapRequiredEvent,
   CalibrationCellWire,
   CalibrationEntry,
@@ -181,6 +183,12 @@ export interface AgentSnapshot {
    *  on the wire; the legacy `status` / `phase` / `detail` /
    *  `needs_attention` / `has_pending_approval` pentad is gone. */
   attention?: AgentAttention | null;
+  /** Per-agent context-window usage from CC's statusline hook. Drives
+   *  the ProducerConsole ctx% header and the auto-handoff threshold
+   *  trigger (handoff-lifecycle DR §B/§E). Absent / `null` when the
+   *  agent has not yet emitted a statusline (typical for non-CC
+   *  agents and for CC agents in their bootstrap window). */
+  ctx_usage?: AgentCtxUsage | null;
   // Other derived fields computed by tmai-core
   display_label?: string;
   has_queued_prompt?: boolean;
@@ -705,6 +713,11 @@ export interface OrchestratorSettings {
   pr_monitor_scope: PrMonitorScope;
   /** Append a live state summary to the orchestrator's spawn prompt (#381) */
   inject_state_snapshot: boolean;
+  /** Auto-handoff trigger threshold: Producer's hand-over-and-restart
+   *  ritual fires when `ctx_usage.pct >= auto_handoff_threshold_pct`
+   *  (handoff-lifecycle DR §B/§E). `0` disables the auto-trigger; the
+   *  manual ritual button still works. Rust-side default is 75. */
+  auto_handoff_threshold_pct: number;
   /** Whether this is a per-project override (true) or global fallback (false) */
   is_project_override: boolean;
   /**
@@ -1103,6 +1116,7 @@ export const api = {
       pr_monitor_exclude_authors?: string[];
       pr_monitor_scope?: PrMonitorScope;
       inject_state_snapshot?: boolean;
+      auto_handoff_threshold_pct?: number;
       /**
        * Tri-state: omit → leave unchanged. `null` → clear the bundle. Object →
        * replace. Persists to `[orchestration.orchestrator]` in config.toml.

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -211,6 +211,7 @@ export const api = {
       pr_monitor_exclude_authors?: string[];
       pr_monitor_scope?: PrMonitorScope;
       inject_state_snapshot?: boolean;
+      auto_handoff_threshold_pct?: number;
       /** Tri-state: omit → unchanged. `null` → clear. Object → replace. */
       orchestrator?: DispatchBundle | null;
       /** Replaces the entire `[orchestration.dispatch]` table. */


### PR DESCRIPTION
Closes #681.

## Summary

Wires the WebUI half of the auto-handoff trigger landed server-side in `tmai-core#355` (handoff-lifecycle DR §B + §E). Reads from the `AgentCtxUsage` type synced via #680 and persists the threshold through the existing `OrchestratorSettings` PUT.

- **`ProducerConsole` ctx% header**: new fixed-height row at the top of the console — `ctx: 142k / 200k (71%) ▮▮▮▮▮▮▮░░░ │ auto-handoff at 75% ⚙`. Producer is resolved by the same filter as the `Handoff & restart` button (`claude:` id scheme + `!is_worktree` + cwd resolves to the unit). Threshold readout flips **zinc → amber (within 10%) → red (≥ threshold)** so the operator can predict the trigger. Placeholder `ctx: — / —` keeps the row at constant height when no Producer exists or its statusline hasn't arrived yet. ⚙ click invokes `onOpenSettings`.
- **`SettingsPanel` threshold control**: new `HandoffThresholdSection` lives in the **Producer group** (primary, not Advanced, per DR §E). Numeric 0–100 input, `0 → Disabled`, validation rejects non-integers / out-of-range. Saves via `api.updateOrchestratorSettings({ auto_handoff_threshold_pct: N })`.
- **Hand-written types**: `AgentSnapshot.ctx_usage?: AgentCtxUsage | null` and `OrchestratorSettings.auto_handoff_threshold_pct: number` added in both `api-http.ts` and `api-tauri.ts`. No edits under `types/generated/**`.

DR reference: `tmai-core/doc/decisions/2026-05-14-handoff-lifecycle-and-kill-ux.md` §B + §E.

## Out of scope

- The ⚙ icon opens SettingsPanel via the existing `onOpenSettings` route the operator-override path already uses; it does **not** auto-scroll to the threshold control. The control is at the top of the Producer group so it's the first non-General control on the page — scroll-to was deemed unnecessary in practice, but I'd like a confirm in review whether this matches your read of the DR.
- Legacy `context_used_pct` / `context_window_size` on `AgentSnapshot` are left untouched, per the issue.
- No changes to `clients/ratatui/` or `tmai-core`.

## Test plan

- [x] `pnpm install && pnpm build` clean
- [x] `pnpm test` — 446 passed, 2 skipped (includes new `ProducerCtxHeader` + `HandoffThresholdSection` suites, plus updated `SettingsPanel`/orchestration/autosave fixtures)
- [x] `pnpm exec tsc -b` clean
- [x] `pnpm exec biome check src` clean
- [x] No hand-edits to `clients/react/src/types/generated/**`
- [x] ProducerConsole still renders when no Producer running (placeholder ctx row asserted in tests)
- [x] Existing handoff-ritual + handover tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プロデューサーコンソールにコンテキスト使用率とオートハンドオフ閾値のステータス表示を追加
  * 設定パネルからオートハンドオフ閾値を編集可能に
  * コンテキスト使用状況をビジュアルバーで表示

* **テスト**
  * 新機能に関する包括的なテストを追加

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/682)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->