### PR TITLE
feat(webui): theme the app shell + terminal font-size pref

### DIFF
--- a/clients/react/src/components/settings/DisplayLayoutSection.tsx
+++ b/clients/react/src/components/settings/DisplayLayoutSection.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 import { useConfirm } from "@/components/layout/ConfirmDialog";
 import { type DisplayMode, DisplayModeSelector } from "@/components/layout/DisplayModeSelector";
+import { TERMINAL_FONT_SIZE_MAX, TERMINAL_FONT_SIZE_MIN } from "@/lib/ui-prefs";
 import { useUIPref, useUIPrefs } from "@/lib/ui-prefs-provider";
 
 const MODE_LABEL: Record<DisplayMode, string> = {
@@ -16,8 +17,18 @@ const MODE_LABEL: Record<DisplayMode, string> = {
  */
 export function DisplayLayoutSection() {
   const [displayMode, setDisplayMode] = useUIPref("displayMode");
+  const [fontSize, setFontSize] = useUIPref("terminalFontSize");
   const { resetPrefs } = useUIPrefs();
   const confirm = useConfirm();
+
+  const stepFontSize = useCallback(
+    (delta: number) => {
+      setFontSize(
+        Math.max(TERMINAL_FONT_SIZE_MIN, Math.min(TERMINAL_FONT_SIZE_MAX, fontSize + delta)),
+      );
+    },
+    [fontSize, setFontSize],
+  );
 
   const handleReset = useCallback(async () => {
     const ok = await confirm({
@@ -47,6 +58,43 @@ export function DisplayLayoutSection() {
             </p>
           </div>
           <DisplayModeSelector mode={displayMode} onChange={setDisplayMode} />
+        </div>
+      </div>
+
+      <div className="mt-3 rounded-lg border border-white/10 bg-white/[0.02] p-3">
+        <div className="flex items-center justify-between gap-3">
+          <div className="flex-1">
+            <span className="text-sm text-zinc-300">Terminal text size</span>
+            <p className="mt-0.5 text-[11px] text-zinc-600">
+              Font size of the agent terminal / preview, in pixels. Applies instantly.
+            </p>
+          </div>
+          <div className="flex items-center gap-1">
+            <button
+              type="button"
+              onClick={() => stepFontSize(-1)}
+              disabled={fontSize <= TERMINAL_FONT_SIZE_MIN}
+              aria-label="Decrease terminal text size"
+              className="touch-target-sm flex h-7 w-7 items-center justify-center rounded-md border border-white/10 text-zinc-400 transition-colors hover:border-white/20 hover:text-zinc-200 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              −
+            </button>
+            <span
+              className="w-12 text-center text-sm tabular-nums text-zinc-300"
+              aria-live="polite"
+            >
+              {fontSize} px
+            </span>
+            <button
+              type="button"
+              onClick={() => stepFontSize(1)}
+              disabled={fontSize >= TERMINAL_FONT_SIZE_MAX}
+              aria-label="Increase terminal text size"
+              className="touch-target-sm flex h-7 w-7 items-center justify-center rounded-md border border-white/10 text-zinc-400 transition-colors hover:border-white/20 hover:text-zinc-200 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              +
+            </button>
+          </div>
         </div>
       </div>
 

--- a/clients/react/src/components/settings/__tests__/DisplayLayoutSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/DisplayLayoutSection.test.tsx
@@ -1,0 +1,33 @@
+// @vitest-environment jsdom
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it } from "vitest";
+import { UI_PREFS_STORAGE_KEY } from "@/lib/ui-prefs";
+import { renderWithProviders } from "@/test/render";
+import { DisplayLayoutSection } from "../DisplayLayoutSection";
+
+describe("DisplayLayoutSection — terminal font size", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("shows the default size and increments it, persisting to ui-prefs", () => {
+    renderWithProviders(<DisplayLayoutSection />);
+
+    expect(screen.getByText("13 px")).toBeTruthy();
+
+    fireEvent.click(screen.getByLabelText("Increase terminal text size"));
+
+    expect(screen.getByText("14 px")).toBeTruthy();
+    expect(JSON.parse(localStorage.getItem(UI_PREFS_STORAGE_KEY) ?? "{}").terminalFontSize).toBe(
+      14,
+    );
+  });
+
+  it("disables the − button at the minimum size", () => {
+    localStorage.setItem(UI_PREFS_STORAGE_KEY, JSON.stringify({ terminalFontSize: 8 }));
+    renderWithProviders(<DisplayLayoutSection />);
+
+    const dec = screen.getByLabelText("Decrease terminal text size") as HTMLButtonElement;
+    expect(dec.disabled).toBe(true);
+  });
+});

--- a/clients/react/src/hooks/__tests__/useTerminal-theme.test.tsx
+++ b/clients/react/src/hooks/__tests__/useTerminal-theme.test.tsx
@@ -9,23 +9,33 @@ import { fireEvent, render, screen } from "@testing-library/react";
 import { useRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-const constructed: Array<{ theme: unknown }> = [];
+interface FakeTerm {
+  options: { fontSize: number };
+}
+const constructed: Array<{ theme: unknown; fontSize: number }> = [];
+let lastInstance: FakeTerm | null = null;
 
 vi.mock("@/lib/api", () => ({
   api: { resizeAgentTerminal: vi.fn().mockResolvedValue(undefined) },
 }));
 
-vi.mock("../useAgentTerminalStream", () => ({
-  useAgentTerminalStream: () => ({ sendKeys: vi.fn() }),
-}));
+// Stable `sendKeys` identity, mirroring the real hook (it's a
+// `useCallback`). Without this the create-effect's `sendKeys` dep would
+// change every render and rebuild the terminal, masking the live
+// font-size update path.
+vi.mock("../useAgentTerminalStream", () => {
+  const sendKeys = vi.fn();
+  return { useAgentTerminalStream: () => ({ sendKeys }) };
+});
 
 vi.mock("@xterm/xterm", () => {
   const disposable = () => ({ dispose: vi.fn() });
-  function Terminal(opts: { theme: unknown }) {
-    constructed.push({ theme: opts.theme });
-    return {
+  function Terminal(opts: { theme: unknown; fontSize: number }) {
+    constructed.push({ theme: opts.theme, fontSize: opts.fontSize });
+    const instance = {
       rows: 30,
       cols: 120,
+      options: { fontSize: opts.fontSize },
       loadAddon: vi.fn(),
       open: vi.fn(),
       focus: vi.fn(),
@@ -38,6 +48,8 @@ vi.mock("@xterm/xterm", () => {
       onResize: vi.fn(disposable),
       onWriteParsed: vi.fn(disposable),
     };
+    lastInstance = instance;
+    return instance;
   }
   return { Terminal };
 });
@@ -63,11 +75,15 @@ function Harness() {
   useApplyTheme(); // CSS-var surface (rest of the UI)
   useTerminal({ agentId: "claude:x", containerRef }); // terminal surface
   const [, setTheme] = useUIPref("theme");
+  const [, setFont] = useUIPref("terminalFontSize");
   return (
     <div>
       <div ref={containerRef} />
       <button type="button" onClick={() => setTheme("zinc")}>
         to-zinc
+      </button>
+      <button type="button" onClick={() => setFont(20)}>
+        font-20
       </button>
     </div>
   );
@@ -81,6 +97,7 @@ describe("theme drives both surfaces (single source)", () => {
   beforeEach(() => {
     localStorage.clear();
     constructed.length = 0;
+    lastInstance = null;
     document.documentElement.removeAttribute("style");
     document.documentElement.removeAttribute("data-theme");
   });
@@ -119,5 +136,24 @@ describe("theme drives both surfaces (single source)", () => {
       "oklch(0.145 0 0)",
     );
     expect(document.documentElement.dataset.theme).toBe("zinc");
+  });
+
+  it("uses the ui-prefs terminal font size and updates it live without a rebuild", () => {
+    render(
+      <UIPrefsProvider>
+        <Harness />
+      </UIPrefsProvider>,
+    );
+
+    // Constructed with the default size (was a hardcoded 13).
+    expect(constructed[0]?.fontSize).toBe(13);
+    const builtCount = constructed.length;
+
+    fireEvent.click(screen.getByText("font-20"));
+
+    // Applied via term.options (live) — NOT by tearing down + rebuilding
+    // the terminal (which would drop the PTY stream).
+    expect(lastInstance?.options.fontSize).toBe(20);
+    expect(constructed.length).toBe(builtCount);
   });
 });

--- a/clients/react/src/hooks/__tests__/useTerminal.test.ts
+++ b/clients/react/src/hooks/__tests__/useTerminal.test.ts
@@ -22,6 +22,7 @@ type ResizeCallback = (dims: { rows: number; cols: number }) => void;
 interface FakeTerminalInstance {
   rows: number;
   cols: number;
+  options: Record<string, unknown>;
   loadAddon: ReturnType<typeof vi.fn>;
   open: ReturnType<typeof vi.fn>;
   onData: ReturnType<typeof vi.fn>;
@@ -48,6 +49,7 @@ vi.mock("@xterm/xterm", () => {
     const instance: FakeTerminalInstance = {
       rows: 30,
       cols: 120,
+      options: {},
       loadAddon: vi.fn(),
       open: vi.fn(),
       onData: vi.fn(() => makeDisposable()),

--- a/clients/react/src/hooks/useActiveTheme.ts
+++ b/clients/react/src/hooks/useActiveTheme.ts
@@ -28,3 +28,11 @@ export function useApplyTheme(): Theme {
   }, [theme]);
   return theme;
 }
+
+// The xterm font size from ui-prefs (px). Same provider-optional fallback
+// as useActiveTheme so the terminal-wiring unit tests (rendered without a
+// provider) keep working.
+export function useTerminalFontSize(): number {
+  const ctx = useUIPrefsOptional();
+  return ctx ? ctx.prefs.terminalFontSize : loadUIPrefs().terminalFontSize;
+}

--- a/clients/react/src/hooks/useTerminal.ts
+++ b/clients/react/src/hooks/useTerminal.ts
@@ -22,7 +22,7 @@ import { Terminal } from "@xterm/xterm";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { api } from "@/lib/api";
 import { toXtermTheme } from "@/lib/theme";
-import { useActiveTheme } from "./useActiveTheme";
+import { useActiveTheme, useTerminalFontSize } from "./useActiveTheme";
 import { type TerminalStreamStatus, useAgentTerminalStream } from "./useAgentTerminalStream";
 
 interface UseTerminalOptions {
@@ -88,13 +88,21 @@ export function useTerminal({
   // palette — a live re-skin with no reload, on both terminal twins.
   const activeTheme = useActiveTheme();
 
+  // Terminal font size is a WebUI pref (was a hardcoded `13`). Read it
+  // without listing it as a dep of the create-effect — resizing the font
+  // must NOT tear down the PTY stream. A dedicated effect below applies
+  // changes live via `term.options`.
+  const terminalFontSize = useTerminalFontSize();
+  const fontSizeRef = useRef(terminalFontSize);
+  fontSizeRef.current = terminalFontSize;
+
   useEffect(() => {
     if (!agentId || !containerRef.current) return;
 
     const container = containerRef.current;
 
     const term = new Terminal({
-      fontSize: 13,
+      fontSize: fontSizeRef.current,
       fontFamily: "'JetBrains Mono', 'Cascadia Code', 'Fira Code', monospace",
       theme: toXtermTheme(activeTheme),
       cursorBlink: true,
@@ -187,6 +195,17 @@ export function useTerminal({
       fitAddonRef.current = null;
     };
   }, [agentId, containerRef, sendKeys, keysHandledExternally, activeTheme]);
+
+  // Apply font-size changes live, without rebuilding the terminal (which
+  // would tear down the stream). `fit()` recomputes rows/cols for the new
+  // glyph metrics and fires `onResize`, which debounce-forwards the new
+  // winsize to the PTY-server via the handler wired in the create-effect.
+  useEffect(() => {
+    const term = termRef.current;
+    if (!term) return;
+    term.options.fontSize = terminalFontSize;
+    fitAddonRef.current?.fit();
+  }, [terminalFontSize]);
 
   // Toggle keyboard attachment (input vs select mode).
   const setAttachable = useCallback(

--- a/clients/react/src/lib/__tests__/theme.test.ts
+++ b/clients/react/src/lib/__tests__/theme.test.ts
@@ -75,6 +75,20 @@ describe("themeCssVars / applyThemeToDocument — the CSS-var surface", () => {
     expect(vars["--color-terminal-background"]).toBe("#09090b");
   });
 
+  it("emits app-shell vars so the chrome (body + glass) re-skins too", () => {
+    const tn = themeCssVars(THEMES.tokyonight);
+    expect(tn["--app-bg"]).toBe(THEMES.tokyonight.palette.shell.appBg);
+    expect(tn["--glass-bg"]).toBe(THEMES.tokyonight.palette.shell.glassBg);
+    expect(tn["--glass-deep-border"]).toBe(THEMES.tokyonight.palette.shell.glassDeepBorder);
+
+    // zinc keeps the exact pre-theme globals.css chrome (pixel-faithful).
+    const z = themeCssVars(THEMES.zinc);
+    expect(z["--app-bg"]).toBe(
+      "linear-gradient(135deg, #0a0a12 0%, #0d1117 40%, #0a0f1a 70%, #0f0a18 100%)",
+    );
+    expect(z["--glass-bg"]).toBe("rgba(15, 15, 25, 0.6)");
+  });
+
   beforeEach(() => {
     document.documentElement.removeAttribute("style");
     document.documentElement.removeAttribute("data-theme");

--- a/clients/react/src/lib/__tests__/ui-prefs.test.ts
+++ b/clients/react/src/lib/__tests__/ui-prefs.test.ts
@@ -36,6 +36,25 @@ describe("ui-prefs", () => {
     expect(loadUIPrefs().theme).toBe(DEFAULT_UI_PREFS.theme);
   });
 
+  it("defaults the terminal font size to 13 and round-trips a change", () => {
+    expect(loadUIPrefs().terminalFontSize).toBe(13);
+    saveUIPrefs({ ...DEFAULT_UI_PREFS, terminalFontSize: 18 });
+    expect(loadUIPrefs().terminalFontSize).toBe(18);
+  });
+
+  it("clamps an out-of-range / non-numeric terminal font size", () => {
+    localStorage.setItem(
+      UI_PREFS_STORAGE_KEY,
+      JSON.stringify({ ...DEFAULT_UI_PREFS, terminalFontSize: 999 }),
+    );
+    expect(loadUIPrefs().terminalFontSize).toBe(32); // TERMINAL_FONT_SIZE_MAX
+    localStorage.setItem(
+      UI_PREFS_STORAGE_KEY,
+      JSON.stringify({ ...DEFAULT_UI_PREFS, terminalFontSize: "big" }),
+    );
+    expect(loadUIPrefs().terminalFontSize).toBe(DEFAULT_UI_PREFS.terminalFontSize);
+  });
+
   it("round-trips a saved blob", () => {
     const next: UIPrefs = {
       ...DEFAULT_UI_PREFS,

--- a/clients/react/src/lib/theme.ts
+++ b/clients/react/src/lib/theme.ts
@@ -90,6 +90,28 @@ export interface AnsiPalette {
   brightWhite: string;
 }
 
+// The hand-written app shell — the `body` backdrop and the `.glass*`
+// translucent panels in globals.css. These are NOT Tailwind `@theme`
+// tokens (the component tree doesn't consume the semantic tokens; the
+// chrome is painted by these classes), so without theming them a theme
+// switch would leave the whole UI looking unchanged. Emitted as plain
+// `--<name>` css vars (no `--color-` prefix on purpose, so Tailwind does
+// not try to generate colour utilities from gradient values).
+export interface ShellPalette {
+  // `body` background. May be a gradient string.
+  appBg: string;
+  glassBg: string;
+  glassBorder: string;
+  glassLightBg: string;
+  glassLightBorder: string;
+  glassCardBg: string;
+  glassCardBorder: string;
+  glassCardHoverBg: string;
+  glassCardHoverBorder: string;
+  glassDeepBg: string;
+  glassDeepBorder: string;
+}
+
 export interface ThemePalette {
   // ── Terminal canvas ── these feed the xterm `ITheme`. They must be
   // hex / rgb(a): xterm's colour parser does not understand `oklch()`.
@@ -105,6 +127,8 @@ export interface ThemePalette {
   scrollbarHover: string;
   scrollbarActive: string;
   ansi?: AnsiPalette;
+  // ── App shell ── body backdrop + glass panels (see ShellPalette).
+  shell: ShellPalette;
   // ── Tailwind semantic tokens ── any valid CSS colour. `zinc` keeps the
   // original OKLch strings verbatim (zero-risk faithful snapshot);
   // `tokyonight` uses hex.
@@ -154,6 +178,19 @@ const TOKYONIGHT: Theme = {
       brightMagenta: "#bb9af7",
       brightCyan: "#7dcfff",
       brightWhite: "#c0caf5",
+    },
+    shell: {
+      appBg: "linear-gradient(135deg, #16161e 0%, #1a1b26 50%, #16161e 100%)",
+      glassBg: "rgba(26, 27, 38, 0.6)",
+      glassBorder: "rgba(192, 202, 245, 0.06)",
+      glassLightBg: "rgba(41, 46, 66, 0.4)",
+      glassLightBorder: "rgba(192, 202, 245, 0.08)",
+      glassCardBg: "rgba(32, 36, 53, 0.5)",
+      glassCardBorder: "rgba(192, 202, 245, 0.05)",
+      glassCardHoverBg: "rgba(41, 46, 66, 0.6)",
+      glassCardHoverBorder: "rgba(192, 202, 245, 0.1)",
+      glassDeepBg: "rgba(22, 22, 30, 0.7)",
+      glassDeepBorder: "rgba(192, 202, 245, 0.08)",
     },
     tokens: {
       background: "#1a1b26",
@@ -206,6 +243,21 @@ const ZINC: Theme = {
     scrollbarActive: SCROLLBAR_ACTIVE,
     // ansi intentionally omitted — preserves xterm's built-in palette,
     // exactly as the previous hardcode (which set no ANSI colours) did.
+    // Shell values copied verbatim from the pre-theme globals.css so the
+    // `zinc` chrome is pixel-identical to what shipped before.
+    shell: {
+      appBg: "linear-gradient(135deg, #0a0a12 0%, #0d1117 40%, #0a0f1a 70%, #0f0a18 100%)",
+      glassBg: "rgba(15, 15, 25, 0.6)",
+      glassBorder: "rgba(255, 255, 255, 0.06)",
+      glassLightBg: "rgba(25, 25, 40, 0.4)",
+      glassLightBorder: "rgba(255, 255, 255, 0.08)",
+      glassCardBg: "rgba(20, 20, 35, 0.5)",
+      glassCardBorder: "rgba(255, 255, 255, 0.05)",
+      glassCardHoverBg: "rgba(30, 30, 50, 0.6)",
+      glassCardHoverBorder: "rgba(255, 255, 255, 0.1)",
+      glassDeepBg: "rgba(10, 10, 15, 0.7)",
+      glassDeepBorder: "rgba(255, 255, 255, 0.08)",
+    },
     tokens: {
       background: "oklch(0.145 0 0)",
       foreground: "oklch(0.985 0 0)",
@@ -299,6 +351,22 @@ export function themeCssVars(theme: Theme): Record<string, string> {
     vars[`--color-${token}`] = theme.palette.tokens[token];
   }
   vars["--color-terminal-background"] = theme.palette.terminalBackground;
+
+  // App-shell vars (no `--color-` prefix — see ShellPalette). globals.css
+  // `body` and `.glass*` read these, so the chrome re-skins too instead
+  // of staying frozen on the old hardcoded gradient / rgba.
+  const s = theme.palette.shell;
+  vars["--app-bg"] = s.appBg;
+  vars["--glass-bg"] = s.glassBg;
+  vars["--glass-border"] = s.glassBorder;
+  vars["--glass-light-bg"] = s.glassLightBg;
+  vars["--glass-light-border"] = s.glassLightBorder;
+  vars["--glass-card-bg"] = s.glassCardBg;
+  vars["--glass-card-border"] = s.glassCardBorder;
+  vars["--glass-card-hover-bg"] = s.glassCardHoverBg;
+  vars["--glass-card-hover-border"] = s.glassCardHoverBorder;
+  vars["--glass-deep-bg"] = s.glassDeepBg;
+  vars["--glass-deep-border"] = s.glassDeepBorder;
   return vars;
 }
 

--- a/clients/react/src/lib/ui-prefs.ts
+++ b/clients/react/src/lib/ui-prefs.ts
@@ -25,6 +25,9 @@ export interface UIPrefs {
   // WebUI colour theme. Presentation-only; lives here (not in tmai-core
   // config / api-spec) by the same convention as every other field.
   theme: ThemeName;
+  // xterm font size (px). Presentation-only, browser-side; replaces the
+  // old hardcoded `fontSize: 13` in useTerminal.
+  terminalFontSize: number;
 }
 
 export const DEFAULT_UI_PREFS: UIPrefs = {
@@ -36,6 +39,7 @@ export const DEFAULT_UI_PREFS: UIPrefs = {
   tripleOuterRatio: 0.55,
   tripleInnerRatio: 0.5,
   theme: DEFAULT_THEME_NAME,
+  terminalFontSize: 13,
 };
 
 export const UI_PREFS_STORAGE_KEY = "tmai:ui:prefs";
@@ -48,9 +52,18 @@ const VALID_THEMES: readonly ThemeName[] = THEME_NAMES;
 const RATIO_MIN = 0.2;
 const RATIO_MAX = 0.8;
 
+// Keep the terminal legible and the layout sane at the extremes.
+export const TERMINAL_FONT_SIZE_MIN = 8;
+export const TERMINAL_FONT_SIZE_MAX = 32;
+
 function clampRatio(value: unknown, fallback: number): number {
   if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
   return Math.max(RATIO_MIN, Math.min(RATIO_MAX, value));
+}
+
+function clampFontSize(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return Math.max(TERMINAL_FONT_SIZE_MIN, Math.min(TERMINAL_FONT_SIZE_MAX, Math.round(value)));
 }
 
 // Validate each field individually so a partially corrupt blob still
@@ -75,6 +88,7 @@ function coercePrefs(raw: unknown): UIPrefs {
     theme: VALID_THEMES.includes(r.theme as ThemeName)
       ? (r.theme as ThemeName)
       : DEFAULT_UI_PREFS.theme,
+    terminalFontSize: clampFontSize(r.terminalFontSize, DEFAULT_UI_PREFS.terminalFontSize),
   };
 }
 

--- a/clients/react/src/styles/globals.css
+++ b/clients/react/src/styles/globals.css
@@ -57,47 +57,69 @@
   --radius-xl: 0.75rem;
 }
 
+/* App-shell vars — the body backdrop and the .glass* panels. The
+   component tree paints with hardcoded palette classes, so without
+   theming these the chrome would not visibly re-skin on a theme switch.
+   Single source is theme.ts (ShellPalette); these are the tokyonight
+   defaults for the first paint, overridden at runtime by
+   applyThemeToDocument. Deliberately NOT under @theme: values include a
+   gradient, and Tailwind must not try to mint colour utilities here. */
+:root {
+  --app-bg: linear-gradient(135deg, #16161e 0%, #1a1b26 50%, #16161e 100%);
+  --glass-bg: rgba(26, 27, 38, 0.6);
+  --glass-border: rgba(192, 202, 245, 0.06);
+  --glass-light-bg: rgba(41, 46, 66, 0.4);
+  --glass-light-border: rgba(192, 202, 245, 0.08);
+  --glass-card-bg: rgba(32, 36, 53, 0.5);
+  --glass-card-border: rgba(192, 202, 245, 0.05);
+  --glass-card-hover-bg: rgba(41, 46, 66, 0.6);
+  --glass-card-hover-border: rgba(192, 202, 245, 0.1);
+  --glass-deep-bg: rgba(22, 22, 30, 0.7);
+  --glass-deep-border: rgba(192, 202, 245, 0.08);
+}
+
 body {
-  background: linear-gradient(135deg, #0a0a12 0%, #0d1117 40%, #0a0f1a 70%, #0f0a18 100%);
+  background: var(--app-bg);
   color: var(--color-foreground);
   font-family: system-ui, -apple-system, sans-serif;
   min-height: 100vh;
 }
 
-/* Glassmorphism utility classes */
+/* Glassmorphism utility classes — colours come from the active theme's
+   ShellPalette (theme.ts); blur radii stay fixed. */
 .glass {
-  background: rgba(15, 15, 25, 0.6);
+  background: var(--glass-bg);
   backdrop-filter: blur(20px);
   -webkit-backdrop-filter: blur(20px);
-  border: 1px solid rgba(255, 255, 255, 0.06);
+  border: 1px solid var(--glass-border);
 }
 
 .glass-light {
-  background: rgba(25, 25, 40, 0.4);
+  background: var(--glass-light-bg);
   backdrop-filter: blur(16px);
   -webkit-backdrop-filter: blur(16px);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--glass-light-border);
 }
 
 .glass-card {
-  background: rgba(20, 20, 35, 0.5);
+  background: var(--glass-card-bg);
   backdrop-filter: blur(12px);
   -webkit-backdrop-filter: blur(12px);
-  border: 1px solid rgba(255, 255, 255, 0.05);
+  border: 1px solid var(--glass-card-border);
   transition: background 0.2s, border-color 0.2s;
 }
 
 .glass-card:hover {
-  background: rgba(30, 30, 50, 0.6);
-  border-color: rgba(255, 255, 255, 0.1);
+  background: var(--glass-card-hover-bg);
+  border-color: var(--glass-card-hover-border);
 }
 
 /* Enhanced glassmorphism with stronger blur for main panels */
 .glass-deep {
-  background: rgba(10, 10, 15, 0.7);
+  background: var(--glass-deep-bg);
   backdrop-filter: blur(24px) saturate(180%);
   -webkit-backdrop-filter: blur(24px) saturate(180%);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  border: 1px solid var(--glass-deep-border);
 }
 
 /* Glow effects for status indicators */


### PR DESCRIPTION
Follow-up to #696 (theme system, now merged).

## Why

#696 wired a correct single-source theme system, but switching themes
left the **UI chrome visually unchanged** outside the terminal. Root
cause: the component tree paints with hardcoded Tailwind palette
classes (`text-zinc-200`, `bg-white/10`, `text-cyan-400`) and consumes
**none** of the `@theme` semantic tokens; `body` was a fixed gradient
and `.glass*` fixed rgba. So the contract's "whole-UI re-skin via
semantic tokens" mechanism, while correctly implemented, had almost no
visible reach. (Flagged as friction on #696.)

## What

**1. Theme the app shell.** A `ShellPalette` is added to
`lib/theme.ts` (still the single source) covering the `body` backdrop
and the five `.glass*` panel surfaces. `globals.css` `body` / `.glass*`
now read theme-driven css vars (emitted by `themeCssVars`, applied
live by `applyThemeToDocument`). `tokyonight` gets a proper Tokyo
Night chrome; **`zinc` keeps the pre-theme gradient + rgba values
verbatim** (pixel-faithful, non-destructive). The whole UI now
visibly re-skins on a theme switch.

**2. Terminal font-size preference.** The hardcoded xterm
`fontSize: 13` becomes a WebUI pref (`terminalFontSize`, default 13,
clamped 8–32), persisted in the same ui-prefs blob. Applied **live**
via `term.options` + `fit()` with no stream rebuild. A − / value / +
stepper is added to the WebUI *Display & Layout* settings.

Shell vars are deliberately **not** `@theme` tokens (values include a
gradient; Tailwind must not mint colour utilities from them) — they
live in a plain `:root` block, overridden at runtime.

## Gate

`pnpm build && pnpm lint && pnpm test` — all green (63 files, 488
passed, 2 pre-existing skips). New coverage: shell vars emitted
(tokyonight) / verbatim (zinc), font-size default/round-trip/clamp,
live font update without rebuild, stepper persistence + min-bound
disable.

Scope: `clients/react/` only — no tmai-core, no api-spec, no
generated files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 表示設定にターミナルテキストサイズ調整機能を追加。増減ボタンで 8～32px の範囲内で自由に変更でき、現在値を常に表示します。
  * テーマ切り替え時にアプリシェルの背景やパネルのスタイルが動的に更新されるようになりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/697?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->