### PR TITLE
feat(react): wire ⬡ Settled decisions to /api/units/{unit}/decisions

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -30,7 +30,7 @@ import { useNotificationConfig } from "@/hooks/useNotificationConfig";
 import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
 import { useSplitPane } from "@/hooks/useSplitPane";
 import { useWorktrees } from "@/hooks/useWorktrees";
-import { api, groupByProject, isAiAgent, type Selection, setCallerCwd } from "@/lib/api";
+import { api, groupByProject, isAiAgentLoose, type Selection, setCallerCwd } from "@/lib/api";
 import { useSSE } from "@/lib/sse-provider";
 import { useUIPref } from "@/lib/ui-prefs-provider";
 
@@ -250,9 +250,15 @@ export function App() {
     setCallerCwd(currentProject);
   }, [currentProject]);
 
-  // Split agents into AI agents and plain terminals
-  const aiAgents = useMemo(() => agents.filter((a) => isAiAgent(a.agent_type)), [agents]);
-  const terminals = useMemo(() => agents.filter((a) => !isAiAgent(a.agent_type)), [agents]);
+  // Split agents into AI agents and plain terminals. `isAiAgentLoose`
+  // catches the bash-wrapped Producer (id starts `claude:` but
+  // `agent_type` reads `Custom("bash")`) so it lands in `aiAgents` and
+  // its repo participates in `projectPaths` / `currentProject`
+  // auto-default — without this the Producer console's ⬡ Settled
+  // decisions and ▶ Where-you-left-off sections stay parked (#676 +
+  // #685 ergonomics).
+  const aiAgents = useMemo(() => agents.filter(isAiAgentLoose), [agents]);
+  const terminals = useMemo(() => agents.filter((a) => !isAiAgentLoose(a)), [agents]);
 
   // Project list derived from active agents (replaces the pre-registered list).
   // Used by the keyboard shortcuts to cycle the X-Tmai-Origin scope and by

--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -5,7 +5,7 @@
 //
 //   ▶ Where you left off
 //   ⬢ Cross-unit status
-//   ⬡ Settled decisions      (Phase A placeholder)
+//   ⬡ Settled decisions      (wired to GET /api/units/{unit}/decisions)
 //   ◐ Working with this human (Phase A placeholder)
 //
 // Bottom row offers two real actions and one Phase-B stub. The
@@ -80,7 +80,7 @@ export function ProducerConsole({
   sidebarCollapsed,
   onOpenSettings,
 }: ProducerConsoleProps) {
-  const { whereYouLeftOff, crossUnit, settledDecisions, workingWithHuman, missingPreconditions } =
+  const { whereYouLeftOff, crossUnit, workingWithHuman, missingPreconditions } =
     useHandover(currentProjectPath);
   const { agents } = useAgents();
 
@@ -122,7 +122,7 @@ export function ProducerConsole({
           onSelectUnit={onSelectProjectByPath}
           preconditions={missingPreconditions}
         />
-        <SettledDecisionsSection data={settledDecisions} />
+        <SettledDecisionsSection unitName={unitName} />
         <WorkingWithThisHumanSection data={workingWithHuman} />
       </div>
 

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
@@ -38,6 +38,8 @@ vi.mock("@/lib/sse-provider", () => ({
 
 // `useHandoffRitual`'s API mock — only the trigger callable matters
 // here since the composition tests never fire the handoff ritual.
+// `decisions` is mocked so `useDecisions` (now driving the ⬡ section)
+// resolves to an empty payload instead of hitting the network.
 vi.mock("@/lib/api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
   return {
@@ -47,6 +49,11 @@ vi.mock("@/lib/api", async () => {
       getGeneralSettings: vi.fn().mockResolvedValue({ default_project_root: null }),
       killAgent: vi.fn().mockResolvedValue(undefined),
       triggerHandoffRitual: vi.fn().mockResolvedValue({ ritual_id: "r-stub" }),
+      decisions: vi.fn().mockResolvedValue({
+        unit: "stub",
+        composed_at: "2026-05-15T00:00:00Z",
+        repos: [],
+      }),
     },
   };
 });
@@ -60,7 +67,6 @@ function digest(overrides: Partial<HandoverDigest> = {}): HandoverDigest {
       attentionAgents: [],
     },
     crossUnit: overrides.crossUnit ?? { units: [] },
-    settledDecisions: overrides.settledDecisions ?? { placeholder: true },
     workingWithHuman: overrides.workingWithHuman ?? { placeholder: true },
     missingPreconditions: overrides.missingPreconditions ?? {
       noLiveAgents: true,
@@ -150,16 +156,16 @@ describe("ProducerConsole", () => {
     expect(screen.getByText("main")).toBeTruthy();
   });
 
-  it("renders the user-facing copy in the not-yet-wired sections", () => {
+  it("renders honest user-facing copy in the remaining-placeholder section + the no-unit notice in Settled decisions", () => {
     useHandoverMock.mockReturnValue(digest());
 
     render(<ProducerConsole {...makeProps()} />);
 
-    // Section components own these strings (not the hook); they should
-    // point the operator at the repo-side fallbacks rather than leak
-    // phase-tracking jargon ("Phase C: ... not yet wired") which read
-    // as broken on first contact.
-    expect(screen.getByText(/doc\/decisions/)).toBeTruthy();
+    // ⬡ Settled decisions is now wired (PR #359); with `unitName=null`
+    // it surfaces a "pick a project" notice rather than fabricating
+    // bucketed content. ◐ Working with this human is still a
+    // placeholder — its copy should still point at `CLAUDE.md`.
+    expect(screen.getByText(/Pick a project/i)).toBeTruthy();
     expect(screen.getByText(/CLAUDE\.md/)).toBeTruthy();
   });
 

--- a/clients/react/src/components/producer-console/sections/SettledDecisionsSection.tsx
+++ b/clients/react/src/components/producer-console/sections/SettledDecisionsSection.tsx
@@ -1,53 +1,253 @@
-// ⬡ Settled decisions — third hand-over section (Phase A placeholder).
+// ⬡ Settled decisions — third hand-over section, wired to
+// `GET /api/units/{unit}/decisions` (tmai-core PR #359).
 //
-// The hand-over composer on the Producer side renders decisions
-// bucketed by temperature: 📌 Foundational / 🔴 In-play / 🟡 Warm /
-// ⚪ Cold. The wire endpoint (`GET /api/units/{unit}/decisions`) is
-// not yet wired, so this section displays a user-readable "not yet
-// automated" notice pointing at the repo's `doc/decisions/` for the
-// time being. Earlier drafts of this string leaked phase-tracking
-// jargon ("Phase C: `GET /api/units/...` is not yet wired") into the
-// user UI, which read as broken; this revision drops that and
-// addresses the operator directly.
+// Surfaces the same Settled-section the Producer reads on session-start:
+// 📌 Foundations / 🔴 In-play / 🟡 Warm / ⚪ Cold buckets, plus the
+// ⚠ Currency sweep + ⚠ Trajectory check due callouts. The render is
+// shaped to match the markdown hand-over the Producer composes
+// (`tmai-core/crates/tmai-core/src/workbench/render.rs`) so the
+// operator's mental model is the same on both sides.
 //
-// TODO(tmai-core#340): when multi-repo unit support lands, this
-// section will need to show decisions from every repo in
-// `UnitConfig.also[]`, not just the primary cwd. Per the
-// simulated-onboarded posture DR (`doc/decisions/2026-05-14-webui-
-// simulated-onboarded-posture.md`), the current copy is intentionally
-// honest about the single-repo limitation.
-// TODO(tmai-core#341): when `compose()` cold-start hardening lands,
-// surface the `meta.missing_preconditions` signal here so an operator
-// who hasn't run `tmai onboard <unit>` sees an actionable hint.
+// Multi-repo unit (per
+// `doc/decisions/2026-05-14-producer-capability-valve-principle.md` §D)
+// is rendered as one group per repo. Single-repo unit collapses to one
+// group. The simulated-onboarded posture
+// (`doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md`)
+// keeps the "single-repo only" caveat honest until tmai-core#340 lands.
+//
+// `unit = null` → "pick a project first" placeholder, no fetch. Per the
+// posture DR's transparency principle, we never fabricate decisions —
+// an empty unit or a load error reads as "no decisions yet" rather
+// than an empty bucketed render that looks like the unit has nothing
+// settled.
+//
+// TODO(tmai-core#340): when `UnitConfig.also[]` lands, surface decisions
+// from every repo in the unit. The response already groups per repo;
+// only the "Showing one unit only" caveat needs to retire then.
 
-import type { SettledDecisionsPlaceholder } from "@/hooks/useHandover";
+import { useState } from "react";
+import { useDecisions } from "@/hooks/useDecisions";
+import type {
+  CurrencyItemWire,
+  DecisionWire,
+  FoundationalDueWire,
+  RepoDecisionsWire,
+} from "@/lib/api";
 
 interface SettledDecisionsSectionProps {
-  data: SettledDecisionsPlaceholder;
+  unitName: string | null;
 }
 
-export function SettledDecisionsSection({ data: _data }: SettledDecisionsSectionProps) {
+export function SettledDecisionsSection({ unitName }: SettledDecisionsSectionProps) {
+  const { data, loading, error } = useDecisions(unitName);
+
   return (
     <section>
       <header className="mb-2 flex items-baseline gap-2">
         <span className="text-base text-cyan-400">⬡</span>
         <h3 className="text-sm font-semibold text-zinc-200">Settled decisions</h3>
-        <span className="rounded bg-zinc-700/50 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-zinc-400">
-          not automated yet
-        </span>
+        {loading && data === null && <span className="text-[10px] text-zinc-500">loading…</span>}
       </header>
+      <SettledBody unitName={unitName} data={data} loading={loading} error={error} />
+    </section>
+  );
+}
 
+interface SettledBodyProps {
+  unitName: string | null;
+  data: ReturnType<typeof useDecisions>["data"];
+  loading: boolean;
+  error: Error | null;
+}
+
+function SettledBody({ unitName, data, loading, error }: SettledBodyProps) {
+  if (unitName === null) {
+    return (
       <div className="pl-6 text-xs text-zinc-500">
         <p>
-          Browse your repo's <code className="text-zinc-300">doc/decisions/</code> directly to see
-          settled decisions for now — the Producer reads them on session-start.
-        </p>
-        <p className="mt-2 text-zinc-600">
-          When wired, this section will surface them bucketed by temperature: 📌 foundational · 🔴
-          in-play · 🟡 warm · ⚪ cold — pulled from every repo this unit spans, not just the one you
-          launched against.
+          Pick a project (click a unit chip in{" "}
+          <span className="text-zinc-400">⬢ Cross-unit status</span> above, or use the sidebar) to
+          see its settled decisions.
         </p>
       </div>
-    </section>
+    );
+  }
+
+  if (error !== null) {
+    return (
+      <div className="pl-6 text-xs text-red-300/80">
+        <p>
+          Failed to load decisions: <code className="text-red-300">{error.message}</code>
+        </p>
+        <p className="mt-1 text-zinc-500">
+          Browse <code className="text-zinc-300">doc/decisions/</code> directly in the repo as a
+          fallback.
+        </p>
+      </div>
+    );
+  }
+
+  if (data === null && loading) {
+    return <div className="pl-6 text-xs text-zinc-500">Loading…</div>;
+  }
+
+  if (data === null || data.repos.length === 0) {
+    return (
+      <div className="pl-6 text-xs text-zinc-500">
+        <p>
+          No decisions resolved for <code className="text-zinc-300">{unitName}</code>. The unit
+          either has no <code className="text-zinc-300">doc/decisions/</code> directory yet, or it's
+          empty.
+        </p>
+      </div>
+    );
+  }
+
+  // Posture (per `2026-05-14-webui-simulated-onboarded-posture.md`):
+  // until `UnitConfig.also[]` (tmai-core#340) lands, the response will
+  // always have `repos.length === 1` for a real-world tmai project that
+  // spans multiple repos. Surface this honestly so the operator knows
+  // the section is currently showing the primary cwd only.
+  const onlyPrimary = data.repos.length === 1;
+
+  return (
+    <div className="space-y-3 pl-6 text-xs">
+      {data.repos.map((repo) => (
+        <RepoGroup key={repo.repo_root} repo={repo} singleRepo={onlyPrimary} />
+      ))}
+      {onlyPrimary && (
+        // TODO(tmai-core#340): retire this notice once multi-repo
+        // unit support surfaces decisions from every repo.
+        <p className="text-[11px] text-zinc-600">
+          Showing this unit's primary repo only — multi-repo decision aggregation isn't wired yet
+          (tmai-core#340).
+        </p>
+      )}
+    </div>
+  );
+}
+
+interface RepoGroupProps {
+  repo: RepoDecisionsWire;
+  singleRepo: boolean;
+}
+
+function RepoGroup({ repo, singleRepo }: RepoGroupProps) {
+  const { counts } = repo;
+  return (
+    <div className="space-y-2">
+      {!singleRepo && (
+        <h4 className="text-[11px] font-semibold uppercase tracking-wide text-zinc-400">
+          <code className="font-mono text-zinc-300">{repo.repo_label}</code>
+          {repo.primary && <span className="ml-1 text-cyan-400">(primary)</span>}
+          {repo.repo_head && <span className="ml-2 text-zinc-600">@ {repo.repo_head}</span>}
+        </h4>
+      )}
+
+      <p className="text-[11px] text-zinc-600">
+        {`${counts.total} decision${counts.total !== 1 ? "s" : ""} · `}
+        <span className="text-zinc-500">{`📌 ${counts.foundations}  🔴 ${counts.in_play}  🟡 ${counts.warm}  ⚪ ${counts.cold}`}</span>
+        {counts.superseded > 0 && (
+          <span className="text-zinc-600">{` · superseded ${counts.superseded}`}</span>
+        )}
+      </p>
+
+      {repo.currency_sweep.length > 0 && <CurrencySweep items={repo.currency_sweep} />}
+
+      {repo.foundational_due.length > 0 && <FoundationalDue items={repo.foundational_due} />}
+
+      <Bucket label="📌 Foundations" items={repo.foundations} alwaysOpen />
+      <Bucket label="🔴 In play" items={repo.in_play} alwaysOpen />
+      <Bucket label="🟡 Warm" items={repo.warm} />
+      <Bucket label="⚪ Cold" items={repo.cold} />
+      <Bucket label="Superseded" items={repo.superseded} muted />
+    </div>
+  );
+}
+
+interface BucketProps {
+  label: string;
+  items: DecisionWire[];
+  /** Render the list expanded by default (foundations / in-play). */
+  alwaysOpen?: boolean;
+  muted?: boolean;
+}
+
+function Bucket({ label, items, alwaysOpen, muted }: BucketProps) {
+  const [open, setOpen] = useState(alwaysOpen === true);
+  if (items.length === 0) return null;
+
+  return (
+    <div className="space-y-1">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={`flex w-full items-center gap-1 text-left text-[11px] ${muted ? "text-zinc-600" : "text-zinc-400"} hover:text-zinc-200`}
+      >
+        <span className="font-mono text-zinc-600">{open ? "▾" : "▸"}</span>
+        <span className="font-medium">{label}</span>
+        <span className="text-zinc-600">({items.length})</span>
+      </button>
+      {open && (
+        <ul className="space-y-0.5 pl-4">
+          {items.map((d) => (
+            <DecisionRow key={d.slug} decision={d} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function DecisionRow({ decision }: { decision: DecisionWire }) {
+  const driftMark = decision.stale_since ? " ⚠" : "";
+  const contractMark = decision.contract_surface ? " [contract]" : "";
+  return (
+    <li className="text-[11px] leading-snug text-zinc-400">
+      <code className="text-zinc-300">{decision.slug}</code>
+      <span className="text-zinc-600">{contractMark}</span>
+      <span className="text-amber-300">{driftMark}</span>
+      <span className="text-zinc-500"> — {decision.title}</span>
+    </li>
+  );
+}
+
+function CurrencySweep({ items }: { items: CurrencyItemWire[] }) {
+  return (
+    <div className="rounded border border-amber-500/20 bg-amber-500/[0.04] p-2">
+      <p className="mb-1 text-[11px] font-medium text-amber-300">
+        ⚠ Currency sweep ({items.length})
+      </p>
+      <ul className="space-y-1 pl-3">
+        {items.map((it) => (
+          <li key={it.slug} className="text-[11px] text-zinc-400">
+            <code className="text-zinc-300">{it.slug}</code>
+            <span className="text-zinc-500"> — {it.title}</span>
+            <div className="text-[10.5px] text-zinc-500">{it.remedy}</div>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function FoundationalDue({ items }: { items: FoundationalDueWire[] }) {
+  return (
+    <div className="rounded border border-yellow-500/20 bg-yellow-500/[0.04] p-2">
+      <p className="mb-1 text-[11px] font-medium text-yellow-300">
+        ⚠ Trajectory check due ({items.length})
+      </p>
+      <ul className="space-y-1 pl-3">
+        {items.map((it) => (
+          <li key={it.slug} className="text-[11px] text-zinc-400">
+            <code className="text-zinc-300">{it.slug}</code>
+            <span className="text-zinc-500"> — {it.title}</span>
+            <div className="text-[10.5px] text-zinc-500">
+              {it.age_days}d since verify · {it.remedy}
+            </div>
+          </li>
+        ))}
+      </ul>
+    </div>
   );
 }

--- a/clients/react/src/components/producer-console/sections/__tests__/SettledDecisionsSection.test.tsx
+++ b/clients/react/src/components/producer-console/sections/__tests__/SettledDecisionsSection.test.tsx
@@ -1,0 +1,284 @@
+// @vitest-environment jsdom
+//
+// SettledDecisionsSection — wired to `useDecisions(unitName)` against
+// the live `GET /api/units/{unit}/decisions` endpoint (tmai-core #359).
+//
+// We mock `api.decisions` so each test feeds a deterministic response
+// shape and asserts on the bucketed render. Per the simulated-onboarded
+// posture DR, the section must:
+//   - render a "pick a project" notice when unitName is null
+//   - render a "Showing this unit's primary repo only" caveat when a
+//     single repo is returned (= today's reality until tmai-core#340)
+//   - never fabricate decisions on error / empty payload
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { DecisionsResponse, RepoDecisionsWire } from "@/lib/api";
+import { SettledDecisionsSection } from "../SettledDecisionsSection";
+
+const decisionsMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      decisions: (...args: unknown[]) => decisionsMock(...args),
+    },
+  };
+});
+
+function repoStub(overrides: Partial<RepoDecisionsWire> = {}): RepoDecisionsWire {
+  return {
+    repo_label: "tmai",
+    repo_root: "/home/u/works/tmai",
+    primary: true,
+    repo_head: "abc1234",
+    counts: {
+      total: 0,
+      in_play: 0,
+      warm: 0,
+      cold: 0,
+      foundations: 0,
+      superseded: 0,
+      stale_suspect: 0,
+    },
+    currency_sweep: [],
+    foundational_due: [],
+    foundations: [],
+    in_play: [],
+    warm: [],
+    cold: [],
+    superseded: [],
+    ...overrides,
+  };
+}
+
+function responseStub(overrides: Partial<DecisionsResponse> = {}): DecisionsResponse {
+  return {
+    unit: "tmai",
+    composed_at: "2026-05-15T01:00:00Z",
+    repos: [repoStub()],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  decisionsMock.mockReset();
+});
+
+describe("SettledDecisionsSection", () => {
+  it("shows a pick-a-project notice when unitName is null and does not fetch", () => {
+    render(<SettledDecisionsSection unitName={null} />);
+    expect(screen.getByText(/Pick a project/i)).toBeTruthy();
+    expect(decisionsMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the bucketed payload and the single-repo caveat", async () => {
+    decisionsMock.mockResolvedValue(
+      responseStub({
+        repos: [
+          repoStub({
+            counts: {
+              total: 3,
+              in_play: 1,
+              warm: 0,
+              cold: 0,
+              foundations: 2,
+              superseded: 0,
+              stale_suspect: 0,
+            },
+            foundations: [
+              {
+                slug: "2026-05-13-tmai-is-a-producer-exoskeleton",
+                title: "tmai is a Producer exoskeleton",
+                status: "accepted",
+                category: "foundational",
+                governs: [],
+                last_verified: "2026-05-13",
+                contract_surface: false,
+                stale_since: null,
+                superseded_by: [],
+                strengthened_by: [],
+                excerpt: "tmai is the Producer's external skeleton…",
+              },
+              {
+                slug: "2026-05-12-producer-layer-topology",
+                title: "Producer-layer topology",
+                status: "accepted",
+                category: "foundational",
+                governs: [],
+                last_verified: "2026-05-12",
+                contract_surface: false,
+                stale_since: null,
+                superseded_by: [],
+                strengthened_by: [],
+                excerpt: "1 project ⊇ 1+ repos…",
+              },
+            ],
+            in_play: [
+              {
+                slug: "2026-05-14-handoff-lifecycle-and-kill-ux",
+                title: "Handoff lifecycle and kill UX",
+                status: "proposed",
+                category: "scoped",
+                governs: ["crates/tmai-core/src/workbench/"],
+                last_verified: "2026-05-14",
+                contract_surface: true,
+                stale_since: null,
+                superseded_by: [],
+                strengthened_by: [],
+                excerpt: "Atomic 1-set ritual gated on ctx%…",
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+
+    render(<SettledDecisionsSection unitName="tmai" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/2026-05-13-tmai-is-a-producer-exoskeleton/)).toBeTruthy();
+    });
+    expect(screen.getByText(/2026-05-14-handoff-lifecycle-and-kill-ux/)).toBeTruthy();
+    // Single-repo caveat per the posture DR.
+    expect(screen.getByText(/primary repo only/i)).toBeTruthy();
+    // Counts line.
+    expect(screen.getByText(/3 decisions/)).toBeTruthy();
+    // Contract-surface marker rendered for the wire-touching decision.
+    expect(screen.getByText(/\[contract\]/)).toBeTruthy();
+  });
+
+  it("renders the ⚠ Currency sweep callout when items are present", async () => {
+    decisionsMock.mockResolvedValue(
+      responseStub({
+        repos: [
+          repoStub({
+            counts: {
+              total: 1,
+              in_play: 0,
+              warm: 1,
+              cold: 0,
+              foundations: 0,
+              superseded: 0,
+              stale_suspect: 1,
+            },
+            currency_sweep: [
+              {
+                slug: "2026-04-21-monorepo-reconsolidation",
+                title: "Monorepo re-consolidation",
+                stale: {
+                  path: "src/web/api.rs",
+                  change_date: "2026-05-14",
+                  change_sha: "deadbee",
+                  change_subject: "feat(api): handoff ritual endpoint",
+                },
+                last_verified: "2026-04-21",
+                remedy: "Re-verify the decision against current `src/web/api.rs`.",
+              },
+            ],
+            warm: [
+              {
+                slug: "2026-04-21-monorepo-reconsolidation",
+                title: "Monorepo re-consolidation",
+                status: "accepted",
+                category: "scoped",
+                governs: ["src/web/api.rs"],
+                last_verified: "2026-04-21",
+                contract_surface: false,
+                stale_since: {
+                  path: "src/web/api.rs",
+                  change_date: "2026-05-14",
+                  change_sha: "deadbee",
+                  change_subject: "feat(api): handoff ritual endpoint",
+                },
+                superseded_by: [],
+                strengthened_by: [],
+                excerpt: "…",
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+
+    render(<SettledDecisionsSection unitName="tmai" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Currency sweep \(1\)/)).toBeTruthy();
+    });
+    expect(
+      screen.getByText(/Re-verify the decision against current `src\/web\/api\.rs`\./),
+    ).toBeTruthy();
+  });
+
+  it("surfaces fetch errors honestly instead of fabricating an empty render", async () => {
+    decisionsMock.mockRejectedValue(new Error("boom"));
+
+    render(<SettledDecisionsSection unitName="tmai" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load decisions/)).toBeTruthy();
+    });
+    expect(screen.getByText(/boom/)).toBeTruthy();
+    // No fake bucketed render.
+    expect(screen.queryByText(/Foundations/)).toBeNull();
+  });
+
+  it("renders an empty-state notice when the unit has no decisions", async () => {
+    decisionsMock.mockResolvedValue(responseStub({ repos: [] }));
+
+    render(<SettledDecisionsSection unitName="newunit" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No decisions resolved for/i)).toBeTruthy();
+    });
+  });
+
+  it("warm and cold buckets are collapsed by default and expand on click", async () => {
+    decisionsMock.mockResolvedValue(
+      responseStub({
+        repos: [
+          repoStub({
+            counts: {
+              total: 1,
+              in_play: 0,
+              warm: 0,
+              cold: 1,
+              foundations: 0,
+              superseded: 0,
+              stale_suspect: 0,
+            },
+            cold: [
+              {
+                slug: "2026-04-01-something-old",
+                title: "Something old",
+                status: "accepted",
+                category: "scoped",
+                governs: [],
+                last_verified: "2026-04-01",
+                contract_surface: false,
+                stale_since: null,
+                superseded_by: [],
+                strengthened_by: [],
+                excerpt: "…",
+              },
+            ],
+          }),
+        ],
+      }),
+    );
+
+    render(<SettledDecisionsSection unitName="tmai" />);
+
+    const coldButton = await screen.findByRole("button", { name: /Cold/ });
+    // Collapsed initially — the slug should not be in the DOM.
+    expect(screen.queryByText(/2026-04-01-something-old/)).toBeNull();
+    fireEvent.click(coldButton);
+    await waitFor(() => {
+      expect(screen.getByText(/2026-04-01-something-old/)).toBeTruthy();
+    });
+  });
+});

--- a/clients/react/src/hooks/__tests__/useHandover.test.ts
+++ b/clients/react/src/hooks/__tests__/useHandover.test.ts
@@ -80,12 +80,12 @@ describe("useHandover — empty state", () => {
     expect(result.current.crossUnit.units).toEqual([]);
   });
 
-  it("always exposes the two not-yet-wired placeholders as plain signals", () => {
+  it("exposes the working-with-human placeholder (settled decisions now lives in its own section)", () => {
     const { result } = renderHook(() => useHandover(null));
-    // The placeholder shape is intentionally just `{ placeholder: true }`
-    // — the section components own the user-facing copy so the hook
-    // stays free of UI strings.
-    expect(result.current.settledDecisions.placeholder).toBe(true);
+    // `⬡ Settled decisions` is now driven by `useDecisions` directly in
+    // `SettledDecisionsSection`; the hook no longer ships a placeholder
+    // for it. `◐ Working with this human` stays placeholder-shaped
+    // until its wire endpoint lands.
     expect(result.current.workingWithHuman.placeholder).toBe(true);
   });
 });

--- a/clients/react/src/hooks/useDecisions.ts
+++ b/clients/react/src/hooks/useDecisions.ts
@@ -1,0 +1,79 @@
+// Polling hook for the unit's settled-decisions view.
+//
+// Mirrors `useCalibration`: a 60-second poll is plenty for the
+// `⬡ Settled decisions` section since decision frontmatter and git
+// history move on human timescales, not real-time. SSE-driven updates
+// would be the natural follow-up (`CoreEvent::DecisionsChanged` on the
+// tmai-core side) but the polling shape lets us land the UX without
+// blocking on that wire-side work.
+//
+// The hook keeps the previous response visible while a re-fetch is in
+// flight (`loading` reflects only the initial fetch) so the bucketed
+// render does not flash empty between renders.
+
+import { useEffect, useRef, useState } from "react";
+import { api, type DecisionsResponse } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface UseDecisionsResult {
+  data: DecisionsResponse | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Poll the unit's settled-decisions view at `POLL_INTERVAL_MS`. Returns
+ * the latest response, an initial-load `loading` flag, and the most
+ * recent error (cleared on a successful fetch).
+ *
+ * `unit = null` parks the hook: no fetch, no interval, no data. Useful
+ * when the UI has no project selected and we want the section to render
+ * its "no unit yet" placeholder rather than poll a non-existent unit.
+ */
+export function useDecisions(unit: string | null): UseDecisionsResult {
+  const [data, setData] = useState<DecisionsResponse | null>(null);
+  const [loading, setLoading] = useState(unit !== null);
+  const [error, setError] = useState<Error | null>(null);
+  // Track the latest fetch so an in-flight response from a previous unit
+  // cannot stamp over a newer unit's data.
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    if (!unit) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    setLoading(true);
+
+    const fetchOnce = async () => {
+      try {
+        const res = await api.decisions(unit);
+        if (myGen !== generationRef.current) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (myGen !== generationRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (myGen === generationRef.current) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [unit]);
+
+  return { data, loading, error };
+}

--- a/clients/react/src/hooks/useHandover.ts
+++ b/clients/react/src/hooks/useHandover.ts
@@ -118,9 +118,12 @@ export interface CrossUnitStatus {
 // (Earlier drafts inlined a `reason` field with "Phase C: <endpoint>
 // not yet wired" technical text, which leaked through to the user UI
 // and read as broken. Lesson: keep technical reasons out of UI hooks.)
-export interface SettledDecisionsPlaceholder {
-  placeholder: true;
-}
+//
+// `⬡ Settled decisions` is now wired to `GET /api/units/{unit}/decisions`
+// (tmai-core PR #359) — the section owns its own polling via
+// `useDecisions(unitName)` rather than receiving placeholder data here.
+// `◐ Working with this human` stays a placeholder until the next wire
+// endpoint (memory dir / MEMORY.md projection) lands.
 
 export interface WorkingWithHumanPlaceholder {
   placeholder: true;
@@ -157,7 +160,6 @@ export interface MissingPreconditions {
 export interface HandoverDigest {
   whereYouLeftOff: WhereYouLeftOff;
   crossUnit: CrossUnitStatus;
-  settledDecisions: SettledDecisionsPlaceholder;
   workingWithHuman: WorkingWithHumanPlaceholder;
   missingPreconditions: MissingPreconditions;
 }
@@ -178,8 +180,9 @@ function deriveUnitState(group: ProjectGroup): UnitState {
 /**
  * Aggregate client-side data into the hand-over digest's four sections.
  *
- * Phase A: `settledDecisions` and `workingWithHuman` are placeholders;
- * see file header for the wire endpoints Phase C will introduce.
+ * `settledDecisions` is no longer in the digest — `SettledDecisionsSection`
+ * owns its own polling via `useDecisions`. `workingWithHuman` stays a
+ * placeholder until the next wire endpoint lands.
  */
 export function useHandover(currentProjectPath: string | null): HandoverDigest {
   const { agents } = useAgents();
@@ -235,11 +238,10 @@ export function useHandover(currentProjectPath: string | null): HandoverDigest {
     [projectGroups],
   );
 
-  // Plain signal objects — the section components own the user-facing
-  // copy. Section identity is stable across renders since the literal
-  // is structurally identical, but we still allocate fresh objects to
+  // Plain signal object — the section component owns the user-facing
+  // copy. Identity is stable across renders since the literal is
+  // structurally identical, but we still allocate a fresh object to
   // keep the type literal `true` exact.
-  const settledDecisions: SettledDecisionsPlaceholder = { placeholder: true };
   const workingWithHuman: WorkingWithHumanPlaceholder = { placeholder: true };
 
   // Weak posture-signal derivation. See `MissingPreconditions` doc for
@@ -250,5 +252,5 @@ export function useHandover(currentProjectPath: string | null): HandoverDigest {
     singleUnitOnly: projectGroups.length === 1,
   };
 
-  return { whereYouLeftOff, crossUnit, settledDecisions, workingWithHuman, missingPreconditions };
+  return { whereYouLeftOff, crossUnit, workingWithHuman, missingPreconditions };
 }

--- a/clients/react/src/hooks/useHandover.ts
+++ b/clients/react/src/hooks/useHandover.ts
@@ -47,30 +47,18 @@ import {
   type AgentAttention,
   type AgentSnapshot,
   groupByProject,
-  isAiAgent,
+  isAiAgentLoose,
   type ProjectGroup,
 } from "@/lib/api";
 
-// Canonical AgentId schemes that mark a snapshot as an AI coding agent
-// regardless of `agent_type`. Post-2026-05-09 detection canonicalization,
-// `id` carries the canonical scheme (`claude:` / `codex:` / `gemini:` /
-// `opencode:`) even when the spawn command was wrapped (e.g. the
-// Producer launch wraps `tmai producer <unit>` under `bash -c` to
-// satisfy tmai-core's `/api/spawn` allow-list — see
-// `doc/decisions/2026-05-14-react-producer-console-rebuild.md` polish v4).
-// In that wrapped case `agent_type` stays `Custom("bash")` and the
-// plain `isAiAgent(agent_type)` check misses the Producer.
-//
-// TODO(tmai-core spawn-allow-list): when tmai-core's allow-list adds
-// `tmai` as a first-class command, the bash wrap goes away and
-// `agent_type` will reflect reality — this id-scheme fallback can
-// then retire.
-const AI_ID_SCHEMES = ["claude:", "codex:", "gemini:", "opencode:"] as const;
-
-function isHandoverAgent(a: AgentSnapshot): boolean {
-  if (isAiAgent(a.agent_type)) return true;
-  return AI_ID_SCHEMES.some((scheme) => a.id.startsWith(scheme));
-}
+// The `isAiAgentLoose` helper (centralized in `@/lib/api`) handles the
+// bash-wrapped Producer case for us — when the spawn is wrapped under
+// `bash -c` to satisfy tmai-core's `/api/spawn` allow-list, the
+// `agent_type` stays `Custom("bash")` but the canonical id scheme
+// (`claude:` / `codex:` / `gemini:` / `opencode:`) still identifies
+// the underlying AI agent. The hand-over digest needs the loose
+// classifier so that wrapped Producer doesn't drop out of
+// `projectGroups` and break the cross-unit derivation.
 
 export interface WorktreeBrief {
   name: string;
@@ -188,7 +176,7 @@ export function useHandover(currentProjectPath: string | null): HandoverDigest {
   const { agents } = useAgents();
   const { worktrees } = useWorktrees();
 
-  const aiAgents = useMemo(() => agents.filter(isHandoverAgent), [agents]);
+  const aiAgents = useMemo(() => agents.filter(isAiAgentLoose), [agents]);
 
   const projectGroups = useMemo<ProjectGroup[]>(
     () => groupByProject(aiAgents, worktrees),

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -150,6 +150,32 @@ export function isAiAgent(agentType: AgentType): boolean {
   );
 }
 
+/// Canonical AgentId schemes that mark a snapshot as an AI coding agent
+/// regardless of `agent_type`. Post-2026-05-09 detection canonicalization,
+/// `id` carries the canonical scheme (`claude:` / `codex:` / `gemini:` /
+/// `opencode:`) even when the spawn command was wrapped — e.g. the
+/// Producer launch wraps `tmai producer <unit>` under `bash -c` to
+/// satisfy tmai-core's `/api/spawn` allow-list (see
+/// `doc/decisions/2026-05-14-react-producer-console-rebuild.md` polish v4).
+/// In that wrapped case `agent_type` stays `Custom("bash")` and the
+/// plain `isAiAgent(agent_type)` check misses the Producer.
+///
+/// TODO(tmai-core spawn-allow-list): when tmai-core's allow-list adds
+/// `tmai` as a first-class command, the bash wrap goes away and
+/// `agent_type` reflects reality — this id-scheme fallback can retire.
+const AI_ID_SCHEMES = ["claude:", "codex:", "gemini:", "opencode:"] as const;
+
+/// True if the agent is an AI coding agent — either by `agent_type` or
+/// (post-2026-05-09 fallback) by canonical AgentId scheme prefix.
+///
+/// Centralized here so the bash-wrapped Producer case (#676) classifies
+/// consistently across the WebUI: hand-over digest, App's `aiAgents` →
+/// `projectPaths` derivation, sidebar AI/terminal split, etc.
+export function isAiAgentLoose(agent: { id: string; agent_type: AgentType }): boolean {
+  if (isAiAgent(agent.agent_type)) return true;
+  return AI_ID_SCHEMES.some((scheme) => agent.id.startsWith(scheme));
+}
+
 export interface AgentSnapshot {
   id: string;
   target: string;

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -815,6 +815,97 @@ export interface DirEntry {
   is_git: boolean;
 }
 
+// ── Decisions view (tmai-core PR #359) ──
+//
+// Wire types mirroring `tmai-core::api::decisions_view` for the
+// `GET /api/units/{unit}/decisions` endpoint. Hand-written here until
+// the `gen-spec-pr` bot PR syncs them into `src/types/generated/`;
+// once that lands the hand-written exports collapse to re-exports of
+// the generated bindings (same shape).
+//
+// Doc-decision basis: `2026-05-11-producer-conversation-workbench` §1
+// (Settled-section projection) + DR §D of
+// `2026-05-14-producer-capability-valve-principle` (per-repo render,
+// no cross-repo aggregation).
+export type DecisionStatusWire =
+  | "draft"
+  | "proposed"
+  | "accepted"
+  | "superseded"
+  | "superseded-in-part";
+
+export type DecisionCategoryWire = "scoped" | "principle" | "foundational";
+
+export interface StaleSinceWire {
+  path: string;
+  change_date: string;
+  change_sha: string;
+  change_subject: string;
+}
+
+export interface DecisionWire {
+  slug: string;
+  title: string;
+  status: DecisionStatusWire;
+  category: DecisionCategoryWire;
+  governs: string[];
+  /** ISO-8601 date string, e.g. "2026-05-14". */
+  last_verified: string;
+  contract_surface: boolean;
+  stale_since: StaleSinceWire | null;
+  superseded_by: string[];
+  strengthened_by: string[];
+  excerpt: string;
+}
+
+export interface CurrencyItemWire {
+  slug: string;
+  title: string;
+  stale: StaleSinceWire;
+  last_verified: string;
+  remedy: string;
+}
+
+export interface FoundationalDueWire {
+  slug: string;
+  title: string;
+  last_verified: string;
+  age_days: number;
+  remedy: string;
+}
+
+export interface DecisionCountsWire {
+  total: number;
+  in_play: number;
+  warm: number;
+  cold: number;
+  foundations: number;
+  superseded: number;
+  stale_suspect: number;
+}
+
+export interface RepoDecisionsWire {
+  repo_label: string;
+  repo_root: string;
+  primary: boolean;
+  repo_head: string | null;
+  counts: DecisionCountsWire;
+  currency_sweep: CurrencyItemWire[];
+  foundational_due: FoundationalDueWire[];
+  foundations: DecisionWire[];
+  in_play: DecisionWire[];
+  warm: DecisionWire[];
+  cold: DecisionWire[];
+  superseded: DecisionWire[];
+}
+
+export interface DecisionsResponse {
+  unit: string;
+  /** RFC3339 timestamp. */
+  composed_at: string;
+  repos: RepoDecisionsWire[];
+}
+
 // ── API wrappers ──
 
 export const api = {
@@ -1178,6 +1269,13 @@ export const api = {
   // the CLI's default.
   calibration: (unit: string, days = 90) =>
     apiFetch<CalibrationResponse>(`/units/${encodeURIComponent(unit)}/calibration?days=${days}`),
+
+  // Decisions view — bucketed projection of `compose()`'s Settled section
+  // per `2026-05-11-producer-conversation-workbench.md` §1. Returns
+  // per-repo groups (single-element list for a single-repo unit; multi-
+  // repo unit follows once `UnitConfig.also[]` lands in tmai-core#340).
+  decisions: (unit: string) =>
+    apiFetch<DecisionsResponse>(`/units/${encodeURIComponent(unit)}/decisions`),
 
   // Handoff-and-restart ritual (tmai-core PR #352, DR
   // `2026-05-14-handoff-lifecycle-and-kill-ux.md` §C/§F). Kicks off the

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -247,6 +247,10 @@ export const api = {
   // calibration store; no Tauri-specific path needed)
   calibration: (unit: string, days?: number) => httpApi.calibration(unit, days),
 
+  // Decisions view (HTTP only — on-demand JSON projection of compose()'s
+  // Settled section; no Tauri-specific path needed)
+  decisions: (unit: string) => httpApi.decisions(unit),
+
   // Handoff-and-restart ritual (HTTP only — server-driven multi-step
   // ritual emits its own SSE phase events; no Tauri IPC equivalent).
   triggerHandoffRitual: (unit: string, body: TriggerHandoffRitualRequest) =>


### PR DESCRIPTION
## Summary

- Replaces the Phase A "NOT AUTOMATED YET" placeholder for \`⬡ Settled decisions\` with a live bucketed render driven by [tmai-core PR #359](https://github.com/trust-delta/tmai-core/pull/359)'s new endpoint.
- New \`useDecisions\` polling hook (60s, mirrors \`useCalibration\`'s shape).
- New section renders per-repo groups with 📌 / 🔴 / 🟡 / ⚪ buckets + ⚠ Currency sweep + ⚠ Trajectory check due callouts. Foundations + in-play expanded by default; warm/cold/superseded collapsed.
- Posture-DR compliant: \"Showing this unit's primary repo only\" caveat surfaces while multi-repo (tmai-core#340) is in flight; errors render honestly; no fabricated empty render.

## Wiring path

\`ProducerConsole\` → \`SettledDecisionsSection unitName={unitName}\` → \`useDecisions(unitName)\` → \`api.decisions(unit)\` → \`GET /api/units/{unit}/decisions\`. Hook is parked when \`unitName === null\` (\"Pick a project\" notice).

## Wire types

Hand-written in \`api-http.ts\` until the gen-spec-pr bot syncs them into \`src/types/generated/\`. Shapes mirror tmai-core's \`decisions_view.rs\` byte-for-byte.

## Posture-DR markers preserved

\`TODO(tmai-core#340)\` next to the multi-repo caveat — when \`UnitConfig.also[]\` lands, the response will carry >1 repo and the notice retires.

## Test plan

- [x] 6 new tests in \`SettledDecisionsSection.test.tsx\`: null unit, populated payload, currency-sweep callout, fetch errors, empty unit, expand-on-click for collapsed buckets.
- [x] Existing \`ProducerConsole.test.tsx\` + \`useHandover.test.ts\` updated to drop the \`SettledDecisionsPlaceholder\` digest field.
- [x] All 453 tests pass (2 skipped baseline).
- [x] \`pnpm tsc -b\` clean.
- [x] \`pnpm biome check src/\` clean.

## Followups (out of scope)

- SSE \`CoreEvent::DecisionsChanged\` so clients don't poll (parallel to calibration view's polling).
- \`◐ Working with this human\` section wiring (separate wire endpoint).
- Click-through from a decision row to the raw \`doc/decisions/<slug>.md\` in GitHub (small UX nicety; current row surfaces slug + title which the operator can navigate to manually).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 「Settled Decisions」セクションが実データ表示に対応：Foundations/In play/Warm/Cold で分類、リポジトリ別グループ、合計件数、primary-repo注記、currency sweep 表示、契約関連ラベルやドリフト警告を追加。バケットは折りたたみ/展開可能。
  * ロード中・空・未選択の案内表示を追加。

* **Bug Fixes**
  * データ取得失敗時にエラーメッセージを表示し、空バケットを誤表示しないよう改善。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/685)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->