### PR TITLE
feat(webui): migrate layout/ to semantic tokens (PR F)

### DIFF
--- a/clients/react/src/components/layout/ConfirmDialog.tsx
+++ b/clients/react/src/components/layout/ConfirmDialog.tsx
@@ -56,7 +56,7 @@ export function ConfirmProvider({ children }: { children: React.ReactNode }) {
         <div
           role="dialog"
           ref={backdropRef}
-          className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm"
+          className="fixed inset-0 z-50 flex items-center justify-center bg-background backdrop-blur-sm"
           onClick={(e) => {
             if (e.target === backdropRef.current) handleResolve(false);
           }}
@@ -64,16 +64,16 @@ export function ConfirmProvider({ children }: { children: React.ReactNode }) {
             if (e.key === "Escape") handleResolve(false);
           }}
         >
-          <div className="w-full max-w-sm rounded-xl border border-white/10 bg-zinc-900 p-5 shadow-2xl">
+          <div className="w-full max-w-sm rounded-xl border border-hairline-strong bg-surface-strong p-5 shadow-2xl">
             {state.title && (
-              <h3 className="mb-1 text-sm font-semibold text-zinc-100">{state.title}</h3>
+              <h3 className="mb-1 text-sm font-semibold text-foreground">{state.title}</h3>
             )}
-            <p className="text-[13px] leading-relaxed text-zinc-400">{state.message}</p>
+            <p className="text-[13px] leading-relaxed text-muted-foreground">{state.message}</p>
             <div className="mt-4 flex justify-end gap-2">
               <button
                 type="button"
                 onClick={() => handleResolve(false)}
-                className="rounded-lg px-3 py-1.5 text-xs text-zinc-400 transition-colors hover:bg-white/10 hover:text-zinc-200"
+                className="rounded-lg px-3 py-1.5 text-xs text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
               >
                 {state.cancelLabel ?? "Cancel"}
               </button>
@@ -83,8 +83,8 @@ export function ConfirmProvider({ children }: { children: React.ReactNode }) {
                 onClick={() => handleResolve(true)}
                 className={`rounded-lg px-3 py-1.5 text-xs font-medium transition-colors ${
                   state.variant === "danger"
-                    ? "bg-red-500/15 text-red-400 hover:bg-red-500/25"
-                    : "bg-cyan-500/15 text-cyan-400 hover:bg-cyan-500/25"
+                    ? "bg-destructive/15 text-destructive hover:bg-destructive/25"
+                    : "bg-primary/15 text-primary hover:bg-primary/25"
                 }`}
               >
                 {state.confirmLabel ?? "Confirm"}

--- a/clients/react/src/components/layout/DisplayModeSelector.tsx
+++ b/clients/react/src/components/layout/DisplayModeSelector.tsx
@@ -26,8 +26,8 @@ function ModeIcon({ mode, active, onClick, title, children }: ModeIconProps) {
       data-mode={mode}
       className={`flex h-7 w-7 items-center justify-center rounded-md transition-colors ${
         active
-          ? "bg-white/10 text-cyan-400"
-          : "text-zinc-500 hover:bg-white/[0.05] hover:text-zinc-300"
+          ? "bg-surface-strong text-primary"
+          : "text-muted-foreground hover:bg-surface hover:text-foreground"
       }`}
     >
       {children}
@@ -111,7 +111,7 @@ function TripleIcon() {
 // Split-V / Triple display modes for the agent main panel.
 export function DisplayModeSelector({ mode, onChange }: DisplayModeSelectorProps) {
   return (
-    <div className="flex items-center gap-0.5 rounded-lg bg-white/[0.03] p-0.5">
+    <div className="flex items-center gap-0.5 rounded-lg bg-surface p-0.5">
       <ModeIcon
         mode="tabs"
         active={mode === "tabs"}

--- a/clients/react/src/components/layout/HelpOverlay.tsx
+++ b/clients/react/src/components/layout/HelpOverlay.tsx
@@ -31,17 +31,17 @@ export function HelpOverlay({ isOpen, onClose }: HelpOverlayProps) {
   ];
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm">
-      <div className="glass-deep relative w-full max-w-2xl rounded-2xl border border-white/10 shadow-2xl animate-scale-in">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-background backdrop-blur-sm">
+      <div className="glass-deep relative w-full max-w-2xl rounded-2xl border border-hairline-strong shadow-2xl animate-scale-in">
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
-          <h2 className="text-lg font-semibold text-zinc-100">Keyboard Shortcuts</h2>
+        <div className="flex items-center justify-between border-b border-hairline-strong px-6 py-4">
+          <h2 className="text-lg font-semibold text-foreground">Keyboard Shortcuts</h2>
           <button
             type="button"
             onClick={onClose}
-            className="rounded-lg p-2 transition-colors hover:bg-white/10"
+            className="rounded-lg p-2 transition-colors hover:bg-surface-strong"
           >
-            <X size={20} className="text-zinc-400" />
+            <X size={20} className="text-muted-foreground" />
           </button>
         </div>
 
@@ -50,16 +50,16 @@ export function HelpOverlay({ isOpen, onClose }: HelpOverlayProps) {
           <div className="grid grid-cols-2 gap-8">
             {shortcuts.map((section) => (
               <div key={section.category}>
-                <h3 className="mb-3 text-sm font-semibold uppercase text-zinc-500">
+                <h3 className="mb-3 text-sm font-semibold uppercase text-muted-foreground">
                   {section.category}
                 </h3>
                 <div className="space-y-2">
                   {section.items.map((item) => (
                     <div key={item.key} className="flex items-start gap-3">
-                      <kbd className="flex-shrink-0 rounded-lg border border-white/10 bg-white/[0.05] px-2.5 py-1 text-xs font-mono font-semibold text-cyan-400">
+                      <kbd className="flex-shrink-0 rounded-lg border border-hairline-strong bg-surface px-2.5 py-1 text-xs font-mono font-semibold text-primary">
                         {item.key}
                       </kbd>
-                      <p className="text-sm text-zinc-400">{item.description}</p>
+                      <p className="text-sm text-muted-foreground">{item.description}</p>
                     </div>
                   ))}
                 </div>
@@ -69,8 +69,8 @@ export function HelpOverlay({ isOpen, onClose }: HelpOverlayProps) {
         </div>
 
         {/* Footer */}
-        <div className="border-t border-white/10 px-6 py-3 text-center text-xs text-zinc-600">
-          Press <kbd className="rounded border border-white/10 bg-white/[0.05] px-1">ESC</kbd> or
+        <div className="border-t border-hairline-strong px-6 py-3 text-center text-xs text-subtle-foreground">
+          Press <kbd className="rounded border border-hairline-strong bg-surface px-1">ESC</kbd> or
           click the X to close
         </div>
       </div>

--- a/clients/react/src/components/layout/SplitPaneLayout.tsx
+++ b/clients/react/src/components/layout/SplitPaneLayout.tsx
@@ -43,8 +43,8 @@ function TabButton({
       onClick={onClick}
       className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
         active
-          ? "bg-white/10 text-cyan-400"
-          : "text-zinc-500 hover:bg-white/[0.05] hover:text-zinc-300"
+          ? "bg-surface-strong text-primary"
+          : "text-muted-foreground hover:bg-surface hover:text-foreground"
       }`}
     >
       {children}
@@ -83,10 +83,10 @@ export function SplitPaneLayout({
   const dividerStyle = isHorizontal ? { width: "5px" } : { height: "5px" };
   const dividerLineClass = isHorizontal
     ? `h-full w-px transition-colors ${
-        isDragging ? "bg-cyan-500/50" : "bg-white/[0.06] group-hover:bg-cyan-500/30"
+        isDragging ? "bg-primary/50" : "bg-surface group-hover:bg-primary/30"
       }`
     : `h-px w-full transition-colors ${
-        isDragging ? "bg-cyan-500/50" : "bg-white/[0.06] group-hover:bg-cyan-500/30"
+        isDragging ? "bg-primary/50" : "bg-surface group-hover:bg-primary/30"
       }`;
   const handleClass = isHorizontal
     ? "absolute flex flex-col gap-1 opacity-0 transition-opacity group-hover:opacity-100"
@@ -118,14 +118,14 @@ export function SplitPaneLayout({
       >
         <div className={dividerLineClass} />
         <div className={handleClass}>
-          <div className="h-1 w-1 rounded-full bg-zinc-500" />
-          <div className="h-1 w-1 rounded-full bg-zinc-500" />
-          <div className="h-1 w-1 rounded-full bg-zinc-500" />
+          <div className="h-1 w-1 rounded-full bg-muted-foreground" />
+          <div className="h-1 w-1 rounded-full bg-muted-foreground" />
+          <div className="h-1 w-1 rounded-full bg-muted-foreground" />
         </div>
       </div>
 
       <div className="flex flex-col overflow-hidden" style={secondPaneStyle}>
-        <div className="flex shrink-0 items-center gap-1 border-b border-white/[0.06] px-3 py-1.5">
+        <div className="flex shrink-0 items-center gap-1 border-b border-hairline px-3 py-1.5">
           <TabButton active={rightTab === "git"} onClick={() => onTabChange("git")}>
             Git
           </TabButton>

--- a/clients/react/src/components/layout/StatusBar.tsx
+++ b/clients/react/src/components/layout/StatusBar.tsx
@@ -41,12 +41,12 @@ export function StatusBar({
 }: StatusBarProps) {
   if (isMobile) {
     return (
-      <div className="flex items-center justify-between border-b border-white/5 px-3 py-2">
+      <div className="flex items-center justify-between border-b border-hairline px-3 py-2">
         <div className="flex items-center gap-2">
           <button
             type="button"
             onClick={onMobileMenuClick}
-            className="touch-target flex items-center justify-center rounded-lg text-zinc-400 transition-colors hover:bg-white/10 hover:text-cyan-400"
+            className="touch-target flex items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
             title="Open navigation"
             aria-label="Open navigation menu"
           >
@@ -63,11 +63,11 @@ export function StatusBar({
               <path d="M3 5h14M3 10h14M3 15h14" />
             </svg>
           </button>
-          <span className="bg-gradient-to-r from-cyan-400 to-blue-400 bg-clip-text text-sm font-bold tracking-wide text-transparent">
+          <span className="bg-gradient-to-r from-[var(--brand-from)] to-[var(--brand-to)] bg-clip-text text-sm font-bold tracking-wide text-transparent">
             tmai
           </span>
           {attentionCount > 0 && (
-            <span className="glow-amber rounded-full bg-amber-500/15 px-2 py-0.5 text-xs text-amber-400">
+            <span className="glow-amber rounded-full bg-warning/15 px-2 py-0.5 text-xs text-warning">
               {attentionCount}
             </span>
           )}
@@ -77,7 +77,7 @@ export function StatusBar({
             <button
               type="button"
               onClick={onReturnToConsole}
-              className="touch-target flex items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400"
+              className="touch-target flex items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
               title="Return to Producer console"
               aria-label="Return to Producer console"
             >
@@ -87,7 +87,7 @@ export function StatusBar({
           <button
             type="button"
             onClick={onSecurityClick}
-            className="touch-target flex items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400"
+            className="touch-target flex items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
             title="Config Audit"
           >
             🛡
@@ -95,7 +95,7 @@ export function StatusBar({
           <button
             type="button"
             onClick={onSettingsClick}
-            className="touch-target flex items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400"
+            className="touch-target flex items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
             title="Settings"
           >
             ⚙
@@ -107,11 +107,11 @@ export function StatusBar({
 
   if (collapsed) {
     return (
-      <div className="flex flex-col items-center gap-2 border-b border-white/5 px-2 py-3">
+      <div className="flex flex-col items-center gap-2 border-b border-hairline px-2 py-3">
         <button
           type="button"
           onClick={onToggleCollapse}
-          className="rounded px-1.5 py-0.5 text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400"
+          className="rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
           title="Expand sidebar"
         >
           <svg
@@ -126,14 +126,14 @@ export function StatusBar({
             <path d="M6 3l5 5-5 5" />
           </svg>
         </button>
-        <span className="bg-gradient-to-r from-cyan-400 to-blue-400 bg-clip-text text-xs font-bold text-transparent">
+        <span className="bg-gradient-to-r from-[var(--brand-from)] to-[var(--brand-to)] bg-clip-text text-xs font-bold text-transparent">
           tm
         </span>
         {onReturnToConsole && (
           <button
             type="button"
             onClick={onReturnToConsole}
-            className="rounded px-1.5 py-0.5 text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400"
+            className="rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
             title="Return to Producer console"
             aria-label="Return to Producer console"
           >
@@ -141,7 +141,7 @@ export function StatusBar({
           </button>
         )}
         {attentionCount > 0 && (
-          <span className="glow-amber rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] text-amber-400">
+          <span className="glow-amber rounded-full bg-warning/15 px-1.5 py-0.5 text-[10px] text-warning">
             {attentionCount}
           </span>
         )}
@@ -150,13 +150,13 @@ export function StatusBar({
   }
 
   return (
-    <div className="flex items-center justify-between border-b border-white/5 px-4 py-3">
+    <div className="flex items-center justify-between border-b border-hairline px-4 py-3">
       <div className="flex items-center gap-2">
         {onToggleCollapse && (
           <button
             type="button"
             onClick={onToggleCollapse}
-            className="rounded px-1 py-0.5 text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400"
+            className="rounded px-1 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
             title="Collapse sidebar"
           >
             <svg
@@ -172,14 +172,14 @@ export function StatusBar({
             </svg>
           </button>
         )}
-        <span className="bg-gradient-to-r from-cyan-400 to-blue-400 bg-clip-text text-sm font-bold tracking-wide text-transparent">
+        <span className="bg-gradient-to-r from-[var(--brand-from)] to-[var(--brand-to)] bg-clip-text text-sm font-bold tracking-wide text-transparent">
           tmai
         </span>
       </div>
       <div className="flex items-center gap-2 text-xs">
-        <span className="text-zinc-500">{agentCount} agents</span>
+        <span className="text-muted-foreground">{agentCount} agents</span>
         {attentionCount > 0 && (
-          <span className="glow-amber rounded-full bg-amber-500/15 px-2.5 py-0.5 text-amber-400">
+          <span className="glow-amber rounded-full bg-warning/15 px-2.5 py-0.5 text-warning">
             {attentionCount}
           </span>
         )}
@@ -188,7 +188,7 @@ export function StatusBar({
           <button
             type="button"
             onClick={onReturnToConsole}
-            className="rounded px-1.5 py-0.5 text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400"
+            className="rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
             title="Return to Producer console"
             aria-label="Return to Producer console"
           >
@@ -198,7 +198,7 @@ export function StatusBar({
         <button
           type="button"
           onClick={onSecurityClick}
-          className="rounded px-1.5 py-0.5 text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400"
+          className="rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
           title="Config Audit"
         >
           🛡
@@ -206,7 +206,7 @@ export function StatusBar({
         <button
           type="button"
           onClick={onSettingsClick}
-          className="rounded px-1.5 py-0.5 text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400"
+          className="rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
           title="Settings"
         >
           ⚙

--- a/clients/react/src/components/layout/TabbedPaneLayout.tsx
+++ b/clients/react/src/components/layout/TabbedPaneLayout.tsx
@@ -25,8 +25,8 @@ function TabButton({
       onClick={onClick}
       className={`rounded-md px-3 py-1 text-xs font-medium transition-colors ${
         active
-          ? "bg-white/10 text-cyan-400"
-          : "text-zinc-500 hover:bg-white/[0.05] hover:text-zinc-300"
+          ? "bg-surface-strong text-primary"
+          : "text-muted-foreground hover:bg-surface hover:text-foreground"
       }`}
     >
       {children}
@@ -47,7 +47,7 @@ export function TabbedPaneLayout({
 }: TabbedPaneLayoutProps) {
   return (
     <div className="flex h-full flex-1 flex-col overflow-hidden">
-      <div className="flex shrink-0 items-center gap-1 border-b border-white/[0.06] px-3 py-1.5">
+      <div className="flex shrink-0 items-center gap-1 border-b border-hairline px-3 py-1.5">
         <TabButton active={active === "preview"} onClick={() => onTabChange("preview")}>
           Preview
         </TabButton>

--- a/clients/react/src/components/layout/ToastContainer.tsx
+++ b/clients/react/src/components/layout/ToastContainer.tsx
@@ -49,21 +49,21 @@ function ToastItem({ toast, onRemove }: ToastItemProps) {
   };
 
   const bgColors = {
-    info: "bg-blue-500/10 border-blue-500/20",
-    success: "bg-emerald-500/10 border-emerald-500/20",
-    error: "bg-red-500/10 border-red-500/20",
+    info: "bg-info/10 border-info/20",
+    success: "bg-success/10 border-success/20",
+    error: "bg-destructive/10 border-destructive/20",
   };
 
   const iconColors = {
-    info: "text-blue-400",
-    success: "text-emerald-400",
-    error: "text-red-400",
+    info: "text-info",
+    success: "text-success",
+    error: "text-destructive",
   };
 
   const textColors = {
-    info: "text-blue-100",
-    success: "text-emerald-100",
-    error: "text-red-100",
+    info: "text-info",
+    success: "text-success",
+    error: "text-destructive",
   };
 
   return (
@@ -78,9 +78,9 @@ function ToastItem({ toast, onRemove }: ToastItemProps) {
       <button
         type="button"
         onClick={() => onRemove(toast.id)}
-        className="flex-shrink-0 rounded p-0.5 transition-colors hover:bg-white/10"
+        className="flex-shrink-0 rounded p-0.5 transition-colors hover:bg-surface-strong"
       >
-        <X size={14} className="text-zinc-500 hover:text-zinc-300" />
+        <X size={14} className="text-muted-foreground hover:text-foreground" />
       </button>
     </div>
   );

--- a/clients/react/src/components/layout/TriplePaneLayout.tsx
+++ b/clients/react/src/components/layout/TriplePaneLayout.tsx
@@ -37,10 +37,10 @@ function Divider({
   const containerStyle = isHorizontal ? { width: "5px" } : { height: "5px" };
   const lineClass = isHorizontal
     ? `h-full w-px transition-colors ${
-        isDragging ? "bg-cyan-500/50" : "bg-white/[0.06] group-hover:bg-cyan-500/30"
+        isDragging ? "bg-primary/50" : "bg-surface group-hover:bg-primary/30"
       }`
     : `h-px w-full transition-colors ${
-        isDragging ? "bg-cyan-500/50" : "bg-white/[0.06] group-hover:bg-cyan-500/30"
+        isDragging ? "bg-primary/50" : "bg-surface group-hover:bg-primary/30"
       }`;
   return (
     // biome-ignore lint/a11y/useSemanticElements: <hr> cannot serve as a draggable split handle
@@ -111,8 +111,8 @@ export function TriplePaneLayout({ preview, git, markdown }: TriplePaneLayoutPro
         style={{ width: rightPercent }}
       >
         <div className="flex flex-col overflow-hidden" style={{ height: topPercent }}>
-          <div className="flex shrink-0 items-center gap-1 border-b border-white/[0.06] px-3 py-1.5">
-            <span className="rounded-md px-3 py-1 text-xs font-medium text-cyan-400">Git</span>
+          <div className="flex shrink-0 items-center gap-1 border-b border-hairline px-3 py-1.5">
+            <span className="rounded-md px-3 py-1 text-xs font-medium text-primary">Git</span>
           </div>
           <div className="flex flex-1 flex-col overflow-hidden">{git}</div>
         </div>
@@ -127,8 +127,8 @@ export function TriplePaneLayout({ preview, git, markdown }: TriplePaneLayoutPro
         />
 
         <div className="flex flex-col overflow-hidden" style={{ height: bottomPercent }}>
-          <div className="flex shrink-0 items-center gap-1 border-b border-white/[0.06] px-3 py-1.5">
-            <span className="rounded-md px-3 py-1 text-xs font-medium text-cyan-400">Docs</span>
+          <div className="flex shrink-0 items-center gap-1 border-b border-hairline px-3 py-1.5">
+            <span className="rounded-md px-3 py-1 text-xs font-medium text-primary">Docs</span>
           </div>
           <div className="flex flex-1 flex-col overflow-hidden">{markdown}</div>
         </div>

--- a/clients/react/src/lib/__tests__/no-raw-palette.test.ts
+++ b/clients/react/src/lib/__tests__/no-raw-palette.test.ts
@@ -25,6 +25,7 @@ const MIGRATED = [
   "components/worktree",
   "components/producer-console",
   "components/agent",
+  "components/layout",
 ];
 
 // A raw Tailwind palette colour utility: <prefix>-<family>[-<shade>][/<alpha>].


### PR DESCRIPTION
**PR F of the semantic-token migration** (follows #702).

## Migration

- **`components/layout/`**: 8 files, ~121 codemod substitutions, **zero residual** raw palette, **zero collapsed-ternary** artifacts (guard green). className strings only.
- Regression guard allowlist: **+ `components/layout`** (covers settings + worktree + producer-console + agent + layout).

## Manual fixup — the "tmai" brand wordmark

`StatusBar.tsx` rendered the brand wordmark with `bg-gradient-to-r from-cyan-400 to-blue-400 bg-clip-text text-transparent` in 3 places (mobile / collapsed / expanded). A generic codemod can't distinguish the brand wordmark from any other cyan→blue gradient, so this is wired by hand to the **brand fx vars introduced in PR A**: `from-[var(--brand-from)] to-[var(--brand-to)]`. It now follows the active theme (tokyonight `#22d3ee→#60a5fa`, light `#2e7de9→#9854f1`, zinc faithful) instead of being collapsed into `primary→info`. Applied **before** the codemod so there's no convert/revert churn.

No codemod-dictionary or token-vocabulary change this PR — brand-vs-generic-gradient is intentionally a targeted manual call, not a rule.

## Gate

`pnpm build && pnpm lint && pnpm test` — green (64 files, **502 passed**, 2 pre-existing skips).

Browser-verify still deferred (vite-on-WSL crash risk + no backend) — recommended at review or on request. Next: PR G (`calibration/` + `markdown/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)