### PR TITLE
feat(webui): theme system with Tokyo Night default

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -21,6 +21,7 @@ import { TerminalPanel } from "@/components/terminal/TerminalPanel";
 import { UsagePanel } from "@/components/usage/UsagePanel";
 import { BranchGraph } from "@/components/worktree/BranchGraph";
 import { WorktreePanel } from "@/components/worktree/WorktreePanel";
+import { useApplyTheme } from "@/hooks/useActiveTheme";
 import { useAgentSelectionFallback } from "@/hooks/useAgentSelectionFallback";
 import { useAgents } from "@/hooks/useAgents";
 import { useCalibration } from "@/hooks/useCalibration";
@@ -35,6 +36,11 @@ import { useSSE } from "@/lib/sse-provider";
 import { useUIPref } from "@/lib/ui-prefs-provider";
 
 export function App() {
+  // Apply the active WebUI theme's css vars to <html> and keep them in
+  // sync when the user switches themes in Settings — re-skins the whole
+  // UI live, no reload.
+  useApplyTheme();
+
   const { agents, attentionCount, loading, refresh } = useAgents();
   const { worktrees, refresh: refreshWorktrees } = useWorktrees();
   const toast = useToast();

--- a/clients/react/src/components/agent/PreviewPanel.tsx
+++ b/clients/react/src/components/agent/PreviewPanel.tsx
@@ -204,7 +204,7 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
   return (
     <div
       ref={containerRef}
-      className={`relative flex flex-1 flex-col overflow-hidden bg-[#0c0c0c] outline-none transition-shadow ${
+      className={`relative flex flex-1 flex-col overflow-hidden bg-[var(--color-terminal-background)] outline-none transition-shadow ${
         focused && hasDomFocus
           ? "shadow-[inset_0_0_0_2px_rgba(34,211,238,0.55),inset_0_0_24px_rgba(34,211,238,0.06)]"
           : "shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)]"

--- a/clients/react/src/components/settings/SettingsPanel.tsx
+++ b/clients/react/src/components/settings/SettingsPanel.tsx
@@ -7,6 +7,7 @@ import { NotificationSection } from "./NotificationSection";
 import { OrchestrationDispatchSection } from "./OrchestrationDispatchSection";
 import { OrchestrationSection } from "./OrchestrationSection";
 import { SpawnSection } from "./SpawnSection";
+import { ThemeSection } from "./ThemeSection";
 import { UsageSection } from "./UsageSection";
 import { WorkflowSection } from "./WorkflowSection";
 import { WorktreeSection } from "./WorktreeSection";
@@ -117,8 +118,9 @@ export function SettingsPanel({ onClose, defaultOpenAdvanced = false }: Settings
 
         <GroupHeader
           label="WebUI (this browser)"
-          description="Per-browser layout for the agent main panel. Stored in localStorage, not in tmai-core."
+          description="Per-browser presentation. Stored in localStorage, not in tmai-core."
         />
+        <ThemeSection />
         <DisplayLayoutSection />
       </div>
     </div>

--- a/clients/react/src/components/settings/ThemeSection.tsx
+++ b/clients/react/src/components/settings/ThemeSection.tsx
@@ -1,0 +1,55 @@
+import { THEME_NAMES, THEMES } from "@/lib/theme";
+import { useUIPref } from "@/lib/ui-prefs-provider";
+
+/**
+ * WebUI-only setting: the colour theme. Lives in the unified WebUI prefs
+ * blob (localStorage), not in tmai-core's config.toml — theme is pure
+ * presentation and has no meaning for the CLI / TUI clients. Selecting a
+ * theme persists immediately and re-skins the terminal and the rest of
+ * the UI live (App's `useApplyTheme` + useTerminal both read the same
+ * `lib/theme` source), so there is no Save button and no reload.
+ */
+export function ThemeSection() {
+  const [theme, setTheme] = useUIPref("theme");
+
+  return (
+    <section>
+      <h3 className="text-sm font-medium text-zinc-300">Theme</h3>
+      <p className="mt-1 text-xs text-zinc-600">
+        Colours for the whole WebUI, including the terminal palette. Stored per-browser; applies
+        instantly.
+      </p>
+
+      <div className="mt-3 grid grid-cols-2 gap-2">
+        {THEME_NAMES.map((name) => {
+          const t = THEMES[name];
+          const active = theme === name;
+          return (
+            <button
+              key={name}
+              type="button"
+              onClick={() => setTheme(name)}
+              aria-pressed={active}
+              className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-left transition-colors ${
+                active
+                  ? "border-cyan-500/50 bg-cyan-500/10 text-cyan-300"
+                  : "border-white/10 bg-white/[0.02] text-zinc-400 hover:border-white/20 hover:text-zinc-200"
+              }`}
+            >
+              {/* Swatch: the theme's terminal bg framed by its accent so
+                  the choice is recognisable without applying it. */}
+              <span
+                className="h-5 w-5 shrink-0 rounded border-2"
+                style={{
+                  backgroundColor: t.palette.terminalBackground,
+                  borderColor: t.palette.tokens.ring,
+                }}
+              />
+              <span className="text-sm">{t.label}</span>
+            </button>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/clients/react/src/components/settings/__tests__/SettingsPanel.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel.test.tsx
@@ -46,6 +46,9 @@ vi.mock("../WorktreeSection", () => ({
 vi.mock("../DisplayLayoutSection", () => ({
   DisplayLayoutSection: () => <div data-testid="section-display">Display</div>,
 }));
+vi.mock("../ThemeSection", () => ({
+  ThemeSection: () => <div data-testid="section-theme">Theme</div>,
+}));
 
 const ADVANCED_TESTIDS = [
   "section-spawn",
@@ -69,10 +72,18 @@ describe("SettingsPanel — Phase B layout", () => {
     expect(screen.getByTestId("section-usage")).toBeTruthy();
   });
 
-  it("renders the WebUI-group section directly", () => {
+  it("renders the WebUI-group sections directly", () => {
     render(<SettingsPanel onClose={vi.fn()} />);
 
     expect(screen.getByTestId("section-display")).toBeTruthy();
+    expect(screen.getByTestId("section-theme")).toBeTruthy();
+  });
+
+  it("puts the theme switcher in the primary flow, not behind Advanced", () => {
+    render(<SettingsPanel onClose={vi.fn()} />);
+
+    const details = screen.getByText(/Advanced/).closest("details");
+    expect(details?.contains(screen.getByTestId("section-theme"))).toBe(false);
   });
 
   it("keeps the Advanced sections hidden by default", () => {

--- a/clients/react/src/components/settings/__tests__/ThemeSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/ThemeSection.test.tsx
@@ -1,0 +1,29 @@
+// @vitest-environment jsdom
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { UI_PREFS_STORAGE_KEY } from "@/lib/ui-prefs";
+import { renderWithProviders } from "@/test/render";
+import { ThemeSection } from "../ThemeSection";
+
+describe("ThemeSection", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("shows Tokyo Night selected by default", () => {
+    renderWithProviders(<ThemeSection />);
+    expect(screen.getByRole("button", { name: /Tokyo Night/ }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+    expect(screen.getByRole("button", { name: /Zinc/ }).getAttribute("aria-pressed")).toBe("false");
+  });
+
+  it("persists the selection to the ui-prefs blob and reflects it", () => {
+    renderWithProviders(<ThemeSection />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Zinc/ }));
+
+    expect(screen.getByRole("button", { name: /Zinc/ }).getAttribute("aria-pressed")).toBe("true");
+    expect(JSON.parse(localStorage.getItem(UI_PREFS_STORAGE_KEY) ?? "{}").theme).toBe("zinc");
+  });
+});

--- a/clients/react/src/components/terminal/TerminalPanel.tsx
+++ b/clients/react/src/components/terminal/TerminalPanel.tsx
@@ -94,7 +94,7 @@ export function TerminalPanel({ agentId }: TerminalPanelProps) {
       {/* biome-ignore lint/a11y/noStaticElementInteractions: terminal container needs pointer events for selection mode */}
       <div
         ref={containerRef}
-        className="flex-1 overflow-hidden bg-[#09090b] p-1"
+        className="flex-1 overflow-hidden bg-[var(--color-terminal-background)] p-1"
         onMouseDown={() => {
           if (inputMode) enterSelectMode();
         }}

--- a/clients/react/src/hooks/__tests__/useTerminal-theme.test.tsx
+++ b/clients/react/src/hooks/__tests__/useTerminal-theme.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+//
+// Proves the contract's single-source property end to end: the xterm
+// ITheme is DERIVED from the active theme (not hardcoded), and switching
+// the theme pref live-updates BOTH surfaces — the terminal canvas and the
+// document's `--color-*` custom properties — with no reload.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { useRef } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const constructed: Array<{ theme: unknown }> = [];
+
+vi.mock("@/lib/api", () => ({
+  api: { resizeAgentTerminal: vi.fn().mockResolvedValue(undefined) },
+}));
+
+vi.mock("../useAgentTerminalStream", () => ({
+  useAgentTerminalStream: () => ({ sendKeys: vi.fn() }),
+}));
+
+vi.mock("@xterm/xterm", () => {
+  const disposable = () => ({ dispose: vi.fn() });
+  function Terminal(opts: { theme: unknown }) {
+    constructed.push({ theme: opts.theme });
+    return {
+      rows: 30,
+      cols: 120,
+      loadAddon: vi.fn(),
+      open: vi.fn(),
+      focus: vi.fn(),
+      blur: vi.fn(),
+      reset: vi.fn(),
+      dispose: vi.fn(),
+      scrollToBottom: vi.fn(),
+      onData: vi.fn(disposable),
+      onBinary: vi.fn(disposable),
+      onResize: vi.fn(disposable),
+      onWriteParsed: vi.fn(disposable),
+    };
+  }
+  return { Terminal };
+});
+
+vi.mock("@xterm/addon-fit", () => {
+  function FitAddon() {
+    return { fit: vi.fn() };
+  }
+  return { FitAddon };
+});
+
+globalThis.ResizeObserver = function ResizeObserver() {
+  return { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn() };
+} as unknown as typeof ResizeObserver;
+
+import { THEMES, toXtermTheme } from "@/lib/theme";
+import { UIPrefsProvider, useUIPref } from "@/lib/ui-prefs-provider";
+import { useApplyTheme } from "../useActiveTheme";
+import { useTerminal } from "../useTerminal";
+
+function Harness() {
+  const containerRef = useRef<HTMLDivElement>(null);
+  useApplyTheme(); // CSS-var surface (rest of the UI)
+  useTerminal({ agentId: "claude:x", containerRef }); // terminal surface
+  const [, setTheme] = useUIPref("theme");
+  return (
+    <div>
+      <div ref={containerRef} />
+      <button type="button" onClick={() => setTheme("zinc")}>
+        to-zinc
+      </button>
+    </div>
+  );
+}
+
+function lastTheme(): unknown {
+  return constructed[constructed.length - 1]?.theme;
+}
+
+describe("theme drives both surfaces (single source)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    constructed.length = 0;
+    document.documentElement.removeAttribute("style");
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("derives the xterm ITheme and css vars from the default (tokyonight) theme", () => {
+    render(
+      <UIPrefsProvider>
+        <Harness />
+      </UIPrefsProvider>,
+    );
+
+    // Terminal surface: ITheme is exactly the derived tokyonight theme.
+    expect(lastTheme()).toEqual(toXtermTheme(THEMES.tokyonight));
+    // Rest-of-UI surface: css vars on <html>.
+    expect(document.documentElement.style.getPropertyValue("--color-background")).toBe("#1a1b26");
+    expect(document.documentElement.dataset.theme).toBe("tokyonight");
+  });
+
+  it("switching the theme pref live-updates both surfaces", () => {
+    render(
+      <UIPrefsProvider>
+        <Harness />
+      </UIPrefsProvider>,
+    );
+
+    fireEvent.click(screen.getByText("to-zinc"));
+
+    // Terminal surface rebuilt with the zinc ITheme (no ANSI overrides).
+    expect(lastTheme()).toEqual(toXtermTheme(THEMES.zinc));
+    // Rest-of-UI surface flipped to zinc's verbatim OKLch tokens.
+    expect(document.documentElement.style.getPropertyValue("--color-background")).toBe(
+      "oklch(0.145 0 0)",
+    );
+    expect(document.documentElement.dataset.theme).toBe("zinc");
+  });
+});

--- a/clients/react/src/hooks/useActiveTheme.ts
+++ b/clients/react/src/hooks/useActiveTheme.ts
@@ -1,0 +1,30 @@
+// React glue over the pure `lib/theme` module.
+//
+// `useActiveTheme` resolves the theme the user picked in ui-prefs into a
+// `Theme` object. `useApplyTheme` additionally writes that theme's css
+// vars onto <html> so the whole UI re-skins live (no reload) whenever the
+// pref changes — it is mounted once near the App root.
+
+import { useEffect } from "react";
+import { applyThemeToDocument, resolveTheme, type Theme } from "@/lib/theme";
+import { loadUIPrefs } from "@/lib/ui-prefs";
+import { useUIPrefsOptional } from "@/lib/ui-prefs-provider";
+
+export function useActiveTheme(): Theme {
+  // When a provider is present (the real app) this is reactive: changing
+  // the `theme` pref re-renders consumers. Without one (isolated terminal
+  // unit tests) fall back to the persisted / default value.
+  const ctx = useUIPrefsOptional();
+  const name = ctx ? ctx.prefs.theme : loadUIPrefs().theme;
+  return resolveTheme(name);
+}
+
+export function useApplyTheme(): Theme {
+  const theme = useActiveTheme();
+  // `resolveTheme` returns a stable singleton per name, so this effect
+  // only re-runs when the user actually switches themes.
+  useEffect(() => {
+    applyThemeToDocument(theme);
+  }, [theme]);
+  return theme;
+}

--- a/clients/react/src/hooks/useTerminal.ts
+++ b/clients/react/src/hooks/useTerminal.ts
@@ -21,6 +21,8 @@ import { FitAddon } from "@xterm/addon-fit";
 import { Terminal } from "@xterm/xterm";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api";
+import { toXtermTheme } from "@/lib/theme";
+import { useActiveTheme } from "./useActiveTheme";
 import { type TerminalStreamStatus, useAgentTerminalStream } from "./useAgentTerminalStream";
 
 interface UseTerminalOptions {
@@ -79,6 +81,13 @@ export function useTerminal({
 
   const { sendKeys } = useAgentTerminalStream({ agentId, onData, onStatus });
 
+  // The xterm ITheme is DERIVED from the active WebUI theme (single
+  // source — see lib/theme.ts), never hardcoded here. `activeTheme` is a
+  // stable singleton per theme name, so listing it as an effect dep means
+  // switching themes tears down and rebuilds the terminal with the new
+  // palette — a live re-skin with no reload, on both terminal twins.
+  const activeTheme = useActiveTheme();
+
   useEffect(() => {
     if (!agentId || !containerRef.current) return;
 
@@ -87,18 +96,7 @@ export function useTerminal({
     const term = new Terminal({
       fontSize: 13,
       fontFamily: "'JetBrains Mono', 'Cascadia Code', 'Fira Code', monospace",
-      theme: {
-        background: "#09090b",
-        foreground: "#fafafa",
-        cursor: "#a1a1aa",
-        selectionBackground: "#3f3f46",
-        // Match the global thin-overlay scrollbar (rgba white/8 → 15 → 18).
-        // xterm v6 paints its own VSCode-style scrollbar; only the colors are
-        // theme-driven, the 6 px width is pinned in globals.css.
-        scrollbarSliderBackground: "rgba(255, 255, 255, 0.08)",
-        scrollbarSliderHoverBackground: "rgba(255, 255, 255, 0.15)",
-        scrollbarSliderActiveBackground: "rgba(255, 255, 255, 0.18)",
-      },
+      theme: toXtermTheme(activeTheme),
       cursorBlink: true,
     });
 
@@ -188,7 +186,7 @@ export function useTerminal({
       termRef.current = null;
       fitAddonRef.current = null;
     };
-  }, [agentId, containerRef, sendKeys, keysHandledExternally]);
+  }, [agentId, containerRef, sendKeys, keysHandledExternally, activeTheme]);
 
   // Toggle keyboard attachment (input vs select mode).
   const setAttachable = useCallback(

--- a/clients/react/src/lib/__tests__/theme.test.ts
+++ b/clients/react/src/lib/__tests__/theme.test.ts
@@ -1,0 +1,96 @@
+// @vitest-environment jsdom
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  applyThemeToDocument,
+  DEFAULT_THEME_NAME,
+  resolveTheme,
+  SEMANTIC_TOKENS,
+  THEMES,
+  themeCssVars,
+  toXtermTheme,
+} from "../theme";
+
+describe("theme registry", () => {
+  it("resolves a known theme to its definition", () => {
+    expect(resolveTheme("zinc")).toBe(THEMES.zinc);
+    expect(resolveTheme("tokyonight")).toBe(THEMES.tokyonight);
+  });
+
+  it("falls back to the default theme for unknown / nullish names", () => {
+    expect(resolveTheme("does-not-exist")).toBe(THEMES[DEFAULT_THEME_NAME]);
+    expect(resolveTheme(null)).toBe(THEMES[DEFAULT_THEME_NAME]);
+    expect(resolveTheme(undefined)).toBe(THEMES[DEFAULT_THEME_NAME]);
+  });
+
+  it("returns a stable singleton (safe as a React effect dependency)", () => {
+    expect(resolveTheme("tokyonight")).toBe(resolveTheme("tokyonight"));
+  });
+
+  it("defaults to tokyonight", () => {
+    expect(DEFAULT_THEME_NAME).toBe("tokyonight");
+  });
+});
+
+describe("toXtermTheme — derived, not hardcoded", () => {
+  it("maps the tokyonight palette including the full 16-colour ANSI set", () => {
+    const t = toXtermTheme(THEMES.tokyonight);
+    expect(t.background).toBe("#1a1b26");
+    expect(t.foreground).toBe("#c0caf5");
+    expect(t.cursor).toBe("#c0caf5");
+    expect(t.selectionBackground).toBe("#283457");
+    // ANSI is set so program output (claude/git/ls) shifts to Tokyo Night.
+    expect(t.red).toBe("#f7768e");
+    expect(t.green).toBe("#9ece6a");
+    expect(t.blue).toBe("#7aa2f7");
+    expect(t.brightBlack).toBe("#414868");
+    expect(t.brightWhite).toBe("#c0caf5");
+  });
+
+  it("preserves the exact pre-theme zinc hardcode and sets NO ANSI overrides", () => {
+    const t = toXtermTheme(THEMES.zinc);
+    expect(t.background).toBe("#09090b");
+    expect(t.foreground).toBe("#fafafa");
+    expect(t.cursor).toBe("#a1a1aa");
+    expect(t.selectionBackground).toBe("#3f3f46");
+    // No ANSI keys → xterm keeps its built-in palette, exactly as the
+    // previous hardcode (which set none) did.
+    expect(t.red).toBeUndefined();
+    expect(t.brightWhite).toBeUndefined();
+  });
+});
+
+describe("themeCssVars / applyThemeToDocument — the CSS-var surface", () => {
+  it("emits a --color-* var for every semantic token plus terminal bg", () => {
+    const vars = themeCssVars(THEMES.tokyonight);
+    for (const token of SEMANTIC_TOKENS) {
+      expect(vars[`--color-${token}`]).toBe(THEMES.tokyonight.palette.tokens[token]);
+    }
+    // Reconciles the PreviewPanel/TerminalPanel container divergence.
+    expect(vars["--color-terminal-background"]).toBe(THEMES.tokyonight.palette.terminalBackground);
+  });
+
+  it("keeps zinc's original OKLch tokens verbatim (faithful snapshot)", () => {
+    const vars = themeCssVars(THEMES.zinc);
+    expect(vars["--color-background"]).toBe("oklch(0.145 0 0)");
+    expect(vars["--color-terminal-background"]).toBe("#09090b");
+  });
+
+  beforeEach(() => {
+    document.documentElement.removeAttribute("style");
+    document.documentElement.removeAttribute("data-theme");
+  });
+
+  it("writes the active theme's vars + data-theme onto <html>", () => {
+    applyThemeToDocument(THEMES.tokyonight);
+    const root = document.documentElement;
+    expect(root.style.getPropertyValue("--color-background")).toBe("#1a1b26");
+    expect(root.style.getPropertyValue("--color-terminal-background")).toBe("#1a1b26");
+    expect(root.dataset.theme).toBe("tokyonight");
+
+    // Switching overrides the previous inline values (live re-skin).
+    applyThemeToDocument(THEMES.zinc);
+    expect(root.style.getPropertyValue("--color-background")).toBe("oklch(0.145 0 0)");
+    expect(root.style.getPropertyValue("--color-terminal-background")).toBe("#09090b");
+    expect(root.dataset.theme).toBe("zinc");
+  });
+});

--- a/clients/react/src/lib/__tests__/ui-prefs.test.ts
+++ b/clients/react/src/lib/__tests__/ui-prefs.test.ts
@@ -17,6 +17,25 @@ describe("ui-prefs", () => {
     expect(loadUIPrefs()).toEqual(DEFAULT_UI_PREFS);
   });
 
+  it("defaults the theme to tokyonight (matches the operator's tmux)", () => {
+    expect(loadUIPrefs().theme).toBe("tokyonight");
+  });
+
+  it("round-trips a theme selection through localStorage", () => {
+    saveUIPrefs({ ...DEFAULT_UI_PREFS, theme: "zinc" });
+    // Persisted to the consolidated blob, not a side key.
+    expect(JSON.parse(localStorage.getItem(UI_PREFS_STORAGE_KEY) ?? "{}").theme).toBe("zinc");
+    expect(loadUIPrefs().theme).toBe("zinc");
+  });
+
+  it("falls back to the default theme for an unknown theme value", () => {
+    localStorage.setItem(
+      UI_PREFS_STORAGE_KEY,
+      JSON.stringify({ ...DEFAULT_UI_PREFS, theme: "midnight" }),
+    );
+    expect(loadUIPrefs().theme).toBe(DEFAULT_UI_PREFS.theme);
+  });
+
   it("round-trips a saved blob", () => {
     const next: UIPrefs = {
       ...DEFAULT_UI_PREFS,

--- a/clients/react/src/lib/theme.ts
+++ b/clients/react/src/lib/theme.ts
@@ -1,0 +1,318 @@
+// WebUI theme system — the single source of truth for every colour the
+// WebUI paints.
+//
+// WHY this module exists: the WebUI's colours used to live in two
+// disconnected places — the xterm `ITheme` hardcoded in
+// `hooks/useTerminal.ts` and the Tailwind `@theme` custom properties in
+// `styles/globals.css`. They could (and did) drift. Everything now derives
+// from one `Theme` object per named theme:
+//
+//   • `toXtermTheme(theme)`     → the xterm.js `ITheme` (terminal canvas)
+//   • `themeCssVars(theme)`     → the `--color-*` custom properties
+//   • `applyThemeToDocument()`  → writes those vars onto <html> at runtime
+//
+// Because both surfaces are *derived from the same palette*, they cannot
+// drift: change the palette and the terminal + the Tailwind tokens move
+// together. The static `@theme` block in globals.css mirrors the default
+// (`tokyonight`) values purely so the very first paint (before JS runs)
+// is already correct and so Tailwind can generate the utility classes —
+// it is NOT a second source; runtime overrides it via
+// `applyThemeToDocument`.
+//
+// Theme is WebUI-only presentation: it is stored in the ui-prefs
+// localStorage blob, never in tmai-core config or the api-spec wire
+// contract (settled convention — see `lib/ui-prefs.ts`).
+
+import type { ITheme } from "@xterm/xterm";
+
+export const THEME_NAMES = ["tokyonight", "zinc"] as const;
+export type ThemeName = (typeof THEME_NAMES)[number];
+
+// New installs default to Tokyo Night so the WebUI matches the operator's
+// tmux out of the box.
+export const DEFAULT_THEME_NAME: ThemeName = "tokyonight";
+
+// The Tailwind semantic tokens, as their `--color-<name>` custom-property
+// suffix. Iterated by `themeCssVars` so the css-var emission and the
+// `Theme` shape can never fall out of sync.
+export const SEMANTIC_TOKENS = [
+  "background",
+  "foreground",
+  "card",
+  "card-foreground",
+  "popover",
+  "popover-foreground",
+  "primary",
+  "primary-foreground",
+  "secondary",
+  "secondary-foreground",
+  "muted",
+  "muted-foreground",
+  "accent",
+  "accent-foreground",
+  "destructive",
+  "destructive-foreground",
+  "border",
+  "input",
+  "ring",
+  "sidebar-background",
+  "sidebar-foreground",
+  "sidebar-primary",
+  "sidebar-primary-foreground",
+  "sidebar-accent",
+  "sidebar-accent-foreground",
+  "sidebar-border",
+  "sidebar-ring",
+] as const;
+export type SemanticToken = (typeof SEMANTIC_TOKENS)[number];
+
+// The 16-colour ANSI palette xterm uses for program output (claude, git,
+// ls, …). Optional on a theme: when absent, `toXtermTheme` leaves these
+// keys unset and xterm keeps its own built-in defaults — this is how the
+// `zinc` theme stays a *faithful* snapshot of today's look (the previous
+// hardcode set no ANSI colours at all).
+export interface AnsiPalette {
+  black: string;
+  red: string;
+  green: string;
+  yellow: string;
+  blue: string;
+  magenta: string;
+  cyan: string;
+  white: string;
+  brightBlack: string;
+  brightRed: string;
+  brightGreen: string;
+  brightYellow: string;
+  brightBlue: string;
+  brightMagenta: string;
+  brightCyan: string;
+  brightWhite: string;
+}
+
+export interface ThemePalette {
+  // ── Terminal canvas ── these feed the xterm `ITheme`. They must be
+  // hex / rgb(a): xterm's colour parser does not understand `oklch()`.
+  terminalBackground: string;
+  terminalForeground: string;
+  terminalCursor: string;
+  terminalSelection: string;
+  // Slider colours for xterm's own VSCode-style scrollbar. Kept on the
+  // theme (not hardcoded in useTerminal) so the single-source property
+  // holds for the scrollbar too; the matching 6px width stays pinned in
+  // globals.css.
+  scrollbar: string;
+  scrollbarHover: string;
+  scrollbarActive: string;
+  ansi?: AnsiPalette;
+  // ── Tailwind semantic tokens ── any valid CSS colour. `zinc` keeps the
+  // original OKLch strings verbatim (zero-risk faithful snapshot);
+  // `tokyonight` uses hex.
+  tokens: Record<SemanticToken, string>;
+}
+
+export interface Theme {
+  name: ThemeName;
+  label: string;
+  palette: ThemePalette;
+}
+
+// Shared neutral overlay for the xterm scrollbar slider. Reads correctly
+// on every dark background, so both built-in themes use it; living here
+// (not inlined per-theme) keeps it single-sourced.
+const SCROLLBAR = "rgba(255, 255, 255, 0.08)";
+const SCROLLBAR_HOVER = "rgba(255, 255, 255, 0.15)";
+const SCROLLBAR_ACTIVE = "rgba(255, 255, 255, 0.18)";
+
+// Tokyo Night (Night) — canonical folke/tokyonight palette; the anchors
+// match the operator's ~/.tmux.conf so the WebUI reads the same as tmux.
+const TOKYONIGHT: Theme = {
+  name: "tokyonight",
+  label: "Tokyo Night",
+  palette: {
+    terminalBackground: "#1a1b26",
+    terminalForeground: "#c0caf5",
+    terminalCursor: "#c0caf5",
+    terminalSelection: "#283457",
+    scrollbar: SCROLLBAR,
+    scrollbarHover: SCROLLBAR_HOVER,
+    scrollbarActive: SCROLLBAR_ACTIVE,
+    ansi: {
+      black: "#15161e",
+      red: "#f7768e",
+      green: "#9ece6a",
+      yellow: "#e0af68",
+      blue: "#7aa2f7",
+      magenta: "#bb9af7",
+      cyan: "#7dcfff",
+      white: "#a9b1d6",
+      brightBlack: "#414868",
+      brightRed: "#f7768e",
+      brightGreen: "#9ece6a",
+      brightYellow: "#e0af68",
+      brightBlue: "#7aa2f7",
+      brightMagenta: "#bb9af7",
+      brightCyan: "#7dcfff",
+      brightWhite: "#c0caf5",
+    },
+    tokens: {
+      background: "#1a1b26",
+      foreground: "#c0caf5",
+      card: "#1a1b26",
+      "card-foreground": "#c0caf5",
+      popover: "#16161e",
+      "popover-foreground": "#c0caf5",
+      primary: "#7aa2f7",
+      "primary-foreground": "#15161e",
+      secondary: "#292e42",
+      "secondary-foreground": "#c0caf5",
+      muted: "#292e42",
+      "muted-foreground": "#565f89",
+      accent: "#292e42",
+      "accent-foreground": "#c0caf5",
+      destructive: "#f7768e",
+      "destructive-foreground": "#15161e",
+      border: "#292e42",
+      input: "#292e42",
+      ring: "#7aa2f7",
+      "sidebar-background": "#16161e",
+      "sidebar-foreground": "#a9b1d6",
+      "sidebar-primary": "#7aa2f7",
+      "sidebar-primary-foreground": "#15161e",
+      "sidebar-accent": "#292e42",
+      "sidebar-accent-foreground": "#c0caf5",
+      "sidebar-border": "#292e42",
+      "sidebar-ring": "#7aa2f7",
+    },
+  },
+};
+
+// `zinc` = a faithful, non-destructive snapshot of the look that shipped
+// before the theme system: the exact xterm hardcode (bg #09090b, fg
+// #fafafa, cursor #a1a1aa, selection #3f3f46, NO ANSI overrides) and the
+// exact OKLch `@theme` tokens. Kept verbatim — converting the OKLch
+// values to hex would be lossy, and copying them as-is guarantees zero
+// drift from "today".
+const ZINC: Theme = {
+  name: "zinc",
+  label: "Zinc (legacy)",
+  palette: {
+    terminalBackground: "#09090b",
+    terminalForeground: "#fafafa",
+    terminalCursor: "#a1a1aa",
+    terminalSelection: "#3f3f46",
+    scrollbar: SCROLLBAR,
+    scrollbarHover: SCROLLBAR_HOVER,
+    scrollbarActive: SCROLLBAR_ACTIVE,
+    // ansi intentionally omitted — preserves xterm's built-in palette,
+    // exactly as the previous hardcode (which set no ANSI colours) did.
+    tokens: {
+      background: "oklch(0.145 0 0)",
+      foreground: "oklch(0.985 0 0)",
+      card: "oklch(0.145 0 0)",
+      "card-foreground": "oklch(0.985 0 0)",
+      popover: "oklch(0.145 0 0)",
+      "popover-foreground": "oklch(0.985 0 0)",
+      primary: "oklch(0.985 0 0)",
+      "primary-foreground": "oklch(0.205 0 0)",
+      secondary: "oklch(0.269 0 0)",
+      "secondary-foreground": "oklch(0.985 0 0)",
+      muted: "oklch(0.269 0 0)",
+      "muted-foreground": "oklch(0.708 0 0)",
+      accent: "oklch(0.269 0 0)",
+      "accent-foreground": "oklch(0.985 0 0)",
+      destructive: "oklch(0.396 0.141 25.723)",
+      "destructive-foreground": "oklch(0.637 0.237 25.331)",
+      border: "oklch(0.269 0 0)",
+      input: "oklch(0.269 0 0)",
+      ring: "oklch(0.556 0 0)",
+      "sidebar-background": "oklch(0.145 0 0)",
+      "sidebar-foreground": "oklch(0.708 0 0)",
+      "sidebar-primary": "oklch(0.985 0 0)",
+      "sidebar-primary-foreground": "oklch(0.205 0 0)",
+      "sidebar-accent": "oklch(0.269 0 0)",
+      "sidebar-accent-foreground": "oklch(0.985 0 0)",
+      "sidebar-border": "oklch(0.269 0 0)",
+      "sidebar-ring": "oklch(0.556 0 0)",
+    },
+  },
+};
+
+export const THEMES: Record<ThemeName, Theme> = Object.freeze({
+  tokyonight: TOKYONIGHT,
+  zinc: ZINC,
+});
+
+// Resolve a (possibly untrusted / persisted) name to a Theme. Returns a
+// stable singleton per name — callers can safely use the result as a
+// React effect dependency; identity only changes when the name changes.
+export function resolveTheme(name: string | null | undefined): Theme {
+  if (name && (THEME_NAMES as readonly string[]).includes(name)) {
+    return THEMES[name as ThemeName];
+  }
+  return THEMES[DEFAULT_THEME_NAME];
+}
+
+// Derive the xterm.js `ITheme` from a theme. The ANSI keys are only set
+// when the palette defines them, so `zinc` keeps xterm's defaults.
+export function toXtermTheme(theme: Theme): ITheme {
+  const p = theme.palette;
+  const base: ITheme = {
+    background: p.terminalBackground,
+    foreground: p.terminalForeground,
+    cursor: p.terminalCursor,
+    selectionBackground: p.terminalSelection,
+    scrollbarSliderBackground: p.scrollbar,
+    scrollbarSliderHoverBackground: p.scrollbarHover,
+    scrollbarSliderActiveBackground: p.scrollbarActive,
+  };
+  if (!p.ansi) return base;
+  const a = p.ansi;
+  return {
+    ...base,
+    black: a.black,
+    red: a.red,
+    green: a.green,
+    yellow: a.yellow,
+    blue: a.blue,
+    magenta: a.magenta,
+    cyan: a.cyan,
+    white: a.white,
+    brightBlack: a.brightBlack,
+    brightRed: a.brightRed,
+    brightGreen: a.brightGreen,
+    brightYellow: a.brightYellow,
+    brightBlue: a.brightBlue,
+    brightMagenta: a.brightMagenta,
+    brightCyan: a.brightCyan,
+    brightWhite: a.brightWhite,
+  };
+}
+
+// Derive the `--color-*` custom properties from a theme. Includes
+// `--color-terminal-background` so the PreviewPanel / TerminalPanel
+// container padding reconciles to the *same* value the xterm canvas
+// paints — the two surfaces can no longer diverge.
+export function themeCssVars(theme: Theme): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const token of SEMANTIC_TOKENS) {
+    vars[`--color-${token}`] = theme.palette.tokens[token];
+  }
+  vars["--color-terminal-background"] = theme.palette.terminalBackground;
+  return vars;
+}
+
+// Write a theme's css vars onto the document root (default <html>). An
+// inline custom property on the root element wins over the static
+// `@theme` `:root` block, so this re-skins the whole UI live with no
+// reload. `data-theme` is also set for any CSS that wants to branch on
+// the active theme by attribute.
+export function applyThemeToDocument(
+  theme: Theme,
+  root: HTMLElement = document.documentElement,
+): void {
+  for (const [key, value] of Object.entries(themeCssVars(theme))) {
+    root.style.setProperty(key, value);
+  }
+  root.dataset.theme = theme.name;
+}

--- a/clients/react/src/lib/ui-prefs-provider.tsx
+++ b/clients/react/src/lib/ui-prefs-provider.tsx
@@ -64,6 +64,13 @@ export function useUIPrefs(): UIPrefsContextValue {
   return ctx;
 }
 
+// Non-throwing variant. `useActiveTheme` lives deep in the terminal hook,
+// which a few unit tests render outside any provider (xterm wiring tests);
+// they should fall back to persisted/default prefs rather than crash.
+export function useUIPrefsOptional(): UIPrefsContextValue | null {
+  return useContext(UIPrefsContext);
+}
+
 // Convenience selector for a single field. Returns `[value, setter]` —
 // shaped like useState so call sites read naturally.
 export function useUIPref<K extends keyof UIPrefs>(

--- a/clients/react/src/lib/ui-prefs.ts
+++ b/clients/react/src/lib/ui-prefs.ts
@@ -10,6 +10,7 @@
 
 import type { DisplayMode } from "@/components/layout/DisplayModeSelector";
 import type { PaneTab } from "@/components/layout/TabbedPaneLayout";
+import { DEFAULT_THEME_NAME, THEME_NAMES, type ThemeName } from "@/lib/theme";
 
 export type RightPanelTab = "git" | "markdown";
 
@@ -21,6 +22,9 @@ export interface UIPrefs {
   splitRatioV: number;
   tripleOuterRatio: number;
   tripleInnerRatio: number;
+  // WebUI colour theme. Presentation-only; lives here (not in tmai-core
+  // config / api-spec) by the same convention as every other field.
+  theme: ThemeName;
 }
 
 export const DEFAULT_UI_PREFS: UIPrefs = {
@@ -31,6 +35,7 @@ export const DEFAULT_UI_PREFS: UIPrefs = {
   splitRatioV: 0.5,
   tripleOuterRatio: 0.55,
   tripleInnerRatio: 0.5,
+  theme: DEFAULT_THEME_NAME,
 };
 
 export const UI_PREFS_STORAGE_KEY = "tmai:ui:prefs";
@@ -38,6 +43,7 @@ export const UI_PREFS_STORAGE_KEY = "tmai:ui:prefs";
 const VALID_DISPLAY_MODES: readonly DisplayMode[] = ["tabs", "split-h", "split-v", "triple"];
 const VALID_PANE_TABS: readonly PaneTab[] = ["preview", "git", "markdown"];
 const VALID_RIGHT_PANEL_TABS: readonly RightPanelTab[] = ["git", "markdown"];
+const VALID_THEMES: readonly ThemeName[] = THEME_NAMES;
 
 const RATIO_MIN = 0.2;
 const RATIO_MAX = 0.8;
@@ -66,6 +72,9 @@ function coercePrefs(raw: unknown): UIPrefs {
     splitRatioV: clampRatio(r.splitRatioV, DEFAULT_UI_PREFS.splitRatioV),
     tripleOuterRatio: clampRatio(r.tripleOuterRatio, DEFAULT_UI_PREFS.tripleOuterRatio),
     tripleInnerRatio: clampRatio(r.tripleInnerRatio, DEFAULT_UI_PREFS.tripleInnerRatio),
+    theme: VALID_THEMES.includes(r.theme as ThemeName)
+      ? (r.theme as ThemeName)
+      : DEFAULT_UI_PREFS.theme,
   };
 }
 

--- a/clients/react/src/main.tsx
+++ b/clients/react/src/main.tsx
@@ -2,9 +2,17 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { ConfirmProvider } from "@/components/layout/ConfirmDialog";
 import { SSEProvider } from "@/lib/sse-provider";
+import { applyThemeToDocument, resolveTheme } from "@/lib/theme";
+import { loadUIPrefs } from "@/lib/ui-prefs";
 import { UIPrefsProvider } from "@/lib/ui-prefs-provider";
 import { App } from "./App";
 import "./styles/globals.css";
+
+// Apply the persisted theme synchronously, before the first React paint,
+// so a non-default theme (e.g. zinc) doesn't flash the tokyonight `@theme`
+// defaults for a frame. `useApplyTheme` (in App) takes over for live
+// switching after mount.
+applyThemeToDocument(resolveTheme(loadUIPrefs().theme));
 
 // biome-ignore lint/style/noNonNullAssertion: root element guaranteed by index.html
 createRoot(document.getElementById("root")!).render(

--- a/clients/react/src/styles/globals.css
+++ b/clients/react/src/styles/globals.css
@@ -10,34 +10,47 @@
   font-display: swap;
 }
 
+/* The single source of truth for these colours is `src/lib/theme.ts`,
+   NOT this block. The values below mirror the default `tokyonight` theme
+   for two reasons only: (1) Tailwind v4 needs the color tokens declared
+   at build time so it can generate the color utility classes;
+   (2) they make the very first paint correct before JS runs.
+   At runtime `applyThemeToDocument()` (lib/theme.ts) writes the active
+   theme's vars as inline custom properties on <html>, which override
+   this `:root` block — that is what makes theme switching live and
+   reload-free. Keep these in sync with THEMES.tokyonight in theme.ts. */
 @theme {
-  --color-background: oklch(0.145 0 0);
-  --color-foreground: oklch(0.985 0 0);
-  --color-card: oklch(0.145 0 0);
-  --color-card-foreground: oklch(0.985 0 0);
-  --color-popover: oklch(0.145 0 0);
-  --color-popover-foreground: oklch(0.985 0 0);
-  --color-primary: oklch(0.985 0 0);
-  --color-primary-foreground: oklch(0.205 0 0);
-  --color-secondary: oklch(0.269 0 0);
-  --color-secondary-foreground: oklch(0.985 0 0);
-  --color-muted: oklch(0.269 0 0);
-  --color-muted-foreground: oklch(0.708 0 0);
-  --color-accent: oklch(0.269 0 0);
-  --color-accent-foreground: oklch(0.985 0 0);
-  --color-destructive: oklch(0.396 0.141 25.723);
-  --color-destructive-foreground: oklch(0.637 0.237 25.331);
-  --color-border: oklch(0.269 0 0);
-  --color-input: oklch(0.269 0 0);
-  --color-ring: oklch(0.556 0 0);
-  --color-sidebar-background: oklch(0.145 0 0);
-  --color-sidebar-foreground: oklch(0.708 0 0);
-  --color-sidebar-primary: oklch(0.985 0 0);
-  --color-sidebar-primary-foreground: oklch(0.205 0 0);
-  --color-sidebar-accent: oklch(0.269 0 0);
-  --color-sidebar-accent-foreground: oklch(0.985 0 0);
-  --color-sidebar-border: oklch(0.269 0 0);
-  --color-sidebar-ring: oklch(0.556 0 0);
+  --color-background: #1a1b26;
+  --color-foreground: #c0caf5;
+  --color-card: #1a1b26;
+  --color-card-foreground: #c0caf5;
+  --color-popover: #16161e;
+  --color-popover-foreground: #c0caf5;
+  --color-primary: #7aa2f7;
+  --color-primary-foreground: #15161e;
+  --color-secondary: #292e42;
+  --color-secondary-foreground: #c0caf5;
+  --color-muted: #292e42;
+  --color-muted-foreground: #565f89;
+  --color-accent: #292e42;
+  --color-accent-foreground: #c0caf5;
+  --color-destructive: #f7768e;
+  --color-destructive-foreground: #15161e;
+  --color-border: #292e42;
+  --color-input: #292e42;
+  --color-ring: #7aa2f7;
+  --color-sidebar-background: #16161e;
+  --color-sidebar-foreground: #a9b1d6;
+  --color-sidebar-primary: #7aa2f7;
+  --color-sidebar-primary-foreground: #15161e;
+  --color-sidebar-accent: #292e42;
+  --color-sidebar-accent-foreground: #c0caf5;
+  --color-sidebar-border: #292e42;
+  --color-sidebar-ring: #7aa2f7;
+  /* Terminal canvas bg — PreviewPanel/TerminalPanel containers read this
+     so their padding gutter matches the xterm canvas (single-sourced via
+     theme.ts → no more #0c0c0c vs #09090b divergence). */
+  --color-terminal-background: #1a1b26;
   --radius-sm: 0.25rem;
   --radius-md: 0.375rem;
   --radius-lg: 0.5rem;


### PR DESCRIPTION
## Why

The WebUI's colours lived in two disconnected, hand-synced places — the xterm `ITheme` hardcoded in `useTerminal.ts` and the Tailwind `@theme` custom properties in `globals.css`. They could (and did) drift. This builds a real theme abstraction with a **single source of truth**, and ships Tokyo Night as the default so the WebUI matches the operator's tmux.

## Single source of truth

`clients/react/src/lib/theme.ts` is the only place colours live. Both surfaces are *derived* from one `Theme` object per named theme so they cannot drift:

- `toXtermTheme(theme)` → the xterm.js `ITheme` (terminal canvas)
- `themeCssVars(theme)` → the `--color-*` custom properties
- `applyThemeToDocument()` → writes those vars onto `<html>` at runtime

The static `@theme` block in `globals.css` now mirrors the **tokyonight** default purely so Tailwind can generate the color utilities and the first paint is correct before JS runs; at runtime an inline custom-property block on `<html>` overrides it (live, reload-free).

## Themes

Resolved through a small registry, persisted in the WebUI ui-prefs store (`localStorage` `tmai:ui:prefs` — never tmai-core config / api-spec, per the settled convention):

- **`tokyonight`** (new default) — canonical folke/tokyonight *Night* palette, including the full 16-colour ANSI set, so program output (claude, git, ls…) renders in Tokyo Night, matching the operator's tmux.
- **`zinc`** — a faithful, **non-destructive** snapshot of today's look: the exact xterm hardcode (bg `#09090b`, fg `#fafafa`, cursor `#a1a1aa`, selection `#3f3f46`, **no** ANSI overrides) and the exact OKLch `@theme` tokens, kept verbatim (zero conversion loss).

## Whole-UI + both terminal twins

- Switching themes in Settings re-skins both terminal twins (`PreviewPanel` + `TerminalPanel` share `useTerminal`) **and** the rest of the UI live, no reload.
- The container-bg divergence (`PreviewPanel` `#0c0c0c` vs `TerminalPanel` `#09090b`) is reconciled to a single theme-derived `--color-terminal-background`, identical to the xterm canvas bg.
- A theme switcher is added to `SettingsPanel`'s primary WebUI group (not behind Advanced).

## Tests / gate

`pnpm build && pnpm lint && pnpm test` — all green (475 passed, 2 pre-existing skips). New coverage: registry resolution, ui-prefs default = `tokyonight` + localStorage round-trip, xterm `ITheme` derived from the active theme (not hardcoded), switching updates **both** surfaces, `ThemeSection` persistence.

Scope: `clients/react/` only — no tmai-core, no api-spec, no generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)