### PR TITLE
feat(webui): migrate producer-console/ to semantic tokens (PR D)

### DIFF
--- a/clients/react/scripts/theme-codemod.mjs
+++ b/clients/react/scripts/theme-codemod.mjs
@@ -37,6 +37,13 @@ import { join } from "node:path";
 // `hover:text-foreground` and `text-cyan-400/80` → `text-primary/80`
 // fall out for free. `$1` is the utility prefix (text/bg/border/…).
 const PREFIX = "(?:text|bg|border|ring|from|via|to|fill|stroke|accent|placeholder|outline|decoration)";
+// Full Tailwind shade range. Status / accent families map to one
+// semantic token regardless of shade (red is `destructive` whether it's
+// red-200 error text on a tint or red-500 a fill), so accepting every
+// shade keeps the mapping consistent and avoids per-area residual
+// whack-a-mole. (The zinc *text* scale is the deliberate exception — it
+// is tiered into foreground/muted/subtle and keeps its own buckets.)
+const SH = "(?:50|100|200|300|400|500|600|700|800|900)";
 
 const RULES = [
   // ── Neutral text scale → foreground / muted / subtle tiers ──
@@ -70,24 +77,18 @@ const RULES = [
   [/(?<![\w-])border-zinc-(?:600|700|800)(?![\w-])/g, "border-hairline-strong"],
 
   // ── Accent (cyan is the product accent) → primary ──
-  [
-    new RegExp(`(?<![\\w-])(${PREFIX})-cyan-(?:200|300|400|500|600)(?![\\w-])`, "g"),
-    "$1-primary",
-  ],
+  [new RegExp(`(?<![\\w-])(${PREFIX})-cyan-${SH}(?![\\w-])`, "g"), "$1-primary"],
   // ── Status families ──
-  [new RegExp(`(?<![\\w-])(${PREFIX})-red-(?:300|400|500|600)(?![\\w-])`, "g"), "$1-destructive"],
+  [new RegExp(`(?<![\\w-])(${PREFIX})-red-${SH}(?![\\w-])`, "g"), "$1-destructive"],
   [
-    new RegExp(`(?<![\\w-])(${PREFIX})-(?:amber|yellow|orange)-(?:200|300|400|500|600)(?![\\w-])`, "g"),
+    new RegExp(`(?<![\\w-])(${PREFIX})-(?:amber|yellow|orange)-${SH}(?![\\w-])`, "g"),
     "$1-warning",
   ],
   [
-    new RegExp(`(?<![\\w-])(${PREFIX})-(?:emerald|green|teal|lime)-(?:200|300|400|500|600)(?![\\w-])`, "g"),
+    new RegExp(`(?<![\\w-])(${PREFIX})-(?:emerald|green|teal|lime)-${SH}(?![\\w-])`, "g"),
     "$1-success",
   ],
-  [
-    new RegExp(`(?<![\\w-])(${PREFIX})-(?:blue|sky|indigo)-(?:200|300|400|500|600)(?![\\w-])`, "g"),
-    "$1-info",
-  ],
+  [new RegExp(`(?<![\\w-])(${PREFIX})-(?:blue|sky|indigo)-${SH}(?![\\w-])`, "g"), "$1-info"],
   // Purple/violet is the WebUI's *secondary* categorical accent (dispatch
   // / agent / "remote" tags) — deliberately distinct from the primary
   // accent. The shadcn `accent`/`accent-foreground` token slots were the
@@ -95,7 +96,7 @@ const RULES = [
   // (surfaces map to surface/elevated), so they are repurposed in
   // theme.ts as this themed secondary accent. See lib/theme.ts.
   [
-    new RegExp(`(?<![\\w-])(${PREFIX})-(?:purple|violet|fuchsia)-(?:200|300|400|500|600)(?![\\w-])`, "g"),
+    new RegExp(`(?<![\\w-])(${PREFIX})-(?:purple|violet|fuchsia)-${SH}(?![\\w-])`, "g"),
     "$1-accent",
   ],
   // Black scrims (`bg-black/20`, `bg-black/[0.3]`) are "recessed to the

--- a/clients/react/src/components/producer-console/HandoffRitualFailureDialog.tsx
+++ b/clients/react/src/components/producer-console/HandoffRitualFailureDialog.tsx
@@ -76,25 +76,25 @@ export function HandoffRitualFailureDialog({
       role="dialog"
       aria-modal="true"
       aria-label="Handoff ritual rejected"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background backdrop-blur-sm"
     >
-      <div className="w-full max-w-lg rounded-xl border border-red-500/30 bg-zinc-900 p-5 shadow-2xl">
-        <h3 className="text-sm font-semibold text-red-200">
-          Handoff ritual rejected — unit <code className="text-cyan-300">{unitName}</code>
+      <div className="w-full max-w-lg rounded-xl border border-destructive/30 bg-surface-strong p-5 shadow-2xl">
+        <h3 className="text-sm font-semibold text-destructive">
+          Handoff ritual rejected — unit <code className="text-primary">{unitName}</code>
         </h3>
 
         <dl className="mt-3 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-[12px]">
-          <dt className="text-zinc-500">reason:</dt>
-          <dd className="font-mono text-zinc-300">{reason}</dd>
+          <dt className="text-muted-foreground">reason:</dt>
+          <dd className="font-mono text-foreground">{reason}</dd>
           {message !== null && (
             <>
-              <dt className="text-zinc-500">detail:</dt>
-              <dd className="whitespace-pre-wrap break-words text-zinc-300">{message}</dd>
+              <dt className="text-muted-foreground">detail:</dt>
+              <dd className="whitespace-pre-wrap break-words text-foreground">{message}</dd>
             </>
           )}
         </dl>
 
-        <p className="mt-3 text-[12px] leading-relaxed text-zinc-400">
+        <p className="mt-3 text-[12px] leading-relaxed text-muted-foreground">
           Producer rejected the handoff ritual (tmai tier-1: Producer's obligation to obey
           instructions). Decide how to proceed:
         </p>
@@ -104,7 +104,7 @@ export function HandoffRitualFailureDialog({
             type="button"
             onClick={onForceKill}
             disabled={producerAgentId === null}
-            className="rounded-md bg-red-500/15 px-3 py-2 text-xs font-medium text-red-300 transition-colors hover:bg-red-500/25 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-md bg-destructive/15 px-3 py-2 text-xs font-medium text-destructive transition-colors hover:bg-destructive/25 disabled:cursor-not-allowed disabled:opacity-50"
             title={
               producerAgentId === null
                 ? "No live Producer to kill"
@@ -118,7 +118,7 @@ export function HandoffRitualFailureDialog({
             type="button"
             onClick={onRetry}
             disabled={retryDisabled}
-            className="rounded-md bg-cyan-500/15 px-3 py-2 text-xs font-medium text-cyan-300 transition-colors hover:bg-cyan-500/25 disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-md bg-primary/15 px-3 py-2 text-xs font-medium text-primary transition-colors hover:bg-primary/25 disabled:cursor-not-allowed disabled:opacity-50"
             title={
               retryDisabled
                 ? "DR §E: second rejection is a hard escalate — no further automatic retry"
@@ -131,7 +131,7 @@ export function HandoffRitualFailureDialog({
           <button
             type="button"
             onClick={onDismiss}
-            className="rounded-md bg-white/[0.04] px-3 py-2 text-xs text-zinc-300 transition-colors hover:bg-white/[0.08]"
+            className="rounded-md bg-surface px-3 py-2 text-xs text-foreground transition-colors hover:bg-surface"
             title="Producer is still alive; next manual handoff or session-end will re-surface this state"
           >
             Continue with stale
@@ -144,7 +144,7 @@ export function HandoffRitualFailureDialog({
               else onDismiss();
             }}
             disabled={resumeUuid === null}
-            className="rounded-md bg-white/[0.04] px-3 py-2 text-xs text-zinc-300 transition-colors hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-50"
+            className="rounded-md bg-surface px-3 py-2 text-xs text-foreground transition-colors hover:bg-surface disabled:cursor-not-allowed disabled:opacity-50"
             title={
               resumeUuid === null
                 ? "No live Producer's session id available"
@@ -156,17 +156,17 @@ export function HandoffRitualFailureDialog({
         </div>
 
         {resumeRevealed && resumeUuid !== null && (
-          <div className="mt-4 rounded-md border border-white/10 bg-black/40 p-3 text-[12px]">
-            <p className="text-zinc-400">
+          <div className="mt-4 rounded-md border border-hairline-strong bg-background p-3 text-[12px]">
+            <p className="text-muted-foreground">
               Run this in a separate terminal where you have <code>claude</code> on PATH:
             </p>
-            <pre className="mt-2 overflow-x-auto font-mono text-cyan-300">
+            <pre className="mt-2 overflow-x-auto font-mono text-primary">
               claude --resume {resumeUuid}
             </pre>
             <button
               type="button"
               onClick={onDismiss}
-              className="mt-2 text-[11px] text-zinc-500 hover:text-zinc-300"
+              className="mt-2 text-[11px] text-muted-foreground hover:text-foreground"
             >
               Close
             </button>

--- a/clients/react/src/components/producer-console/HandoffRitualOverlay.tsx
+++ b/clients/react/src/components/producer-console/HandoffRitualOverlay.tsx
@@ -54,9 +54,9 @@ const STATUS_MARK = {
 } as const;
 
 const STATUS_CLASS = {
-  done: "text-emerald-400",
-  current: "text-cyan-300",
-  pending: "text-zinc-600",
+  done: "text-success",
+  current: "text-primary",
+  pending: "text-subtle-foreground",
 } as const;
 
 export function HandoffRitualOverlay({ unitName, ritualId, phases }: HandoffRitualOverlayProps) {
@@ -84,11 +84,11 @@ export function HandoffRitualOverlay({ unitName, ritualId, phases }: HandoffRitu
       role="dialog"
       aria-modal="true"
       aria-label="Handoff and restart in progress"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background backdrop-blur-sm"
     >
-      <div className="w-full max-w-lg rounded-xl border border-white/10 bg-zinc-900 p-5 shadow-2xl">
-        <h3 className="text-sm font-semibold text-zinc-100">
-          Handoff & restart — unit <code className="text-cyan-300">{unitName}</code>
+      <div className="w-full max-w-lg rounded-xl border border-hairline-strong bg-surface-strong p-5 shadow-2xl">
+        <h3 className="text-sm font-semibold text-foreground">
+          Handoff & restart — unit <code className="text-primary">{unitName}</code>
         </h3>
         <ul className="mt-4 space-y-2">
           {FORWARD_PHASES.map((row) => {
@@ -106,21 +106,23 @@ export function HandoffRitualOverlay({ unitName, ritualId, phases }: HandoffRitu
                 <span
                   className={
                     status === "done"
-                      ? "text-zinc-300"
+                      ? "text-foreground"
                       : status === "current"
-                        ? "text-cyan-200"
-                        : "text-zinc-500"
+                        ? "text-primary"
+                        : "text-muted-foreground"
                   }
                 >
                   {row.label}
                 </span>
-                {row.detail && <span className="text-[11px] text-zinc-500">— {row.detail}</span>}
+                {row.detail && (
+                  <span className="text-[11px] text-muted-foreground">— {row.detail}</span>
+                )}
               </li>
             );
           })}
         </ul>
         {ritualId !== null && (
-          <p className="mt-4 font-mono text-[10px] text-zinc-600">ritual_id: {ritualId}</p>
+          <p className="mt-4 font-mono text-[10px] text-subtle-foreground">ritual_id: {ritualId}</p>
         )}
       </div>
     </div>

--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -91,26 +91,26 @@ export function ProducerConsole({
         currentProjectPath={currentProjectPath}
         onOpenSettings={onOpenSettings}
       />
-      <header className="border-b border-white/5 px-6 py-4">
-        <h2 className="text-lg font-semibold text-zinc-200">Welcome to tmai</h2>
-        <p className="mt-1 text-xs text-zinc-400">
-          tmai routes your work through a <strong className="text-cyan-300">Producer</strong> — one
+      <header className="border-b border-hairline px-6 py-4">
+        <h2 className="text-lg font-semibold text-foreground">Welcome to tmai</h2>
+        <p className="mt-1 text-xs text-muted-foreground">
+          tmai routes your work through a <strong className="text-primary">Producer</strong> — one
           CC session per project that reads your decisions / memory, briefs you on what needs
           attention, and dispatches workers. You talk to the Producer, not to individual agents.
         </p>
-        <p className="mt-2 text-xs text-zinc-500">
-          <span className="text-zinc-400">Quick start:</span>{" "}
-          <strong className="text-zinc-300">①</strong> Read the digest below.{" "}
-          <strong className="text-zinc-300">②</strong> Click{" "}
-          <span className="text-cyan-300">Open Producer terminal</span> at the bottom — tmai spawns
+        <p className="mt-2 text-xs text-muted-foreground">
+          <span className="text-muted-foreground">Quick start:</span>{" "}
+          <strong className="text-foreground">①</strong> Read the digest below.{" "}
+          <strong className="text-foreground">②</strong> Click{" "}
+          <span className="text-primary">Open Producer terminal</span> at the bottom — tmai spawns
           the Producer session and switches this pane to it.{" "}
-          <strong className="text-zinc-300">③</strong> The Producer reads your context and briefs
+          <strong className="text-foreground">③</strong> The Producer reads your context and briefs
           you on what to look at first; you converse with it right here.
         </p>
-        <p className="mt-1.5 text-[11px] text-zinc-600">
+        <p className="mt-1.5 text-[11px] text-subtle-foreground">
           Need direct agent control (legacy)?{" "}
-          <span className="text-zinc-500">Operator override</span> at the bottom · expandable
-          sidebar on the left.
+          <span className="text-muted-foreground">Operator override</span> at the bottom ·
+          expandable sidebar on the left.
         </p>
       </header>
 

--- a/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
@@ -198,12 +198,12 @@ export function ProducerConsoleActions({
   );
 
   return (
-    <div className="border-t border-white/5">
+    <div className="border-t border-hairline">
       <div className="flex items-center gap-2 px-6 py-3">
         <button
           type="button"
           onClick={handleProducerClick}
-          className="rounded-md bg-cyan-500/10 px-3 py-1.5 text-xs text-cyan-300 transition-colors hover:bg-cyan-500/20"
+          className="rounded-md bg-primary/10 px-3 py-1.5 text-xs text-primary transition-colors hover:bg-primary/20"
           title={
             unitName === null
               ? "Pick a repo root and launch the Producer there"
@@ -217,7 +217,7 @@ export function ProducerConsoleActions({
           type="button"
           onClick={handleHandoffClick}
           disabled={producer === null || unitName === null}
-          className="rounded-md bg-white/[0.04] px-3 py-1.5 text-xs text-zinc-300 transition-colors hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-50"
+          className="rounded-md bg-surface px-3 py-1.5 text-xs text-foreground transition-colors hover:bg-surface disabled:cursor-not-allowed disabled:opacity-50"
           title={
             producer === null
               ? "No live Producer for this unit — launch one first via Open Producer terminal"
@@ -231,7 +231,7 @@ export function ProducerConsoleActions({
           type="button"
           onClick={onOpenCalibration}
           disabled={unitName === null}
-          className="rounded-md bg-white/[0.04] px-3 py-1.5 text-xs text-zinc-300 transition-colors hover:bg-white/[0.08] disabled:cursor-not-allowed disabled:opacity-50"
+          className="rounded-md bg-surface px-3 py-1.5 text-xs text-foreground transition-colors hover:bg-surface disabled:cursor-not-allowed disabled:opacity-50"
           title={
             unitName === null
               ? "No unit resolvable yet — launch the Producer (or pick a project) first"
@@ -240,12 +240,12 @@ export function ProducerConsoleActions({
         >
           Calibration ▸
           {tripwireCount > 0 && (
-            <span className="ml-1.5 rounded-full bg-red-500/30 px-1.5 py-0.5 text-[10px] text-red-200">
+            <span className="ml-1.5 rounded-full bg-destructive/30 px-1.5 py-0.5 text-[10px] text-destructive">
               ⚡ {tripwireCount}
             </span>
           )}
           {tripwireCount === 0 && calCount > 0 && (
-            <span className="ml-1.5 text-[10px] text-zinc-500">{calCount}</span>
+            <span className="ml-1.5 text-[10px] text-muted-foreground">{calCount}</span>
           )}
         </button>
 
@@ -254,7 +254,7 @@ export function ProducerConsoleActions({
           onClick={() => setOverrideOpen((o) => !o)}
           aria-expanded={overrideOpen}
           aria-controls="operator-override-panel"
-          className="ml-auto rounded-md bg-white/[0.02] px-3 py-1.5 text-xs text-zinc-400 transition-colors hover:bg-white/[0.06] hover:text-zinc-200"
+          className="ml-auto rounded-md bg-surface px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-surface hover:text-foreground"
           title="Bypass the Producer — for emergency / debug use only"
         >
           Operator override {overrideOpen ? "▴" : "▾"}
@@ -262,12 +262,11 @@ export function ProducerConsoleActions({
       </div>
 
       {overrideOpen && (
-        <div
-          id="operator-override-panel"
-          className="border-t border-white/5 bg-white/[0.02] px-6 py-3"
-        >
-          <p className="text-[11px] uppercase tracking-wider text-zinc-500">Operator override</p>
-          <p className="mt-1 text-xs text-zinc-500">
+        <div id="operator-override-panel" className="border-t border-hairline bg-surface px-6 py-3">
+          <p className="text-[11px] uppercase tracking-wider text-muted-foreground">
+            Operator override
+          </p>
+          <p className="mt-1 text-xs text-muted-foreground">
             These shortcuts bypass the Producer. The post-inversion default is to let the Producer
             route work — use these only when the Producer isn't running, you need to intervene
             directly, or you're debugging.
@@ -280,22 +279,24 @@ export function ProducerConsoleActions({
               <button
                 type="button"
                 onClick={onOpenSidebar}
-                className="block w-full rounded-md border border-white/5 bg-white/[0.02] px-3 py-2 text-left text-xs text-zinc-300 transition-colors hover:bg-white/[0.06]"
+                className="block w-full rounded-md border border-hairline bg-surface px-3 py-2 text-left text-xs text-foreground transition-colors hover:bg-surface"
                 title="Re-expand the sidebar and show the raw agent list"
               >
                 Show sidebar ▸{" "}
-                <span className="text-zinc-500">(legacy agent list / per-project shortcuts)</span>
+                <span className="text-muted-foreground">
+                  (legacy agent list / per-project shortcuts)
+                </span>
               </button>
             )}
 
             <button
               type="button"
               onClick={onOpenSettings}
-              className="block w-full rounded-md border border-white/5 bg-white/[0.02] px-3 py-2 text-left text-xs text-zinc-300 transition-colors hover:bg-white/[0.06]"
+              className="block w-full rounded-md border border-hairline bg-surface px-3 py-2 text-left text-xs text-foreground transition-colors hover:bg-surface"
               title="Open Settings — orchestration / dispatch bundles still live here"
             >
               Open Settings ▸{" "}
-              <span className="text-zinc-500">
+              <span className="text-muted-foreground">
                 (orchestration rules, dispatch bundles, guardrails, …)
               </span>
             </button>
@@ -330,7 +331,7 @@ export function ProducerConsoleActions({
         <div
           role="status"
           aria-live="polite"
-          className="fixed bottom-4 right-4 z-40 rounded-md border border-emerald-500/30 bg-zinc-900 px-4 py-2 text-xs text-emerald-300 shadow-lg"
+          className="fixed bottom-4 right-4 z-40 rounded-md border border-success/30 bg-surface-strong px-4 py-2 text-xs text-success shadow-lg"
         >
           Handoff complete — fresh Producer is ready.
         </div>
@@ -346,14 +347,14 @@ export function ProducerConsoleActions({
                 type="button"
                 onClick={() => handlePickPath(currentPath)}
                 disabled={!currentPath}
-                className="w-full rounded bg-cyan-500/10 px-3 py-1.5 text-center text-xs text-cyan-300 transition-colors hover:bg-cyan-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+                className="w-full rounded bg-primary/10 px-3 py-1.5 text-center text-xs text-primary transition-colors hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
               >
                 Launch Producer here ▸
               </button>
-              <p className="text-[10px] text-zinc-600">
+              <p className="text-[10px] text-subtle-foreground">
                 tmai will spawn{" "}
-                <code className="text-zinc-500">tmai producer &lt;basename&gt;</code> in this
-                directory.
+                <code className="text-muted-foreground">tmai producer &lt;basename&gt;</code> in
+                this directory.
               </p>
             </div>
           )}

--- a/clients/react/src/components/producer-console/ProducerCtxHeader.tsx
+++ b/clients/react/src/components/producer-console/ProducerCtxHeader.tsx
@@ -78,11 +78,11 @@ export function renderBar(pct: number): { filled: number; empty: number; chars: 
 // Threshold == 0 means auto-handoff is disabled — never colour the
 // readout in that mode; the row instead labels it "disabled".
 export function thresholdColorClass(pct: number | null, threshold: number): string {
-  if (threshold <= 0) return "text-zinc-500";
-  if (pct === null) return "text-zinc-500";
-  if (pct >= threshold) return "text-red-300";
-  if (pct >= threshold - 10) return "text-amber-300";
-  return "text-zinc-400";
+  if (threshold <= 0) return "text-muted-foreground";
+  if (pct === null) return "text-muted-foreground";
+  if (pct >= threshold) return "text-destructive";
+  if (pct >= threshold - 10) return "text-warning";
+  return "text-muted-foreground";
 }
 
 export function ProducerCtxHeader({
@@ -126,26 +126,26 @@ export function ProducerCtxHeader({
   const readoutColor = thresholdColorClass(ctx?.pct ?? null, effectiveThreshold);
 
   return (
-    <div className="border-b border-white/5 bg-white/[0.02] px-6 py-2 text-xs">
-      <div className="flex items-center gap-3 text-zinc-400">
+    <div className="border-b border-hairline bg-surface px-6 py-2 text-xs">
+      <div className="flex items-center gap-3 text-muted-foreground">
         {ctx ? (
           <>
-            <span className="font-mono text-zinc-300">
-              ctx: <span className="text-zinc-200">{formatThousands(ctx.used)}</span>
+            <span className="font-mono text-foreground">
+              ctx: <span className="text-foreground">{formatThousands(ctx.used)}</span>
               {" / "}
-              <span className="text-zinc-200">{formatThousands(ctx.total)}</span>
+              <span className="text-foreground">{formatThousands(ctx.total)}</span>
               {" ("}
-              <span className="text-zinc-200">{ctx.pct}%</span>
+              <span className="text-foreground">{ctx.pct}%</span>
               {")"}
             </span>
-            <span className="font-mono text-zinc-500" aria-hidden="true">
+            <span className="font-mono text-muted-foreground" aria-hidden="true">
               {renderBar(ctx.pct).chars}
             </span>
           </>
         ) : (
-          <span className="font-mono text-zinc-600">ctx: — / —</span>
+          <span className="font-mono text-subtle-foreground">ctx: — / —</span>
         )}
-        <span className="text-zinc-700" aria-hidden="true">
+        <span className="text-subtle-foreground" aria-hidden="true">
           │
         </span>
         <span className={`font-mono ${readoutColor}`}>{thresholdLabel}</span>
@@ -154,7 +154,7 @@ export function ProducerCtxHeader({
           onClick={onOpenSettings}
           aria-label="Open settings — auto-handoff threshold"
           title="Open settings — auto-handoff threshold"
-          className="ml-0 rounded text-zinc-500 transition-colors hover:text-zinc-200"
+          className="ml-0 rounded text-muted-foreground transition-colors hover:text-foreground"
         >
           ⚙
         </button>

--- a/clients/react/src/components/producer-console/__tests__/ProducerCtxHeader.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerCtxHeader.test.tsx
@@ -93,16 +93,18 @@ describe("ProducerCtxHeader — pure helpers", () => {
     expect(renderBar(150).filled).toBe(10);
   });
 
-  it("thresholdColorClass flips zinc / amber / red across the boundary", () => {
-    expect(thresholdColorClass(50, 75)).toMatch(/zinc/);
-    expect(thresholdColorClass(66, 75)).toMatch(/amber/);
-    expect(thresholdColorClass(74, 75)).toMatch(/amber/);
-    expect(thresholdColorClass(75, 75)).toMatch(/red/);
-    expect(thresholdColorClass(95, 75)).toMatch(/red/);
-    // Disabled threshold keeps the readout zinc regardless of pct
-    expect(thresholdColorClass(99, 0)).toMatch(/zinc/);
-    // null pct (no ctx_usage yet) → zinc
-    expect(thresholdColorClass(null, 75)).toMatch(/zinc/);
+  // Migrated off raw palette onto semantic tokens (zinc→muted-foreground,
+  // amber→warning, red→destructive) — see scripts/theme-codemod.mjs.
+  it("thresholdColorClass flips muted / warning / destructive across the boundary", () => {
+    expect(thresholdColorClass(50, 75)).toMatch(/muted-foreground/);
+    expect(thresholdColorClass(66, 75)).toMatch(/warning/);
+    expect(thresholdColorClass(74, 75)).toMatch(/warning/);
+    expect(thresholdColorClass(75, 75)).toMatch(/destructive/);
+    expect(thresholdColorClass(95, 75)).toMatch(/destructive/);
+    // Disabled threshold keeps the readout muted regardless of pct
+    expect(thresholdColorClass(99, 0)).toMatch(/muted-foreground/);
+    // null pct (no ctx_usage yet) → muted
+    expect(thresholdColorClass(null, 75)).toMatch(/muted-foreground/);
   });
 });
 

--- a/clients/react/src/components/producer-console/sections/ActiveApproachesSection.tsx
+++ b/clients/react/src/components/producer-console/sections/ActiveApproachesSection.tsx
@@ -32,9 +32,11 @@ export function ActiveApproachesSection({ unitName }: ActiveApproachesSectionPro
   return (
     <section>
       <header className="mb-2 flex items-baseline gap-2">
-        <span className="text-base text-cyan-400">▣</span>
-        <h3 className="text-sm font-semibold text-zinc-200">Active approaches</h3>
-        {loading && data === null && <span className="text-[10px] text-zinc-500">loading…</span>}
+        <span className="text-base text-primary">▣</span>
+        <h3 className="text-sm font-semibold text-foreground">Active approaches</h3>
+        {loading && data === null && (
+          <span className="text-[10px] text-muted-foreground">loading…</span>
+        )}
       </header>
       <Body unitName={unitName} data={data} loading={loading} error={error} />
     </section>
@@ -51,10 +53,11 @@ interface BodyProps {
 function Body({ unitName, data, loading, error }: BodyProps) {
   if (unitName === null) {
     return (
-      <div className="pl-6 text-xs text-zinc-500">
+      <div className="pl-6 text-xs text-muted-foreground">
         <p>
-          Pick a project (a unit chip in <span className="text-zinc-400">⬢ Cross-unit status</span>{" "}
-          above, or the sidebar) to see its active approaches awaiting a verdict.
+          Pick a project (a unit chip in{" "}
+          <span className="text-muted-foreground">⬢ Cross-unit status</span> above, or the sidebar)
+          to see its active approaches awaiting a verdict.
         </p>
       </div>
     );
@@ -62,12 +65,12 @@ function Body({ unitName, data, loading, error }: BodyProps) {
 
   if (error !== null) {
     return (
-      <div className="pl-6 text-xs text-red-300/80">
+      <div className="pl-6 text-xs text-destructive/80">
         <p>
-          Failed to load approaches: <code className="text-red-300">{error.message}</code>
+          Failed to load approaches: <code className="text-destructive">{error.message}</code>
         </p>
-        <p className="mt-1 text-zinc-500">
-          Browse <code className="text-zinc-300">doc/approaches/</code> directly in the repo as a
+        <p className="mt-1 text-muted-foreground">
+          Browse <code className="text-foreground">doc/approaches/</code> directly in the repo as a
           fallback.
         </p>
       </div>
@@ -75,16 +78,16 @@ function Body({ unitName, data, loading, error }: BodyProps) {
   }
 
   if (data === null && loading) {
-    return <div className="pl-6 text-xs text-zinc-500">Loading…</div>;
+    return <div className="pl-6 text-xs text-muted-foreground">Loading…</div>;
   }
 
   if (data === null || data.repos.length === 0) {
     return (
-      <div className="pl-6 text-xs text-zinc-500">
+      <div className="pl-6 text-xs text-muted-foreground">
         <p>
-          No active approaches for <code className="text-zinc-300">{unitName}</code>. The unit
-          either has no <code className="text-zinc-300">doc/approaches/</code> directory yet, or no
-          record is <code className="text-zinc-300">status: active</code>.
+          No active approaches for <code className="text-foreground">{unitName}</code>. The unit
+          either has no <code className="text-foreground">doc/approaches/</code> directory yet, or
+          no record is <code className="text-foreground">status: active</code>.
         </p>
       </div>
     );
@@ -100,7 +103,7 @@ function Body({ unitName, data, loading, error }: BodyProps) {
       {onlyPrimary && (
         // TODO(tmai-core#340): retire once multi-repo unit support surfaces
         // approaches from every repo (same axis as the decisions side).
-        <p className="text-[11px] text-zinc-600">
+        <p className="text-[11px] text-subtle-foreground">
           Showing this unit's primary repo only — multi-repo approach aggregation isn't wired yet
           (tmai-core#340).
         </p>
@@ -190,26 +193,28 @@ function RepoGroup({ repo, singleRepo }: { repo: RepoApproachesWire; singleRepo:
   return (
     <div className="space-y-2">
       {!singleRepo && (
-        <h4 className="text-[11px] font-semibold uppercase tracking-wide text-zinc-400">
-          <code className="font-mono text-zinc-300">{repo.repo_label}</code>
-          {repo.primary && <span className="ml-1 text-cyan-400">(primary)</span>}
-          {repo.repo_head && <span className="ml-2 text-zinc-600">@ {repo.repo_head}</span>}
+        <h4 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          <code className="font-mono text-foreground">{repo.repo_label}</code>
+          {repo.primary && <span className="ml-1 text-primary">(primary)</span>}
+          {repo.repo_head && (
+            <span className="ml-2 text-subtle-foreground">@ {repo.repo_head}</span>
+          )}
         </h4>
       )}
 
-      <p className="text-[11px] text-zinc-600">
+      <p className="text-[11px] text-subtle-foreground">
         {`${repo.active.length} active · `}
-        <span className="text-zinc-500">{`⚡ ${verdict.length}  🟡 ${watch.length}  ⚪ ${quiet.length}`}</span>
+        <span className="text-muted-foreground">{`⚡ ${verdict.length}  🟡 ${watch.length}  ⚪ ${quiet.length}`}</span>
       </p>
 
       <VerdictBand items={verdict} />
       <CollapsibleBand label="🟡 Watch" items={watch} />
       <CollapsibleBand label="⚪ Running quietly" items={quiet} muted />
 
-      <p className="text-[10.5px] leading-relaxed text-zinc-600">
+      <p className="text-[10.5px] leading-relaxed text-subtle-foreground">
         ⚡ groups approaches whose review-trigger objectively fired (a date passed). Whether each
-        verdict is <span className="text-zinc-500">yours</span> or Producer-resolvable needs engine
-        eval — tmai-core#381.
+        verdict is <span className="text-muted-foreground">yours</span> or Producer-resolvable needs
+        engine eval — tmai-core#381.
         {coreOnlyCount > 0 && (
           <>
             {" "}
@@ -227,33 +232,33 @@ function RepoGroup({ repo, singleRepo }: { repo: RepoApproachesWire; singleRepo:
 function VerdictBand({ items }: { items: Classified[] }) {
   if (items.length === 0) {
     return (
-      <p className="rounded border border-zinc-700/40 bg-zinc-800/30 px-2 py-1 text-[11px] text-zinc-500">
+      <p className="rounded border border-hairline-strong/40 bg-surface-strong/30 px-2 py-1 text-[11px] text-muted-foreground">
         ⚡ No verdict due — no active approach has a fired date trigger.
       </p>
     );
   }
   return (
-    <div className="rounded border border-amber-500/30 bg-amber-500/[0.05] p-2">
-      <p className="mb-1 text-[11px] font-semibold text-amber-300">
+    <div className="rounded border border-warning/30 bg-warning/[0.05] p-2">
+      <p className="mb-1 text-[11px] font-semibold text-warning">
         ⚡ Your verdict ({items.length})
       </p>
       <ul className="space-y-2 pl-1">
         {items.map((c) => (
           <li key={c.approach.slug} className="text-[11px] leading-snug">
-            <code className="text-zinc-200">{c.approach.slug}</code>
-            <span className="text-zinc-500"> — {c.approach.title}</span>
-            <div className="text-amber-300/90">{c.reason}</div>
-            <div className="text-zinc-500">
-              serves: <span className="text-zinc-400">{c.approach.serves.join(", ")}</span>
+            <code className="text-foreground">{c.approach.slug}</code>
+            <span className="text-muted-foreground"> — {c.approach.title}</span>
+            <div className="text-warning/90">{c.reason}</div>
+            <div className="text-muted-foreground">
+              serves: <span className="text-muted-foreground">{c.approach.serves.join(", ")}</span>
             </div>
-            <div className="text-zinc-500">
-              ✓ <span className="text-zinc-400">{c.approach.success_signal}</span>
+            <div className="text-muted-foreground">
+              ✓ <span className="text-muted-foreground">{c.approach.success_signal}</span>
             </div>
-            <div className="text-zinc-500">
-              ✗ <span className="text-zinc-400">{c.approach.failure_signal}</span>
+            <div className="text-muted-foreground">
+              ✗ <span className="text-muted-foreground">{c.approach.failure_signal}</span>
             </div>
             {c.coreOnly && (
-              <div className="text-[10.5px] text-zinc-600">
+              <div className="text-[10.5px] text-subtle-foreground">
                 also carries an engine-only trigger (tmai-core#381)
               </div>
             )}
@@ -280,19 +285,19 @@ function CollapsibleBand({
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className={`flex w-full items-center gap-1 text-left text-[11px] ${muted ? "text-zinc-600" : "text-zinc-400"} hover:text-zinc-200`}
+        className={`flex w-full items-center gap-1 text-left text-[11px] ${muted ? "text-subtle-foreground" : "text-muted-foreground"} hover:text-foreground`}
       >
-        <span className="font-mono text-zinc-600">{open ? "▾" : "▸"}</span>
+        <span className="font-mono text-subtle-foreground">{open ? "▾" : "▸"}</span>
         <span className="font-medium">{label}</span>
-        <span className="text-zinc-600">({items.length})</span>
+        <span className="text-subtle-foreground">({items.length})</span>
       </button>
       {open && (
         <ul className="space-y-1 pl-4">
           {items.map((c) => (
-            <li key={c.approach.slug} className="text-[11px] leading-snug text-zinc-400">
-              <code className="text-zinc-300">{c.approach.slug}</code>
-              <span className="text-zinc-500"> — {c.approach.title}</span>
-              <div className="text-[10.5px] text-zinc-600">{c.reason}</div>
+            <li key={c.approach.slug} className="text-[11px] leading-snug text-muted-foreground">
+              <code className="text-foreground">{c.approach.slug}</code>
+              <span className="text-muted-foreground"> — {c.approach.title}</span>
+              <div className="text-[10.5px] text-subtle-foreground">{c.reason}</div>
             </li>
           ))}
         </ul>

--- a/clients/react/src/components/producer-console/sections/CrossUnitStatusSection.tsx
+++ b/clients/react/src/components/producer-console/sections/CrossUnitStatusSection.tsx
@@ -40,20 +40,20 @@ export function CrossUnitStatusSection({
   return (
     <section>
       <header className="mb-2 flex items-baseline gap-2">
-        <span className="text-base text-cyan-400">⬢</span>
-        <h3 className="text-sm font-semibold text-zinc-200">Cross-unit status</h3>
-        <span className="text-xs text-zinc-500">
+        <span className="text-base text-primary">⬢</span>
+        <h3 className="text-sm font-semibold text-foreground">Cross-unit status</h3>
+        <span className="text-xs text-muted-foreground">
           {data.units.length} unit{data.units.length === 1 ? "" : "s"} derived from live agents
         </span>
       </header>
 
       {data.units.length === 0 ? (
-        <p className="pl-6 text-xs text-zinc-500">
+        <p className="pl-6 text-xs text-muted-foreground">
           No active units. Spawn an agent on any project to populate this list — dormant configured
           units aren't surfaced here yet.
         </p>
       ) : (
-        <ul className="space-y-0.5 pl-6 text-xs text-zinc-300">
+        <ul className="space-y-0.5 pl-6 text-xs text-foreground">
           {data.units.map((u) => {
             const isActive = u.path === activePath;
             return (
@@ -61,20 +61,20 @@ export function CrossUnitStatusSection({
                 <button
                   type="button"
                   onClick={() => onSelectUnit(u.path, u.name)}
-                  className={`flex w-full items-baseline gap-2 rounded px-2 py-1 text-left transition-colors hover:bg-white/[0.04] ${
-                    isActive ? "bg-white/[0.04]" : ""
+                  className={`flex w-full items-baseline gap-2 rounded px-2 py-1 text-left transition-colors hover:bg-surface ${
+                    isActive ? "bg-surface" : ""
                   }`}
                 >
                   <StatePill state={u.state} />
-                  <code className="text-zinc-200">{u.name}</code>
-                  <span className="text-zinc-600">
+                  <code className="text-foreground">{u.name}</code>
+                  <span className="text-subtle-foreground">
                     {u.attentionCount > 0 && (
-                      <span className="text-amber-400">{u.attentionCount}↑ </span>
+                      <span className="text-warning">{u.attentionCount}↑ </span>
                     )}
                     {u.agentCount} agent{u.agentCount === 1 ? "" : "s"}
                   </span>
                   {isActive && (
-                    <span className="ml-auto text-[10px] uppercase tracking-wider text-cyan-400">
+                    <span className="ml-auto text-[10px] uppercase tracking-wider text-primary">
                       active
                     </span>
                   )}
@@ -88,7 +88,7 @@ export function CrossUnitStatusSection({
       {preconditions?.singleUnitOnly && (
         // TODO(tmai-core#340): remove this notice once multi-repo /
         // dormant-unit reconciliation lands.
-        <p className="mt-2 pl-6 text-[11px] text-zinc-600">
+        <p className="mt-2 pl-6 text-[11px] text-subtle-foreground">
           Showing one unit only — a tmai project can span multiple repos and have dormant configured
           units, but that view isn't wired yet.
         </p>
@@ -101,19 +101,19 @@ function StatePill({ state }: { state: UnitState }) {
   switch (state) {
     case "needs-you":
       return (
-        <span className="text-red-400" title="agent(s) on the attention axis">
+        <span className="text-destructive" title="agent(s) on the attention axis">
           🔴
         </span>
       );
     case "in-progress":
       return (
-        <span className="text-amber-300" title="agents present, none waiting on you">
+        <span className="text-warning" title="agents present, none waiting on you">
           🟡
         </span>
       );
     case "quiet":
       return (
-        <span className="text-zinc-500" title="no agents">
+        <span className="text-muted-foreground" title="no agents">
           ⚪
         </span>
       );

--- a/clients/react/src/components/producer-console/sections/SettledDecisionsSection.tsx
+++ b/clients/react/src/components/producer-console/sections/SettledDecisionsSection.tsx
@@ -44,9 +44,11 @@ export function SettledDecisionsSection({ unitName }: SettledDecisionsSectionPro
   return (
     <section>
       <header className="mb-2 flex items-baseline gap-2">
-        <span className="text-base text-cyan-400">⬡</span>
-        <h3 className="text-sm font-semibold text-zinc-200">Settled decisions</h3>
-        {loading && data === null && <span className="text-[10px] text-zinc-500">loading…</span>}
+        <span className="text-base text-primary">⬡</span>
+        <h3 className="text-sm font-semibold text-foreground">Settled decisions</h3>
+        {loading && data === null && (
+          <span className="text-[10px] text-muted-foreground">loading…</span>
+        )}
       </header>
       <SettledBody unitName={unitName} data={data} loading={loading} error={error} />
     </section>
@@ -63,11 +65,11 @@ interface SettledBodyProps {
 function SettledBody({ unitName, data, loading, error }: SettledBodyProps) {
   if (unitName === null) {
     return (
-      <div className="pl-6 text-xs text-zinc-500">
+      <div className="pl-6 text-xs text-muted-foreground">
         <p>
           Pick a project (click a unit chip in{" "}
-          <span className="text-zinc-400">⬢ Cross-unit status</span> above, or use the sidebar) to
-          see its settled decisions.
+          <span className="text-muted-foreground">⬢ Cross-unit status</span> above, or use the
+          sidebar) to see its settled decisions.
         </p>
       </div>
     );
@@ -75,12 +77,12 @@ function SettledBody({ unitName, data, loading, error }: SettledBodyProps) {
 
   if (error !== null) {
     return (
-      <div className="pl-6 text-xs text-red-300/80">
+      <div className="pl-6 text-xs text-destructive/80">
         <p>
-          Failed to load decisions: <code className="text-red-300">{error.message}</code>
+          Failed to load decisions: <code className="text-destructive">{error.message}</code>
         </p>
-        <p className="mt-1 text-zinc-500">
-          Browse <code className="text-zinc-300">doc/decisions/</code> directly in the repo as a
+        <p className="mt-1 text-muted-foreground">
+          Browse <code className="text-foreground">doc/decisions/</code> directly in the repo as a
           fallback.
         </p>
       </div>
@@ -88,16 +90,16 @@ function SettledBody({ unitName, data, loading, error }: SettledBodyProps) {
   }
 
   if (data === null && loading) {
-    return <div className="pl-6 text-xs text-zinc-500">Loading…</div>;
+    return <div className="pl-6 text-xs text-muted-foreground">Loading…</div>;
   }
 
   if (data === null || data.repos.length === 0) {
     return (
-      <div className="pl-6 text-xs text-zinc-500">
+      <div className="pl-6 text-xs text-muted-foreground">
         <p>
-          No decisions resolved for <code className="text-zinc-300">{unitName}</code>. The unit
-          either has no <code className="text-zinc-300">doc/decisions/</code> directory yet, or it's
-          empty.
+          No decisions resolved for <code className="text-foreground">{unitName}</code>. The unit
+          either has no <code className="text-foreground">doc/decisions/</code> directory yet, or
+          it's empty.
         </p>
       </div>
     );
@@ -118,7 +120,7 @@ function SettledBody({ unitName, data, loading, error }: SettledBodyProps) {
       {onlyPrimary && (
         // TODO(tmai-core#340): retire this notice once multi-repo
         // unit support surfaces decisions from every repo.
-        <p className="text-[11px] text-zinc-600">
+        <p className="text-[11px] text-subtle-foreground">
           Showing this unit's primary repo only — multi-repo decision aggregation isn't wired yet
           (tmai-core#340).
         </p>
@@ -137,18 +139,20 @@ function RepoGroup({ repo, singleRepo }: RepoGroupProps) {
   return (
     <div className="space-y-2">
       {!singleRepo && (
-        <h4 className="text-[11px] font-semibold uppercase tracking-wide text-zinc-400">
-          <code className="font-mono text-zinc-300">{repo.repo_label}</code>
-          {repo.primary && <span className="ml-1 text-cyan-400">(primary)</span>}
-          {repo.repo_head && <span className="ml-2 text-zinc-600">@ {repo.repo_head}</span>}
+        <h4 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          <code className="font-mono text-foreground">{repo.repo_label}</code>
+          {repo.primary && <span className="ml-1 text-primary">(primary)</span>}
+          {repo.repo_head && (
+            <span className="ml-2 text-subtle-foreground">@ {repo.repo_head}</span>
+          )}
         </h4>
       )}
 
-      <p className="text-[11px] text-zinc-600">
+      <p className="text-[11px] text-subtle-foreground">
         {`${counts.total} decision${counts.total !== 1 ? "s" : ""} · `}
-        <span className="text-zinc-500">{`📌 ${counts.foundations}  🔴 ${counts.in_play}  🟡 ${counts.warm}  ⚪ ${counts.cold}`}</span>
+        <span className="text-muted-foreground">{`📌 ${counts.foundations}  🔴 ${counts.in_play}  🟡 ${counts.warm}  ⚪ ${counts.cold}`}</span>
         {counts.superseded > 0 && (
-          <span className="text-zinc-600">{` · superseded ${counts.superseded}`}</span>
+          <span className="text-subtle-foreground">{` · superseded ${counts.superseded}`}</span>
         )}
       </p>
 
@@ -182,11 +186,11 @@ function Bucket({ label, items, alwaysOpen, muted }: BucketProps) {
       <button
         type="button"
         onClick={() => setOpen((v) => !v)}
-        className={`flex w-full items-center gap-1 text-left text-[11px] ${muted ? "text-zinc-600" : "text-zinc-400"} hover:text-zinc-200`}
+        className={`flex w-full items-center gap-1 text-left text-[11px] ${muted ? "text-subtle-foreground" : "text-muted-foreground"} hover:text-foreground`}
       >
-        <span className="font-mono text-zinc-600">{open ? "▾" : "▸"}</span>
+        <span className="font-mono text-subtle-foreground">{open ? "▾" : "▸"}</span>
         <span className="font-medium">{label}</span>
-        <span className="text-zinc-600">({items.length})</span>
+        <span className="text-subtle-foreground">({items.length})</span>
       </button>
       {open && (
         <ul className="space-y-0.5 pl-4">
@@ -203,27 +207,25 @@ function DecisionRow({ decision }: { decision: DecisionWire }) {
   const driftMark = decision.stale_since ? " ⚠" : "";
   const contractMark = decision.contract_surface ? " [contract]" : "";
   return (
-    <li className="text-[11px] leading-snug text-zinc-400">
-      <code className="text-zinc-300">{decision.slug}</code>
-      <span className="text-zinc-600">{contractMark}</span>
-      <span className="text-amber-300">{driftMark}</span>
-      <span className="text-zinc-500"> — {decision.title}</span>
+    <li className="text-[11px] leading-snug text-muted-foreground">
+      <code className="text-foreground">{decision.slug}</code>
+      <span className="text-subtle-foreground">{contractMark}</span>
+      <span className="text-warning">{driftMark}</span>
+      <span className="text-muted-foreground"> — {decision.title}</span>
     </li>
   );
 }
 
 function CurrencySweep({ items }: { items: CurrencyItemWire[] }) {
   return (
-    <div className="rounded border border-amber-500/20 bg-amber-500/[0.04] p-2">
-      <p className="mb-1 text-[11px] font-medium text-amber-300">
-        ⚠ Currency sweep ({items.length})
-      </p>
+    <div className="rounded border border-warning/20 bg-warning/[0.04] p-2">
+      <p className="mb-1 text-[11px] font-medium text-warning">⚠ Currency sweep ({items.length})</p>
       <ul className="space-y-1 pl-3">
         {items.map((it) => (
-          <li key={it.slug} className="text-[11px] text-zinc-400">
-            <code className="text-zinc-300">{it.slug}</code>
-            <span className="text-zinc-500"> — {it.title}</span>
-            <div className="text-[10.5px] text-zinc-500">{it.remedy}</div>
+          <li key={it.slug} className="text-[11px] text-muted-foreground">
+            <code className="text-foreground">{it.slug}</code>
+            <span className="text-muted-foreground"> — {it.title}</span>
+            <div className="text-[10.5px] text-muted-foreground">{it.remedy}</div>
           </li>
         ))}
       </ul>
@@ -233,16 +235,16 @@ function CurrencySweep({ items }: { items: CurrencyItemWire[] }) {
 
 function FoundationalDue({ items }: { items: FoundationalDueWire[] }) {
   return (
-    <div className="rounded border border-yellow-500/20 bg-yellow-500/[0.04] p-2">
-      <p className="mb-1 text-[11px] font-medium text-yellow-300">
+    <div className="rounded border border-warning/20 bg-warning/[0.04] p-2">
+      <p className="mb-1 text-[11px] font-medium text-warning">
         ⚠ Trajectory check due ({items.length})
       </p>
       <ul className="space-y-1 pl-3">
         {items.map((it) => (
-          <li key={it.slug} className="text-[11px] text-zinc-400">
-            <code className="text-zinc-300">{it.slug}</code>
-            <span className="text-zinc-500"> — {it.title}</span>
-            <div className="text-[10.5px] text-zinc-500">
+          <li key={it.slug} className="text-[11px] text-muted-foreground">
+            <code className="text-foreground">{it.slug}</code>
+            <span className="text-muted-foreground"> — {it.title}</span>
+            <div className="text-[10.5px] text-muted-foreground">
               {it.age_days}d since verify · {it.remedy}
             </div>
           </li>

--- a/clients/react/src/components/producer-console/sections/WhereYouLeftOffSection.tsx
+++ b/clients/react/src/components/producer-console/sections/WhereYouLeftOffSection.tsx
@@ -17,11 +17,11 @@ export function WhereYouLeftOffSection({ data }: WhereYouLeftOffSectionProps) {
   return (
     <section>
       <header className="mb-2 flex items-baseline gap-2">
-        <span className="text-base text-cyan-400">▶</span>
-        <h3 className="text-sm font-semibold text-zinc-200">Where you left off</h3>
+        <span className="text-base text-primary">▶</span>
+        <h3 className="text-sm font-semibold text-foreground">Where you left off</h3>
         {activeProjectName && (
-          <span className="text-xs text-zinc-500">
-            on <code className="text-zinc-300">{activeProjectName}</code>
+          <span className="text-xs text-muted-foreground">
+            on <code className="text-foreground">{activeProjectName}</code>
           </span>
         )}
       </header>
@@ -40,7 +40,7 @@ export function WhereYouLeftOffSection({ data }: WhereYouLeftOffSectionProps) {
 
 function EmptyProject() {
   return (
-    <p className="pl-6 text-xs text-zinc-500">
+    <p className="pl-6 text-xs text-muted-foreground">
       No project scoped yet. Click + on a project in the sidebar to spawn an agent, or pick an
       existing project to focus this view.
     </p>
@@ -49,20 +49,20 @@ function EmptyProject() {
 
 function WorktreeList({ worktrees }: { worktrees: WorktreeBrief[] }) {
   if (worktrees.length === 0) {
-    return <p className="text-xs text-zinc-500">No worktrees discovered yet.</p>;
+    return <p className="text-xs text-muted-foreground">No worktrees discovered yet.</p>;
   }
   return (
     <div>
-      <p className="text-[11px] uppercase tracking-wider text-zinc-500">Worktrees</p>
-      <ul className="mt-1 space-y-0.5 text-xs text-zinc-300">
+      <p className="text-[11px] uppercase tracking-wider text-muted-foreground">Worktrees</p>
+      <ul className="mt-1 space-y-0.5 text-xs text-foreground">
         {worktrees.map((wt) => (
           <li key={`${wt.path}-${wt.name}`} className="flex items-baseline gap-2">
-            <code className="text-zinc-200">
+            <code className="text-foreground">
               {wt.isMain ? "main" : wt.name}
-              {wt.dirty && <span className="ml-1 text-amber-400">●</span>}
+              {wt.dirty && <span className="ml-1 text-warning">●</span>}
             </code>
-            {wt.branch && <span className="text-zinc-500">({wt.branch})</span>}
-            <span className="text-zinc-600">
+            {wt.branch && <span className="text-muted-foreground">({wt.branch})</span>}
+            <span className="text-subtle-foreground">
               {wt.agentCount} agent{wt.agentCount === 1 ? "" : "s"}
             </span>
           </li>
@@ -76,25 +76,26 @@ function AttentionAgentsList({ agents }: { agents: AttentionAgentBrief[] }) {
   if (agents.length === 0) {
     return (
       <div>
-        <p className="text-[11px] uppercase tracking-wider text-zinc-500">Attention</p>
-        <p className="mt-1 text-xs text-zinc-500">
-          No agent is waiting on you on this project. <span className="text-zinc-600">✓</span>
+        <p className="text-[11px] uppercase tracking-wider text-muted-foreground">Attention</p>
+        <p className="mt-1 text-xs text-muted-foreground">
+          No agent is waiting on you on this project.{" "}
+          <span className="text-subtle-foreground">✓</span>
         </p>
       </div>
     );
   }
   return (
     <div>
-      <p className="text-[11px] uppercase tracking-wider text-zinc-500">Attention</p>
-      <ul className="mt-1 space-y-0.5 text-xs text-zinc-300">
+      <p className="text-[11px] uppercase tracking-wider text-muted-foreground">Attention</p>
+      <ul className="mt-1 space-y-0.5 text-xs text-foreground">
         {agents.map((a) => (
           <li key={a.target} className="flex items-baseline gap-2">
             <AttentionGlyph kind={a.attention} />
-            <code className="text-zinc-200">{a.displayName}</code>
+            <code className="text-foreground">{a.displayName}</code>
             {a.isOrchestrator && (
-              <span className="rounded bg-cyan-500/10 px-1 text-[10px] text-cyan-300">orch</span>
+              <span className="rounded bg-primary/10 px-1 text-[10px] text-primary">orch</span>
             )}
-            <span className="text-zinc-600">{a.cwd}</span>
+            <span className="text-subtle-foreground">{a.cwd}</span>
           </li>
         ))}
       </ul>
@@ -109,19 +110,19 @@ function AttentionGlyph({ kind }: { kind: AttentionAgentBrief["attention"] }) {
   switch (kind) {
     case "halted":
       return (
-        <span className="text-amber-400" title="permission/selection prompt">
+        <span className="text-warning" title="permission/selection prompt">
           ◐
         </span>
       );
     case "started":
       return (
-        <span className="text-cyan-300" title="just spawned, awaiting first prompt">
+        <span className="text-primary" title="just spawned, awaiting first prompt">
           ○
         </span>
       );
     case "completed":
       return (
-        <span className="text-zinc-300" title="turn finished, awaiting your next move">
+        <span className="text-foreground" title="turn finished, awaiting your next move">
           ○
         </span>
       );

--- a/clients/react/src/components/producer-console/sections/WorkingWithThisHumanSection.tsx
+++ b/clients/react/src/components/producer-console/sections/WorkingWithThisHumanSection.tsx
@@ -34,9 +34,11 @@ export function WorkingWithThisHumanSection({ unitName }: WorkingWithThisHumanSe
   return (
     <section>
       <header className="mb-2 flex items-baseline gap-2">
-        <span className="text-base text-cyan-400">◐</span>
-        <h3 className="text-sm font-semibold text-zinc-200">Working with this human</h3>
-        {loading && data === null && <span className="text-[10px] text-zinc-500">loading…</span>}
+        <span className="text-base text-primary">◐</span>
+        <h3 className="text-sm font-semibold text-foreground">Working with this human</h3>
+        {loading && data === null && (
+          <span className="text-[10px] text-muted-foreground">loading…</span>
+        )}
       </header>
       <WorkingBody unitName={unitName} data={data} loading={loading} error={error} />
     </section>
@@ -53,11 +55,11 @@ interface WorkingBodyProps {
 function WorkingBody({ unitName, data, loading, error }: WorkingBodyProps) {
   if (unitName === null) {
     return (
-      <div className="pl-6 text-xs text-zinc-500">
+      <div className="pl-6 text-xs text-muted-foreground">
         <p>
           Pick a project (click a unit chip in{" "}
-          <span className="text-zinc-400">⬢ Cross-unit status</span> above, or use the sidebar) to
-          see this unit's memory index and working-with-human context.
+          <span className="text-muted-foreground">⬢ Cross-unit status</span> above, or use the
+          sidebar) to see this unit's memory index and working-with-human context.
         </p>
       </div>
     );
@@ -65,27 +67,27 @@ function WorkingBody({ unitName, data, loading, error }: WorkingBodyProps) {
 
   if (error !== null) {
     return (
-      <div className="pl-6 text-xs text-red-300/80">
+      <div className="pl-6 text-xs text-destructive/80">
         <p>
           Failed to load working-with-human view:{" "}
-          <code className="text-red-300">{error.message}</code>
+          <code className="text-destructive">{error.message}</code>
         </p>
-        <p className="mt-1 text-zinc-500">
-          Baseline norms live in your repo's <code className="text-zinc-300">CLAUDE.md</code>
+        <p className="mt-1 text-muted-foreground">
+          Baseline norms live in your repo's <code className="text-foreground">CLAUDE.md</code>
           {"; per-conversation memory under "}
-          <code className="text-zinc-300">~/.claude/projects/</code>.
+          <code className="text-foreground">~/.claude/projects/</code>.
         </p>
       </div>
     );
   }
 
   if (data === null && loading) {
-    return <div className="pl-6 text-xs text-zinc-500">Loading…</div>;
+    return <div className="pl-6 text-xs text-muted-foreground">Loading…</div>;
   }
 
   if (data === null) {
     return (
-      <div className="pl-6 text-xs text-zinc-500">
+      <div className="pl-6 text-xs text-muted-foreground">
         <p>No data resolved for this unit.</p>
       </div>
     );
@@ -93,16 +95,16 @@ function WorkingBody({ unitName, data, loading, error }: WorkingBodyProps) {
 
   if (data.dir === null) {
     return (
-      <div className="pl-6 text-xs text-zinc-500">
+      <div className="pl-6 text-xs text-muted-foreground">
         <p>
-          No memory directory configured for <code className="text-zinc-300">{data.unit}</code>. The
-          Producer will work from <code className="text-zinc-300">CLAUDE.md</code> + decision
+          No memory directory configured for <code className="text-foreground">{data.unit}</code>.
+          The Producer will work from <code className="text-foreground">CLAUDE.md</code> + decision
           records only.
         </p>
-        <p className="mt-1 text-zinc-600">
-          To opt in: set <code className="text-zinc-300">[[unit]].memory_dir</code> in{" "}
-          <code className="text-zinc-300">~/.config/tmai/config.toml</code>, or create{" "}
-          <code className="text-zinc-300">~/.claude/projects/&lt;slug&gt;/memory/</code> for the
+        <p className="mt-1 text-subtle-foreground">
+          To opt in: set <code className="text-foreground">[[unit]].memory_dir</code> in{" "}
+          <code className="text-foreground">~/.config/tmai/config.toml</code>, or create{" "}
+          <code className="text-foreground">~/.claude/projects/&lt;slug&gt;/memory/</code> for the
           unit's primary repo.
         </p>
       </div>
@@ -111,21 +113,21 @@ function WorkingBody({ unitName, data, loading, error }: WorkingBodyProps) {
 
   return (
     <div className="space-y-2 pl-6 text-xs">
-      <p className="text-zinc-500">
-        Process rules: per repo's <code className="text-zinc-300">CLAUDE.md</code>.
+      <p className="text-muted-foreground">
+        Process rules: per repo's <code className="text-foreground">CLAUDE.md</code>.
         Cross-conversation memory index lives at{" "}
-        <code className="text-[10.5px] text-zinc-400">{data.dir}</code>.
+        <code className="text-[10.5px] text-muted-foreground">{data.dir}</code>.
       </p>
       {data.memory_index === null || data.memory_index.trim() === "" ? (
-        <p className="text-zinc-600">
-          (no <code className="text-zinc-300">MEMORY.md</code> found in this dir yet)
+        <p className="text-subtle-foreground">
+          (no <code className="text-foreground">MEMORY.md</code> found in this dir yet)
         </p>
       ) : (
-        <details className="rounded border border-white/5 bg-white/[0.02]">
-          <summary className="cursor-pointer select-none px-3 py-1.5 text-[11px] text-zinc-300 hover:text-zinc-100">
+        <details className="rounded border border-hairline bg-surface">
+          <summary className="cursor-pointer select-none px-3 py-1.5 text-[11px] text-foreground hover:text-foreground">
             Memory index ({lineCount(data.memory_index)} lines)
           </summary>
-          <div className="prose prose-invert prose-sm max-w-none border-t border-white/5 px-3 py-2 text-zinc-300 [&_a]:text-cyan-300 [&_code]:rounded [&_code]:bg-white/[0.04] [&_code]:px-1 [&_code]:py-px [&_code]:text-zinc-300 [&_h1]:text-sm [&_h1]:font-semibold [&_h2]:text-sm [&_h2]:font-semibold [&_h3]:text-xs [&_h3]:font-semibold [&_li]:my-0.5 [&_ol]:my-1 [&_p]:my-1 [&_pre]:rounded [&_pre]:bg-black/30 [&_pre]:p-2 [&_strong]:text-zinc-200 [&_ul]:my-1">
+          <div className="prose prose-invert prose-sm max-w-none border-t border-hairline px-3 py-2 text-foreground [&_a]:text-primary [&_code]:rounded [&_code]:bg-surface [&_code]:px-1 [&_code]:py-px [&_code]:text-foreground [&_h1]:text-sm [&_h1]:font-semibold [&_h2]:text-sm [&_h2]:font-semibold [&_h3]:text-xs [&_h3]:font-semibold [&_li]:my-0.5 [&_ol]:my-1 [&_p]:my-1 [&_pre]:rounded [&_pre]:bg-background [&_pre]:p-2 [&_strong]:text-foreground [&_ul]:my-1">
             <Markdown remarkPlugins={[remarkGfm]}>{data.memory_index}</Markdown>
           </div>
         </details>

--- a/clients/react/src/lib/__tests__/no-raw-palette.test.ts
+++ b/clients/react/src/lib/__tests__/no-raw-palette.test.ts
@@ -20,7 +20,7 @@ import { describe, expect, it } from "vitest";
 const SRC = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
 // Directories (relative to src/) that have completed the migration.
-const MIGRATED = ["components/settings", "components/worktree"];
+const MIGRATED = ["components/settings", "components/worktree", "components/producer-console"];
 
 // A raw Tailwind palette colour utility: <prefix>-<family>[-<shade>][/<alpha>].
 // Semantic tokens (foreground / surface / primary / hairline / …) do not


### PR DESCRIPTION
**PR D of the semantic-token migration** (follows #700).

## Migration

- **`components/producer-console/`**: 10 files, ~276 codemod substitutions, **zero residual** raw palette, **zero collapsed-ternary** artifacts (guard green). Component logic untouched — className strings only. All colour families were already covered by the dictionary (zinc/white/cyan/red/amber/yellow/emerald/black) — **no token-vocabulary change** needed this PR.
- Regression guard allowlist: **+ `components/producer-console`** (raw-palette and collapsed-ternary checks both green).

## Canonical codemod hardening

Normalised every status/accent family rule to the **full Tailwind shade range** (`SH = 50…900`). A family maps to one semantic token regardless of shade — `red-200` (light error text on a tint) and `red-500` (a fill) are both `destructive`. The previous per-family shade lists missed light tints (e.g. `text-red-200`), which caused per-area residual whack-a-mole. The zinc **text** scale keeps its deliberate `foreground` / `muted-foreground` / `subtle-foreground` tiering (the intended exception).

## Test follow-through

`ProducerCtxHeader.test.tsx` asserted raw palette family names returned by `thresholdColorClass` (`zinc`/`amber`/`red`); updated to assert the semantic tokens (`muted-foreground`/`warning`/`destructive`).

## Gate

`pnpm build && pnpm lint && pnpm test` — green (64 files, **498 passed**, 2 pre-existing skips, guard now covering settings + worktree + producer-console).

Browser-verify still deferred (vite-on-WSL crash risk + no backend) — recommended at review or on request. Next: PR E (`agent/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)