### PR TITLE
chore(gen): sync generated spec + types from tmai-core@24546d135a

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -178,15 +178,6 @@
         "success_signal": {
           "type": "string"
         },
-        "tier": {
-          "description": "Authority level (1 = tier-1, 2 = tier-2). `None` ⇒ untiered.",
-          "format": "int32",
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
         "title": {
           "type": "string"
         }
@@ -590,7 +581,7 @@
       "type": "object"
     },
     "DecisionCategory": {
-      "description": "What kind of decision this is — drives the workbench's temperature treatment.\n\nOrthogonal to [`DecisionFrontmatter::tier`]: `category` is the *kind*\n(blast radius / abstraction); `tier` is the *authority* (who may change it).\nThey correlate strongly — `foundational` defaults to tier-1, `scoped` /\n`principle` to tier-2 — but the binding is in `tier:`, not here.",
+      "description": "What kind of decision this is — drives the workbench's temperature treatment.\n\n`category` is the *kind* (blast radius / abstraction), not the authority.\nAuthority is not a stored field: it is derived from the slot\n(`doc/decisions/` ⇒ a human-accepted decision vs `doc/approaches/` ⇒ a\nProducer-run experiment), `category: foundational`, and the act itself\n(accepting a decision is a human gate; running an approach is the\nProducer's). See `doc/decisions/2026-05-16-authority-attaches-to-the-act.md`.",
       "enum": [
         "scoped",
         "principle",

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -437,15 +437,6 @@
           "success_signal": {
             "type": "string"
           },
-          "tier": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int32",
-            "description": "Authority level (1 = tier-1, 2 = tier-2). `None` ⇒ untiered.",
-            "minimum": 0
-          },
           "title": {
             "type": "string"
           }
@@ -1992,7 +1983,7 @@
       },
       "DecisionCategory": {
         "type": "string",
-        "description": "What kind of decision this is — drives the workbench's temperature treatment.\n\nOrthogonal to [`DecisionFrontmatter::tier`]: `category` is the *kind*\n(blast radius / abstraction); `tier` is the *authority* (who may change it).\nThey correlate strongly — `foundational` defaults to tier-1, `scoped` /\n`principle` to tier-2 — but the binding is in `tier:`, not here.",
+        "description": "What kind of decision this is — drives the workbench's temperature treatment.\n\n`category` is the *kind* (blast radius / abstraction), not the authority.\nAuthority is not a stored field: it is derived from the slot\n(`doc/decisions/` ⇒ a human-accepted decision vs `doc/approaches/` ⇒ a\nProducer-run experiment), `category: foundational`, and the act itself\n(accepting a decision is a human gate; running an approach is the\nProducer's). See `doc/decisions/2026-05-16-authority-attaches-to-the-act.md`.",
         "enum": [
           "scoped",
           "principle",

--- a/clients/ratatui/src/types/generated/approach_wire.rs
+++ b/clients/ratatui/src/types/generated/approach_wire.rs
@@ -23,7 +23,5 @@ pub struct ApproachWire {
     pub slug: String,
     pub status: ApproachStatus,
     pub success_signal: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub tier: Option<Value>,
     pub title: String,
 }

--- a/clients/react/src/types/generated/ApproachWire.ts
+++ b/clients/react/src/types/generated/ApproachWire.ts
@@ -14,11 +14,7 @@ export type ApproachWire = { slug: string, title: string,
  * creation date. Approaches don't carry a `last_verified` field;
  * re-evaluation is signal-driven via `review_triggers`.
  */
-date: string, status: ApproachStatus, 
-/**
- * Authority level (1 = tier-1, 2 = tier-2). `None` ⇒ untiered.
- */
-tier: number | null, governs: Array<string>, 
+date: string, status: ApproachStatus, governs: Array<string>, 
 /**
  * `serves:` — non-empty per parse-time validation.
  */

--- a/clients/react/src/types/generated/DecisionCategory.ts
+++ b/clients/react/src/types/generated/DecisionCategory.ts
@@ -3,9 +3,11 @@
 /**
  * What kind of decision this is — drives the workbench's temperature treatment.
  *
- * Orthogonal to [`DecisionFrontmatter::tier`]: `category` is the *kind*
- * (blast radius / abstraction); `tier` is the *authority* (who may change it).
- * They correlate strongly — `foundational` defaults to tier-1, `scoped` /
- * `principle` to tier-2 — but the binding is in `tier:`, not here.
+ * `category` is the *kind* (blast radius / abstraction), not the authority.
+ * Authority is not a stored field: it is derived from the slot
+ * (`doc/decisions/` ⇒ a human-accepted decision vs `doc/approaches/` ⇒ a
+ * Producer-run experiment), `category: foundational`, and the act itself
+ * (accepting a decision is a human gate; running an approach is the
+ * Producer's). See `doc/decisions/2026-05-16-authority-attaches-to-the-act.md`.
  */
 export type DecisionCategory = "scoped" | "principle" | "foundational";


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@24546d135a (PR #377 — Phase 4 of authority-derived-from-act)

## Why this is a manual sync (not the bot)

The `gen-spec-pr` workflow on `tmai-core` runs on that repo's **private** GitHub Actions allotment, which is **billing-exhausted** (jobs fail to *start* in 1–2 s). The bot did not fire for tmai-core@24546d135a. Per the bot-PR recovery convention, the Producer regenerated the artifacts locally (`tmai-xtask openapi/schema/mcp-snapshot/ts-types/rust-types`, mirroring `gen-spec-pr.yml` exactly) and opened this PR on the `bot/` branch prefix so the generated-artifact hand-edit guard exempts it. **This repo's (public) Actions are unaffected — CI here is a real signal.**

## What changed (Phase 4 wire delta only)

tmai-core PR #377 removed the stored `tier:` from the wire (authority is now derived from the slot + `category: foundational` + the act, not stored). Net effect on generated artifacts:

- `api-spec/openapi.json` — `ApproachWire` loses `tier`; `DecisionCategory` description updated. (`tier` now appears 0× in openapi.)
- `api-spec/corevents.schema.json` — embedded `DecisionCategory` description update.
- `clients/react/src/types/generated/ApproachWire.ts` — `tier` field removed.
- `clients/react/src/types/generated/DecisionCategory.ts` — doc-comment update.
- `clients/ratatui/src/types/generated/approach_wire.rs` — `tier` field removed.
- `versions.toml` — no change (core/api_spec already at 3.0.1).
- `mcp-tools.json` — no drift.

Verified: public-side React consumes no `approach.tier` (only the independent calibration `tier_routed`), so this is a non-breaking field removal for the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## APIスキーマの更新

* **API変更**
  * `ApproachWire`スキーマから`tier`プロパティを削除しました
  * `DecisionCategory`の説明を更新し、権限がどのように決定文書とアプローチ文書から導出されるかを明確にしました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/694?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->