### PR TITLE
feat(webui): migrate agent/ to semantic tokens (PR E)

### DIFF
--- a/clients/react/scripts/theme-codemod.mjs
+++ b/clients/react/scripts/theme-codemod.mjs
@@ -43,7 +43,7 @@ const PREFIX = "(?:text|bg|border|ring|from|via|to|fill|stroke|accent|placeholde
 // shade keeps the mapping consistent and avoids per-area residual
 // whack-a-mole. (The zinc *text* scale is the deliberate exception — it
 // is tiered into foreground/muted/subtle and keeps its own buckets.)
-const SH = "(?:50|100|200|300|400|500|600|700|800|900)";
+const SH = "(?:50|100|200|300|400|500|600|700|800|900|950)";
 
 const RULES = [
   // ── Neutral text scale → foreground / muted / subtle tiers ──
@@ -70,16 +70,24 @@ const RULES = [
   // focus ring is upgraded to ring-primary by hand, matching this
   // codebase's focus convention.)
   [/(?<![\w-])ring-white(?:\/(?:\[[0-9.]+\]|[0-9]{1,3}))?(?![\w-])/g, "ring-hairline-strong"],
+  // Solid white text = emphasised foreground (reads near-white on dark
+  // themes, dark on light — correct contrast either way). Faded white
+  // text (`text-white/70`) = secondary text.
+  [/(?<![\w-])text-white\/(?:\[[0-9.]+\]|[0-9]{1,3})(?![\w-])/g, "text-muted-foreground"],
+  [/(?<![\w-])text-white(?![\w/[-])/g, "text-foreground"],
 
   // ── Neutral fills/borders that aren't white overlays ──
   [/(?<![\w-])bg-zinc-(?:400|500|600)(?![\w-])/g, "bg-muted-foreground"],
   [/(?<![\w-])bg-zinc-(?:700|800|900|950)(?![\w-])/g, "bg-surface-strong"],
-  [/(?<![\w-])border-zinc-(?:600|700|800)(?![\w-])/g, "border-hairline-strong"],
+  [new RegExp(`(?<![\\w-])border-zinc-${SH}(?![\\w-])`, "g"), "border-hairline-strong"],
 
   // ── Accent (cyan is the product accent) → primary ──
   [new RegExp(`(?<![\\w-])(${PREFIX})-cyan-${SH}(?![\\w-])`, "g"), "$1-primary"],
   // ── Status families ──
-  [new RegExp(`(?<![\\w-])(${PREFIX})-red-${SH}(?![\\w-])`, "g"), "$1-destructive"],
+  // red/rose/pink are the destructive/alert family (e.g. AgentCard's
+  // `halted` attention pill used rose, distinct from the cyan/sky/zinc
+  // pills — `destructive` is the right semantic for "blocked / urgent").
+  [new RegExp(`(?<![\\w-])(${PREFIX})-(?:red|rose|pink)-${SH}(?![\\w-])`, "g"), "$1-destructive"],
   [
     new RegExp(`(?<![\\w-])(${PREFIX})-(?:amber|yellow|orange)-${SH}(?![\\w-])`, "g"),
     "$1-warning",

--- a/clients/react/src/components/agent/AgentActions.tsx
+++ b/clients/react/src/components/agent/AgentActions.tsx
@@ -61,15 +61,18 @@ export function AgentActions({ agent, passthrough }: AgentActionsProps) {
   }, [needsPermission, handleApprove]);
 
   return (
-    <div className="glass flex flex-wrap items-center gap-2 border-0 border-b border-white/5 px-3 py-2">
-      <span className="truncate text-sm font-medium text-zinc-300">{agent.display_name}</span>
+    <div className="glass flex flex-wrap items-center gap-2 border-0 border-b border-hairline px-3 py-2">
+      <span className="truncate text-sm font-medium text-foreground">{agent.display_name}</span>
       <span
         className={cn(
           "shrink-0 rounded px-1.5 py-0.5 text-xs",
-          needsPermission && "bg-red-500/20 text-red-400",
-          isProcessing && "bg-cyan-500/20 text-cyan-400",
-          isIdle && "bg-zinc-500/20 text-zinc-400",
-          !needsPermission && !isProcessing && !isIdle && "bg-zinc-700/50 text-zinc-400",
+          needsPermission && "bg-destructive/20 text-destructive",
+          isProcessing && "bg-primary/20 text-primary",
+          isIdle && "bg-muted-foreground/20 text-muted-foreground",
+          !needsPermission &&
+            !isProcessing &&
+            !isIdle &&
+            "bg-surface-strong/50 text-muted-foreground",
         )}
       >
         {name}
@@ -82,7 +85,7 @@ export function AgentActions({ agent, passthrough }: AgentActionsProps) {
           <button
             type="button"
             onClick={handleApprove}
-            className="touch-target-sm rounded-md bg-emerald-500/20 px-3 py-1.5 text-xs font-medium text-emerald-400 transition-colors hover:bg-emerald-500/30"
+            className="touch-target-sm rounded-md bg-success/20 px-3 py-1.5 text-xs font-medium text-success transition-colors hover:bg-success/30"
             title="Ctrl+Enter"
           >
             Approve
@@ -90,7 +93,7 @@ export function AgentActions({ agent, passthrough }: AgentActionsProps) {
           <button
             type="button"
             onClick={handleReject}
-            className="touch-target-sm glass-card rounded-md px-3 py-1.5 text-xs font-medium text-zinc-300 transition-colors"
+            className="touch-target-sm glass-card rounded-md px-3 py-1.5 text-xs font-medium text-foreground transition-colors"
           >
             Reject
           </button>
@@ -100,7 +103,7 @@ export function AgentActions({ agent, passthrough }: AgentActionsProps) {
       <button
         type="button"
         onClick={handleKill}
-        className="touch-target-sm rounded-md px-2 py-1.5 text-xs text-zinc-600 transition-colors hover:text-red-400"
+        className="touch-target-sm rounded-md px-2 py-1.5 text-xs text-subtle-foreground transition-colors hover:text-destructive"
         title="Kill agent"
       >
         Kill

--- a/clients/react/src/components/agent/AgentCard.tsx
+++ b/clients/react/src/components/agent/AgentCard.tsx
@@ -34,26 +34,26 @@ function attentionPill(state: AgentAttention | null): {
       // Cyan = "engaging — agent just spawned, awaiting first prompt".
       // Reuses the visual the legacy "Bootstrap" pill carried.
       label: "Started",
-      style: "bg-cyan-500/20 text-cyan-300 border-cyan-500/30",
+      style: "bg-primary/20 text-primary border-primary/30",
     };
   }
   if (state === "halted") {
     return {
       label: "Halted",
-      style: "bg-rose-500/20 text-rose-300 border-rose-500/30",
+      style: "bg-destructive/20 text-destructive border-destructive/30",
     };
   }
   if (state === "completed") {
     return {
       label: "Done",
-      style: "bg-sky-500/20 text-sky-300 border-sky-500/30",
+      style: "bg-info/20 text-info border-info/30",
     };
   }
   // null — agent is running, no user action needed. Muted styling so
   // the ambient state does not compete with the three blocking pills.
   return {
     label: "Running",
-    style: "bg-zinc-500/10 text-zinc-400 border-zinc-500/20",
+    style: "bg-muted-foreground/10 text-muted-foreground border-hairline-strong/20",
   };
 }
 
@@ -63,24 +63,24 @@ function agentTypeLabel(agentType: AgentType): {
   label: string;
   color: string;
 } {
-  if (agentType === "ClaudeCode") return { icon: "⬡", label: "Claude", color: "text-orange-400" };
-  if (agentType === "CodexCli") return { icon: "◆", label: "Codex", color: "text-green-400" };
-  if (agentType === "GeminiCli") return { icon: "✦", label: "Gemini", color: "text-blue-400" };
-  if (agentType === "OpenCode") return { icon: "◇", label: "OpenCode", color: "text-purple-400" };
+  if (agentType === "ClaudeCode") return { icon: "⬡", label: "Claude", color: "text-warning" };
+  if (agentType === "CodexCli") return { icon: "◆", label: "Codex", color: "text-success" };
+  if (agentType === "GeminiCli") return { icon: "✦", label: "Gemini", color: "text-info" };
+  if (agentType === "OpenCode") return { icon: "◇", label: "OpenCode", color: "text-accent" };
   if (typeof agentType === "object" && "Custom" in agentType)
-    return { icon: "›", label: agentType.Custom, color: "text-zinc-400" };
-  return { icon: "›", label: "agent", color: "text-zinc-400" };
+    return { icon: "›", label: agentType.Custom, color: "text-muted-foreground" };
+  return { icon: "›", label: "agent", color: "text-muted-foreground" };
 }
 
 // Model tier styling: color gradient per model family
 function modelStyle(displayName: string): { color: string; glow: string } {
   const lower = displayName.toLowerCase();
   if (lower.includes("opus"))
-    return { color: "text-amber-400/80", glow: "drop-shadow-[0_0_3px_rgba(251,191,36,0.3)]" };
+    return { color: "text-warning/80", glow: "drop-shadow-[0_0_3px_rgba(251,191,36,0.3)]" };
   if (lower.includes("sonnet"))
-    return { color: "text-violet-400/80", glow: "drop-shadow-[0_0_3px_rgba(167,139,250,0.2)]" };
-  if (lower.includes("haiku")) return { color: "text-emerald-400/70", glow: "" };
-  return { color: "text-zinc-500", glow: "" };
+    return { color: "text-accent/80", glow: "drop-shadow-[0_0_3px_rgba(167,139,250,0.2)]" };
+  if (lower.includes("haiku")) return { color: "text-success/70", glow: "" };
+  return { color: "text-muted-foreground", glow: "" };
 }
 
 // Build tooltip describing detection and send details
@@ -130,7 +130,9 @@ function ChannelBadge({
     <span
       className={cn(
         "rounded-sm px-1 py-px text-[9px] font-medium leading-tight transition-subtle",
-        active ? `${activeColor} border border-current/20` : "text-zinc-700 border border-zinc-800",
+        active
+          ? `${activeColor} border border-current/20`
+          : "text-subtle-foreground border border-hairline-strong",
       )}
     >
       {label}
@@ -182,10 +184,10 @@ export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
       onClick={onClick}
       className={cn(
         "glass-card group w-full rounded-xl px-3 py-2 text-left transition-subtle",
-        "hover:bg-white/[0.08] hover:border-white/10",
-        agent.is_orchestrator && "!border-cyan-500/20 bg-cyan-500/[0.04]",
-        selected && "!border-cyan-500/30 !bg-cyan-500/10",
-        hasAttention && "!border-amber-500/30 animate-glow-pulse",
+        "hover:bg-surface hover:border-hairline-strong",
+        agent.is_orchestrator && "!border-primary/20 bg-primary/[0.04]",
+        selected && "!border-primary/30 !bg-primary/10",
+        hasAttention && "!border-warning/30 animate-glow-pulse",
         glow && selected && glow,
       )}
     >
@@ -193,11 +195,11 @@ export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-1.5 truncate">
           {agent.is_orchestrator && (
-            <span className="shrink-0 rounded border border-cyan-500/30 bg-cyan-500/10 px-1 py-px text-[9px] font-semibold text-cyan-400">
+            <span className="shrink-0 rounded border border-primary/30 bg-primary/10 px-1 py-px text-[9px] font-semibold text-primary">
               ORCH
             </span>
           )}
-          <span className="truncate text-sm font-medium text-zinc-200 group-hover:text-zinc-100 transition-subtle">
+          <span className="truncate text-sm font-medium text-foreground group-hover:text-foreground transition-subtle">
             {isAi ? typeInfo.label : agent.display_name || typeInfo.label}
             {isAi && agent.model_display_name && (
               <span
@@ -225,26 +227,26 @@ export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
       </div>
 
       {/* Row 2: connection channel badges + branch */}
-      <div className="mt-1 flex items-center gap-1 text-xs text-zinc-500 transition-subtle group-hover:text-zinc-400">
+      <div className="mt-1 flex items-center gap-1 text-xs text-muted-foreground transition-subtle group-hover:text-muted-foreground">
         {isAi && (
           <div className="flex items-center gap-0.5" title={tooltip}>
             {(channels.has_hook || channels.has_websocket) && (
               <ChannelBadge
                 label={channels.has_websocket ? "WS" : "Hook"}
                 active={channels.has_hook || channels.has_websocket}
-                activeColor="text-cyan-400"
+                activeColor="text-primary"
               />
             )}
             {(channels.has_ipc ||
               channels.has_hook ||
               channels.has_websocket ||
               channels.has_tmux) && (
-              <ChannelBadge label="IPC" active={channels.has_ipc} activeColor="text-emerald-400" />
+              <ChannelBadge label="IPC" active={channels.has_ipc} activeColor="text-success" />
             )}
             {channels.has_tmux && (
-              <ChannelBadge label="tmux" active={channels.has_tmux} activeColor="text-yellow-400" />
+              <ChannelBadge label="tmux" active={channels.has_tmux} activeColor="text-warning" />
             )}
-            {channels.has_pty && <ChannelBadge label="PTY" active activeColor="text-violet-400" />}
+            {channels.has_pty && <ChannelBadge label="PTY" active activeColor="text-accent" />}
             {/* Fallback: no known channel */}
             {!channels.has_hook &&
               !channels.has_websocket &&
@@ -261,30 +263,30 @@ export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
           <span
             className={cn(
               "truncate text-right",
-              agent.is_worktree ? "text-emerald-600" : "text-zinc-600",
-              "group-hover:text-zinc-500 transition-subtle",
+              agent.is_worktree ? "text-success" : "text-subtle-foreground",
+              "group-hover:text-muted-foreground transition-subtle",
             )}
             title={`${agent.is_worktree ? "worktree: " : "branch: "}${agent.git_branch}${agent.git_dirty ? " (dirty)" : ""}`}
           >
             {agent.is_worktree && "🌿"}
             {agent.git_branch}
-            {agent.git_dirty && <span className="text-amber-500">*</span>}
+            {agent.git_dirty && <span className="text-warning">*</span>}
           </span>
         ) : (
           <span
-            className="truncate text-right text-zinc-600 group-hover:text-zinc-500 transition-subtle"
+            className="truncate text-right text-subtle-foreground group-hover:text-muted-foreground transition-subtle"
             title={agent.cwd}
           >
             {agent.display_cwd}
           </span>
         )}
         {agent.active_subagents > 0 && (
-          <span className="shrink-0 text-zinc-600 group-hover:text-zinc-400 transition-subtle">
+          <span className="shrink-0 text-subtle-foreground group-hover:text-muted-foreground transition-subtle">
             ⑂{agent.active_subagents}
           </span>
         )}
         {agent.compaction_count > 0 && (
-          <span className="shrink-0 text-zinc-600 group-hover:text-zinc-400 transition-subtle">
+          <span className="shrink-0 text-subtle-foreground group-hover:text-muted-foreground transition-subtle">
             ♻{agent.compaction_count}
           </span>
         )}

--- a/clients/react/src/components/agent/AgentList.tsx
+++ b/clients/react/src/components/agent/AgentList.tsx
@@ -38,7 +38,7 @@ export function AgentList({
 
   if (loading) {
     return (
-      <div className="flex flex-1 items-center justify-center text-sm text-zinc-500">
+      <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
         Initializing...
       </div>
     );
@@ -53,18 +53,18 @@ export function AgentList({
           collapsed, opt-in via the Operator override panel or the
           sidebar toggle — so the operator has a direct-agent
           escape hatch. The label below makes that intent visible. */}
-      <div className="mb-2 border-b border-white/5 pb-2">
-        <p className="text-[11px] uppercase tracking-wider text-amber-400/70">
+      <div className="mb-2 border-b border-hairline pb-2">
+        <p className="text-[11px] uppercase tracking-wider text-warning/70">
           Operator view (legacy)
         </p>
-        <p className="mt-0.5 text-[10px] leading-tight text-zinc-600">
+        <p className="mt-0.5 text-[10px] leading-tight text-subtle-foreground">
           Direct agent / project access. The new main flow is the Producer console — use this
           sidebar only when you need to bypass the Producer.
         </p>
       </div>
       <NewAgentLauncher onSpawned={onSpawned} />
       {projects.length === 0 ? (
-        <p className="px-2 py-6 text-center text-xs text-zinc-600">
+        <p className="px-2 py-6 text-center text-xs text-subtle-foreground">
           No agents — pick a directory above to spawn one.
         </p>
       ) : (

--- a/clients/react/src/components/agent/PreviewPanel.tsx
+++ b/clients/react/src/components/agent/PreviewPanel.tsx
@@ -255,7 +255,7 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
               <TranscriptView records={transcriptRecords} />
             </div>
           ) : (
-            <div className="py-4 text-sm text-zinc-600">No transcript records yet</div>
+            <div className="py-4 text-sm text-subtle-foreground">No transcript records yet</div>
           )}
         </div>
       )}
@@ -287,22 +287,22 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
       />
 
       {incomingPrompt && (
-        <div className="mx-3 mb-1 flex items-center gap-1.5 rounded border border-amber-500/20 bg-amber-500/10 px-2 py-1 text-[10px] text-amber-400">
+        <div className="mx-3 mb-1 flex items-center gap-1.5 rounded border border-warning/20 bg-warning/10 px-2 py-1 text-[10px] text-warning">
           <span className="shrink-0">⚠ Incoming notification:</span>
-          <span className="truncate text-amber-300">{incomingPrompt}</span>
+          <span className="truncate text-warning">{incomingPrompt}</span>
         </div>
       )}
 
-      <div className="flex items-center gap-2 border-t border-white/5 px-3 py-1.5">
-        <div className="inline-flex rounded bg-white/5 p-0.5">
+      <div className="flex items-center gap-2 border-t border-hairline px-3 py-1.5">
+        <div className="inline-flex rounded bg-surface p-0.5">
           <button
             type="button"
             onMouseDown={(e) => e.preventDefault()}
             onClick={() => setActiveTab("live")}
             className={`touch-target-sm rounded px-2 py-0.5 text-xs transition-colors ${
               activeTab === "live"
-                ? "bg-cyan-500/20 text-cyan-400"
-                : "text-zinc-500 hover:text-zinc-300"
+                ? "bg-primary/20 text-primary"
+                : "text-muted-foreground hover:text-foreground"
             }`}
             title="Live xterm preview"
           >
@@ -314,8 +314,8 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
             onClick={() => setActiveTab("transcript")}
             className={`touch-target-sm rounded px-2 py-0.5 text-xs transition-colors ${
               activeTab === "transcript"
-                ? "bg-cyan-500/20 text-cyan-400"
-                : "text-zinc-500 hover:text-zinc-300"
+                ? "bg-primary/20 text-primary"
+                : "text-muted-foreground hover:text-foreground"
             }`}
             title="JSONL transcript (heavier; loaded on demand)"
           >
@@ -342,10 +342,10 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
             title="Queued Prompts"
             renderItem={(item) => (
               <div>
-                <p className="truncate text-[11px] text-zinc-200" title={item.prompt}>
+                <p className="truncate text-[11px] text-foreground" title={item.prompt}>
                   {item.prompt}
                 </p>
-                <p className="mt-0.5 text-[10px] text-zinc-500">
+                <p className="mt-0.5 text-[10px] text-muted-foreground">
                   {item.origin && <span className="mr-2">{originLabel(item.origin)}</span>}
                   {new Date(item.queued_at).toLocaleTimeString()}
                 </p>

--- a/clients/react/src/components/agent/TranscriptView.tsx
+++ b/clients/react/src/components/agent/TranscriptView.tsx
@@ -9,33 +9,33 @@ interface TranscriptViewProps {
 
 // Shared prose class names for markdown rendering (matches MarkdownPanel.tsx)
 const PROSE_CLASSES = `prose prose-invert prose-sm max-w-none
-  prose-headings:text-zinc-100 prose-headings:font-semibold
-  prose-p:text-zinc-300 prose-p:leading-relaxed prose-p:my-1
-  prose-a:text-blue-400 prose-a:no-underline hover:prose-a:underline
-  prose-strong:text-zinc-200
-  prose-code:text-cyan-400 prose-code:bg-white/5 prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:before:content-none prose-code:after:content-none
-  prose-pre:bg-zinc-900/50 prose-pre:border prose-pre:border-white/5 prose-pre:rounded-lg prose-pre:my-1
-  prose-li:text-zinc-300 prose-li:my-0
+  prose-headings:text-foreground prose-headings:font-semibold
+  prose-p:text-foreground prose-p:leading-relaxed prose-p:my-1
+  prose-a:text-info prose-a:no-underline hover:prose-a:underline
+  prose-strong:text-foreground
+  prose-code:text-primary prose-code:bg-surface prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:before:content-none prose-code:after:content-none
+  prose-pre:bg-surface-strong/50 prose-pre:border prose-pre:border-hairline prose-pre:rounded-lg prose-pre:my-1
+  prose-li:text-foreground prose-li:my-0
   prose-ul:my-1 prose-ol:my-1
-  prose-th:text-zinc-300 prose-th:border-white/10
-  prose-td:text-zinc-400 prose-td:border-white/10
-  prose-hr:border-white/10
-  prose-blockquote:border-blue-500/30 prose-blockquote:text-zinc-400`;
+  prose-th:text-foreground prose-th:border-hairline-strong
+  prose-td:text-muted-foreground prose-td:border-hairline-strong
+  prose-hr:border-hairline-strong
+  prose-blockquote:border-info/30 prose-blockquote:text-muted-foreground`;
 
 // Tool name color mapping (cyan/teal palette matching Claude Code)
 const TOOL_COLORS: Record<string, string> = {
-  Bash: "text-amber-400",
-  Read: "text-cyan-400",
-  Edit: "text-fuchsia-400",
-  Write: "text-fuchsia-400",
-  Grep: "text-teal-400",
-  Glob: "text-teal-400",
-  Agent: "text-violet-400",
+  Bash: "text-warning",
+  Read: "text-primary",
+  Edit: "text-accent",
+  Write: "text-accent",
+  Grep: "text-success",
+  Glob: "text-success",
+  Agent: "text-accent",
 };
 
 // Get color class for a tool name
 function toolColor(name: string): string {
-  return TOOL_COLORS[name] ?? "text-cyan-400";
+  return TOOL_COLORS[name] ?? "text-primary";
 }
 
 // Truncate a string at a max length
@@ -57,8 +57,8 @@ const UserRecord = memo(function UserRecord({
   const firstLine = record.text.split("\n")[0] ?? record.text;
   return (
     <div className="py-1.5">
-      <span className="text-white font-bold">{"❯ "}</span>
-      <span className="text-white font-semibold">{truncate(firstLine, 200)}</span>
+      <span className="text-foreground font-bold">{"❯ "}</span>
+      <span className="text-foreground font-semibold">{truncate(firstLine, 200)}</span>
     </div>
   );
 });
@@ -88,12 +88,14 @@ const ThinkingRecord = memo(function ThinkingRecord({
   const [open, setOpen] = useState(false);
   return (
     <details className="py-1 group" open={open} onToggle={(e) => setOpen(e.currentTarget.open)}>
-      <summary className="cursor-pointer text-zinc-500 text-xs select-none hover:text-zinc-400 transition-colors">
+      <summary className="cursor-pointer text-muted-foreground text-xs select-none hover:text-muted-foreground transition-colors">
         <span className="mr-1">{"💭"}</span>
         Thinking ({lineCount} {lineCount === 1 ? "line" : "lines"})
       </summary>
       {open && (
-        <div className={`mt-1 pl-4 border-l border-zinc-700/50 text-zinc-500 ${PROSE_CLASSES}`}>
+        <div
+          className={`mt-1 pl-4 border-l border-hairline-strong/50 text-muted-foreground ${PROSE_CLASSES}`}
+        >
           <Markdown remarkPlugins={[remarkGfm]}>{record.text}</Markdown>
         </div>
       )}
@@ -115,18 +117,18 @@ const ToolUseRecord = memo(function ToolUseRecord({
         {"● "}
         <span className="font-medium">{record.tool_name}</span>
       </span>
-      {summary && <span className="text-zinc-500 text-xs ml-1">({summary})</span>}
+      {summary && <span className="text-muted-foreground text-xs ml-1">({summary})</span>}
       {record.input_full && (
         <button
           type="button"
           onClick={() => setShowFull(!showFull)}
-          className="ml-2 text-zinc-600 text-xs hover:text-zinc-400 transition-colors"
+          className="ml-2 text-subtle-foreground text-xs hover:text-muted-foreground transition-colors"
         >
           {showFull ? "▾ hide" : "▸ details"}
         </button>
       )}
       {showFull && record.input_full && (
-        <pre className="mt-1 ml-4 text-xs text-zinc-500 bg-zinc-900/50 border border-white/5 rounded p-2 overflow-x-auto max-h-40">
+        <pre className="mt-1 ml-4 text-xs text-muted-foreground bg-surface-strong/50 border border-hairline rounded p-2 overflow-x-auto max-h-40">
           {JSON.stringify(record.input_full, null, 2)}
         </pre>
       )}
@@ -156,14 +158,18 @@ const ToolResultRecord = memo(function ToolResultRecord({
   return (
     <div
       className={`py-1 pl-3 ml-2 my-0.5 rounded border-l-2 font-mono text-xs leading-relaxed ${
-        isError ? "border-red-500/40 bg-red-950/20" : "border-zinc-700/50 bg-zinc-900/30"
+        isError
+          ? "border-destructive/40 bg-destructive/20"
+          : "border-hairline-strong/50 bg-surface-strong/30"
       }`}
     >
       <div className="flex items-start gap-1">
-        <span className={`shrink-0 ${isError ? "text-red-500" : "text-zinc-600"}`}>⎿</span>
+        <span className={`shrink-0 ${isError ? "text-destructive" : "text-subtle-foreground"}`}>
+          ⎿
+        </span>
         <pre
           className={`whitespace-pre-wrap break-words ${
-            isError ? "text-red-400/80" : "text-zinc-500"
+            isError ? "text-destructive/80" : "text-muted-foreground"
           }`}
         >
           {truncate(visibleText, 600)}
@@ -173,7 +179,7 @@ const ToolResultRecord = memo(function ToolResultRecord({
         <button
           type="button"
           onClick={() => setExpanded(!expanded)}
-          className="mt-1 text-zinc-600 text-[10px] hover:text-zinc-400 transition-colors"
+          className="mt-1 text-subtle-foreground text-[10px] hover:text-muted-foreground transition-colors"
         >
           {expanded ? "▾ collapse" : `▸ ${lines.length} lines — show all`}
         </button>
@@ -184,7 +190,7 @@ const ToolResultRecord = memo(function ToolResultRecord({
 
 // Turn separator — subtle divider rendered before each new user turn
 const TurnSeparator = memo(function TurnSeparator() {
-  return <div className="my-2 border-t border-white/5" />;
+  return <div className="my-2 border-t border-hairline" />;
 });
 
 // Render a single transcript record by type, with optional turn separator
@@ -240,7 +246,7 @@ export function TranscriptView({ records }: TranscriptViewProps) {
         <button
           type="button"
           onClick={() => setShowAll(true)}
-          className="self-start mx-2 my-1 px-2 py-1 text-xs text-zinc-500 hover:text-zinc-300 transition-colors rounded border border-white/5 hover:border-white/10"
+          className="self-start mx-2 my-1 px-2 py-1 text-xs text-muted-foreground hover:text-foreground transition-colors rounded border border-hairline hover:border-hairline-strong"
         >
           ▸ Show {hiddenCount} earlier record{hiddenCount === 1 ? "" : "s"}
         </button>

--- a/clients/react/src/components/agent/__tests__/transcript-view.test.ts
+++ b/clients/react/src/components/agent/__tests__/transcript-view.test.ts
@@ -178,13 +178,14 @@ describe("transcript polling bail-out", () => {
 });
 
 describe("record type styling expectations", () => {
-  it("UserRecord uses ❯ prefix and bold white", () => {
-    // Verify the design contract: user records get the Claude Code prompt style
+  it("UserRecord uses ❯ prefix and bold foreground", () => {
+    // Design contract, post semantic-token migration: user records get
+    // the Claude Code prompt style (text-white → text-foreground).
     const prefix = "❯";
-    const styleClasses = "text-white font-bold";
+    const styleClasses = "text-foreground font-bold";
     expect(prefix).toBe("❯");
     expect(styleClasses).toContain("font-bold");
-    expect(styleClasses).toContain("text-white");
+    expect(styleClasses).toContain("text-foreground");
   });
 
   it("ToolUseRecord uses ● prefix", () => {
@@ -192,15 +193,15 @@ describe("record type styling expectations", () => {
     expect(prefix).toBe("●");
   });
 
-  it("ToolResultRecord uses ⎿ prefix with gray block", () => {
+  it("ToolResultRecord uses ⎿ prefix with a muted surface block", () => {
     const prefix = "⎿";
-    const blockClasses = "border-zinc-700/50 bg-zinc-900/30";
+    const blockClasses = "border-hairline-strong/50 bg-surface-strong/30";
     expect(prefix).toBe("⎿");
-    expect(blockClasses).toContain("bg-zinc-900/30");
+    expect(blockClasses).toContain("bg-surface-strong");
   });
 
-  it("error tool results use red styling", () => {
-    const errorClasses = "border-red-500/40 bg-red-950/20";
-    expect(errorClasses).toContain("red");
+  it("error tool results use destructive styling", () => {
+    const errorClasses = "border-destructive/40 bg-destructive/20";
+    expect(errorClasses).toContain("destructive");
   });
 });

--- a/clients/react/src/lib/__tests__/no-raw-palette.test.ts
+++ b/clients/react/src/lib/__tests__/no-raw-palette.test.ts
@@ -20,7 +20,12 @@ import { describe, expect, it } from "vitest";
 const SRC = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
 // Directories (relative to src/) that have completed the migration.
-const MIGRATED = ["components/settings", "components/worktree", "components/producer-console"];
+const MIGRATED = [
+  "components/settings",
+  "components/worktree",
+  "components/producer-console",
+  "components/agent",
+];
 
 // A raw Tailwind palette colour utility: <prefix>-<family>[-<shade>][/<alpha>].
 // Semantic tokens (foreground / surface / primary / hairline / …) do not


### PR DESCRIPTION
**PR E of the semantic-token migration** (follows #701).

## Migration

- **`components/agent/`**: 5 files, ~140 codemod substitutions, **zero residual** raw palette, **zero collapsed-ternary** artifacts (guard green). className strings only — component logic untouched.
- Regression guard allowlist: **+ `components/agent`** (covers settings + worktree + producer-console + agent).

## Canonical codemod hardening (applies to every remaining area PR)

- **`rose`/`pink` → `destructive`.** `AgentCard`'s `halted` attention pill used `rose`, deliberately distinct from the `started` (cyan→primary), `completed` (sky→info) and `running` (zinc→muted) pills. "Blocked / needs-attention" is semantically the alert token — `destructive`. No token-vocabulary change; no clash with another state in that map.
- **`SH` shade range extended with `950`** — caught `bg-red-950/20` in `TranscriptView`.
- **`text-white` → `text-foreground`** (emphasised text: reads near-white on the dark themes, dark on `light` — correct contrast either way). **`text-white/<alpha>` → `text-muted-foreground`** (faded white = secondary text).
- **`border-zinc` widened to the full shade range → `border-hairline-strong`** (a zinc border is a neutral hairline at any shade; the rule was `600|700|800` only, which left `border-zinc-500/20` residual on the `running` pill).

## Test follow-through

`transcript-view.test.ts` design-contract tests mirrored the old palette literals (`text-white`, `border-zinc-700/bg-zinc-900`, `red`); updated to the migrated semantic tokens (`text-foreground`, `border-hairline-strong/bg-surface-strong`, `destructive`) so the documented contract matches the migrated source.

## Gate

`pnpm build && pnpm lint && pnpm test` — green (64 files, **500 passed**, 2 pre-existing skips).

Browser-verify still deferred (vite-on-WSL crash risk + no backend) — recommended at review or on request. Next: PR F (`layout/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * UI全体のデザイントークン統一を実施。固定色指定からセマンティックなテーマトークン（前景色、背景色、警告色、成功色など）への置き換えで、より一貫性のあるビジュアルデザインを実現しました
  * エージェント表示、トランスクリプトビュー、プレビューパネルなど主要コンポーネントのカラースキームを更新

* **Tests**
  * デザイントークン移行に伴うテスト期待値を更新

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/702?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->