### PR TITLE
fix(react): defend HandoffThresholdSection against missing auto_handoff_threshold_pct

### DIFF
--- a/clients/react/src/components/settings/HandoffThresholdSection.tsx
+++ b/clients/react/src/components/settings/HandoffThresholdSection.tsx
@@ -45,7 +45,7 @@ export function HandoffThresholdSection() {
       .getOrchestratorSettings()
       .then((s) => {
         setOrchestrator(s);
-        setDraft(String(s.auto_handoff_threshold_pct));
+        setDraft(String(s.auto_handoff_threshold_pct ?? 0));
       })
       .catch(() => {});
   }, []);
@@ -72,7 +72,12 @@ export function HandoffThresholdSection() {
     });
   };
 
-  const currentPct = orchestrator.auto_handoff_threshold_pct;
+  // `auto_handoff_threshold_pct` is required on the wire post-handoff-lifecycle
+  // DR, but a tmai-core binary built before `core-v3.x` (efb8804) omits it.
+  // Mirror the `?? 0` defaulting that ProducerCtxHeader uses so the row reads
+  // "Disabled" (truthful — no auto-handoff is configured) instead of
+  // fabricating "Triggers at undefined%".
+  const currentPct = orchestrator.auto_handoff_threshold_pct ?? 0;
   const disabled = currentPct === 0;
   const statusLabel = disabled ? "Disabled" : `Triggers at ${currentPct}%`;
 

--- a/clients/react/src/components/settings/__tests__/HandoffThresholdSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/HandoffThresholdSection.test.tsx
@@ -107,6 +107,23 @@ describe("HandoffThresholdSection", () => {
     expect(screen.queryByText(/Triggers at/)).toBeNull();
   });
 
+  // Defensive guard against a pre-handoff-lifecycle tmai-core binary that
+  // omits `auto_handoff_threshold_pct` from the wire — the row must read
+  // "Disabled" (truthful) rather than fabricate "Triggers at undefined%".
+  it("missing wire field renders as Disabled (not 'Triggers at undefined%')", async () => {
+    const stale = orchestrator(0);
+    delete (stale as Partial<OrchestratorSettings>).auto_handoff_threshold_pct;
+    getMock.mockResolvedValue(stale);
+    render(<HandoffThresholdSection />);
+    await waitFor(() => {
+      const input = screen.getByLabelText(/Auto-handoff threshold percent/i) as HTMLInputElement;
+      expect(input.value).toBe("0");
+    });
+    expect(screen.getByText(/Disabled/i)).toBeTruthy();
+    expect(screen.queryByText(/undefined/)).toBeNull();
+    expect(screen.queryByText(/Triggers at/)).toBeNull();
+  });
+
   it("blur commits a valid edit via PUT round-trip", async () => {
     getMock.mockResolvedValue(orchestrator(75));
     updateMock.mockResolvedValue(undefined);


### PR DESCRIPTION
## Summary

- Surfaced during browser-verify of #681/#682 against a locally-running tmai-core that's behind origin/main: the WebUI rendered **"Triggers at undefined%"** and an empty input because `auto_handoff_threshold_pct` was absent from the `/api/settings/orchestrator` response.
- `ProducerCtxHeader` already defends against this with `threshold ?? 0`; `HandoffThresholdSection` did not.
- Added the same defaulting so the row truthfully reads **"Disabled"** (no auto-handoff is configured when the wire field is absent) and the input shows `0`.
- Aligns with `doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md`'s **transparency over completeness** principle — never fabricate.

## Why this can happen at all

The handoff-lifecycle DR's wire contract (tmai-core efb8804, `core-v3.x`) makes `auto_handoff_threshold_pct` a required field. A pre-efb8804 engine omits it. During dogfooding the running binary can be older than the synced wire types in this repo (bot PR cadence). The DR-blessed graceful-degradation pattern compensates without lying about the value.

## Test plan

- [x] New unit test covers the stale-engine shape (`auto_handoff_threshold_pct` deleted from the response) and asserts the row renders `Disabled`, the input shows `0`, and no `undefined` leaks into the DOM.
- [x] Existing 6 tests for the section still pass (447 total, 2 skipped).
- [x] Live browser-verified post-HMR: row swapped from `Triggers at undefined%` → `Disabled`.
- [x] `biome check` clean on the two changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## バグ修正
* ハンドオフしきい値設定において、バックエンド設定データが欠落している場合、ユーザーインターフェースが「無効」状態として正しく表示されるようになりました。データ欠落時のUI表示の安定性が向上しています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/684)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->