### PR TITLE
feat(react): wire ◐ Working with this human to /api/units/{unit}/working-with-human

### DIFF
--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -6,7 +6,7 @@
 //   ▶ Where you left off
 //   ⬢ Cross-unit status
 //   ⬡ Settled decisions      (wired to GET /api/units/{unit}/decisions)
-//   ◐ Working with this human (Phase A placeholder)
+//   ◐ Working with this human (wired to GET /api/units/{unit}/working-with-human)
 //
 // Bottom row offers two real actions and one Phase-B stub. The
 // tier-1 tripwire banner is hoisted by `App.tsx` above the entire
@@ -80,8 +80,7 @@ export function ProducerConsole({
   sidebarCollapsed,
   onOpenSettings,
 }: ProducerConsoleProps) {
-  const { whereYouLeftOff, crossUnit, workingWithHuman, missingPreconditions } =
-    useHandover(currentProjectPath);
+  const { whereYouLeftOff, crossUnit, missingPreconditions } = useHandover(currentProjectPath);
   const { agents } = useAgents();
 
   return (
@@ -123,7 +122,7 @@ export function ProducerConsole({
           preconditions={missingPreconditions}
         />
         <SettledDecisionsSection unitName={unitName} />
-        <WorkingWithThisHumanSection data={workingWithHuman} />
+        <WorkingWithThisHumanSection unitName={unitName} />
       </div>
 
       <ProducerConsoleActions

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
@@ -38,8 +38,8 @@ vi.mock("@/lib/sse-provider", () => ({
 
 // `useHandoffRitual`'s API mock — only the trigger callable matters
 // here since the composition tests never fire the handoff ritual.
-// `decisions` is mocked so `useDecisions` (now driving the ⬡ section)
-// resolves to an empty payload instead of hitting the network.
+// `decisions` + `workingWithHuman` are mocked so the two wired
+// sections resolve to empty payloads instead of hitting the network.
 vi.mock("@/lib/api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
   return {
@@ -54,6 +54,11 @@ vi.mock("@/lib/api", async () => {
         composed_at: "2026-05-15T00:00:00Z",
         repos: [],
       }),
+      workingWithHuman: vi.fn().mockResolvedValue({
+        unit: "stub",
+        dir: null,
+        memory_index: null,
+      }),
     },
   };
 });
@@ -67,7 +72,6 @@ function digest(overrides: Partial<HandoverDigest> = {}): HandoverDigest {
       attentionAgents: [],
     },
     crossUnit: overrides.crossUnit ?? { units: [] },
-    workingWithHuman: overrides.workingWithHuman ?? { placeholder: true },
     missingPreconditions: overrides.missingPreconditions ?? {
       noLiveAgents: true,
       singleUnitOnly: false,
@@ -156,17 +160,19 @@ describe("ProducerConsole", () => {
     expect(screen.getByText("main")).toBeTruthy();
   });
 
-  it("renders honest user-facing copy in the remaining-placeholder section + the no-unit notice in Settled decisions", () => {
+  it("renders the no-unit-yet copy in both wired sections (Settled + Working-with-human)", () => {
     useHandoverMock.mockReturnValue(digest());
 
     render(<ProducerConsole {...makeProps()} />);
 
-    // ⬡ Settled decisions is now wired (PR #359); with `unitName=null`
-    // it surfaces a "pick a project" notice rather than fabricating
-    // bucketed content. ◐ Working with this human is still a
-    // placeholder — its copy should still point at `CLAUDE.md`.
-    expect(screen.getByText(/Pick a project/i)).toBeTruthy();
-    expect(screen.getByText(/CLAUDE\.md/)).toBeTruthy();
+    // ⬡ Settled decisions + ◐ Working with this human both poll their
+    // own endpoint; with `unitName=null` each surfaces an honest
+    // "pick a project" notice rather than fabricating content.
+    // Distinguish the two by the section-specific tail of the copy.
+    expect(screen.getByText(/to see its settled decisions/i)).toBeTruthy();
+    expect(
+      screen.getByText(/this unit's memory index and working-with-human context/i),
+    ).toBeTruthy();
   });
 
   it("renders cross-unit rows and routes click to onSelectProjectByPath", () => {

--- a/clients/react/src/components/producer-console/sections/WorkingWithThisHumanSection.tsx
+++ b/clients/react/src/components/producer-console/sections/WorkingWithThisHumanSection.tsx
@@ -1,48 +1,139 @@
-// ◐ Working with this human — fourth hand-over section (Phase A placeholder).
+// ◐ Working with this human — fourth hand-over section, wired to
+// `GET /api/units/{unit}/working-with-human` (tmai-core PR #360).
 //
-// The Producer's `compose()` baseline builder emits a "working-norms
-// delta" — process rules that diverge from the baseline `CLAUDE.md`,
-// computed at session-start. The read endpoint is not yet wired, so
-// this section displays a user-readable pointer at the baseline
-// `CLAUDE.md` for the time being. (Earlier drafts surfaced phase-
-// tracking text into this UI which made the section read as broken;
-// this revision speaks to the operator directly instead.)
+// Surfaces the same `◐` section the Producer reads on session-start:
+// the memory directory path + the raw `MEMORY.md` index. Per the
+// workbench renderer (`tmai-core/crates/tmai-core/src/workbench/render.rs`)
+// the on-disk per-entry memory files are *pointed at* but not inlined
+// — the index is the load-bearing content. This section follows the
+// same shape: header + rendered MEMORY.md inside a collapsible
+// `<details>` so the digest stays scannable.
 //
-// TODO(tmai-core#341): the cold-start hardening issue is the natural
-// place to expose `compose()` output (including this baseline delta)
-// over the wire. Per the simulated-onboarded posture DR
-// (`doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md`),
-// the current "see CLAUDE.md for now" copy is honest about the gap
-// rather than fabricating a synthetic delta.
+// `unit = null` → "pick a project first" placeholder, no fetch. Per
+// the simulated-onboarded posture DR, an unresolved memory dir
+// (`dir = null`) reads as "no memory dir configured" rather than
+// fabricating a synthetic baseline.
+//
+// TODO(tmai-core multi-repo memory): the wire surfaces the *primary*
+// repo's memory dir only — `hand_over_for_unit` currently composes
+// just that one. When per-repo `memory_dir` lands as a sibling of the
+// per-repo `decisions_dir` follow-up, this section will render one
+// group per repo (mirroring `SettledDecisionsSection`).
 
-import type { WorkingWithHumanPlaceholder } from "@/hooks/useHandover";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { useWorkingWithHuman } from "@/hooks/useWorkingWithHuman";
 
 interface WorkingWithThisHumanSectionProps {
-  data: WorkingWithHumanPlaceholder;
+  unitName: string | null;
 }
 
-export function WorkingWithThisHumanSection({ data: _data }: WorkingWithThisHumanSectionProps) {
+export function WorkingWithThisHumanSection({ unitName }: WorkingWithThisHumanSectionProps) {
+  const { data, loading, error } = useWorkingWithHuman(unitName);
+
   return (
     <section>
       <header className="mb-2 flex items-baseline gap-2">
         <span className="text-base text-cyan-400">◐</span>
         <h3 className="text-sm font-semibold text-zinc-200">Working with this human</h3>
-        <span className="rounded bg-zinc-700/50 px-1.5 py-0.5 text-[10px] uppercase tracking-wider text-zinc-400">
-          not automated yet
-        </span>
+        {loading && data === null && <span className="text-[10px] text-zinc-500">loading…</span>}
       </header>
-
-      <div className="pl-6 text-xs text-zinc-500">
-        <p>
-          See your repo's <code className="text-zinc-300">CLAUDE.md</code> for the baseline norms
-          (language, review rituals, branch conventions, …) — the Producer reads it on
-          session-start.
-        </p>
-        <p className="mt-2 text-zinc-600">
-          When wired, this section will surface deltas from the baseline computed by the Producer's
-          hand-over composer.
-        </p>
-      </div>
+      <WorkingBody unitName={unitName} data={data} loading={loading} error={error} />
     </section>
   );
+}
+
+interface WorkingBodyProps {
+  unitName: string | null;
+  data: ReturnType<typeof useWorkingWithHuman>["data"];
+  loading: boolean;
+  error: Error | null;
+}
+
+function WorkingBody({ unitName, data, loading, error }: WorkingBodyProps) {
+  if (unitName === null) {
+    return (
+      <div className="pl-6 text-xs text-zinc-500">
+        <p>
+          Pick a project (click a unit chip in{" "}
+          <span className="text-zinc-400">⬢ Cross-unit status</span> above, or use the sidebar) to
+          see this unit's memory index and working-with-human context.
+        </p>
+      </div>
+    );
+  }
+
+  if (error !== null) {
+    return (
+      <div className="pl-6 text-xs text-red-300/80">
+        <p>
+          Failed to load working-with-human view:{" "}
+          <code className="text-red-300">{error.message}</code>
+        </p>
+        <p className="mt-1 text-zinc-500">
+          Baseline norms live in your repo's <code className="text-zinc-300">CLAUDE.md</code>
+          {"; per-conversation memory under "}
+          <code className="text-zinc-300">~/.claude/projects/</code>.
+        </p>
+      </div>
+    );
+  }
+
+  if (data === null && loading) {
+    return <div className="pl-6 text-xs text-zinc-500">Loading…</div>;
+  }
+
+  if (data === null) {
+    return (
+      <div className="pl-6 text-xs text-zinc-500">
+        <p>No data resolved for this unit.</p>
+      </div>
+    );
+  }
+
+  if (data.dir === null) {
+    return (
+      <div className="pl-6 text-xs text-zinc-500">
+        <p>
+          No memory directory configured for <code className="text-zinc-300">{data.unit}</code>. The
+          Producer will work from <code className="text-zinc-300">CLAUDE.md</code> + decision
+          records only.
+        </p>
+        <p className="mt-1 text-zinc-600">
+          To opt in: set <code className="text-zinc-300">[[unit]].memory_dir</code> in{" "}
+          <code className="text-zinc-300">~/.config/tmai/config.toml</code>, or create{" "}
+          <code className="text-zinc-300">~/.claude/projects/&lt;slug&gt;/memory/</code> for the
+          unit's primary repo.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-2 pl-6 text-xs">
+      <p className="text-zinc-500">
+        Process rules: per repo's <code className="text-zinc-300">CLAUDE.md</code>.
+        Cross-conversation memory index lives at{" "}
+        <code className="text-[10.5px] text-zinc-400">{data.dir}</code>.
+      </p>
+      {data.memory_index === null || data.memory_index.trim() === "" ? (
+        <p className="text-zinc-600">
+          (no <code className="text-zinc-300">MEMORY.md</code> found in this dir yet)
+        </p>
+      ) : (
+        <details className="rounded border border-white/5 bg-white/[0.02]">
+          <summary className="cursor-pointer select-none px-3 py-1.5 text-[11px] text-zinc-300 hover:text-zinc-100">
+            Memory index ({lineCount(data.memory_index)} lines)
+          </summary>
+          <div className="prose prose-invert prose-sm max-w-none border-t border-white/5 px-3 py-2 text-zinc-300 [&_a]:text-cyan-300 [&_code]:rounded [&_code]:bg-white/[0.04] [&_code]:px-1 [&_code]:py-px [&_code]:text-zinc-300 [&_h1]:text-sm [&_h1]:font-semibold [&_h2]:text-sm [&_h2]:font-semibold [&_h3]:text-xs [&_h3]:font-semibold [&_li]:my-0.5 [&_ol]:my-1 [&_p]:my-1 [&_pre]:rounded [&_pre]:bg-black/30 [&_pre]:p-2 [&_strong]:text-zinc-200 [&_ul]:my-1">
+            <Markdown remarkPlugins={[remarkGfm]}>{data.memory_index}</Markdown>
+          </div>
+        </details>
+      )}
+    </div>
+  );
+}
+
+function lineCount(s: string): number {
+  return s.split("\n").length;
 }

--- a/clients/react/src/components/producer-console/sections/__tests__/WorkingWithThisHumanSection.test.tsx
+++ b/clients/react/src/components/producer-console/sections/__tests__/WorkingWithThisHumanSection.test.tsx
@@ -1,0 +1,105 @@
+// @vitest-environment jsdom
+//
+// WorkingWithThisHumanSection — wired to `useWorkingWithHuman(unitName)`
+// against the live `GET /api/units/{unit}/working-with-human` endpoint
+// (tmai-core #360).
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { WorkingWithHumanResponse } from "@/lib/api";
+import { WorkingWithThisHumanSection } from "../WorkingWithThisHumanSection";
+
+const workingWithHumanMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      workingWithHuman: (...args: unknown[]) => workingWithHumanMock(...args),
+    },
+  };
+});
+
+function responseStub(overrides: Partial<WorkingWithHumanResponse> = {}): WorkingWithHumanResponse {
+  return {
+    unit: "tmai",
+    dir: "/home/u/.claude/projects/-home-u-works-tmai/memory",
+    memory_index: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  workingWithHumanMock.mockReset();
+});
+
+describe("WorkingWithThisHumanSection", () => {
+  it("shows the pick-a-project notice when unitName is null and does not fetch", () => {
+    render(<WorkingWithThisHumanSection unitName={null} />);
+    expect(
+      screen.getByText(/this unit's memory index and working-with-human context/i),
+    ).toBeTruthy();
+    expect(workingWithHumanMock).not.toHaveBeenCalled();
+  });
+
+  it("renders the no-memory-dir notice when the unit has no resolvable memory dir", async () => {
+    workingWithHumanMock.mockResolvedValue(responseStub({ dir: null, memory_index: null }));
+
+    render(<WorkingWithThisHumanSection unitName="tmai" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No memory directory configured for/i)).toBeTruthy();
+    });
+    // Honest opt-in hint, not fabricated content.
+    expect(screen.getByText(/\[\[unit\]\]\.memory_dir/)).toBeTruthy();
+  });
+
+  it("renders the memory index inside a collapsible details when present", async () => {
+    workingWithHumanMock.mockResolvedValue(
+      responseStub({
+        memory_index: "# Memory index\n\n- entry 1\n- entry 2\n",
+      }),
+    );
+
+    render(<WorkingWithThisHumanSection unitName="tmai" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Cross-conversation memory index lives at/i)).toBeTruthy();
+    });
+    // Summary line shows the line count of the index for at-a-glance scan.
+    const summary = await screen.findByText(/Memory index \(\d+ lines\)/);
+    expect(summary).toBeTruthy();
+    // Markdown rendered inside — the heading from the index ends up
+    // in the DOM (even if collapsed by default).
+    const heading = await screen.findByRole("heading", { name: /Memory index/ });
+    expect(heading).toBeTruthy();
+  });
+
+  it("renders an empty-state notice when memory_index is missing", async () => {
+    workingWithHumanMock.mockResolvedValue(responseStub({ memory_index: null }));
+
+    render(<WorkingWithThisHumanSection unitName="tmai" />);
+
+    // The notice text is broken up by a `<code>MEMORY.md</code>` element,
+    // so match on the parent paragraph's full textContent.
+    await waitFor(() => {
+      const para = Array.from(document.querySelectorAll("p")).find((p) =>
+        /no .*MEMORY\.md.* found in this dir yet/i.test(p.textContent ?? ""),
+      );
+      expect(para).toBeDefined();
+    });
+  });
+
+  it("surfaces fetch errors honestly", async () => {
+    workingWithHumanMock.mockRejectedValue(new Error("kaboom"));
+
+    render(<WorkingWithThisHumanSection unitName="tmai" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load working-with-human view/i)).toBeTruthy();
+    });
+    expect(screen.getByText(/kaboom/)).toBeTruthy();
+  });
+});

--- a/clients/react/src/hooks/__tests__/useHandover.test.ts
+++ b/clients/react/src/hooks/__tests__/useHandover.test.ts
@@ -80,13 +80,19 @@ describe("useHandover — empty state", () => {
     expect(result.current.crossUnit.units).toEqual([]);
   });
 
-  it("exposes the working-with-human placeholder (settled decisions now lives in its own section)", () => {
+  it("returns only client-derived sections — the two compose-driven sections own their own polling", () => {
     const { result } = renderHook(() => useHandover(null));
-    // `⬡ Settled decisions` is now driven by `useDecisions` directly in
-    // `SettledDecisionsSection`; the hook no longer ships a placeholder
-    // for it. `◐ Working with this human` stays placeholder-shaped
-    // until its wire endpoint lands.
-    expect(result.current.workingWithHuman.placeholder).toBe(true);
+    // Both `⬡ Settled decisions` and `◐ Working with this human` now
+    // poll their respective endpoints directly (via `useDecisions` /
+    // `useWorkingWithHuman`); the hook keeps only the client-derived
+    // signals.
+    expect(result.current.whereYouLeftOff).toBeDefined();
+    expect(result.current.crossUnit).toBeDefined();
+    expect(result.current.missingPreconditions).toBeDefined();
+    // Property-absence guard: a stray placeholder on the digest type
+    // would re-introduce the contract drift removed here.
+    expect("workingWithHuman" in result.current).toBe(false);
+    expect("settledDecisions" in result.current).toBe(false);
   });
 });
 

--- a/clients/react/src/hooks/useHandover.ts
+++ b/clients/react/src/hooks/useHandover.ts
@@ -101,21 +101,13 @@ export interface CrossUnitStatus {
   units: UnitStatus[];
 }
 
-// Placeholder shapes are intentionally tiny — the section components
-// hard-code the user-facing copy so the hook stays free of UI strings.
-// (Earlier drafts inlined a `reason` field with "Phase C: <endpoint>
-// not yet wired" technical text, which leaked through to the user UI
-// and read as broken. Lesson: keep technical reasons out of UI hooks.)
-//
-// `⬡ Settled decisions` is now wired to `GET /api/units/{unit}/decisions`
-// (tmai-core PR #359) — the section owns its own polling via
-// `useDecisions(unitName)` rather than receiving placeholder data here.
-// `◐ Working with this human` stays a placeholder until the next wire
-// endpoint (memory dir / MEMORY.md projection) lands.
-
-export interface WorkingWithHumanPlaceholder {
-  placeholder: true;
-}
+// Both compose-driven sections (`⬡ Settled decisions` and `◐ Working
+// with this human`) are now wired to their respective wire endpoints
+// — the sections own their own polling via `useDecisions(unitName)` /
+// `useWorkingWithHuman(unitName)` rather than receiving placeholder
+// data from this hook. The hook keeps only the client-derived signals:
+// `whereYouLeftOff` (project scoping + attention agents) and
+// `crossUnit` (per-unit hotness).
 
 /**
  * Weak client-side signals that the unit might be incompletely onboarded
@@ -148,7 +140,6 @@ export interface MissingPreconditions {
 export interface HandoverDigest {
   whereYouLeftOff: WhereYouLeftOff;
   crossUnit: CrossUnitStatus;
-  workingWithHuman: WorkingWithHumanPlaceholder;
   missingPreconditions: MissingPreconditions;
 }
 
@@ -166,11 +157,11 @@ function deriveUnitState(group: ProjectGroup): UnitState {
 }
 
 /**
- * Aggregate client-side data into the hand-over digest's four sections.
- *
- * `settledDecisions` is no longer in the digest — `SettledDecisionsSection`
- * owns its own polling via `useDecisions`. `workingWithHuman` stays a
- * placeholder until the next wire endpoint lands.
+ * Aggregate client-side data into the hand-over digest's client-derived
+ * sections. The two compose-driven sections (`⬡ Settled decisions`,
+ * `◐ Working with this human`) are now wired directly to their own
+ * endpoints — `SettledDecisionsSection` + `WorkingWithThisHumanSection`
+ * each own their own polling hook.
  */
 export function useHandover(currentProjectPath: string | null): HandoverDigest {
   const { agents } = useAgents();
@@ -226,12 +217,6 @@ export function useHandover(currentProjectPath: string | null): HandoverDigest {
     [projectGroups],
   );
 
-  // Plain signal object — the section component owns the user-facing
-  // copy. Identity is stable across renders since the literal is
-  // structurally identical, but we still allocate a fresh object to
-  // keep the type literal `true` exact.
-  const workingWithHuman: WorkingWithHumanPlaceholder = { placeholder: true };
-
   // Weak posture-signal derivation. See `MissingPreconditions` doc for
   // why these are tagged TODO(tmai-core#NNN) — they get retired once
   // the wire side surfaces the real precondition data.
@@ -240,5 +225,5 @@ export function useHandover(currentProjectPath: string | null): HandoverDigest {
     singleUnitOnly: projectGroups.length === 1,
   };
 
-  return { whereYouLeftOff, crossUnit, workingWithHuman, missingPreconditions };
+  return { whereYouLeftOff, crossUnit, missingPreconditions };
 }

--- a/clients/react/src/hooks/useWorkingWithHuman.ts
+++ b/clients/react/src/hooks/useWorkingWithHuman.ts
@@ -1,0 +1,72 @@
+// Polling hook for the unit's `◐ Working with this human` view.
+//
+// Mirrors `useDecisions` / `useCalibration`: 60s poll, parked when
+// `unit` is null, generation guard against in-flight stamping. The
+// memory directory + `MEMORY.md` change on human timescales (operators
+// editing memory entries occasionally); polling is fine. SSE follow-up
+// (`CoreEvent::MemoryChanged`) would be the natural next step.
+
+import { useEffect, useRef, useState } from "react";
+import { api, type WorkingWithHumanResponse } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface UseWorkingWithHumanResult {
+  data: WorkingWithHumanResponse | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Poll the unit's working-with-human view at `POLL_INTERVAL_MS`.
+ * Returns the latest response, an initial-load `loading` flag, and the
+ * most recent error (cleared on a successful fetch).
+ *
+ * `unit = null` parks the hook: no fetch, no interval. The section
+ * then renders a "pick a project" notice rather than thrashing the
+ * server on a non-existent unit.
+ */
+export function useWorkingWithHuman(unit: string | null): UseWorkingWithHumanResult {
+  const [data, setData] = useState<WorkingWithHumanResponse | null>(null);
+  const [loading, setLoading] = useState(unit !== null);
+  const [error, setError] = useState<Error | null>(null);
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    if (!unit) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    setLoading(true);
+
+    const fetchOnce = async () => {
+      try {
+        const res = await api.workingWithHuman(unit);
+        if (myGen !== generationRef.current) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (myGen !== generationRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (myGen === generationRef.current) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [unit]);
+
+  return { data, loading, error };
+}

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -932,6 +932,24 @@ export interface DecisionsResponse {
   repos: RepoDecisionsWire[];
 }
 
+// ── Working-with-human view (tmai-core PR #360) ──
+//
+// Mirror of `tmai-core::api::working_with_human_view::WorkingWithHumanResponse`.
+// `dir = null` ⇒ no memory dir resolves for this unit; `dir` non-null
+// + `memory_index = null` ⇒ the directory exists but `MEMORY.md` is
+// absent. Hand-written until `gen-spec-pr` syncs the generated type.
+
+export interface WorkingWithHumanResponse {
+  unit: string;
+  /** Absolute path of the resolved memory directory. `null` when no
+   *  override is configured and the auto-derived
+   *  `~/.claude/projects/<slug>/memory` doesn't exist. */
+  dir: string | null;
+  /** Raw markdown contents of `MEMORY.md` under `dir`. `null` when
+   *  the file is absent. */
+  memory_index: string | null;
+}
+
 // ── API wrappers ──
 
 export const api = {
@@ -1302,6 +1320,14 @@ export const api = {
   // repo unit follows once `UnitConfig.also[]` lands in tmai-core#340).
   decisions: (unit: string) =>
     apiFetch<DecisionsResponse>(`/units/${encodeURIComponent(unit)}/decisions`),
+
+  // Working-with-human view — memory dir + MEMORY.md projection of
+  // `compose()`'s ◐ section per the same DR. Surfaces the same content
+  // the Producer reads on session-start (process rules, cross-conversation
+  // memory index) so the WebUI can render the digest's fourth section
+  // without a Producer being attached.
+  workingWithHuman: (unit: string) =>
+    apiFetch<WorkingWithHumanResponse>(`/units/${encodeURIComponent(unit)}/working-with-human`),
 
   // Handoff-and-restart ritual (tmai-core PR #352, DR
   // `2026-05-14-handoff-lifecycle-and-kill-ux.md` §C/§F). Kicks off the

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -251,6 +251,10 @@ export const api = {
   // Settled section; no Tauri-specific path needed)
   decisions: (unit: string) => httpApi.decisions(unit),
 
+  // Working-with-human view (HTTP only — on-demand JSON projection of
+  // compose()'s ◐ section; no Tauri-specific path needed)
+  workingWithHuman: (unit: string) => httpApi.workingWithHuman(unit),
+
   // Handoff-and-restart ritual (HTTP only — server-driven multi-step
   // ritual emits its own SSE phase events; no Tauri IPC equivalent).
   triggerHandoffRitual: (unit: string, body: TriggerHandoffRitualRequest) =>


### PR DESCRIPTION
## Summary

- Retires the last \"NOT AUTOMATED YET\" placeholder in the Producer console digest. ◐ section now consumes [tmai-core PR #360](https://github.com/trust-delta/tmai-core/pull/360)'s new endpoint.
- New \`useWorkingWithHuman\` polling hook (60s, mirrors \`useDecisions\` / \`useCalibration\`).
- Section renders memory dir path + \`MEMORY.md\` index inside a collapsible \`<details>\`, with markdown body rendered via react-markdown + remark-gfm (same stack \`MarkdownPanel\` already uses).
- Posture-DR compliant: never fabricates a baseline; missing memory dir gives an actionable opt-in hint; fetch errors render honestly.

## Wiring path

\`ProducerConsole\` → \`WorkingWithThisHumanSection unitName={unitName}\` → \`useWorkingWithHuman(unitName)\` → \`api.workingWithHuman(unit)\` → \`GET /api/units/{unit}/working-with-human\`. Hook parks when \`unitName === null\`.

## States the section surfaces

| State | Render |
|---|---|
| \`unitName === null\` | \"Pick a project …\" notice (no fetch) |
| Fetch error | \"Failed to load … &lt;message&gt;\" + fallback pointer to CLAUDE.md |
| \`dir === null\` | \"No memory directory configured\" + opt-in hint |
| \`dir\` non-null + \`memory_index === null\` | \"(no \`MEMORY.md\` found in this dir yet)\" |
| Populated | Process-rules copy + dir path + \`<details>\` with rendered markdown |

## useHandover housekeeping

The last placeholder field (\`workingWithHuman\`) is removed from \`HandoverDigest\`. The hook now returns only the two client-derived sections (\`whereYouLeftOff\`, \`crossUnit\`) + \`missingPreconditions\`. Both compose-driven sections own their own polling.

## Test plan

- [x] 5 new tests in \`WorkingWithThisHumanSection.test.tsx\`: null unit, no-memory-dir notice, rendered index in collapsible details, missing \`MEMORY.md\`, fetch error
- [x] \`ProducerConsole.test.tsx\` + \`useHandover.test.ts\` updated for the new contract
- [x] All 458 tests pass (2 skipped baseline)
- [x] \`pnpm tsc -b\` clean
- [x] \`pnpm biome check src/\` clean
- [x] Live-verified honest error UX in browser (running engine doesn't have #360 yet → \"Failed to load … 404\")

## Followups (out of scope)

- SSE \`CoreEvent::MemoryChanged\` so clients don't poll
- Per-repo \`memory_dir\` for multi-repo units — \`TODO(tmai-core multi-repo memory)\` marker preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)