### PR TITLE
feat(webui): migrate worktree/ to semantic tokens (PR C)

### DIFF
--- a/clients/react/scripts/theme-codemod.mjs
+++ b/clients/react/scripts/theme-codemod.mjs
@@ -58,6 +58,11 @@ const RULES = [
   [/(?<![\w-])border-white\/5(?!\d)/g, "border-hairline"],
   [/(?<![\w-])border-white\/(?:10|15|20|30)(?!\d)/g, "border-hairline-strong"],
   [/(?<![\w-])border-white(?![\w/[-])/g, "border-hairline-strong"],
+  // Ring overlays → the strong hairline. (A resting-vs-focus pair that
+  // collapses to the same ring is a deliberate manual-fixup point: the
+  // focus ring is upgraded to ring-primary by hand, matching this
+  // codebase's focus convention.)
+  [/(?<![\w-])ring-white(?:\/(?:\[[0-9.]+\]|[0-9]{1,3}))?(?![\w-])/g, "ring-hairline-strong"],
 
   // ── Neutral fills/borders that aren't white overlays ──
   [/(?<![\w-])bg-zinc-(?:400|500|600)(?![\w-])/g, "bg-muted-foreground"],
@@ -83,6 +88,22 @@ const RULES = [
     new RegExp(`(?<![\\w-])(${PREFIX})-(?:blue|sky|indigo)-(?:200|300|400|500|600)(?![\\w-])`, "g"),
     "$1-info",
   ],
+  // Purple/violet is the WebUI's *secondary* categorical accent (dispatch
+  // / agent / "remote" tags) — deliberately distinct from the primary
+  // accent. The shadcn `accent`/`accent-foreground` token slots were the
+  // muted-hover-surface convention but are UNUSED in this codebase
+  // (surfaces map to surface/elevated), so they are repurposed in
+  // theme.ts as this themed secondary accent. See lib/theme.ts.
+  [
+    new RegExp(`(?<![\\w-])(${PREFIX})-(?:purple|violet|fuchsia)-(?:200|300|400|500|600)(?![\\w-])`, "g"),
+    "$1-accent",
+  ],
+  // Black scrims (`bg-black/20`, `bg-black/[0.3]`) are "recessed to the
+  // base background" surfaces (inset side-panels, form inputs). Map to
+  // the theme base bg so they invert correctly under a light theme
+  // instead of staying a hardcoded black darkener. The `/alpha` is
+  // dropped on purpose — the token is the solid recessed surface.
+  [/(?<![\w-])bg-black(?:\/(?:\[[0-9.]+\]|[0-9]{1,3}))?(?![\w-])/g, "bg-background"],
 ];
 
 function* walk(dir) {

--- a/clients/react/src/components/worktree/ActionPanel.tsx
+++ b/clients/react/src/components/worktree/ActionPanel.tsx
@@ -300,20 +300,20 @@ export const ActionPanel = memo(function ActionPanel({
   }, [ciSummary, rerunBusy, projectPath, activeNode.name]);
 
   return (
-    <div className="w-80 shrink-0 overflow-y-auto border-l border-white/5 bg-black/20">
+    <div className="w-80 shrink-0 overflow-y-auto border-l border-hairline bg-background">
       <div className="p-4">
         {/* Node info header */}
         <div className="mb-4">
           <div className="flex items-center gap-2">
             {activeNode.isWorktree && <span className="text-sm">🌿</span>}
-            <h3 className="text-sm font-semibold text-zinc-100">{activeNode.name}</h3>
+            <h3 className="text-sm font-semibold text-foreground">{activeNode.name}</h3>
             {activeNode.lastCommitTime != null && (
               <span
                 className={`text-[10px] ${(() => {
                   const days = Math.floor((Date.now() / 1000 - activeNode.lastCommitTime) / 86400);
-                  if (days <= 3) return "text-zinc-500";
-                  if (days <= 14) return "text-yellow-500/70";
-                  return "text-red-400/70";
+                  if (days <= 3) return "text-muted-foreground";
+                  if (days <= 14) return "text-warning/70";
+                  return "text-destructive/70";
                 })()}`}
               >
                 {(() => {
@@ -330,25 +330,21 @@ export const ActionPanel = memo(function ActionPanel({
           </div>
           <div className="mt-1 flex flex-wrap gap-2 text-[11px]">
             {activeNode.isMain && (
-              <span className="rounded bg-emerald-500/15 px-1.5 py-0.5 text-emerald-400">
-                default
-              </span>
+              <span className="rounded bg-success/15 px-1.5 py-0.5 text-success">default</span>
             )}
             {activeNode.isWorktree && (
-              <span className="rounded bg-emerald-500/15 px-1.5 py-0.5 text-emerald-400">
-                worktree
-              </span>
+              <span className="rounded bg-success/15 px-1.5 py-0.5 text-success">worktree</span>
             )}
             {activeNode.isCurrent && (
-              <span className="rounded bg-cyan-500/15 px-1.5 py-0.5 text-cyan-400">HEAD</span>
+              <span className="rounded bg-primary/15 px-1.5 py-0.5 text-primary">HEAD</span>
             )}
             {activeNode.hasAgent && (
-              <span className="rounded bg-cyan-500/15 px-1.5 py-0.5 text-cyan-400">
+              <span className="rounded bg-primary/15 px-1.5 py-0.5 text-primary">
                 {activeNode.agentStatus || "active"}
               </span>
             )}
             {activeNode.isDirty && (
-              <span className="rounded bg-amber-500/15 px-1.5 py-0.5 text-amber-400">modified</span>
+              <span className="rounded bg-warning/15 px-1.5 py-0.5 text-warning">modified</span>
             )}
             {/* Branch lifecycle state badge */}
             {(() => {
@@ -366,9 +362,9 @@ export const ActionPanel = memo(function ActionPanel({
             const ds = activeNode.diffSummary ?? branchDiffStat;
             if (!ds) return null;
             return (
-              <div className="mt-2 text-xs text-zinc-500">
-                <span className="text-emerald-400">+{ds.insertions}</span>{" "}
-                <span className="text-red-400">-{ds.deletions}</span>
+              <div className="mt-2 text-xs text-muted-foreground">
+                <span className="text-success">+{ds.insertions}</span>{" "}
+                <span className="text-destructive">-{ds.deletions}</span>
                 {" \u00B7 "}
                 {ds.files_changed} file{ds.files_changed !== 1 ? "s" : ""}
               </div>
@@ -376,28 +372,30 @@ export const ActionPanel = memo(function ActionPanel({
           })()}
           {/* Remote tracking info */}
           {activeNode.remote ? (
-            <div className="mt-2 rounded bg-white/[0.03] px-2 py-1.5 text-[11px]">
-              <div className="flex items-center gap-1.5 text-zinc-500">
-                <span className="text-zinc-600">remote:</span>
-                <span className="font-mono text-zinc-400">{activeNode.remote.remote_branch}</span>
+            <div className="mt-2 rounded bg-surface px-2 py-1.5 text-[11px]">
+              <div className="flex items-center gap-1.5 text-muted-foreground">
+                <span className="text-subtle-foreground">remote:</span>
+                <span className="font-mono text-muted-foreground">
+                  {activeNode.remote.remote_branch}
+                </span>
               </div>
               <div className="mt-0.5 flex items-center gap-2">
                 {activeNode.remote.ahead === 0 && activeNode.remote.behind === 0 ? (
-                  <span className="text-zinc-500">= up to date</span>
+                  <span className="text-muted-foreground">= up to date</span>
                 ) : (
                   <>
                     {activeNode.remote.ahead > 0 && (
-                      <span className="text-amber-400">{activeNode.remote.ahead} to push</span>
+                      <span className="text-warning">{activeNode.remote.ahead} to push</span>
                     )}
                     {activeNode.remote.behind > 0 && (
-                      <span className="text-cyan-400">{activeNode.remote.behind} to pull</span>
+                      <span className="text-primary">{activeNode.remote.behind} to pull</span>
                     )}
                   </>
                 )}
               </div>
             </div>
           ) : (
-            <div className="mt-2 text-[11px] text-zinc-600">no remote tracking</div>
+            <div className="mt-2 text-[11px] text-subtle-foreground">no remote tracking</div>
           )}
           {/* PR info */}
           {prInfo && (
@@ -411,23 +409,25 @@ export const ActionPanel = memo(function ActionPanel({
             </div>
           )}
           {/* CI checks */}
-          {ciLoading && <div className="mt-2 text-[11px] text-zinc-600">Loading checks...</div>}
+          {ciLoading && (
+            <div className="mt-2 text-[11px] text-subtle-foreground">Loading checks...</div>
+          )}
           {ciSummary && ciSummary.checks.length > 0 && (
             <div className="mt-2">
               <button
                 type="button"
                 onClick={() => setCiExpanded((v) => !v)}
-                className="flex items-center gap-1.5 text-[11px] text-zinc-400 transition-colors hover:text-zinc-200"
+                className="flex items-center gap-1.5 text-[11px] text-muted-foreground transition-colors hover:text-foreground"
               >
                 <span
                   className={`inline-block h-2 w-2 rounded-full ${
                     ciSummary.rollup === "SUCCESS"
-                      ? "bg-green-400"
+                      ? "bg-success"
                       : ciSummary.rollup === "FAILURE"
-                        ? "bg-red-400"
+                        ? "bg-destructive"
                         : ciSummary.rollup === "PENDING"
-                          ? "bg-yellow-400"
-                          : "bg-zinc-600"
+                          ? "bg-warning"
+                          : "bg-muted-foreground"
                   }`}
                 />
                 <span>
@@ -440,7 +440,7 @@ export const ActionPanel = memo(function ActionPanel({
                         ? "running"
                         : "unknown"}
                 </span>
-                <span className="text-[10px] text-zinc-600">
+                <span className="text-[10px] text-subtle-foreground">
                   ({ciSummary.checks.length} check
                   {ciSummary.checks.length !== 1 ? "s" : ""})
                 </span>
@@ -466,34 +466,34 @@ export const ActionPanel = memo(function ActionPanel({
                             window.open(check.url, "_blank", "noopener,noreferrer");
                           }
                         }}
-                        className="flex items-center gap-1.5 rounded bg-white/[0.03] px-2 py-1 text-left text-[11px] transition-colors hover:bg-white/[0.06]"
+                        className="flex items-center gap-1.5 rounded bg-surface px-2 py-1 text-left text-[11px] transition-colors hover:bg-surface"
                       >
                         <span
                           className={`inline-block h-1.5 w-1.5 shrink-0 rounded-full ${
                             check.conclusion === "success"
-                              ? "bg-green-400"
+                              ? "bg-success"
                               : check.conclusion === "failure"
-                                ? "bg-red-400"
+                                ? "bg-destructive"
                                 : check.status === "in_progress" || check.status === "queued"
-                                  ? "bg-yellow-400"
-                                  : "bg-zinc-600"
+                                  ? "bg-warning"
+                                  : "bg-muted-foreground"
                           }`}
                         />
-                        <span className="truncate text-zinc-300">{check.name}</span>
+                        <span className="truncate text-foreground">{check.name}</span>
                         {canViewLog && (
-                          <span className="text-[9px] text-red-400/60" title="View failure log">
+                          <span className="text-[9px] text-destructive/60" title="View failure log">
                             log
                           </span>
                         )}
                         <span
                           className={`ml-auto shrink-0 text-[10px] ${
                             check.conclusion === "success"
-                              ? "text-green-400"
+                              ? "text-success"
                               : check.conclusion === "failure"
-                                ? "text-red-400"
+                                ? "text-destructive"
                                 : check.status === "in_progress"
-                                  ? "text-yellow-400"
-                                  : "text-zinc-600"
+                                  ? "text-warning"
+                                  : "text-subtle-foreground"
                           }`}
                         >
                           {check.conclusion ?? check.status}
@@ -511,7 +511,7 @@ export const ActionPanel = memo(function ActionPanel({
                     type="button"
                     onClick={handleRerunFailed}
                     disabled={rerunBusy}
-                    className="mt-1.5 w-full rounded bg-red-500/10 px-2 py-1 text-[11px] text-red-400 transition-colors hover:bg-red-500/20 disabled:opacity-50"
+                    className="mt-1.5 w-full rounded bg-destructive/10 px-2 py-1 text-[11px] text-destructive transition-colors hover:bg-destructive/20 disabled:opacity-50"
                   >
                     {rerunBusy ? "Re-running..." : "Re-run failed checks"}
                   </button>
@@ -519,7 +519,7 @@ export const ActionPanel = memo(function ActionPanel({
             </div>
           )}
           {ciSummary && ciSummary.checks.length === 0 && !ciLoading && !prInfo?.check_status && (
-            <div className="mt-2 text-[11px] text-zinc-600">No CI checks</div>
+            <div className="mt-2 text-[11px] text-subtle-foreground">No CI checks</div>
           )}
           {/* Linked issues — clickable to navigate to Issues tab */}
           {(() => {
@@ -533,14 +533,14 @@ export const ActionPanel = memo(function ActionPanel({
             if (linked.length === 0) return null;
             return (
               <div className="mt-2">
-                <div className="mb-1 text-[11px] text-zinc-500">Linked issues</div>
+                <div className="mb-1 text-[11px] text-muted-foreground">Linked issues</div>
                 <div className="flex flex-col gap-1">
                   {linked.map((issue) => (
                     <button
                       key={issue.number}
                       type="button"
                       onClick={() => onNavigateToIssue?.(issue)}
-                      className="flex items-start gap-1.5 rounded bg-white/[0.03] px-2 py-1.5 text-left text-[11px] transition-colors hover:bg-white/[0.06]"
+                      className="flex items-start gap-1.5 rounded bg-surface px-2 py-1.5 text-left text-[11px] transition-colors hover:bg-surface"
                       title={`Go to issue #${issue.number}`}
                     >
                       <svg
@@ -548,14 +548,14 @@ export const ActionPanel = memo(function ActionPanel({
                         height="10"
                         viewBox="0 0 16 16"
                         fill="currentColor"
-                        className="mt-0.5 shrink-0 text-green-400"
+                        className="mt-0.5 shrink-0 text-success"
                         aria-hidden="true"
                       >
                         <path d="M8 9.5a1.5 1.5 0 1 0 0-3 1.5 1.5 0 0 0 0 3Z" />
                         <path d="M8 0a8 8 0 1 1 0 16A8 8 0 0 1 8 0ZM1.5 8a6.5 6.5 0 1 0 13 0 6.5 6.5 0 0 0-13 0Z" />
                       </svg>
-                      <span className="shrink-0 text-green-400">#{issue.number}</span>
-                      <span className="truncate text-zinc-300">{issue.title}</span>
+                      <span className="shrink-0 text-success">#{issue.number}</span>
+                      <span className="truncate text-foreground">{issue.title}</span>
                       {issue.labels.length > 0 && (
                         <div className="ml-auto flex shrink-0 gap-1">
                           {issue.labels.slice(0, 2).map((label) => (
@@ -583,7 +583,7 @@ export const ActionPanel = memo(function ActionPanel({
         {/* Incoming PRs (PRs targeting this branch) */}
         {targetPrs.length > 0 && (
           <div className="mb-4">
-            <div className="mb-2 text-[11px] font-medium uppercase tracking-wider text-zinc-500">
+            <div className="mb-2 text-[11px] font-medium uppercase tracking-wider text-muted-foreground">
               Incoming PRs ({targetPrs.length})
             </div>
             <div className="flex max-h-96 flex-col gap-1.5 overflow-y-auto pr-1">
@@ -618,7 +618,7 @@ export const ActionPanel = memo(function ActionPanel({
             <button
               type="button"
               onClick={() => onOpenDetail({ kind: "diff" })}
-              className="w-full rounded-lg bg-white/5 px-3 py-2 text-left text-xs text-zinc-300 transition-colors hover:bg-white/10"
+              className="w-full rounded-lg bg-surface px-3 py-2 text-left text-xs text-foreground transition-colors hover:bg-surface-strong"
             >
               View Diff
             </button>
@@ -630,7 +630,7 @@ export const ActionPanel = memo(function ActionPanel({
               type="button"
               onClick={handleCheckoutRemote}
               disabled={actionBusy}
-              className="w-full rounded-lg bg-purple-500/15 px-3 py-2 text-left text-xs font-medium text-purple-400 transition-colors hover:bg-purple-500/25 disabled:opacity-50"
+              className="w-full rounded-lg bg-accent/15 px-3 py-2 text-left text-xs font-medium text-accent transition-colors hover:bg-accent/25 disabled:opacity-50"
             >
               {actionBusy ? "Checking out..." : "Checkout (Create Local Branch)"}
             </button>
@@ -649,14 +649,14 @@ export const ActionPanel = memo(function ActionPanel({
                 <>
                   {/* Merged branch guidance */}
                   {isMerged && (
-                    <div className="rounded-lg bg-purple-500/10 px-3 py-2 text-xs text-purple-400">
+                    <div className="rounded-lg bg-accent/10 px-3 py-2 text-xs text-accent">
                       This branch has been merged. You can safely delete it.
                     </div>
                   )}
 
                   {/* Stale branch guidance */}
                   {isStale && (
-                    <div className="rounded-lg bg-amber-500/10 px-3 py-2 text-xs text-amber-400">
+                    <div className="rounded-lg bg-warning/10 px-3 py-2 text-xs text-warning">
                       {activeNode.behind} commit
                       {activeNode.behind !== 1 ? "s" : ""} behind {baseBranch} — pull or rebase
                       before resuming work.
@@ -669,7 +669,7 @@ export const ActionPanel = memo(function ActionPanel({
                       href={prInfo.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="block w-full rounded-lg bg-blue-500/15 px-3 py-2 text-left text-xs font-medium text-blue-400 transition-colors hover:bg-blue-500/25"
+                      className="block w-full rounded-lg bg-info/15 px-3 py-2 text-left text-xs font-medium text-info transition-colors hover:bg-info/25"
                     >
                       View PR #{prInfo.number} on GitHub
                     </a>
@@ -684,7 +684,7 @@ export const ActionPanel = memo(function ActionPanel({
                           if (activeNode.agentTarget) onFocusAgent(activeNode.agentTarget);
                         }}
                         disabled={isStale}
-                        className="w-full rounded-lg bg-cyan-500/15 px-3 py-2 text-left text-xs font-medium text-cyan-400 transition-colors hover:bg-cyan-500/25 disabled:opacity-30"
+                        className="w-full rounded-lg bg-primary/15 px-3 py-2 text-left text-xs font-medium text-primary transition-colors hover:bg-primary/25 disabled:opacity-30"
                         title={isStale ? "Pull from main before focusing agent" : undefined}
                       >
                         Focus Agent
@@ -696,7 +696,7 @@ export const ActionPanel = memo(function ActionPanel({
                           type="button"
                           onClick={() => confirmIfAgentActive("Launch agent", handleLaunchAgent)}
                           disabled={actionBusy || isStale}
-                          className="w-full rounded-lg bg-cyan-500/15 px-3 py-2 text-left text-xs font-medium text-cyan-400 transition-colors hover:bg-cyan-500/25 disabled:opacity-30"
+                          className="w-full rounded-lg bg-primary/15 px-3 py-2 text-left text-xs font-medium text-primary transition-colors hover:bg-primary/25 disabled:opacity-30"
                           title={isStale ? "Pull from main before launching agent" : undefined}
                         >
                           {actionBusy ? "Launching..." : "Launch Agent"}
@@ -719,7 +719,7 @@ export const ActionPanel = memo(function ActionPanel({
                           )
                         }
                         disabled={actionBusy || isStale}
-                        className="w-full rounded-lg bg-purple-500/15 px-3 py-2 text-left text-xs font-medium text-purple-400 transition-colors hover:bg-purple-500/25 disabled:opacity-30"
+                        className="w-full rounded-lg bg-accent/15 px-3 py-2 text-left text-xs font-medium text-accent transition-colors hover:bg-accent/25 disabled:opacity-30"
                         title={isStale ? "Pull from main before merging" : undefined}
                       >
                         {prInfo
@@ -734,7 +734,7 @@ export const ActionPanel = memo(function ActionPanel({
                           )
                         }
                         disabled={actionBusy || isStale}
-                        className="w-full rounded-lg bg-blue-500/15 px-3 py-2 text-left text-xs font-medium text-blue-400 transition-colors hover:bg-blue-500/25 disabled:opacity-30"
+                        className="w-full rounded-lg bg-info/15 px-3 py-2 text-left text-xs font-medium text-info transition-colors hover:bg-info/25 disabled:opacity-30"
                         title={isStale ? "Pull from main before creating PR" : undefined}
                       >
                         AI Create PR → {baseBranch}
@@ -744,7 +744,7 @@ export const ActionPanel = memo(function ActionPanel({
 
                   {/* Behind warning — shown for non-merged branches (prominent in stale already handled above) */}
                   {!isMerged && !isStale && activeNode.behind > 0 && (
-                    <div className="rounded-lg bg-amber-500/10 px-3 py-2 text-xs text-amber-400">
+                    <div className="rounded-lg bg-warning/10 px-3 py-2 text-xs text-warning">
                       {activeNode.behind} commit
                       {activeNode.behind !== 1 ? "s" : ""} behind {baseBranch}
                     </div>
@@ -756,7 +756,7 @@ export const ActionPanel = memo(function ActionPanel({
                       type="button"
                       onClick={() => confirmIfAgentActive("Move", handleMoveToWorktree)}
                       disabled={actionBusy}
-                      className="w-full rounded-lg bg-amber-500/15 px-3 py-2 text-left text-xs font-medium text-amber-400 transition-colors hover:bg-amber-500/25 disabled:opacity-50"
+                      className="w-full rounded-lg bg-warning/15 px-3 py-2 text-left text-xs font-medium text-warning transition-colors hover:bg-warning/25 disabled:opacity-50"
                     >
                       {actionBusy ? "Moving..." : "Move to Worktree"}
                     </button>
@@ -769,7 +769,7 @@ export const ActionPanel = memo(function ActionPanel({
                       <button
                         type="button"
                         onClick={() => setShowNewWorktree(true)}
-                        className="w-full rounded-lg bg-emerald-500/15 px-3 py-2 text-left text-xs font-medium text-emerald-400 transition-colors hover:bg-emerald-500/25"
+                        className="w-full rounded-lg bg-success/15 px-3 py-2 text-left text-xs font-medium text-success transition-colors hover:bg-success/25"
                       >
                         Create Worktree
                       </button>
@@ -785,7 +785,7 @@ export const ActionPanel = memo(function ActionPanel({
                     ))}
 
                   {/* Delete — primary for merged, confirmation-gated for open PR */}
-                  <hr className="border-white/5" />
+                  <hr className="border-hairline" />
                   {!confirmDelete ? (
                     <button
                       type="button"
@@ -799,8 +799,8 @@ export const ActionPanel = memo(function ActionPanel({
                       disabled={!activeNode.isWorktree && activeNode.isCurrent}
                       className={`w-full rounded-lg px-3 py-2 text-left text-xs transition-colors disabled:opacity-30 ${
                         isMerged
-                          ? "bg-red-500/20 font-medium text-red-400 hover:bg-red-500/30"
-                          : "bg-red-500/10 text-red-400 hover:bg-red-500/20"
+                          ? "bg-destructive/20 font-medium text-destructive hover:bg-destructive/30"
+                          : "bg-destructive/10 text-destructive hover:bg-destructive/20"
                       }`}
                     >
                       {isMerged
@@ -808,28 +808,28 @@ export const ActionPanel = memo(function ActionPanel({
                         : `Delete ${activeNode.isWorktree ? "Worktree" : "Branch"}`}
                     </button>
                   ) : (
-                    <div className="rounded-lg border border-red-500/20 bg-red-500/5 p-2">
+                    <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-2">
                       {hasOpenPr && (
-                        <div className="mb-2 text-[11px] text-amber-400">
+                        <div className="mb-2 text-[11px] text-warning">
                           Warning: PR #{prInfo?.number} is still open
                         </div>
                       )}
-                      <label className="flex items-center gap-1.5 text-[11px] text-zinc-400">
+                      <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
                         <input
                           type="checkbox"
                           checked={forceDelete}
                           onChange={(e) => setForceDelete(e.target.checked)}
-                          className="accent-red-500"
+                          className="accent-destructive"
                         />
                         Force delete{!activeNode.isWorktree ? " (unmerged)" : ""}
                       </label>
                       {!activeNode.isWorktree && activeNode.remote && (
-                        <label className="mt-1 flex items-center gap-1.5 text-[11px] text-zinc-400">
+                        <label className="mt-1 flex items-center gap-1.5 text-[11px] text-muted-foreground">
                           <input
                             type="checkbox"
                             checked={deleteRemote}
                             onChange={(e) => setDeleteRemote(e.target.checked)}
-                            className="accent-red-500"
+                            className="accent-destructive"
                           />
                           Also delete remote branch
                         </label>
@@ -841,7 +841,7 @@ export const ActionPanel = memo(function ActionPanel({
                             activeNode.isWorktree ? handleDeleteWorktree : handleDeleteBranch
                           }
                           disabled={actionBusy}
-                          className="rounded bg-red-500/20 px-2 py-1 text-xs text-red-400 hover:bg-red-500/30 disabled:opacity-50"
+                          className="rounded bg-destructive/20 px-2 py-1 text-xs text-destructive hover:bg-destructive/30 disabled:opacity-50"
                         >
                           {actionBusy ? "..." : "Confirm"}
                         </button>
@@ -852,7 +852,7 @@ export const ActionPanel = memo(function ActionPanel({
                             setForceDelete(false);
                             setDeleteRemote(true);
                           }}
-                          className="text-xs text-zinc-500 hover:text-zinc-300"
+                          className="text-xs text-muted-foreground hover:text-foreground"
                         >
                           Cancel
                         </button>
@@ -869,7 +869,7 @@ export const ActionPanel = memo(function ActionPanel({
               <button
                 type="button"
                 onClick={() => setShowNewWorktree(true)}
-                className="w-full rounded-lg bg-emerald-500/15 px-3 py-2 text-left text-xs font-medium text-emerald-400 transition-colors hover:bg-emerald-500/25"
+                className="w-full rounded-lg bg-success/15 px-3 py-2 text-left text-xs font-medium text-success transition-colors hover:bg-success/25"
               >
                 Create Worktree
               </button>
@@ -887,7 +887,7 @@ export const ActionPanel = memo(function ActionPanel({
 
         {/* Error display */}
         {actionError && (
-          <div className="mt-3 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2 text-xs text-red-400">
+          <div className="mt-3 rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2 text-xs text-destructive">
             {actionError}
           </div>
         )}

--- a/clients/react/src/components/worktree/BranchGraph.tsx
+++ b/clients/react/src/components/worktree/BranchGraph.tsx
@@ -60,9 +60,9 @@ function formatRelativeTime(unixSecs: number): string {
 // Return CSS color class for commit age: recent → aging → stale
 function commitAgeColor(unixSecs: number): string {
   const days = Math.floor((Date.now() / 1000 - unixSecs) / 86400);
-  if (days <= 3) return "text-zinc-400";
-  if (days <= 14) return "text-yellow-500/70";
-  return "text-red-400/70";
+  if (days <= 3) return "text-muted-foreground";
+  if (days <= 14) return "text-warning/70";
+  return "text-destructive/70";
 }
 
 const BRANCH_DEPTH_WARNING = 3;
@@ -79,7 +79,7 @@ function ActionPanelToggle({ collapsed, onToggle }: { collapsed: boolean; onTogg
     <button
       type="button"
       onClick={onToggle}
-      className="flex h-full w-5 shrink-0 items-center justify-center border-l border-white/5 text-zinc-600 transition-colors hover:bg-white/5 hover:text-zinc-400"
+      className="flex h-full w-5 shrink-0 items-center justify-center border-l border-hairline text-subtle-foreground transition-colors hover:bg-surface hover:text-muted-foreground"
       title={collapsed ? "Show action panel" : "Hide action panel"}
     >
       <svg
@@ -550,7 +550,7 @@ export function BranchGraph({
 
   if (loading) {
     return (
-      <div className="flex flex-1 items-center justify-center text-sm text-zinc-500">
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
         Loading branches...
       </div>
     );
@@ -559,7 +559,7 @@ export function BranchGraph({
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       {/* Header */}
-      <div className="glass shrink-0 border-b border-white/5 px-4 py-3 md:px-6 md:py-4">
+      <div className="glass shrink-0 border-b border-hairline px-4 py-3 md:px-6 md:py-4">
         {/* Row 1: icon + name + tab switcher */}
         <div className="flex flex-wrap items-center gap-2">
           <svg
@@ -567,7 +567,7 @@ export function BranchGraph({
             height="18"
             viewBox="0 0 16 16"
             fill="none"
-            className="shrink-0 text-emerald-400"
+            className="shrink-0 text-success"
             role="img"
             aria-label="Branch graph"
           >
@@ -578,11 +578,11 @@ export function BranchGraph({
             <line x1="4" y1="6" x2="4" y2="10" stroke="currentColor" strokeWidth="1.5" />
             <path d="M4 6 C4 8, 8 8, 12 8" stroke="currentColor" strokeWidth="1.5" fill="none" />
           </svg>
-          <h2 className="truncate text-base font-semibold text-zinc-100 md:text-lg">
+          <h2 className="truncate text-base font-semibold text-foreground md:text-lg">
             {projectName}
           </h2>
           {/* Tab switcher */}
-          <div className="flex gap-1 rounded-lg bg-white/5 p-0.5">
+          <div className="flex gap-1 rounded-lg bg-surface p-0.5">
             <button
               type="button"
               onClick={() => {
@@ -590,7 +590,9 @@ export function BranchGraph({
                 setSelectedIssue(null);
               }}
               className={`touch-target-sm rounded-md px-2.5 py-1 text-xs transition-colors ${
-                !showIssues ? "bg-white/10 text-zinc-200" : "text-zinc-500 hover:text-zinc-300"
+                !showIssues
+                  ? "bg-surface-strong text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
               }`}
             >
               Branches
@@ -599,7 +601,9 @@ export function BranchGraph({
               type="button"
               onClick={() => setShowIssues(true)}
               className={`touch-target-sm rounded-md px-2.5 py-1 text-xs transition-colors ${
-                showIssues ? "bg-white/10 text-zinc-200" : "text-zinc-500 hover:text-zinc-300"
+                showIssues
+                  ? "bg-surface-strong text-foreground"
+                  : "text-muted-foreground hover:text-foreground"
               }`}
             >
               Issues{issues.length > 0 ? ` (${issues.length})` : ""}
@@ -610,7 +614,7 @@ export function BranchGraph({
           <div className="flex items-center gap-1.5">
             {branches?.last_fetch && (
               <span
-                className="hidden text-[10px] text-zinc-600 md:block"
+                className="hidden text-[10px] text-subtle-foreground md:block"
                 title={new Date(branches.last_fetch * 1000).toLocaleString()}
               >
                 fetched {formatRelativeTime(branches.last_fetch)}
@@ -621,7 +625,7 @@ export function BranchGraph({
                 type="button"
                 onClick={handleBulkDeleteMerged}
                 disabled={bulkDeleteBusy}
-                className="touch-target-sm rounded-lg bg-red-500/10 px-2.5 py-1.5 text-xs text-red-400 transition-colors hover:bg-red-500/20 hover:text-red-300 disabled:opacity-50"
+                className="touch-target-sm rounded-lg bg-destructive/10 px-2.5 py-1.5 text-xs text-destructive transition-colors hover:bg-destructive/20 hover:text-destructive disabled:opacity-50"
               >
                 {bulkDeleteBusy ? "Deleting..." : `Delete Merged (${mergedBranches.length})`}
               </button>
@@ -630,7 +634,7 @@ export function BranchGraph({
               type="button"
               onClick={handleRefresh}
               disabled={refreshBusy}
-              className="touch-target-sm rounded-lg bg-white/5 px-2.5 py-1.5 text-xs text-zinc-400 transition-colors hover:bg-white/10 hover:text-zinc-200 disabled:opacity-50"
+              className="touch-target-sm rounded-lg bg-surface px-2.5 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground disabled:opacity-50"
             >
               {refreshBusy ? "..." : "Refresh"}
             </button>
@@ -638,7 +642,7 @@ export function BranchGraph({
         </div>
         {/* Row 2: stats (hidden on smallest screens) */}
         {!showIssues && (
-          <div className="mt-1 hidden text-xs text-zinc-500 sm:block">
+          <div className="mt-1 hidden text-xs text-muted-foreground sm:block">
             {branchCount} branch{branchCount !== 1 ? "es" : ""}
             {(() => {
               const wtCount = projectWorktrees.filter((w) => !w.is_main).length;
@@ -654,7 +658,7 @@ export function BranchGraph({
             )}
           </div>
         )}
-        {refreshError && <div className="mt-2 text-xs text-red-400">{refreshError}</div>}
+        {refreshError && <div className="mt-2 text-xs text-destructive">{refreshError}</div>}
       </div>
 
       <div className="flex flex-1 overflow-hidden">
@@ -712,7 +716,7 @@ export function BranchGraph({
                   onToggleCollapse={toggleCollapse}
                 />
               ) : (
-                <div className="flex items-center justify-center py-20 text-sm text-zinc-500">
+                <div className="flex items-center justify-center py-20 text-sm text-muted-foreground">
                   {graphData?.commits.length === 0
                     ? "No commits found"
                     : "Only the default branch exists"}
@@ -728,7 +732,7 @@ export function BranchGraph({
                       savedScrollTop.current = scrollRef.current?.scrollTop ?? null;
                       setGraphLimit((prev) => prev + 200);
                     }}
-                    className="rounded-lg bg-white/5 px-4 py-2 text-xs text-zinc-400 transition-colors hover:bg-white/10 hover:text-zinc-200"
+                    className="rounded-lg bg-surface px-4 py-2 text-xs text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
                   >
                     Load more commits ({graphLimit} shown)
                   </button>
@@ -746,8 +750,8 @@ export function BranchGraph({
                   n.ahead === 0 &&
                   !n.isCurrent,
               ).length > 0 && (
-                <div className="mt-6 border-t border-white/5 pt-4">
-                  <div className="mb-2 text-[11px] text-zinc-600">Inactive branches</div>
+                <div className="mt-6 border-t border-hairline pt-4">
+                  <div className="mb-2 text-[11px] text-subtle-foreground">Inactive branches</div>
                   <div className="flex flex-wrap gap-1.5">
                     {nodes
                       .filter(
@@ -767,13 +771,13 @@ export function BranchGraph({
                           onClick={() => selectBranch(n.name)}
                           className={`rounded-md px-2 py-1 text-[11px] transition-colors ${
                             selectedNode === n.name
-                              ? "bg-cyan-500/15 text-cyan-400"
-                              : "bg-white/5 text-zinc-500 hover:bg-white/10 hover:text-zinc-300"
+                              ? "bg-primary/15 text-primary"
+                              : "bg-surface text-muted-foreground hover:bg-surface-strong hover:text-foreground"
                           }`}
                         >
                           {n.name}
                           {n.behind > 0 && (
-                            <span className="ml-1 text-[10px] text-red-400">{n.behind}↓</span>
+                            <span className="ml-1 text-[10px] text-destructive">{n.behind}↓</span>
                           )}
                           {n.lastCommitTime != null && (
                             <span
@@ -790,8 +794,8 @@ export function BranchGraph({
 
               {/* Remote-only branches (no local counterpart) */}
               {nodes.filter((n) => n.isRemoteOnly).length > 0 && (
-                <div className="mt-6 border-t border-white/5 pt-4">
-                  <div className="mb-2 text-[11px] text-zinc-600">Remote branches</div>
+                <div className="mt-6 border-t border-hairline pt-4">
+                  <div className="mb-2 text-[11px] text-subtle-foreground">Remote branches</div>
                   <div className="flex flex-wrap gap-1.5">
                     {nodes
                       .filter((n) => n.isRemoteOnly)
@@ -802,11 +806,11 @@ export function BranchGraph({
                           onClick={() => selectBranch(n.name)}
                           className={`rounded-md px-2 py-1 text-[11px] transition-colors ${
                             selectedNode === n.name
-                              ? "bg-purple-500/15 text-purple-400"
-                              : "bg-white/5 text-zinc-500 hover:bg-white/10 hover:text-zinc-300"
+                              ? "bg-accent/15 text-accent"
+                              : "bg-surface text-muted-foreground hover:bg-surface-strong hover:text-foreground"
                           }`}
                         >
-                          <span className="mr-1 text-[10px] text-purple-500/60">remote</span>
+                          <span className="mr-1 text-[10px] text-accent/60">remote</span>
                           {n.name}
                           {n.lastCommitTime != null && (
                             <span

--- a/clients/react/src/components/worktree/CommitLog.tsx
+++ b/clients/react/src/components/worktree/CommitLog.tsx
@@ -38,35 +38,35 @@ export function CommitLog({ repoPath, base, branch, count }: CommitLogProps) {
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
-        className="flex items-center gap-1.5 text-xs text-zinc-400 hover:text-zinc-200 transition-colors"
+        className="flex items-center gap-1.5 text-xs text-muted-foreground hover:text-foreground transition-colors"
       >
         <span className="text-[10px]">{expanded ? "\u25BE" : "\u25B8"}</span>
         <span>Commits ({count})</span>
       </button>
       {expanded && (
         <div className="mt-1.5">
-          {loading && <div className="text-[11px] text-zinc-600 py-1">Loading...</div>}
+          {loading && <div className="text-[11px] text-subtle-foreground py-1">Loading...</div>}
           {commits && commits.length === 0 && !loading && (
-            <div className="text-[11px] text-zinc-600 py-1">No commits</div>
+            <div className="text-[11px] text-subtle-foreground py-1">No commits</div>
           )}
           {commits?.map((c) => (
-            <div key={c.sha} className="border-b border-white/5 last:border-0">
+            <div key={c.sha} className="border-b border-hairline last:border-0">
               <button
                 type="button"
                 onClick={() => setExpandedSha((prev) => (prev === c.sha ? null : c.sha))}
-                className="flex w-full items-baseline gap-2 py-1 text-left hover:bg-white/[0.03] rounded px-1 -mx-1 transition-colors"
+                className="flex w-full items-baseline gap-2 py-1 text-left hover:bg-surface rounded px-1 -mx-1 transition-colors"
               >
-                <CopyableSha sha={c.sha} className="text-[10px] text-cyan-600" />
-                <span className="text-[11px] text-zinc-400 truncate">{c.subject}</span>
+                <CopyableSha sha={c.sha} className="text-[10px] text-primary" />
+                <span className="text-[11px] text-muted-foreground truncate">{c.subject}</span>
               </button>
               {expandedSha === c.sha && (
                 <div className="px-1 pb-2 select-text">
-                  <div className="rounded bg-white/[0.03] px-2 py-1.5 text-[11px] text-zinc-300 font-mono whitespace-pre-wrap break-words">
+                  <div className="rounded bg-surface px-2 py-1.5 text-[11px] text-foreground font-mono whitespace-pre-wrap break-words">
                     {c.subject}
                     {c.body && (
                       <>
                         {"\n\n"}
-                        <span className="text-zinc-500">{c.body}</span>
+                        <span className="text-muted-foreground">{c.body}</span>
                       </>
                     )}
                   </div>

--- a/clients/react/src/components/worktree/CreateWorktreeForm.tsx
+++ b/clients/react/src/components/worktree/CreateWorktreeForm.tsx
@@ -47,12 +47,12 @@ export function CreateWorktreeForm({
   }, [name, busy, projectPath, baseBranch, onCreated]);
 
   return (
-    <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-2">
-      <div className="mb-1 text-[11px] text-zinc-500">
-        from: <span className="text-emerald-400">{baseBranch}</span>
+    <div className="rounded-lg border border-success/20 bg-success/5 p-2">
+      <div className="mb-1 text-[11px] text-muted-foreground">
+        from: <span className="text-success">{baseBranch}</span>
       </div>
       {depth + 1 >= depthWarning && (
-        <div className="mb-2 rounded bg-amber-500/10 px-2 py-1.5 text-[11px] text-amber-400">
+        <div className="mb-2 rounded bg-warning/10 px-2 py-1.5 text-[11px] text-warning">
           This will be {depth + 1} levels deep from main. Consider merging the parent branch first.
         </div>
       )}
@@ -70,18 +70,18 @@ export function CreateWorktreeForm({
             if (e.key === "Escape") onCancel();
           }}
           placeholder="worktree name"
-          className="flex-1 rounded bg-black/30 px-2 py-1 text-xs text-zinc-200 placeholder-zinc-600 outline-none ring-1 ring-emerald-500/30 focus:ring-emerald-500/60"
+          className="flex-1 rounded bg-background px-2 py-1 text-xs text-foreground placeholder-subtle-foreground outline-none ring-1 ring-success/30 focus:ring-success/60"
         />
         <button
           type="button"
           onClick={handleCreate}
           disabled={!name.trim() || busy}
-          className="rounded px-2 py-1 text-xs text-emerald-400 hover:bg-emerald-500/10 disabled:opacity-30"
+          className="rounded px-2 py-1 text-xs text-success hover:bg-success/10 disabled:opacity-30"
         >
           Go
         </button>
       </div>
-      {error && <span className="text-[10px] text-red-400">{error}</span>}
+      {error && <span className="text-[10px] text-destructive">{error}</span>}
     </div>
   );
 }

--- a/clients/react/src/components/worktree/DetailPanel.tsx
+++ b/clients/react/src/components/worktree/DetailPanel.tsx
@@ -12,17 +12,17 @@ import {
 } from "@/lib/api";
 
 const proseClassName = `prose prose-invert prose-sm max-w-none
-  prose-headings:text-zinc-100 prose-headings:font-semibold
-  prose-p:text-zinc-300 prose-p:leading-relaxed
-  prose-a:text-blue-400 prose-a:no-underline hover:prose-a:underline
-  prose-strong:text-zinc-200
-  prose-code:text-cyan-400 prose-code:bg-white/5 prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:before:content-none prose-code:after:content-none
-  prose-pre:bg-zinc-900/50 prose-pre:border prose-pre:border-white/5 prose-pre:rounded-lg
-  prose-li:text-zinc-300
-  prose-th:text-zinc-300 prose-th:border-white/10
-  prose-td:text-zinc-400 prose-td:border-white/10
-  prose-hr:border-white/10
-  prose-blockquote:border-blue-500/30 prose-blockquote:text-zinc-400`;
+  prose-headings:text-foreground prose-headings:font-semibold
+  prose-p:text-foreground prose-p:leading-relaxed
+  prose-a:text-info prose-a:no-underline hover:prose-a:underline
+  prose-strong:text-foreground
+  prose-code:text-primary prose-code:bg-surface prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:before:content-none prose-code:after:content-none
+  prose-pre:bg-surface-strong/50 prose-pre:border prose-pre:border-hairline prose-pre:rounded-lg
+  prose-li:text-foreground
+  prose-th:text-foreground prose-th:border-hairline-strong
+  prose-td:text-muted-foreground prose-td:border-hairline-strong
+  prose-hr:border-hairline-strong
+  prose-blockquote:border-info/30 prose-blockquote:text-muted-foreground`;
 
 import { DiffViewer } from "./DiffViewer";
 import type { BranchNode } from "./graph/types";
@@ -126,9 +126,9 @@ function DiffView({
     return () => clearInterval(interval);
   }, [fetchDiff]);
 
-  if (loading) return <div className="text-sm text-zinc-500">Loading diff...</div>;
-  if (error) return <div className="text-sm text-red-400">{error}</div>;
-  if (!diffData?.diff) return <div className="text-sm text-zinc-500">No changes</div>;
+  if (loading) return <div className="text-sm text-muted-foreground">Loading diff...</div>;
+  if (error) return <div className="text-sm text-destructive">{error}</div>;
+  if (!diffData?.diff) return <div className="text-sm text-muted-foreground">No changes</div>;
   return <DiffViewer diff={diffData.diff} />;
 }
 
@@ -160,29 +160,30 @@ function PrCommentsView({ projectPath, prNumber }: { projectPath: string; prNumb
     return () => clearInterval(interval);
   }, [fetchComments]);
 
-  if (loading) return <div className="text-sm text-zinc-500">Loading comments...</div>;
-  if (error) return <div className="text-sm text-red-400">{error}</div>;
-  if (comments.length === 0) return <div className="text-sm text-zinc-500">No comments</div>;
+  if (loading) return <div className="text-sm text-muted-foreground">Loading comments...</div>;
+  if (error) return <div className="text-sm text-destructive">{error}</div>;
+  if (comments.length === 0)
+    return <div className="text-sm text-muted-foreground">No comments</div>;
 
   return (
     <div className="flex flex-col gap-4">
       {comments.map((comment) => (
-        <div key={comment.url} className="rounded-lg border border-white/5 bg-white/[0.02] p-3">
+        <div key={comment.url} className="rounded-lg border border-hairline bg-surface p-3">
           <div className="flex items-center gap-2 text-xs">
-            <span className="font-semibold text-zinc-200">{comment.author}</span>
-            <span className="text-zinc-600">{formatRelative(comment.created_at)}</span>
+            <span className="font-semibold text-foreground">{comment.author}</span>
+            <span className="text-subtle-foreground">{formatRelative(comment.created_at)}</span>
             {comment.comment_type !== "comment" && (
-              <span className="rounded bg-blue-500/15 px-1 py-0.5 text-[10px] text-blue-400">
+              <span className="rounded bg-info/15 px-1 py-0.5 text-[10px] text-info">
                 {comment.comment_type}
               </span>
             )}
           </div>
           {/* Review comment: show file path and diff hunk context */}
           {comment.path && (
-            <div className="mt-2 rounded bg-zinc-800/50 px-2 py-1.5">
-              <div className="text-[11px] font-mono text-zinc-400">{comment.path}</div>
+            <div className="mt-2 rounded bg-surface-strong/50 px-2 py-1.5">
+              <div className="text-[11px] font-mono text-muted-foreground">{comment.path}</div>
               {comment.diff_hunk && (
-                <pre className="mt-1 text-[10px] leading-relaxed text-zinc-600 overflow-x-auto">
+                <pre className="mt-1 text-[10px] leading-relaxed text-subtle-foreground overflow-x-auto">
                   {comment.diff_hunk}
                 </pre>
               )}
@@ -225,9 +226,10 @@ function PrFilesView({ projectPath, prNumber }: { projectPath: string; prNumber:
     return () => clearInterval(interval);
   }, [fetchFiles]);
 
-  if (loading) return <div className="text-sm text-zinc-500">Loading files...</div>;
-  if (error) return <div className="text-sm text-red-400">{error}</div>;
-  if (files.length === 0) return <div className="text-sm text-zinc-500">No changed files</div>;
+  if (loading) return <div className="text-sm text-muted-foreground">Loading files...</div>;
+  if (error) return <div className="text-sm text-destructive">{error}</div>;
+  if (files.length === 0)
+    return <div className="text-sm text-muted-foreground">No changed files</div>;
 
   const sorted = [...files].sort((a, b) => a.path.localeCompare(b.path));
   const totalAdd = sorted.reduce((sum, f) => sum + f.additions, 0);
@@ -235,20 +237,20 @@ function PrFilesView({ projectPath, prNumber }: { projectPath: string; prNumber:
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="text-xs text-zinc-400">
+      <div className="text-xs text-muted-foreground">
         {sorted.length} file{sorted.length !== 1 ? "s" : ""} changed:{" "}
-        <span className="text-emerald-400">+{totalAdd}</span>{" "}
-        <span className="text-red-400">-{totalDel}</span>
+        <span className="text-success">+{totalAdd}</span>{" "}
+        <span className="text-destructive">-{totalDel}</span>
       </div>
       <div className="flex flex-col gap-1">
         {sorted.map((file) => (
           <div
             key={file.path}
-            className="flex items-center gap-2 rounded bg-white/[0.03] px-3 py-1.5 text-xs"
+            className="flex items-center gap-2 rounded bg-surface px-3 py-1.5 text-xs"
           >
-            <span className="flex-1 break-all font-mono text-zinc-300">{file.path}</span>
-            <span className="shrink-0 text-emerald-400">+{file.additions}</span>
-            <span className="shrink-0 text-red-400">-{file.deletions}</span>
+            <span className="flex-1 break-all font-mono text-foreground">{file.path}</span>
+            <span className="shrink-0 text-success">+{file.additions}</span>
+            <span className="shrink-0 text-destructive">-{file.deletions}</span>
           </div>
         ))}
       </div>
@@ -284,42 +286,42 @@ function MergeStatusView({ projectPath, prNumber }: { projectPath: string; prNum
     return () => clearInterval(interval);
   }, [fetchStatus]);
 
-  if (loading) return <div className="text-sm text-zinc-500">Loading merge status...</div>;
-  if (error) return <div className="text-sm text-red-400">{error}</div>;
-  if (!status) return <div className="text-sm text-zinc-500">No data</div>;
+  if (loading) return <div className="text-sm text-muted-foreground">Loading merge status...</div>;
+  if (error) return <div className="text-sm text-destructive">{error}</div>;
+  if (!status) return <div className="text-sm text-muted-foreground">No data</div>;
 
   // Determine icon and color for each check item
   const mergeableIcon =
     status.mergeable === "MERGEABLE"
-      ? { icon: "\u2713", color: "text-green-400" }
+      ? { icon: "\u2713", color: "text-success" }
       : status.mergeable === "CONFLICTING"
-        ? { icon: "\u2717", color: "text-red-400" }
-        : { icon: "?", color: "text-yellow-400" };
+        ? { icon: "\u2717", color: "text-destructive" }
+        : { icon: "?", color: "text-warning" };
 
   const stateIcon =
     status.merge_state_status === "CLEAN"
-      ? { icon: "\u2713", color: "text-green-400" }
+      ? { icon: "\u2713", color: "text-success" }
       : status.merge_state_status === "BLOCKED"
-        ? { icon: "\u2717", color: "text-red-400" }
+        ? { icon: "\u2717", color: "text-destructive" }
         : status.merge_state_status === "BEHIND"
-          ? { icon: "\u2193", color: "text-yellow-400" }
-          : { icon: "\u2022", color: "text-zinc-400" };
+          ? { icon: "\u2193", color: "text-warning" }
+          : { icon: "\u2022", color: "text-muted-foreground" };
 
   const reviewIcon = !status.review_decision
-    ? { icon: "\u2014", color: "text-zinc-600" }
+    ? { icon: "\u2014", color: "text-subtle-foreground" }
     : status.review_decision === "APPROVED"
-      ? { icon: "\u2713", color: "text-green-400" }
+      ? { icon: "\u2713", color: "text-success" }
       : status.review_decision === "CHANGES_REQUESTED"
-        ? { icon: "\u2717", color: "text-orange-400" }
-        : { icon: "\u25CB", color: "text-yellow-400" };
+        ? { icon: "\u2717", color: "text-warning" }
+        : { icon: "\u25CB", color: "text-warning" };
 
   const ciIcon = !status.check_status
-    ? { icon: "\u2014", color: "text-zinc-600" }
+    ? { icon: "\u2014", color: "text-subtle-foreground" }
     : status.check_status === "SUCCESS"
-      ? { icon: "\u2713", color: "text-green-400" }
+      ? { icon: "\u2713", color: "text-success" }
       : status.check_status === "FAILURE"
-        ? { icon: "\u2717", color: "text-red-400" }
-        : { icon: "\u25CB", color: "text-yellow-400" };
+        ? { icon: "\u2717", color: "text-destructive" }
+        : { icon: "\u25CB", color: "text-warning" };
 
   return (
     <div className="flex flex-col gap-3">
@@ -335,11 +337,11 @@ function MergeStatusView({ projectPath, prNumber }: { projectPath: string; prNum
       ].map((item) => (
         <div
           key={item.label}
-          className="flex items-center gap-3 rounded bg-white/[0.03] px-3 py-2 text-sm"
+          className="flex items-center gap-3 rounded bg-surface px-3 py-2 text-sm"
         >
           <span className={`text-base ${item.color}`}>{item.icon}</span>
-          <span className="text-zinc-400">{item.label}</span>
-          <span className="ml-auto font-mono text-xs text-zinc-300">{item.value}</span>
+          <span className="text-muted-foreground">{item.label}</span>
+          <span className="ml-auto font-mono text-xs text-foreground">{item.value}</span>
         </div>
       ))}
     </div>
@@ -375,14 +377,14 @@ function CiLogView({ projectPath, runId }: { projectPath: string; runId: number 
     return () => clearInterval(interval);
   }, [fetchLog]);
 
-  if (loading) return <div className="text-sm text-zinc-500">Loading CI log...</div>;
-  if (error) return <div className="text-sm text-red-400">{error}</div>;
-  if (!logData?.log_text) return <div className="text-sm text-zinc-500">No log output</div>;
+  if (loading) return <div className="text-sm text-muted-foreground">Loading CI log...</div>;
+  if (error) return <div className="text-sm text-destructive">{error}</div>;
+  if (!logData?.log_text) return <div className="text-sm text-muted-foreground">No log output</div>;
 
   return (
     <pre
       ref={preRef}
-      className="max-w-full overflow-auto rounded-lg bg-zinc-900/80 p-4 text-[11px] leading-relaxed font-mono text-zinc-300"
+      className="max-w-full overflow-auto rounded-lg bg-surface-strong/80 p-4 text-[11px] leading-relaxed font-mono text-foreground"
     >
       {stripAnsi(logData.log_text)}
     </pre>
@@ -398,14 +400,14 @@ export function DetailPanel({
   onClose,
 }: DetailPanelProps) {
   return (
-    <div className="min-w-[480px] flex-[2] overflow-hidden flex flex-col border-l border-white/5 bg-black/20">
+    <div className="min-w-[480px] flex-[2] overflow-hidden flex flex-col border-l border-hairline bg-background">
       {/* Header */}
-      <div className="shrink-0 flex items-center gap-2 border-b border-white/5 px-4 py-2">
-        <h3 className="flex-1 text-sm font-semibold text-zinc-100 truncate">{viewTitle(view)}</h3>
+      <div className="shrink-0 flex items-center gap-2 border-b border-hairline px-4 py-2">
+        <h3 className="flex-1 text-sm font-semibold text-foreground truncate">{viewTitle(view)}</h3>
         <button
           type="button"
           onClick={onClose}
-          className="shrink-0 rounded p-1 text-zinc-500 transition-colors hover:bg-white/10 hover:text-zinc-200"
+          className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
           title="Close detail panel"
         >
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none">

--- a/clients/react/src/components/worktree/DiffViewer.tsx
+++ b/clients/react/src/components/worktree/DiffViewer.tsx
@@ -60,26 +60,28 @@ export function DiffViewer({ diff }: DiffViewerProps) {
   };
 
   if (files.length === 0) {
-    return <div className="px-4 py-6 text-center text-sm text-zinc-500">No changes</div>;
+    return <div className="px-4 py-6 text-center text-sm text-muted-foreground">No changes</div>;
   }
 
   return (
     <div className="flex flex-col gap-2">
       {files.map((file) => (
-        <div key={file.filename} className="overflow-hidden rounded-lg border border-white/5">
+        <div key={file.filename} className="overflow-hidden rounded-lg border border-hairline">
           {/* File header */}
           <button
             type="button"
             onClick={() => toggleFile(file.filename)}
-            className="flex w-full items-center gap-2 bg-white/[0.03] px-3 py-1.5 text-left transition-colors hover:bg-white/[0.06]"
+            className="flex w-full items-center gap-2 bg-surface px-3 py-1.5 text-left transition-colors hover:bg-surface"
           >
-            <span className="text-[10px] text-zinc-600">
+            <span className="text-[10px] text-subtle-foreground">
               {collapsedFiles.has(file.filename) ? "▸" : "▾"}
             </span>
-            <span className="flex-1 truncate text-xs font-mono text-zinc-300">{file.filename}</span>
+            <span className="flex-1 truncate text-xs font-mono text-foreground">
+              {file.filename}
+            </span>
             <span className="shrink-0 text-[10px]">
-              <span className="text-emerald-400">+{file.insertions}</span>{" "}
-              <span className="text-red-400">-{file.deletions}</span>
+              <span className="text-success">+{file.insertions}</span>{" "}
+              <span className="text-destructive">-{file.deletions}</span>
             </span>
           </button>
 
@@ -92,15 +94,15 @@ export function DiffViewer({ diff }: DiffViewerProps) {
                   key={`${file.filename}-L${lineIdx}`}
                   className={cn(
                     "px-3",
-                    line.startsWith("+") &&
-                      !line.startsWith("+++") &&
-                      "bg-emerald-500/10 text-emerald-300",
-                    line.startsWith("-") && !line.startsWith("---") && "bg-red-500/10 text-red-300",
-                    line.startsWith("@@") && "bg-blue-500/10 text-blue-300",
+                    line.startsWith("+") && !line.startsWith("+++") && "bg-success/10 text-success",
+                    line.startsWith("-") &&
+                      !line.startsWith("---") &&
+                      "bg-destructive/10 text-destructive",
+                    line.startsWith("@@") && "bg-info/10 text-info",
                     !line.startsWith("+") &&
                       !line.startsWith("-") &&
                       !line.startsWith("@@") &&
-                      "text-zinc-500",
+                      "text-muted-foreground",
                   )}
                 >
                   {line}

--- a/clients/react/src/components/worktree/IssueActionView.tsx
+++ b/clients/react/src/components/worktree/IssueActionView.tsx
@@ -106,26 +106,24 @@ export function IssueActionView({
   })();
 
   return (
-    <div className="w-80 shrink-0 overflow-y-auto border-l border-white/5 bg-black/20">
+    <div className="w-80 shrink-0 overflow-y-auto border-l border-hairline bg-background">
       <div className="p-4">
         {selectedIssue ? (
           <>
             {/* Issue header */}
             <div className="mb-4">
               <div className="flex items-center gap-2">
-                <span className="text-lg font-semibold text-green-400">
-                  #{selectedIssue.number}
-                </span>
+                <span className="text-lg font-semibold text-success">#{selectedIssue.number}</span>
                 <a
                   href={selectedIssue.url}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-[10px] text-zinc-500 hover:text-zinc-300"
+                  className="text-[10px] text-muted-foreground hover:text-foreground"
                 >
                   open in GitHub
                 </a>
               </div>
-              <h3 className="mt-1 text-sm font-medium text-zinc-100">{selectedIssue.title}</h3>
+              <h3 className="mt-1 text-sm font-medium text-foreground">{selectedIssue.title}</h3>
               {selectedIssue.labels.length > 0 && (
                 <div className="mt-2 flex flex-wrap gap-1">
                   {selectedIssue.labels.map((label) => (
@@ -143,7 +141,7 @@ export function IssueActionView({
                 </div>
               )}
               {selectedIssue.assignees.length > 0 && (
-                <div className="mt-2 text-[11px] text-zinc-500">
+                <div className="mt-2 text-[11px] text-muted-foreground">
                   Assigned: {selectedIssue.assignees.join(", ")}
                 </div>
               )}
@@ -151,34 +149,34 @@ export function IssueActionView({
 
             {matchingWorktree ? (
               /* Existing worktree status */
-              <div className="rounded-lg border border-cyan-500/20 bg-cyan-500/5 p-3">
-                <div className="mb-2 text-[11px] font-medium text-cyan-400">
+              <div className="rounded-lg border border-primary/20 bg-primary/5 p-3">
+                <div className="mb-2 text-[11px] font-medium text-primary">
                   {matchingWorktree.agent_status === "in-progress" ||
                   matchingWorktree.agent_status === "waiting"
                     ? "Agent In Progress"
                     : "Worktree Exists"}
                 </div>
-                <div className="mb-1 text-[11px] text-zinc-400">
-                  <span className="text-zinc-500">branch:</span>{" "}
-                  <span className="text-cyan-400">
+                <div className="mb-1 text-[11px] text-muted-foreground">
+                  <span className="text-muted-foreground">branch:</span>{" "}
+                  <span className="text-primary">
                     {matchingWorktree.branch ?? matchingWorktree.name}
                   </span>
                 </div>
                 {matchingWorktree.agent_target && (
-                  <div className="mb-1 text-[11px] text-zinc-400">
-                    <span className="text-zinc-500">agent:</span>{" "}
-                    <span className="text-cyan-400">{matchingWorktree.agent_target}</span>
+                  <div className="mb-1 text-[11px] text-muted-foreground">
+                    <span className="text-muted-foreground">agent:</span>{" "}
+                    <span className="text-primary">{matchingWorktree.agent_target}</span>
                   </div>
                 )}
                 {matchingWorktree.agent_status && (
-                  <div className="mb-2 text-[11px] text-zinc-400">
-                    <span className="text-zinc-500">status:</span>{" "}
+                  <div className="mb-2 text-[11px] text-muted-foreground">
+                    <span className="text-muted-foreground">status:</span>{" "}
                     <span
                       className={
                         matchingWorktree.agent_status === "in-progress" ||
                         matchingWorktree.agent_status === "waiting"
-                          ? "text-cyan-400"
-                          : "text-amber-400"
+                          ? "text-primary"
+                          : "text-warning"
                       }
                     >
                       {matchingWorktree.agent_status}
@@ -191,17 +189,17 @@ export function IssueActionView({
                     const branch = matchingWorktree.branch ?? matchingWorktree.name;
                     onSelectWorktreeBranch?.(branch);
                   }}
-                  className="mt-1 w-full rounded-lg bg-cyan-500/20 px-3 py-2 text-xs font-medium text-cyan-400 transition-colors hover:bg-cyan-500/30"
+                  className="mt-1 w-full rounded-lg bg-primary/20 px-3 py-2 text-xs font-medium text-primary transition-colors hover:bg-primary/30"
                 >
                   Go to Worktree
                 </button>
               </div>
             ) : (
               /* Start Work form */
-              <div className="rounded-lg border border-emerald-500/20 bg-emerald-500/5 p-3">
-                <div className="mb-2 text-[11px] font-medium text-emerald-400">Start Work</div>
-                <div className="mb-1.5 text-[11px] text-zinc-500">
-                  base: <span className="text-emerald-400">{defaultBranch ?? "main"}</span>
+              <div className="rounded-lg border border-success/20 bg-success/5 p-3">
+                <div className="mb-2 text-[11px] font-medium text-success">Start Work</div>
+                <div className="mb-1.5 text-[11px] text-muted-foreground">
+                  base: <span className="text-success">{defaultBranch ?? "main"}</span>
                 </div>
                 <div className="flex items-center gap-1">
                   <input
@@ -216,21 +214,21 @@ export function IssueActionView({
                       if (e.key === "Enter") handleStartWork();
                     }}
                     placeholder="worktree name"
-                    className="flex-1 rounded bg-black/30 px-2 py-1.5 text-xs text-zinc-200 placeholder-zinc-600 outline-none ring-1 ring-emerald-500/30 focus:ring-emerald-500/60"
+                    className="flex-1 rounded bg-background px-2 py-1.5 text-xs text-foreground placeholder-subtle-foreground outline-none ring-1 ring-success/30 focus:ring-success/60"
                   />
                 </div>
-                <div className="mt-1 text-[10px] text-zinc-600">
+                <div className="mt-1 text-[10px] text-subtle-foreground">
                   Creates worktree + launches agent
                 </div>
                 {startWorkError && (
-                  <div className="mt-1 text-[10px] text-red-400">{startWorkError}</div>
+                  <div className="mt-1 text-[10px] text-destructive">{startWorkError}</div>
                 )}
                 <div className="mt-2 flex gap-2">
                   <button
                     type="button"
                     onClick={() => handleStartWork()}
                     disabled={!startWorkName.trim() || startWorkBusy}
-                    className="flex-1 rounded-lg bg-emerald-500/20 px-3 py-2 text-xs font-medium text-emerald-400 transition-colors hover:bg-emerald-500/30 disabled:opacity-40"
+                    className="flex-1 rounded-lg bg-success/20 px-3 py-2 text-xs font-medium text-success transition-colors hover:bg-success/30 disabled:opacity-40"
                   >
                     {startWorkBusy ? "Creating..." : "Launch Agent"}
                   </button>
@@ -240,7 +238,7 @@ export function IssueActionView({
                       selectedIssue && handleStartWork(buildResolvePrompt(selectedIssue))
                     }
                     disabled={!startWorkName.trim() || startWorkBusy}
-                    className="flex-1 rounded-lg bg-amber-500/20 px-3 py-2 text-xs font-medium text-amber-400 transition-colors hover:bg-amber-500/30 disabled:opacity-40"
+                    className="flex-1 rounded-lg bg-warning/20 px-3 py-2 text-xs font-medium text-warning transition-colors hover:bg-warning/30 disabled:opacity-40"
                     title="Worktree作成 → issue内容を含むプロンプトでエージェント起動 → 実装・テスト・PR作成まで自動実行"
                   >
                     {startWorkBusy ? "Creating..." : "Create & Resolve ▶"}
@@ -250,7 +248,7 @@ export function IssueActionView({
             )}
           </>
         ) : (
-          <div className="text-sm text-zinc-500">Select an issue to start work</div>
+          <div className="text-sm text-muted-foreground">Select an issue to start work</div>
         )}
       </div>
     </div>

--- a/clients/react/src/components/worktree/IssueDetailPanel.tsx
+++ b/clients/react/src/components/worktree/IssueDetailPanel.tsx
@@ -21,17 +21,17 @@ function formatRelative(iso: string): string {
 
 // Shared prose class for rendered markdown
 const proseClassName = `prose prose-invert prose-sm max-w-none
-  prose-headings:text-zinc-100 prose-headings:font-semibold
-  prose-p:text-zinc-300 prose-p:leading-relaxed
-  prose-a:text-blue-400 prose-a:no-underline hover:prose-a:underline
-  prose-strong:text-zinc-200
-  prose-code:text-cyan-400 prose-code:bg-white/5 prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:before:content-none prose-code:after:content-none
-  prose-pre:bg-zinc-900/50 prose-pre:border prose-pre:border-white/5 prose-pre:rounded-lg
-  prose-li:text-zinc-300
-  prose-th:text-zinc-300 prose-th:border-white/10
-  prose-td:text-zinc-400 prose-td:border-white/10
-  prose-hr:border-white/10
-  prose-blockquote:border-blue-500/30 prose-blockquote:text-zinc-400`;
+  prose-headings:text-foreground prose-headings:font-semibold
+  prose-p:text-foreground prose-p:leading-relaxed
+  prose-a:text-info prose-a:no-underline hover:prose-a:underline
+  prose-strong:text-foreground
+  prose-code:text-primary prose-code:bg-surface prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:before:content-none prose-code:after:content-none
+  prose-pre:bg-surface-strong/50 prose-pre:border prose-pre:border-hairline prose-pre:rounded-lg
+  prose-li:text-foreground
+  prose-th:text-foreground prose-th:border-hairline-strong
+  prose-td:text-muted-foreground prose-td:border-hairline-strong
+  prose-hr:border-hairline-strong
+  prose-blockquote:border-info/30 prose-blockquote:text-muted-foreground`;
 
 // Issue detail panel — shows full issue info when selected in Issues tab
 export function IssueDetailPanel({ issueNumber, projectPath, onClose }: IssueDetailPanelProps) {
@@ -64,16 +64,16 @@ export function IssueDetailPanel({ issueNumber, projectPath, onClose }: IssueDet
   }, [fetchDetail]);
 
   return (
-    <div className="min-w-[480px] flex-[2] overflow-hidden flex flex-col border-l border-white/5 bg-black/20">
+    <div className="min-w-[480px] flex-[2] overflow-hidden flex flex-col border-l border-hairline bg-background">
       {/* Header */}
-      <div className="shrink-0 flex items-center gap-2 border-b border-white/5 px-4 py-2">
-        <h3 className="flex-1 text-sm font-semibold text-zinc-100 truncate">
+      <div className="shrink-0 flex items-center gap-2 border-b border-hairline px-4 py-2">
+        <h3 className="flex-1 text-sm font-semibold text-foreground truncate">
           Issue #{issueNumber}
         </h3>
         <button
           type="button"
           onClick={onClose}
-          className="shrink-0 rounded p-1 text-zinc-500 transition-colors hover:bg-white/10 hover:text-zinc-200"
+          className="shrink-0 rounded p-1 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
           title="Close detail panel"
         >
           <svg width="14" height="14" viewBox="0 0 14 14" fill="none">
@@ -90,8 +90,8 @@ export function IssueDetailPanel({ issueNumber, projectPath, onClose }: IssueDet
 
       {/* Body */}
       <div className="flex-1 overflow-auto p-4">
-        {loading && <div className="text-sm text-zinc-500">Loading issue detail...</div>}
-        {error && <div className="text-sm text-red-400">{error}</div>}
+        {loading && <div className="text-sm text-muted-foreground">Loading issue detail...</div>}
+        {error && <div className="text-sm text-destructive">{error}</div>}
         {!loading && !error && detail && (
           <div className="flex flex-col gap-4">
             {/* Title and state */}
@@ -100,8 +100,8 @@ export function IssueDetailPanel({ issueNumber, projectPath, onClose }: IssueDet
                 <span
                   className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${
                     detail.state === "OPEN"
-                      ? "bg-green-500/15 text-green-400"
-                      : "bg-purple-500/15 text-purple-400"
+                      ? "bg-success/15 text-success"
+                      : "bg-accent/15 text-accent"
                   }`}
                 >
                   {detail.state}
@@ -119,11 +119,11 @@ export function IssueDetailPanel({ issueNumber, projectPath, onClose }: IssueDet
                   </span>
                 ))}
               </div>
-              <h2 className="mt-2 text-base font-semibold text-zinc-100">{detail.title}</h2>
+              <h2 className="mt-2 text-base font-semibold text-foreground">{detail.title}</h2>
             </div>
 
             {/* Metadata */}
-            <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-zinc-500">
+            <div className="flex flex-wrap gap-x-4 gap-y-1 text-[11px] text-muted-foreground">
               {detail.assignees.length > 0 && <span>Assignees: {detail.assignees.join(", ")}</span>}
               {detail.created_at && <span>Created {formatRelative(detail.created_at)}</span>}
               {detail.updated_at && <span>Updated {formatRelative(detail.updated_at)}</span>}
@@ -134,7 +134,7 @@ export function IssueDetailPanel({ issueNumber, projectPath, onClose }: IssueDet
               href={detail.url}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex w-fit items-center gap-1.5 rounded-md bg-white/5 px-2.5 py-1.5 text-xs text-zinc-300 transition-colors hover:bg-white/10 hover:text-zinc-100"
+              className="inline-flex w-fit items-center gap-1.5 rounded-md bg-surface px-2.5 py-1.5 text-xs text-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
             >
               Open on GitHub
               <svg width="12" height="12" viewBox="0 0 12 12" fill="none">
@@ -151,9 +151,7 @@ export function IssueDetailPanel({ issueNumber, projectPath, onClose }: IssueDet
 
             {/* Body (rendered markdown) */}
             {detail.body && (
-              <div
-                className={`rounded-lg border border-white/5 bg-white/[0.02] p-4 ${proseClassName}`}
-              >
+              <div className={`rounded-lg border border-hairline bg-surface p-4 ${proseClassName}`}>
                 <Markdown remarkPlugins={[remarkGfm]}>{detail.body}</Markdown>
               </div>
             )}
@@ -161,17 +159,19 @@ export function IssueDetailPanel({ issueNumber, projectPath, onClose }: IssueDet
             {/* Comments */}
             {detail.comments.length > 0 && (
               <div className="flex flex-col gap-3">
-                <h4 className="text-xs font-semibold text-zinc-400">
+                <h4 className="text-xs font-semibold text-muted-foreground">
                   {detail.comments.length} comment{detail.comments.length !== 1 ? "s" : ""}
                 </h4>
                 {detail.comments.map((comment) => (
                   <div
                     key={comment.url}
-                    className="rounded-lg border border-white/5 bg-white/[0.02] p-3"
+                    className="rounded-lg border border-hairline bg-surface p-3"
                   >
                     <div className="flex items-center gap-2 text-xs">
-                      <span className="font-semibold text-zinc-200">{comment.author}</span>
-                      <span className="text-zinc-600">{formatRelative(comment.created_at)}</span>
+                      <span className="font-semibold text-foreground">{comment.author}</span>
+                      <span className="text-subtle-foreground">
+                        {formatRelative(comment.created_at)}
+                      </span>
                     </div>
                     <div className={`mt-2 ${proseClassName}`}>
                       <Markdown remarkPlugins={[remarkGfm]}>{comment.body}</Markdown>

--- a/clients/react/src/components/worktree/IssuesPanel.tsx
+++ b/clients/react/src/components/worktree/IssuesPanel.tsx
@@ -159,7 +159,7 @@ export function IssuesPanel({
           value={searchQuery}
           onChange={(e) => setSearchQuery(e.target.value)}
           placeholder="Search issues..."
-          className="w-full rounded-lg bg-white/5 px-3 py-2 text-sm text-zinc-200 placeholder-zinc-600 outline-none ring-1 ring-white/10 transition-colors focus:ring-white/20"
+          className="w-full rounded-lg bg-surface px-3 py-2 text-sm text-foreground placeholder-subtle-foreground outline-none ring-1 ring-hairline-strong transition-colors focus:ring-primary/40"
         />
         {allLabels.length > 0 && (
           <div className="mt-2 flex flex-wrap gap-1.5">
@@ -185,14 +185,14 @@ export function IssuesPanel({
       </div>
 
       {/* Issue count */}
-      <div className="mb-3 text-[11px] text-zinc-500">
+      <div className="mb-3 text-[11px] text-muted-foreground">
         {filteredIssues.length} issue{filteredIssues.length !== 1 ? "s" : ""}
         {filteredIssues.length !== issues.length ? ` (${issues.length} total)` : ""}
       </div>
 
       {/* Issue list */}
       {filteredIssues.length === 0 ? (
-        <div className="flex items-center justify-center py-20 text-sm text-zinc-500">
+        <div className="flex items-center justify-center py-20 text-sm text-muted-foreground">
           {issues.length === 0 ? "No open issues" : "No issues match filters"}
         </div>
       ) : (
@@ -209,17 +209,15 @@ export function IssuesPanel({
                 onClick={() => onSelectIssue(isSelected ? null : issue)}
                 className={`rounded-lg border p-3 text-left transition-colors ${
                   isSelected
-                    ? "border-cyan-500/30 bg-cyan-500/[0.06]"
-                    : "border-white/5 bg-white/[0.02] hover:bg-white/[0.05]"
+                    ? "border-primary/30 bg-primary/[0.06]"
+                    : "border-hairline bg-surface hover:bg-surface"
                 }`}
               >
                 <div className="flex items-start gap-2">
-                  <span className="shrink-0 text-sm font-medium text-green-400">
-                    #{issue.number}
-                  </span>
+                  <span className="shrink-0 text-sm font-medium text-success">#{issue.number}</span>
                   <div className="min-w-0 flex-1">
                     <div className="flex items-center gap-2">
-                      <span className="text-sm text-zinc-200">{issue.title}</span>
+                      <span className="text-sm text-foreground">{issue.title}</span>
                       {/* Cross-navigation badges: clickable to jump to branch/PR */}
                       {wtStatus && (
                         <button
@@ -231,8 +229,8 @@ export function IssuesPanel({
                           }}
                           className={`inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
                             wtStatus.isAgentActive
-                              ? "bg-cyan-500/15 text-cyan-400 hover:bg-cyan-500/25"
-                              : "bg-amber-500/15 text-amber-400 hover:bg-amber-500/25"
+                              ? "bg-primary/15 text-primary hover:bg-primary/25"
+                              : "bg-warning/15 text-warning hover:bg-warning/25"
                           }`}
                           title={`Go to branch: ${wtStatus.worktree.branch ?? wtStatus.worktree.name}`}
                         >
@@ -257,10 +255,10 @@ export function IssuesPanel({
                           }}
                           className={`inline-flex shrink-0 items-center gap-1 rounded-full px-1.5 py-0.5 text-[10px] font-medium transition-colors ${
                             prLink.pr.state === "MERGED"
-                              ? "bg-purple-500/15 text-purple-400 hover:bg-purple-500/25"
+                              ? "bg-accent/15 text-accent hover:bg-accent/25"
                               : prLink.pr.is_draft
-                                ? "bg-zinc-500/15 text-zinc-400 hover:bg-zinc-500/25"
-                                : "bg-green-500/15 text-green-400 hover:bg-green-500/25"
+                                ? "bg-muted-foreground/15 text-muted-foreground hover:bg-muted-foreground/25"
+                                : "bg-success/15 text-success hover:bg-success/25"
                           }`}
                           title={`Go to PR #${prLink.pr.number}: ${prLink.pr.title}`}
                         >
@@ -286,7 +284,7 @@ export function IssuesPanel({
                             e.stopPropagation();
                             onNavigateToBranch?.(linkedBranch);
                           }}
-                          className="inline-flex shrink-0 items-center gap-1 rounded-full bg-zinc-500/15 px-1.5 py-0.5 text-[10px] font-medium text-zinc-400 transition-colors hover:bg-zinc-500/25"
+                          className="inline-flex shrink-0 items-center gap-1 rounded-full bg-muted-foreground/15 px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-muted-foreground/25"
                           title={`Go to branch: ${linkedBranch}`}
                         >
                           <svg
@@ -321,7 +319,7 @@ export function IssuesPanel({
                     )}
                     {/* Assignees */}
                     {issue.assignees.length > 0 && (
-                      <div className="mt-1 text-[10px] text-zinc-500">
+                      <div className="mt-1 text-[10px] text-muted-foreground">
                         {issue.assignees.join(", ")}
                       </div>
                     )}

--- a/clients/react/src/components/worktree/PrCard.tsx
+++ b/clients/react/src/components/worktree/PrCard.tsx
@@ -25,13 +25,13 @@ interface PrCardProps {
 function ciColor(status: PrInfo["check_status"]): string {
   switch (status) {
     case "SUCCESS":
-      return "text-green-400";
+      return "text-success";
     case "FAILURE":
-      return "text-red-400";
+      return "text-destructive";
     case "PENDING":
-      return "text-yellow-400";
+      return "text-warning";
     default:
-      return "text-zinc-600";
+      return "text-subtle-foreground";
   }
 }
 
@@ -39,13 +39,13 @@ function ciColor(status: PrInfo["check_status"]): string {
 function ciDotBg(status: PrInfo["check_status"]): string {
   switch (status) {
     case "SUCCESS":
-      return "bg-green-400";
+      return "bg-success";
     case "FAILURE":
-      return "bg-red-400";
+      return "bg-destructive";
     case "PENDING":
-      return "bg-yellow-400";
+      return "bg-warning";
     default:
-      return "bg-zinc-600";
+      return "bg-muted-foreground";
   }
 }
 
@@ -85,19 +85,19 @@ export function PrCard({
     return issues.filter((i) => nums.includes(i.number));
   })();
   return (
-    <div className="rounded-lg border border-white/5 bg-white/[0.03] p-2">
+    <div className="rounded-lg border border-hairline bg-surface p-2">
       {/* Header: PR number + draft badge + review decision */}
       <div className="flex items-center gap-1.5 text-[11px]">
         <a
           href={pr.url}
           target="_blank"
           rel="noopener noreferrer"
-          className="font-medium text-green-400 hover:underline"
+          className="font-medium text-success hover:underline"
         >
           PR #{pr.number}
         </a>
         {pr.is_draft && (
-          <span className="rounded bg-zinc-500/15 px-1 py-0.5 text-[10px] text-zinc-500">
+          <span className="rounded bg-muted-foreground/15 px-1 py-0.5 text-[10px] text-muted-foreground">
             draft
           </span>
         )}
@@ -105,10 +105,10 @@ export function PrCard({
           <span
             className={`text-[10px] ${
               pr.review_decision === "APPROVED"
-                ? "text-green-400"
+                ? "text-success"
                 : pr.review_decision === "CHANGES_REQUESTED"
-                  ? "text-orange-400"
-                  : "text-zinc-500"
+                  ? "text-warning"
+                  : "text-muted-foreground"
             }`}
           >
             {pr.review_decision === "APPROVED"
@@ -121,21 +121,21 @@ export function PrCard({
       </div>
 
       {/* Title */}
-      <div className="mt-0.5 truncate text-[11px] text-zinc-400">{pr.title}</div>
+      <div className="mt-0.5 truncate text-[11px] text-muted-foreground">{pr.title}</div>
 
       {/* Branch flow (incoming PRs) */}
       {showBranchFlow && targetBranch && (
-        <div className="mt-0.5 text-[10px] text-zinc-600">
+        <div className="mt-0.5 text-[10px] text-subtle-foreground">
           {pr.head_branch} → {targetBranch}
         </div>
       )}
 
       {/* Stats: additions/deletions + reviews/comments */}
-      <div className="mt-0.5 flex items-center gap-2 text-[10px] text-zinc-600">
+      <div className="mt-0.5 flex items-center gap-2 text-[10px] text-subtle-foreground">
         {(pr.additions > 0 || pr.deletions > 0) && (
           <span>
-            <span className="text-emerald-400">+{pr.additions}</span>{" "}
-            <span className="text-red-400">-{pr.deletions}</span>
+            <span className="text-success">+{pr.additions}</span>{" "}
+            <span className="text-destructive">-{pr.deletions}</span>
           </span>
         )}
         {pr.reviews > 0 && (
@@ -163,21 +163,21 @@ export function PrCard({
         <button
           type="button"
           onClick={() => onOpenDetail({ kind: "pr-comments", prNumber: pr.number })}
-          className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-zinc-400 transition-colors hover:bg-white/10 hover:text-zinc-200"
+          className="rounded bg-surface px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
         >
           Comments
         </button>
         <button
           type="button"
           onClick={() => onOpenDetail({ kind: "pr-files", prNumber: pr.number })}
-          className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-zinc-400 transition-colors hover:bg-white/10 hover:text-zinc-200"
+          className="rounded bg-surface px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
         >
           Files
         </button>
         <button
           type="button"
           onClick={() => onOpenDetail({ kind: "merge-status", prNumber: pr.number })}
-          className="rounded bg-white/5 px-1.5 py-0.5 text-[10px] text-zinc-400 transition-colors hover:bg-white/10 hover:text-zinc-200"
+          className="rounded bg-surface px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
         >
           Merge
         </button>
@@ -189,7 +189,7 @@ export function PrCard({
               key={issue.number}
               type="button"
               onClick={() => onNavigateToIssue(issue)}
-              className="inline-flex items-center gap-0.5 rounded bg-green-500/10 px-1.5 py-0.5 text-[10px] text-green-400 transition-colors hover:bg-green-500/20 hover:text-green-300"
+              className="inline-flex items-center gap-0.5 rounded bg-success/10 px-1.5 py-0.5 text-[10px] text-success transition-colors hover:bg-success/20 hover:text-success"
               title={`Go to issue #${issue.number}: ${issue.title}`}
             >
               <svg width="9" height="9" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
@@ -203,7 +203,7 @@ export function PrCard({
           <button
             type="button"
             onClick={() => onNavigateToBranch(pr.head_branch)}
-            className="inline-flex items-center gap-0.5 rounded bg-emerald-500/10 px-1.5 py-0.5 text-[10px] text-emerald-400 transition-colors hover:bg-emerald-500/20 hover:text-emerald-300"
+            className="inline-flex items-center gap-0.5 rounded bg-success/10 px-1.5 py-0.5 text-[10px] text-success transition-colors hover:bg-success/20 hover:text-success"
             title={`Go to branch: ${pr.head_branch}`}
           >
             <svg width="9" height="9" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
@@ -220,7 +220,7 @@ export function PrCard({
           type="button"
           onClick={onAiMerge}
           disabled={actionBusy}
-          className="mt-1.5 w-full rounded bg-purple-500/15 px-2 py-1 text-[11px] font-medium text-purple-400 transition-colors hover:bg-purple-500/25 disabled:opacity-50"
+          className="mt-1.5 w-full rounded bg-accent/15 px-2 py-1 text-[11px] font-medium text-accent transition-colors hover:bg-accent/25 disabled:opacity-50"
         >
           AI Merge PR #{pr.number}
         </button>

--- a/clients/react/src/components/worktree/WorktreeCard.tsx
+++ b/clients/react/src/components/worktree/WorktreeCard.tsx
@@ -17,25 +17,25 @@ export function WorktreeCard({ worktree, selected, onClick }: WorktreeCardProps)
       onClick={onClick}
       className={cn(
         "glass-card w-full rounded-xl px-3 py-2 text-left transition-all",
-        selected && "!border-emerald-500/30 !bg-emerald-500/10",
+        selected && "!border-success/30 !bg-success/10",
       )}
     >
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-1.5 truncate">
-          <span className="text-[10px] text-emerald-500">🌿</span>
-          <span className="truncate text-sm font-medium text-zinc-200">
+          <span className="text-[10px] text-success">🌿</span>
+          <span className="truncate text-sm font-medium text-foreground">
             {worktree.branch || worktree.name}
           </span>
-          {worktree.is_dirty && <span className="text-[10px] text-amber-500">*</span>}
+          {worktree.is_dirty && <span className="text-[10px] text-warning">*</span>}
         </div>
         {ds && (
-          <span className="shrink-0 text-[10px] text-zinc-500">
-            <span className="text-emerald-400">+{ds.insertions}</span>{" "}
-            <span className="text-red-400">-{ds.deletions}</span>
+          <span className="shrink-0 text-[10px] text-muted-foreground">
+            <span className="text-success">+{ds.insertions}</span>{" "}
+            <span className="text-destructive">-{ds.deletions}</span>
           </span>
         )}
       </div>
-      <div className="mt-1 flex items-center gap-1.5 text-xs text-zinc-600">
+      <div className="mt-1 flex items-center gap-1.5 text-xs text-subtle-foreground">
         <span>No agent</span>
         {ds && (
           <>

--- a/clients/react/src/components/worktree/WorktreePanel.tsx
+++ b/clients/react/src/components/worktree/WorktreePanel.tsx
@@ -70,33 +70,33 @@ export function WorktreePanel({ worktree, onLaunched, onDeleted }: WorktreePanel
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       {/* Header */}
-      <div className="glass shrink-0 border-b border-white/5 px-4 py-3 md:px-6 md:py-4">
+      <div className="glass shrink-0 border-b border-hairline px-4 py-3 md:px-6 md:py-4">
         <div className="flex flex-wrap items-start justify-between gap-2">
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <span className="text-emerald-500">🌿</span>
-              <h2 className="truncate text-base font-semibold text-zinc-100 md:text-lg">
+              <span className="text-success">🌿</span>
+              <h2 className="truncate text-base font-semibold text-foreground md:text-lg">
                 {worktree.branch || worktree.name}
               </h2>
-              {worktree.is_dirty && <span className="shrink-0 text-sm text-amber-500">*</span>}
+              {worktree.is_dirty && <span className="shrink-0 text-sm text-warning">*</span>}
             </div>
-            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-zinc-500">
+            <div className="mt-1 flex flex-wrap items-center gap-2 text-xs text-muted-foreground">
               {ds && (
                 <span>
-                  <span className="text-emerald-400">+{ds.insertions}</span>{" "}
-                  <span className="text-red-400">-{ds.deletions}</span>
+                  <span className="text-success">+{ds.insertions}</span>{" "}
+                  <span className="text-destructive">-{ds.deletions}</span>
                   {" · "}
                   {ds.files_changed} file{ds.files_changed !== 1 ? "s" : ""}
                 </span>
               )}
               {hasAgent ? (
-                <span className="text-cyan-400">Agent: {worktree.agent_status || "active"}</span>
+                <span className="text-primary">Agent: {worktree.agent_status || "active"}</span>
               ) : (
-                <span className="text-zinc-600">No agent</span>
+                <span className="text-subtle-foreground">No agent</span>
               )}
             </div>
           </div>
-          <div className="shrink-0 text-xs text-zinc-500">
+          <div className="shrink-0 text-xs text-muted-foreground">
             <span className="font-mono">{worktree.repo_name}</span>
           </div>
         </div>
@@ -108,7 +108,7 @@ export function WorktreePanel({ worktree, onLaunched, onDeleted }: WorktreePanel
               type="button"
               onClick={handleLaunch}
               disabled={launching}
-              className="touch-target-sm rounded-lg bg-cyan-500/15 px-3 py-1.5 text-xs font-medium text-cyan-400 transition-colors hover:bg-cyan-500/25 disabled:opacity-50"
+              className="touch-target-sm rounded-lg bg-primary/15 px-3 py-1.5 text-xs font-medium text-primary transition-colors hover:bg-primary/25 disabled:opacity-50"
             >
               {launching ? "Launching..." : "Launch Agent"}
             </button>
@@ -117,18 +117,18 @@ export function WorktreePanel({ worktree, onLaunched, onDeleted }: WorktreePanel
             <button
               type="button"
               onClick={() => setConfirmDelete(true)}
-              className="touch-target-sm rounded-lg bg-red-500/10 px-3 py-1.5 text-xs font-medium text-red-400 transition-colors hover:bg-red-500/20"
+              className="touch-target-sm rounded-lg bg-destructive/10 px-3 py-1.5 text-xs font-medium text-destructive transition-colors hover:bg-destructive/20"
             >
               Delete
             </button>
           ) : (
-            <div className="flex flex-wrap items-center gap-2 rounded-lg border border-red-500/20 bg-red-500/5 px-3 py-2">
-              <label className="flex items-center gap-1.5 text-[11px] text-zinc-400">
+            <div className="flex flex-wrap items-center gap-2 rounded-lg border border-destructive/20 bg-destructive/5 px-3 py-2">
+              <label className="flex items-center gap-1.5 text-[11px] text-muted-foreground">
                 <input
                   type="checkbox"
                   checked={forceDelete}
                   onChange={(e) => setForceDelete(e.target.checked)}
-                  className="accent-red-500"
+                  className="accent-destructive"
                 />
                 Force
               </label>
@@ -136,7 +136,7 @@ export function WorktreePanel({ worktree, onLaunched, onDeleted }: WorktreePanel
                 type="button"
                 onClick={handleDelete}
                 disabled={deleting}
-                className="touch-target-sm rounded bg-red-500/20 px-2 py-1 text-xs text-red-400 transition-colors hover:bg-red-500/30 disabled:opacity-50"
+                className="touch-target-sm rounded bg-destructive/20 px-2 py-1 text-xs text-destructive transition-colors hover:bg-destructive/30 disabled:opacity-50"
               >
                 {deleting ? "Deleting..." : "Confirm"}
               </button>
@@ -146,7 +146,7 @@ export function WorktreePanel({ worktree, onLaunched, onDeleted }: WorktreePanel
                   setConfirmDelete(false);
                   setForceDelete(false);
                 }}
-                className="touch-target-sm text-xs text-zinc-500 transition-colors hover:text-zinc-300"
+                className="touch-target-sm text-xs text-muted-foreground transition-colors hover:text-foreground"
               >
                 Cancel
               </button>
@@ -156,7 +156,7 @@ export function WorktreePanel({ worktree, onLaunched, onDeleted }: WorktreePanel
             type="button"
             onClick={fetchDiff}
             disabled={diffLoading}
-            className="touch-target-sm rounded-lg bg-white/5 px-3 py-1.5 text-xs text-zinc-400 transition-colors hover:bg-white/10 disabled:opacity-50"
+            className="touch-target-sm rounded-lg bg-surface px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-surface-strong disabled:opacity-50"
           >
             {diffLoading ? "Loading..." : "Refresh Diff"}
           </button>
@@ -166,15 +166,17 @@ export function WorktreePanel({ worktree, onLaunched, onDeleted }: WorktreePanel
       {/* Diff content */}
       <div className="flex-1 overflow-y-auto p-4">
         {diffError ? (
-          <div className="rounded-lg border border-red-500/20 bg-red-500/5 px-4 py-3 text-sm text-red-400">
+          <div className="rounded-lg border border-destructive/20 bg-destructive/5 px-4 py-3 text-sm text-destructive">
             {diffError}
           </div>
         ) : diffLoading && !diffData ? (
-          <div className="py-8 text-center text-sm text-zinc-500">Loading diff...</div>
+          <div className="py-8 text-center text-sm text-muted-foreground">Loading diff...</div>
         ) : diffData?.diff ? (
           <DiffViewer diff={diffData.diff} />
         ) : (
-          <div className="py-8 text-center text-sm text-zinc-500">No changes vs base branch</div>
+          <div className="py-8 text-center text-sm text-muted-foreground">
+            No changes vs base branch
+          </div>
         )}
       </div>
     </div>

--- a/clients/react/src/components/worktree/__tests__/branch-state.test.ts
+++ b/clients/react/src/components/worktree/__tests__/branch-state.test.ts
@@ -126,11 +126,14 @@ describe("branchStateLabel", () => {
 });
 
 describe("branchStateBadgeClass", () => {
-  it("returns non-empty classes for non-default states", () => {
-    expect(branchStateBadgeClass("merged")).toContain("purple");
-    expect(branchStateBadgeClass("has-open-pr")).toContain("blue");
-    expect(branchStateBadgeClass("active")).toContain("cyan");
-    expect(branchStateBadgeClass("stale")).toContain("amber");
+  it("returns the semantic-token class for each non-default state", () => {
+    // Migrated off raw palette (purple/blue/cyan/amber) onto theme
+    // tokens — see scripts/theme-codemod.mjs. `merged` uses the
+    // repurposed secondary accent.
+    expect(branchStateBadgeClass("merged")).toContain("accent");
+    expect(branchStateBadgeClass("has-open-pr")).toContain("info");
+    expect(branchStateBadgeClass("active")).toContain("primary");
+    expect(branchStateBadgeClass("stale")).toContain("warning");
   });
 
   it("returns empty string for default state", () => {

--- a/clients/react/src/components/worktree/branch-state.ts
+++ b/clients/react/src/components/worktree/branch-state.ts
@@ -45,13 +45,13 @@ export function branchStateLabel(state: BranchState): string {
 export function branchStateBadgeClass(state: BranchState): string {
   switch (state) {
     case "merged":
-      return "bg-purple-500/15 text-purple-400";
+      return "bg-accent/15 text-accent";
     case "has-open-pr":
-      return "bg-blue-500/15 text-blue-400";
+      return "bg-info/15 text-info";
     case "active":
-      return "bg-cyan-500/15 text-cyan-400";
+      return "bg-primary/15 text-primary";
     case "stale":
-      return "bg-amber-500/15 text-amber-400";
+      return "bg-warning/15 text-warning";
     case "default":
       return "";
   }

--- a/clients/react/src/components/worktree/graph/LaneGraph.tsx
+++ b/clients/react/src/components/worktree/graph/LaneGraph.tsx
@@ -528,10 +528,10 @@ export const LaneGraph = memo(function LaneGraph({
                 <span className="text-[10px]" style={{ color, opacity: 0.5 }}>
                   {"\u22EE"}
                 </span>
-                <span className="text-[10px] text-zinc-500">
+                <span className="text-[10px] text-muted-foreground">
                   {row.foldCount} commit{row.foldCount > 1 ? "s" : ""} hidden
                 </span>
-                <span className="text-[9px] text-zinc-600">click to expand</span>
+                <span className="text-[9px] text-subtle-foreground">click to expand</span>
               </button>
             );
           }
@@ -552,8 +552,8 @@ export const LaneGraph = memo(function LaneGraph({
               type="button"
               key={row.sha}
               className={`absolute flex cursor-pointer items-center gap-2 px-2 text-left transition-colors ${
-                isHovered ? "bg-white/[0.02]" : ""
-              } ${isExpanded ? "bg-cyan-500/[0.04]" : ""}`}
+                isHovered ? "bg-surface" : ""
+              } ${isExpanded ? "bg-primary/[0.04]" : ""}`}
               style={{ height: ROW_H, top: row.y - ROW_H / 2, left: 0, right: 0 }}
               onMouseEnter={() => setHoveredSha(row.sha)}
               onMouseLeave={() => setHoveredSha(null)}
@@ -626,26 +626,26 @@ export const LaneGraph = memo(function LaneGraph({
                       {pr.is_draft && <span className="text-[9px] opacity-60">draft</span>}
                       {/* Review decision icon */}
                       {pr.review_decision === "APPROVED" && (
-                        <span className="text-green-400">{"\u2714"}</span>
+                        <span className="text-success">{"\u2714"}</span>
                       )}
                       {pr.review_decision === "CHANGES_REQUESTED" && (
-                        <span className="text-orange-400">{"\u2716"}</span>
+                        <span className="text-warning">{"\u2716"}</span>
                       )}
                       {/* CI dot */}
                       {pr.check_status && (
                         <span
                           className={`inline-block h-2 w-2 rounded-full ${
                             pr.check_status === "SUCCESS"
-                              ? "bg-green-400"
+                              ? "bg-success"
                               : pr.check_status === "FAILURE"
-                                ? "bg-red-400"
-                                : "bg-yellow-400"
+                                ? "bg-destructive"
+                                : "bg-warning"
                           }`}
                         />
                       )}
                       {/* Review count */}
                       {pr.reviews > 0 && (
-                        <span className="text-[9px] text-zinc-500">{pr.reviews}r</span>
+                        <span className="text-[9px] text-muted-foreground">{pr.reviews}r</span>
                       )}
                     </a>
                   )}
@@ -659,7 +659,7 @@ export const LaneGraph = memo(function LaneGraph({
       {/* Commit detail overlay */}
       {expandedRow && expandedRow.kind === "commit" && (
         <div
-          className="absolute z-10 rounded-lg border border-white/10 bg-zinc-900/95 shadow-xl backdrop-blur-sm"
+          className="absolute z-10 rounded-lg border border-hairline-strong bg-surface-strong/95 shadow-xl backdrop-blur-sm"
           style={{
             left: svgWidth + 8,
             top: expandedRow.y + ROW_H / 2 + 4,
@@ -672,7 +672,7 @@ export const LaneGraph = memo(function LaneGraph({
               <CopyableSha
                 sha={commitDetail?.sha ?? expandedRow.sha}
                 displayLength={40}
-                className="text-[11px] text-cyan-400"
+                className="text-[11px] text-primary"
               />
               <button
                 type="button"
@@ -680,22 +680,22 @@ export const LaneGraph = memo(function LaneGraph({
                   setExpandedSha(null);
                   setCommitDetail(null);
                 }}
-                className="text-[10px] text-zinc-600 hover:text-zinc-300 transition-colors"
+                className="text-[10px] text-subtle-foreground hover:text-foreground transition-colors"
               >
                 Esc
               </button>
             </div>
-            <div className="mt-1.5 text-xs font-medium text-zinc-200 select-text">
+            <div className="mt-1.5 text-xs font-medium text-foreground select-text">
               {expandedRow.subject}
             </div>
             {detailLoading ? (
-              <div className="mt-2 text-[11px] text-zinc-600">Loading...</div>
+              <div className="mt-2 text-[11px] text-subtle-foreground">Loading...</div>
             ) : commitDetail?.body ? (
-              <div className="mt-2 rounded bg-white/[0.03] px-2 py-1.5 text-[11px] text-zinc-400 font-mono whitespace-pre-wrap break-words select-text max-h-48 overflow-y-auto">
+              <div className="mt-2 rounded bg-surface px-2 py-1.5 text-[11px] text-muted-foreground font-mono whitespace-pre-wrap break-words select-text max-h-48 overflow-y-auto">
                 {commitDetail.body}
               </div>
             ) : null}
-            <div className="mt-2 flex items-center gap-1.5 text-[10px] text-zinc-600">
+            <div className="mt-2 flex items-center gap-1.5 text-[10px] text-subtle-foreground">
               <span
                 className="rounded px-1.5 py-0.5"
                 style={{
@@ -708,9 +708,7 @@ export const LaneGraph = memo(function LaneGraph({
                 {branchForLane(expandedRow.lane)}
               </span>
               {expandedRow.isMerge && (
-                <span className="rounded bg-purple-500/10 px-1.5 py-0.5 text-purple-400">
-                  merge
-                </span>
+                <span className="rounded bg-accent/10 px-1.5 py-0.5 text-accent">merge</span>
               )}
             </div>
           </div>

--- a/clients/react/src/lib/__tests__/no-raw-palette.test.ts
+++ b/clients/react/src/lib/__tests__/no-raw-palette.test.ts
@@ -20,7 +20,7 @@ import { describe, expect, it } from "vitest";
 const SRC = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
 // Directories (relative to src/) that have completed the migration.
-const MIGRATED = ["components/settings"];
+const MIGRATED = ["components/settings", "components/worktree"];
 
 // A raw Tailwind palette colour utility: <prefix>-<family>[-<shade>][/<alpha>].
 // Semantic tokens (foreground / surface / primary / hairline / …) do not

--- a/clients/react/src/lib/theme.ts
+++ b/clients/react/src/lib/theme.ts
@@ -263,8 +263,13 @@ const TOKYONIGHT: Theme = {
       "secondary-foreground": "#c0caf5",
       muted: "#292e42",
       "muted-foreground": "#565f89",
-      accent: "#292e42",
-      "accent-foreground": "#c0caf5",
+      // `accent` is REPURPOSED: shadcn's muted-hover-surface meaning is
+      // unused in this codebase (surfaces map to surface/elevated), so
+      // accent is the WebUI's themed *secondary* categorical accent —
+      // what the hardcoded `purple/violet` (dispatch / agent / "remote"
+      // tags) migrates to. Tokyo Night magenta; distinct from primary.
+      accent: "#bb9af7",
+      "accent-foreground": "#15161e",
       destructive: "#f7768e",
       "destructive-foreground": "#15161e",
       warning: "#e0af68",
@@ -349,10 +354,10 @@ const ZINC: Theme = {
     },
     // Values mirror the Tailwind palette colours the components actually
     // hardcoded (zinc-200/400/600, cyan-400, red-400, amber/emerald/blue
-    // -500, white/N overlays) so the codemod swap is a faithful re-skin,
-    // not a re-colour, when `zinc` is selected. Tokens the canonical
-    // mapping never emits (card/popover/secondary/accent/border/input/
-    // ring/sidebar-*) keep their original neutral OKLch.
+    // -500, purple-400, white/N overlays) so the codemod swap is a
+    // faithful re-skin, not a re-colour, when `zinc` is selected. Tokens
+    // the canonical mapping never emits (card/popover/secondary/border/
+    // input/ring/sidebar-*) keep their original neutral OKLch.
     tokens: {
       background: "oklch(0.145 0 0)",
       foreground: "#e4e4e7",
@@ -366,8 +371,10 @@ const ZINC: Theme = {
       "secondary-foreground": "oklch(0.985 0 0)",
       muted: "oklch(0.269 0 0)",
       "muted-foreground": "#a1a1aa",
-      accent: "oklch(0.269 0 0)",
-      "accent-foreground": "oklch(0.985 0 0)",
+      // Repurposed secondary accent (see tokyonight). Faithful to the
+      // dominant `text-purple-400` the components hardcoded.
+      accent: "#c084fc",
+      "accent-foreground": "#18181b",
       destructive: "#f87171",
       "destructive-foreground": "oklch(0.637 0.237 25.331)",
       warning: "#f59e0b",
@@ -466,8 +473,9 @@ const LIGHT: Theme = {
       "secondary-foreground": "#3760bf",
       muted: "#c4c8da",
       "muted-foreground": "#6172b0",
-      accent: "#c4c8da",
-      "accent-foreground": "#3760bf",
+      // Repurposed secondary accent (see tokyonight). Tokyo Night Day magenta.
+      accent: "#9854f1",
+      "accent-foreground": "#ffffff",
       destructive: "#f52a65",
       "destructive-foreground": "#ffffff",
       warning: "#8c6c3e",

--- a/clients/react/src/styles/globals.css
+++ b/clients/react/src/styles/globals.css
@@ -32,8 +32,11 @@
   --color-secondary-foreground: #c0caf5;
   --color-muted: #292e42;
   --color-muted-foreground: #565f89;
-  --color-accent: #292e42;
-  --color-accent-foreground: #c0caf5;
+  /* accent = the WebUI's themed secondary categorical accent (purple/
+     violet migrate here) — repurposed from shadcn's unused muted-surface
+     slot. Mirror THEMES.tokyonight in theme.ts. */
+  --color-accent: #bb9af7;
+  --color-accent-foreground: #15161e;
   --color-destructive: #f7768e;
   --color-destructive-foreground: #15161e;
   /* Status + surface + dim-text tokens (migration targets; no component


### PR DESCRIPTION
**PR C of the semantic-token migration** (follows #699). `worktree/` — the largest area.

## Migration

- **`components/worktree/`**: 15 files, ~515 codemod substitutions, **zero residual** raw palette (guard green). Includes the `branch-state.ts` logic helper and `graph/LaneGraph.tsx`. Component logic / ternaries untouched — className strings only. **Zero collapsed-ternary artifacts.**
- Regression guard allowlist: **+ `components/worktree`** (both the raw-palette and the collapsed-ternary checks pass for it).

## Canonical codemod extended (applies to every remaining area PR)

- **`purple/violet/fuchsia` → `accent`.** Purple is the WebUI's *secondary categorical accent* (dispatch / agent / "remote" tags), deliberately distinct from the primary accent. shadcn's `accent`/`accent-foreground` slots (muted-hover-surface convention) are **unused in this codebase** — verified no component consumed them; surfaces map to `surface`/`elevated`. They are **repurposed** in `theme.ts` as this themed secondary accent: Tokyo Night magenta `#bb9af7`, light `#9854f1`, zinc `#c084fc` (faithful to the dominant `text-purple-400`).
- **`bg-black/<alpha>` → `bg-background`.** Black scrims (inset side-panels, form inputs) become "recessed to the theme base", so they invert correctly under a light theme instead of staying a hardcoded black darkener.
- **`ring-white/<alpha>` → `ring-hairline-strong`.**

## Manual fixup (codemod can't decide)

`IssuesPanel` search input was `ring-white/10 … focus:ring-white/20`. After the generic ring rule the focus ring would equal the resting ring (lost emphasis), so it's restored as `focus:ring-primary/40` — matching this codebase's focus convention (settings inputs use `focus:border-primary/30`).

## Test follow-through

`branch-state.test.ts` asserted raw palette family names (`purple`/`blue`/`cyan`/`amber`) returned by `branchStateBadgeClass`; updated to assert the semantic tokens (`accent`/`info`/`primary`/`warning`).

## Faithfulness / honest deltas

`zinc` token values were already tuned in #699; `accent` is added to that tuned set (`#c084fc` ≈ dominant `text-purple-400`). Sub-perceptual consolidation deltas (off-shade purples, white/N ring alpha) are the documented, agreed consequence of collapsing onto semantic tokens; dominant shades are exact. Under tokyonight/light `worktree/` now properly re-skins (purple → themed magenta, distinct from primary).

## Gate

`pnpm build && pnpm lint && pnpm test` — green (64 files, **496 passed**, 2 pre-existing skips, incl. the guard now covering settings + worktree).

Browser-verify still deferred (vite-on-WSL crash risk + no backend) — recommended at review or on request. Next: PR D (`producer-console/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)