### PR TITLE
feat(producer-console): Active approaches Verdict-inbox (A1, client-degraded)

### DIFF
--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -27,6 +27,7 @@ import { useHandover } from "@/hooks/useHandover";
 import type { CalibrationResponse } from "@/lib/api";
 import { ProducerConsoleActions } from "./ProducerConsoleActions";
 import { ProducerCtxHeader } from "./ProducerCtxHeader";
+import { ActiveApproachesSection } from "./sections/ActiveApproachesSection";
 import { CrossUnitStatusSection } from "./sections/CrossUnitStatusSection";
 import { SettledDecisionsSection } from "./sections/SettledDecisionsSection";
 import { WhereYouLeftOffSection } from "./sections/WhereYouLeftOffSection";
@@ -122,6 +123,7 @@ export function ProducerConsole({
           preconditions={missingPreconditions}
         />
         <SettledDecisionsSection unitName={unitName} />
+        <ActiveApproachesSection unitName={unitName} />
         <WorkingWithThisHumanSection unitName={unitName} />
       </div>
 

--- a/clients/react/src/components/producer-console/sections/ActiveApproachesSection.tsx
+++ b/clients/react/src/components/producer-console/sections/ActiveApproachesSection.tsx
@@ -1,0 +1,302 @@
+// ▣ Active approaches — the Producer console's Verdict-inbox, wired to
+// `GET /api/units/{unit}/approaches` (tmai-core PR #369).
+//
+// Essence (deliberately NOT the decisions surface — see
+// `doc/decisions/2026-05-16-authority-attaches-to-the-act.md`): a decision
+// is a settled commitment the operator attends to when it drifts; an
+// approach is a *live experiment with a pending verdict*. So this surface
+// triages by "does this need your verdict now?", not by temperature
+// buckets. Low-priority bands are collapsed; only ⚡ is open.
+//
+// Client-degraded by design (A1). The wire is `status: active` only and
+// carries no resolved trigger/verdict state, so the client can faithfully
+// evaluate only `kind: date` triggers (vs today) + `confidence`. Triggers
+// the engine must resolve (pr-*/issue-closed/decision-status/approach-
+// status/manual) and the human-vs-Producer verdict split are surfaced
+// honestly, never fabricated — per the simulated-onboarded posture
+// (`doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md`):
+// graceful degradation, transparency over completeness, retirable
+// compensation. Full fidelity is tracked in tmai-core#381.
+
+import { useState } from "react";
+import { useApproaches } from "@/hooks/useApproaches";
+import type { ApproachWire, RepoApproachesWire, ReviewTriggerWire } from "@/lib/api";
+
+interface ActiveApproachesSectionProps {
+  unitName: string | null;
+}
+
+export function ActiveApproachesSection({ unitName }: ActiveApproachesSectionProps) {
+  const { data, loading, error } = useApproaches(unitName);
+
+  return (
+    <section>
+      <header className="mb-2 flex items-baseline gap-2">
+        <span className="text-base text-cyan-400">▣</span>
+        <h3 className="text-sm font-semibold text-zinc-200">Active approaches</h3>
+        {loading && data === null && <span className="text-[10px] text-zinc-500">loading…</span>}
+      </header>
+      <Body unitName={unitName} data={data} loading={loading} error={error} />
+    </section>
+  );
+}
+
+interface BodyProps {
+  unitName: string | null;
+  data: ReturnType<typeof useApproaches>["data"];
+  loading: boolean;
+  error: Error | null;
+}
+
+function Body({ unitName, data, loading, error }: BodyProps) {
+  if (unitName === null) {
+    return (
+      <div className="pl-6 text-xs text-zinc-500">
+        <p>
+          Pick a project (a unit chip in <span className="text-zinc-400">⬢ Cross-unit status</span>{" "}
+          above, or the sidebar) to see its active approaches awaiting a verdict.
+        </p>
+      </div>
+    );
+  }
+
+  if (error !== null) {
+    return (
+      <div className="pl-6 text-xs text-red-300/80">
+        <p>
+          Failed to load approaches: <code className="text-red-300">{error.message}</code>
+        </p>
+        <p className="mt-1 text-zinc-500">
+          Browse <code className="text-zinc-300">doc/approaches/</code> directly in the repo as a
+          fallback.
+        </p>
+      </div>
+    );
+  }
+
+  if (data === null && loading) {
+    return <div className="pl-6 text-xs text-zinc-500">Loading…</div>;
+  }
+
+  if (data === null || data.repos.length === 0) {
+    return (
+      <div className="pl-6 text-xs text-zinc-500">
+        <p>
+          No active approaches for <code className="text-zinc-300">{unitName}</code>. The unit
+          either has no <code className="text-zinc-300">doc/approaches/</code> directory yet, or no
+          record is <code className="text-zinc-300">status: active</code>.
+        </p>
+      </div>
+    );
+  }
+
+  const onlyPrimary = data.repos.length === 1;
+
+  return (
+    <div className="space-y-3 pl-6 text-xs">
+      {data.repos.map((repo) => (
+        <RepoGroup key={repo.repo_root} repo={repo} singleRepo={onlyPrimary} />
+      ))}
+      {onlyPrimary && (
+        // TODO(tmai-core#340): retire once multi-repo unit support surfaces
+        // approaches from every repo (same axis as the decisions side).
+        <p className="text-[11px] text-zinc-600">
+          Showing this unit's primary repo only — multi-repo approach aggregation isn't wired yet
+          (tmai-core#340).
+        </p>
+      )}
+    </div>
+  );
+}
+
+type Band = "verdict" | "watch" | "quiet";
+
+interface Classified {
+  approach: ApproachWire;
+  band: Band;
+  /** Why it landed in this band — shown so the routing is legible. */
+  reason: string;
+  /** True when the approach carries a trigger only the engine can
+   *  resolve; surfaced honestly rather than guessed (tmai-core#381). */
+  coreOnly: boolean;
+}
+
+function isoToday(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function withinDays(isoDate: string, days: number): boolean {
+  const then = new Date(`${isoDate}T00:00:00Z`).getTime();
+  if (Number.isNaN(then)) return false;
+  const now = Date.now();
+  return then > now && then - now <= days * 86_400_000;
+}
+
+const CORE_ONLY_KINDS: ReadonlySet<ReviewTriggerWire["kind"]> = new Set([
+  "pr-closed",
+  "pr-merged",
+  "issue-closed",
+  "decision-status",
+  "approach-status",
+  "manual",
+]);
+
+function classify(a: ApproachWire): Classified {
+  const today = isoToday();
+  const dateTriggers = a.review_triggers.filter(
+    (t): t is Extract<ReviewTriggerWire, { kind: "date" }> => t.kind === "date",
+  );
+  const fired = dateTriggers.find((t) => t.value <= today);
+  const imminent = dateTriggers.find((t) => withinDays(t.value, 30));
+  const coreOnly = a.review_triggers.some((t) => CORE_ONLY_KINDS.has(t.kind));
+
+  if (fired) {
+    return {
+      approach: a,
+      band: "verdict",
+      reason: `trigger fired: date ${fired.value} has passed`,
+      coreOnly,
+    };
+  }
+  if (a.confidence === "low") {
+    return { approach: a, band: "watch", reason: "Producer confidence: low", coreOnly };
+  }
+  if (imminent) {
+    return {
+      approach: a,
+      band: "watch",
+      reason: `date trigger ${imminent.value} is within 30 days`,
+      coreOnly,
+    };
+  }
+  if (coreOnly) {
+    return {
+      approach: a,
+      band: "watch",
+      reason: "trigger needs engine eval (PR / issue / decision-status / manual)",
+      coreOnly,
+    };
+  }
+  return { approach: a, band: "quiet", reason: "running — no near trigger", coreOnly };
+}
+
+function RepoGroup({ repo, singleRepo }: { repo: RepoApproachesWire; singleRepo: boolean }) {
+  const classified = repo.active.map(classify);
+  const verdict = classified.filter((c) => c.band === "verdict");
+  const watch = classified.filter((c) => c.band === "watch");
+  const quiet = classified.filter((c) => c.band === "quiet");
+  const coreOnlyCount = classified.filter((c) => c.coreOnly).length;
+
+  return (
+    <div className="space-y-2">
+      {!singleRepo && (
+        <h4 className="text-[11px] font-semibold uppercase tracking-wide text-zinc-400">
+          <code className="font-mono text-zinc-300">{repo.repo_label}</code>
+          {repo.primary && <span className="ml-1 text-cyan-400">(primary)</span>}
+          {repo.repo_head && <span className="ml-2 text-zinc-600">@ {repo.repo_head}</span>}
+        </h4>
+      )}
+
+      <p className="text-[11px] text-zinc-600">
+        {`${repo.active.length} active · `}
+        <span className="text-zinc-500">{`⚡ ${verdict.length}  🟡 ${watch.length}  ⚪ ${quiet.length}`}</span>
+      </p>
+
+      <VerdictBand items={verdict} />
+      <CollapsibleBand label="🟡 Watch" items={watch} />
+      <CollapsibleBand label="⚪ Running quietly" items={quiet} muted />
+
+      <p className="text-[10.5px] leading-relaxed text-zinc-600">
+        ⚡ groups approaches whose review-trigger objectively fired (a date passed). Whether each
+        verdict is <span className="text-zinc-500">yours</span> or Producer-resolvable needs engine
+        eval — tmai-core#381.
+        {coreOnlyCount > 0 && (
+          <>
+            {" "}
+            {coreOnlyCount} carr{coreOnlyCount === 1 ? "ies" : "y"} triggers only the engine can
+            evaluate (shown under Watch until tmai-core#381).
+          </>
+        )}{" "}
+        Settled (validated / rejected / replaced) approaches are audit-trail and not on the wire yet
+        (tmai-core#381).
+      </p>
+    </div>
+  );
+}
+
+function VerdictBand({ items }: { items: Classified[] }) {
+  if (items.length === 0) {
+    return (
+      <p className="rounded border border-zinc-700/40 bg-zinc-800/30 px-2 py-1 text-[11px] text-zinc-500">
+        ⚡ No verdict due — no active approach has a fired date trigger.
+      </p>
+    );
+  }
+  return (
+    <div className="rounded border border-amber-500/30 bg-amber-500/[0.05] p-2">
+      <p className="mb-1 text-[11px] font-semibold text-amber-300">
+        ⚡ Your verdict ({items.length})
+      </p>
+      <ul className="space-y-2 pl-1">
+        {items.map((c) => (
+          <li key={c.approach.slug} className="text-[11px] leading-snug">
+            <code className="text-zinc-200">{c.approach.slug}</code>
+            <span className="text-zinc-500"> — {c.approach.title}</span>
+            <div className="text-amber-300/90">{c.reason}</div>
+            <div className="text-zinc-500">
+              serves: <span className="text-zinc-400">{c.approach.serves.join(", ")}</span>
+            </div>
+            <div className="text-zinc-500">
+              ✓ <span className="text-zinc-400">{c.approach.success_signal}</span>
+            </div>
+            <div className="text-zinc-500">
+              ✗ <span className="text-zinc-400">{c.approach.failure_signal}</span>
+            </div>
+            {c.coreOnly && (
+              <div className="text-[10.5px] text-zinc-600">
+                also carries an engine-only trigger (tmai-core#381)
+              </div>
+            )}
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+function CollapsibleBand({
+  label,
+  items,
+  muted,
+}: {
+  label: string;
+  items: Classified[];
+  muted?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  if (items.length === 0) return null;
+  return (
+    <div className="space-y-1">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={`flex w-full items-center gap-1 text-left text-[11px] ${muted ? "text-zinc-600" : "text-zinc-400"} hover:text-zinc-200`}
+      >
+        <span className="font-mono text-zinc-600">{open ? "▾" : "▸"}</span>
+        <span className="font-medium">{label}</span>
+        <span className="text-zinc-600">({items.length})</span>
+      </button>
+      {open && (
+        <ul className="space-y-1 pl-4">
+          {items.map((c) => (
+            <li key={c.approach.slug} className="text-[11px] leading-snug text-zinc-400">
+              <code className="text-zinc-300">{c.approach.slug}</code>
+              <span className="text-zinc-500"> — {c.approach.title}</span>
+              <div className="text-[10.5px] text-zinc-600">{c.reason}</div>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/clients/react/src/components/producer-console/sections/__tests__/ActiveApproachesSection.test.tsx
+++ b/clients/react/src/components/producer-console/sections/__tests__/ActiveApproachesSection.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+//
+// ActiveApproachesSection — the Verdict-inbox, wired to
+// `useApproaches(unitName)` against `GET /api/units/{unit}/approaches`
+// (tmai-core #369). We mock `api.approaches` so each test feeds a
+// deterministic active-only payload and asserts on the band routing.
+//
+// Per the simulated-onboarded posture DR the section must: pick-a-project
+// notice on null unit; honest error (no fabricated render); honest empty
+// state; honest degradation for engine-only triggers + the settled gap
+// (tmai-core#381); single-repo caveat (tmai-core#340).
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApproachesResponse, ApproachWire, RepoApproachesWire } from "@/lib/api";
+
+const approachesMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      approaches: (...args: unknown[]) => approachesMock(...args),
+    },
+  };
+});
+
+import { ActiveApproachesSection } from "../ActiveApproachesSection";
+
+function approachStub(overrides: Partial<ApproachWire> = {}): ApproachWire {
+  return {
+    slug: "2026-05-16-some-approach",
+    title: "Some approach",
+    date: "2026-05-16",
+    status: "active",
+    governs: [],
+    serves: ["2026-05-15-protect-scarce-human-judgment"],
+    success_signal: "the thing works",
+    failure_signal: "the thing does not work",
+    review_triggers: [{ kind: "date", value: "2099-01-01" }],
+    confidence: "high",
+    replaced_by: [],
+    excerpt: "…",
+    ...overrides,
+  };
+}
+
+function repoStub(overrides: Partial<RepoApproachesWire> = {}): RepoApproachesWire {
+  return {
+    repo_label: "tmai-core",
+    repo_root: "/home/u/works/tmai-core",
+    primary: true,
+    repo_head: "abc1234",
+    active: [],
+    ...overrides,
+  };
+}
+
+function responseStub(overrides: Partial<ApproachesResponse> = {}): ApproachesResponse {
+  return {
+    unit: "tmai",
+    composed_at: "2026-05-16T01:00:00Z",
+    repos: [repoStub()],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  approachesMock.mockReset();
+});
+
+describe("ActiveApproachesSection", () => {
+  it("shows a pick-a-project notice when unitName is null and does not fetch", () => {
+    render(<ActiveApproachesSection unitName={null} />);
+    expect(screen.getByText(/Pick a project/i)).toBeTruthy();
+    expect(approachesMock).not.toHaveBeenCalled();
+  });
+
+  it("routes a fired date trigger into ⚡ Your verdict, open, with the verdict criteria", async () => {
+    approachesMock.mockResolvedValue(
+      responseStub({
+        repos: [
+          repoStub({
+            active: [
+              approachStub({
+                slug: "2026-05-16-authority-derived-from-act",
+                title: "Authority derived from the act",
+                review_triggers: [{ kind: "date", value: "2020-01-01" }],
+                success_signal: "corpus is clearer",
+                failure_signal: "judgment-load is not lower",
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    render(<ActiveApproachesSection unitName="tmai" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Your verdict \(1\)/)).toBeTruthy();
+    });
+    // ⚡ band is open by default — slug + verdict criteria visible without a click.
+    expect(screen.getByText(/2026-05-16-authority-derived-from-act/)).toBeTruthy();
+    expect(screen.getByText(/date 2020-01-01 has passed/)).toBeTruthy();
+    expect(screen.getByText(/corpus is clearer/)).toBeTruthy();
+    expect(screen.getByText(/judgment-load is not lower/)).toBeTruthy();
+  });
+
+  it("routes a low-confidence approach into 🟡 Watch, collapsed, expands on click", async () => {
+    approachesMock.mockResolvedValue(
+      responseStub({
+        repos: [
+          repoStub({
+            active: [
+              approachStub({
+                slug: "2026-05-16-low-conf-thing",
+                confidence: "low",
+                review_triggers: [{ kind: "date", value: "2099-01-01" }],
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    render(<ActiveApproachesSection unitName="tmai" />);
+
+    const watchBtn = await screen.findByRole("button", { name: /Watch/ });
+    // Collapsed initially.
+    expect(screen.queryByText(/2026-05-16-low-conf-thing/)).toBeNull();
+    fireEvent.click(watchBtn);
+    await waitFor(() => {
+      expect(screen.getByText(/2026-05-16-low-conf-thing/)).toBeTruthy();
+    });
+    expect(screen.getByText(/Producer confidence: low/)).toBeTruthy();
+  });
+
+  it("surfaces engine-only triggers honestly under Watch (not fabricated as fired)", async () => {
+    approachesMock.mockResolvedValue(
+      responseStub({
+        repos: [
+          repoStub({
+            active: [
+              approachStub({
+                slug: "2026-05-16-manual-only",
+                confidence: "high",
+                review_triggers: [{ kind: "manual", description: "until codex work begins" }],
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    render(<ActiveApproachesSection unitName="tmai" />);
+
+    // Lands in the collapsed Watch band (button by role, house pattern).
+    const watchBtn = await screen.findByRole("button", { name: /Watch/ });
+    expect(watchBtn.textContent).toMatch(/\(1\)/);
+    // Not fabricated as fired — no fired date trigger.
+    expect(screen.getByText(/⚡ No verdict due/)).toBeTruthy();
+    // Honest degradation note references the tracking issue.
+    expect(screen.getByText(/tmai-core#381/)).toBeTruthy();
+  });
+
+  it("surfaces fetch errors honestly instead of fabricating an empty render", async () => {
+    approachesMock.mockRejectedValue(new Error("boom"));
+
+    render(<ActiveApproachesSection unitName="tmai" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load approaches/)).toBeTruthy();
+    });
+    expect(screen.getByText(/boom/)).toBeTruthy();
+    expect(screen.queryByText(/Your verdict/)).toBeNull();
+  });
+
+  it("renders an empty-state notice when the unit has no active approaches", async () => {
+    approachesMock.mockResolvedValue(responseStub({ repos: [] }));
+
+    render(<ActiveApproachesSection unitName="newunit" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No active approaches for/i)).toBeTruthy();
+    });
+  });
+
+  it("shows the single-repo caveat (tmai-core#340)", async () => {
+    approachesMock.mockResolvedValue(
+      responseStub({ repos: [repoStub({ active: [approachStub()] })] }),
+    );
+
+    render(<ActiveApproachesSection unitName="tmai" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/primary repo only/i)).toBeTruthy();
+    });
+    expect(screen.getByText(/tmai-core#340/)).toBeTruthy();
+  });
+});

--- a/clients/react/src/hooks/useApproaches.ts
+++ b/clients/react/src/hooks/useApproaches.ts
@@ -1,0 +1,71 @@
+// Polling hook for the unit's `▣ Active approaches` view (tmai-core
+// PR #369) — the data behind the Producer console's Verdict-inbox.
+//
+// Approaches change on the timescale a Producer raises/closes an
+// experiment — rare, human-paced. A 60-second poll (same cadence as
+// `useCalibration`) is ample; no SSE here yet (the next session-start
+// compose cleans up any tail). Mirrors `useCalibration`'s shape: keeps
+// the previous response visible while a re-fetch is in flight so the
+// inbox does not flicker; `loading` reflects only the initial fetch.
+//
+// `unit = null` parks the hook (no fetch, no interval) — used when no
+// project is selected so the section can render a placeholder rather
+// than poll a non-existent unit.
+
+import { useEffect, useRef, useState } from "react";
+import { type ApproachesResponse, api } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface UseApproachesResult {
+  data: ApproachesResponse | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useApproaches(unit: string | null): UseApproachesResult {
+  const [data, setData] = useState<ApproachesResponse | null>(null);
+  const [loading, setLoading] = useState(unit !== null);
+  const [error, setError] = useState<Error | null>(null);
+  // An in-flight response from a previous unit must not stamp over a
+  // newer unit's data (same guard as useCalibration).
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    if (!unit) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    setLoading(true);
+
+    const fetchOnce = async () => {
+      try {
+        const res = await api.approaches(unit);
+        if (myGen !== generationRef.current) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (myGen !== generationRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (myGen === generationRef.current) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [unit]);
+
+  return { data, loading, error };
+}

--- a/clients/react/src/hooks/useApproaches.ts
+++ b/clients/react/src/hooks/useApproaches.ts
@@ -39,6 +39,14 @@ export function useApproaches(unit: string | null): UseApproachesResult {
       return;
     }
     const myGen = ++generationRef.current;
+    // Clear on unit *change* (this effect's only re-trigger — deps are
+    // [unit]) so the previous unit's inbox is never shown under the new
+    // unit's header. The 60s same-unit re-poll goes through fetchOnce,
+    // which intentionally keeps the last response visible (anti-flicker);
+    // that path is untouched. Transparency-over-completeness:
+    // doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md.
+    setData(null);
+    setError(null);
     setLoading(true);
 
     const fetchOnce = async () => {

--- a/clients/react/src/hooks/useCalibration.ts
+++ b/clients/react/src/hooks/useCalibration.ts
@@ -48,6 +48,15 @@ export function useCalibration(unit: string | null, days = 90): UseCalibrationRe
       return;
     }
     const myGen = ++generationRef.current;
+    // Clear on unit/days *change* (this effect's only re-triggers — deps
+    // are [unit, days]) so a previous query's tripwire/chip is never
+    // shown under a new unit's context. The 60s same-query re-poll goes
+    // through fetchOnce, which intentionally keeps the last response
+    // visible (anti-flicker); that path is untouched. Mirrors the same
+    // guard in useApproaches; transparency-over-completeness per
+    // doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md.
+    setData(null);
+    setError(null);
     setLoading(true);
 
     const fetchOnce = async () => {

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -950,6 +950,68 @@ export interface WorkingWithHumanResponse {
   memory_index: string | null;
 }
 
+// ── Active approaches view (tmai-core PR #369) ──
+//
+// Mirror of `tmai-core::api::approaches_view`. `RepoApproachesWire.active`
+// carries `status: active` records only — validated / rejected / replaced
+// are filtered at compose time (audit-trail, not yet on the wire; the
+// console's Verdict-inbox surfaces that gap honestly per
+// `doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md`).
+// Hand-written until `gen-spec-pr` syncs the generated type; A2 fidelity
+// (core-computed trigger firing + verdict authority + settled projection)
+// is tracked in tmai-core#381.
+
+export type ApproachStatusWire = "active" | "validated" | "rejected" | "replaced";
+
+/** One review trigger, tagged on `kind` (mirrors the Rust enum 1:1; the
+ *  `Date` value is an ISO-8601 string on the wire). Only `date` is
+ *  client-evaluable; the rest need core/gh resolution (tmai-core#381). */
+export type ReviewTriggerWire =
+  | { kind: "date"; value: string }
+  | { kind: "pr-closed"; ref: string }
+  | { kind: "pr-merged"; ref: string }
+  | { kind: "issue-closed"; ref: string }
+  | { kind: "decision-status"; ref: string; "target-status": string }
+  | { kind: "approach-status"; ref: string; "target-status": string }
+  | { kind: "manual"; description: string };
+
+export interface ApproachWire {
+  slug: string;
+  title: string;
+  /** ISO-8601 date from the slug prefix (creation date — approaches have
+   *  no `last_verified`; re-evaluation is signal-driven). */
+  date: string;
+  status: ApproachStatusWire;
+  governs: string[];
+  /** `serves:` — the decision slug(s) this approach's means serve. */
+  serves: string[];
+  success_signal: string;
+  failure_signal: string;
+  review_triggers: ReviewTriggerWire[];
+  /** Producer confidence; `null` when none on record. */
+  confidence: "high" | "low" | null;
+  /** Successor approach slugs — meaningful only when `status: replaced`. */
+  replaced_by: string[];
+  /** First-paragraph summary of the body. */
+  excerpt: string;
+}
+
+export interface RepoApproachesWire {
+  repo_label: string;
+  repo_root: string;
+  primary: boolean;
+  repo_head: string | null;
+  /** `status: active` records only (see module note). */
+  active: ApproachWire[];
+}
+
+export interface ApproachesResponse {
+  unit: string;
+  /** RFC3339 compose timestamp. */
+  composed_at: string;
+  repos: RepoApproachesWire[];
+}
+
 // ── API wrappers ──
 
 export const api = {
@@ -1320,6 +1382,13 @@ export const api = {
   // repo unit follows once `UnitConfig.also[]` lands in tmai-core#340).
   decisions: (unit: string) =>
     apiFetch<DecisionsResponse>(`/units/${encodeURIComponent(unit)}/decisions`),
+
+  // Active approaches view — `▣ Active approaches` slice of `compose()`
+  // (tmai-core PR #369). `status: active` records only; per-repo groups
+  // (multi-repo follows tmai-core#340, same as decisions). The console
+  // turns this into the Verdict-inbox.
+  approaches: (unit: string) =>
+    apiFetch<ApproachesResponse>(`/units/${encodeURIComponent(unit)}/approaches`),
 
   // Working-with-human view — memory dir + MEMORY.md projection of
   // `compose()`'s ◐ section per the same DR. Surfaces the same content

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -251,6 +251,10 @@ export const api = {
   // Settled section; no Tauri-specific path needed)
   decisions: (unit: string) => httpApi.decisions(unit),
 
+  // Active approaches view (HTTP only — on-demand JSON projection of
+  // compose()'s ▣ section; no Tauri-specific path needed)
+  approaches: (unit: string) => httpApi.approaches(unit),
+
   // Working-with-human view (HTTP only — on-demand JSON projection of
   // compose()'s ◐ section; no Tauri-specific path needed)
   workingWithHuman: (unit: string) => httpApi.workingWithHuman(unit),


### PR DESCRIPTION
## What

Wires the **▣ Active approaches** slice of `compose()` (tmai-core PR #369) into the Producer console as a **Verdict-inbox**.

An approach is a *live experiment with a pending verdict* — so this surface triages by **"does this need your verdict now?"**, not by the decisions surface's temperature buckets. Only the **⚡ Your verdict** band is open; **🟡 Watch** / **⚪ Running quietly** are collapsed.

## Client-degraded by design (A1)

The wire carries `status: active` records only and no resolved trigger/verdict state, so the client faithfully evaluates only `kind: date` triggers (vs today) + `confidence`. Everything it cannot resolve is surfaced **honestly, never fabricated**, per the simulated-onboarded posture DR (`doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md`):

- Engine-only triggers (`pr-*` / `issue-closed` / `decision-status` / `approach-status` / `manual`) → shown under Watch with an explicit "needs engine eval" note.
- Human-vs-Producer verdict split → stated as a known gap inline.
- Settled (`validated` / `rejected` / `replaced`) band → absent because the wire is active-only; called out, not faked.

Full fidelity (core-computed trigger firing + verdict authority + settled projection) = **A2, tracked in tmai-core#381**. Multi-repo approach aggregation = **tmai-core#340** (same axis as the decisions side; `TODO()` markers left for grep-unwind).

## Files

- `lib/api-http.ts` — hand-mirrored `ApproachWire` / `RepoApproachesWire` / `ApproachesResponse` / `ReviewTriggerWire` / `ApproachStatusWire` + `approaches()` (gen-spec-pr is billing-dead; manual mirror is the current convention)
- `lib/api-tauri.ts` — HTTP delegate
- `hooks/useApproaches.ts` — 60s poll hook (`useCalibration` sibling)
- `components/producer-console/sections/ActiveApproachesSection.tsx` + `ProducerConsole.tsx` wire-up (after `SettledDecisionsSection`)
- `sections/__tests__/ActiveApproachesSection.test.tsx`

## Verification

- `pnpm build` (tsc -b strict, `any` banned) ✅
- `pnpm lint` (biome) ✅
- `pnpm test` ✅ — 59 files, 465 passed, 2 skipped (full regression incl. the new section's 7 cases)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Producer Consoleに「Active Approaches」セクションを追加しました。アプローチを「Your verdict」「Watch」「Running quietly」の3つのカテゴリで分類して表示します。データは60秒間隔で自動更新されます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/695?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->