### PR TITLE
feat(webui): migrate calibration/ + markdown/ to semantic tokens (PR G)

### DIFF
--- a/clients/react/src/components/calibration/CalibrationChip.tsx
+++ b/clients/react/src/components/calibration/CalibrationChip.tsx
@@ -31,7 +31,7 @@ export function CalibrationChip({ data, onClick }: CalibrationChipProps) {
       <button
         type="button"
         onClick={onClick}
-        className="glow-red rounded-full bg-red-500/20 px-2.5 py-0.5 text-[11px] font-semibold text-red-300 hover:bg-red-500/30 transition-colors"
+        className="glow-red rounded-full bg-destructive/20 px-2.5 py-0.5 text-[11px] font-semibold text-destructive hover:bg-destructive/30 transition-colors"
         title={`${tripwire} tier-1 tripwire violation(s) — DR §B.4 zero tolerance`}
       >
         ⚡ {tripwire}
@@ -47,7 +47,7 @@ export function CalibrationChip({ data, onClick }: CalibrationChipProps) {
     <button
       type="button"
       onClick={onClick}
-      className="rounded-full bg-zinc-700/50 px-2 py-0.5 text-[11px] text-zinc-400 hover:bg-zinc-700/80 hover:text-zinc-200 transition-colors"
+      className="rounded-full bg-surface-strong/50 px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-surface-strong/80 hover:text-foreground transition-colors"
       title={`${data.total_in_window}/${data.total_in_store} calibration entries — click for details`}
     >
       cal {data.total_in_window}

--- a/clients/react/src/components/calibration/CalibrationPanel.tsx
+++ b/clients/react/src/components/calibration/CalibrationPanel.tsx
@@ -27,27 +27,27 @@ export function CalibrationPanel({ unit, onClose }: CalibrationPanelProps) {
 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
-      <header className="flex items-center justify-between border-b border-white/5 px-6 py-4">
+      <header className="flex items-center justify-between border-b border-hairline px-6 py-4">
         <div>
-          <h2 className="text-lg font-semibold text-zinc-200">Calibration</h2>
-          <p className="text-xs text-zinc-500">
-            Unit: <code className="text-zinc-300">{unit}</code> · DR §B.3 read-only window into
+          <h2 className="text-lg font-semibold text-foreground">Calibration</h2>
+          <p className="text-xs text-muted-foreground">
+            Unit: <code className="text-foreground">{unit}</code> · DR §B.3 read-only window into
             Producer hit-rate
           </p>
         </div>
         <button
           type="button"
           onClick={onClose}
-          className="rounded-md px-3 py-1 text-sm text-zinc-500 transition-colors hover:bg-white/10 hover:text-zinc-300"
+          className="rounded-md px-3 py-1 text-sm text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
         >
           Close
         </button>
       </header>
 
       <div className="flex-1 space-y-6 overflow-y-auto px-6 py-4 text-sm">
-        {loading && !data && <p className="text-zinc-500">Loading…</p>}
+        {loading && !data && <p className="text-muted-foreground">Loading…</p>}
         {error && !data && (
-          <p className="text-red-400">
+          <p className="text-destructive">
             Failed to load calibration: <code>{error.message}</code>
           </p>
         )}
@@ -66,22 +66,22 @@ function CalibrationContent({
   const shallow = !empty && data.total_in_store < data.bootstrap_threshold;
   return (
     <>
-      <section className="rounded-md border border-white/5 bg-white/[0.02] px-4 py-3">
-        <p className="text-xs uppercase tracking-wider text-zinc-500">Window</p>
-        <p className="mt-1 text-zinc-200">
+      <section className="rounded-md border border-hairline bg-surface px-4 py-3">
+        <p className="text-xs uppercase tracking-wider text-muted-foreground">Window</p>
+        <p className="mt-1 text-foreground">
           {data.days === 0 ? "Whole store" : `Last ${data.days} days`}{" "}
-          <span className="text-zinc-500">
+          <span className="text-muted-foreground">
             ({data.total_in_window} entries; {data.total_in_store} in store)
           </span>
         </p>
         {empty && (
-          <p className="mt-2 text-xs text-zinc-500">
+          <p className="mt-2 text-xs text-muted-foreground">
             Store is empty. The Producer has not recorded any triage verdicts for this unit yet —
             run <code>tmai producer {data.unit} --synthesize</code> to start one.
           </p>
         )}
         {shallow && (
-          <p className="mt-2 text-xs text-amber-300/80">
+          <p className="mt-2 text-xs text-warning/80">
             Only {data.total_in_store} entries in the store (&lt; {data.bootstrap_threshold}{" "}
             bootstrap threshold). Numbers below carry low confidence; lean toward asking the human,
             not these stats. (DR §B.5)
@@ -102,16 +102,16 @@ function CellTable({ cells }: { cells: CalibrationCellWire[] }) {
   if (cells.length === 0) {
     return (
       <section>
-        <h3 className="text-xs uppercase tracking-wider text-zinc-500">Verdicts</h3>
-        <p className="mt-2 text-zinc-500">(no entries in this window)</p>
+        <h3 className="text-xs uppercase tracking-wider text-muted-foreground">Verdicts</h3>
+        <p className="mt-2 text-muted-foreground">(no entries in this window)</p>
       </section>
     );
   }
   return (
     <section>
-      <h3 className="text-xs uppercase tracking-wider text-zinc-500">Verdicts</h3>
+      <h3 className="text-xs uppercase tracking-wider text-muted-foreground">Verdicts</h3>
       <table className="mt-2 w-full text-left">
-        <thead className="text-[11px] uppercase tracking-wider text-zinc-500">
+        <thead className="text-[11px] uppercase tracking-wider text-muted-foreground">
           <tr>
             <th className="px-2 py-1 font-medium">Verdict</th>
             <th className="px-2 py-1 font-medium">Confidence</th>
@@ -121,24 +121,28 @@ function CellTable({ cells }: { cells: CalibrationCellWire[] }) {
             <th className="px-2 py-1 text-right font-medium">accuracy</th>
           </tr>
         </thead>
-        <tbody className="text-zinc-300">
+        <tbody className="text-foreground">
           {cells.map((c) => {
             const accuracy = c.n === 0 ? null : (c.hits / c.n) * 100;
             const smallN = c.n < 5;
             return (
-              <tr key={`${c.verdict}-${c.confidence}`} className="border-t border-white/5">
+              <tr key={`${c.verdict}-${c.confidence}`} className="border-t border-hairline">
                 <td className="px-2 py-1 font-mono text-xs">{c.verdict}</td>
                 <td className="px-2 py-1 font-mono text-xs">{c.confidence}</td>
                 <td className="px-2 py-1 text-right tabular-nums">{c.n}</td>
-                <td className="px-2 py-1 text-right tabular-nums text-emerald-400/90">{c.hits}</td>
-                <td className="px-2 py-1 text-right tabular-nums text-red-400/90">{c.misses}</td>
+                <td className="px-2 py-1 text-right tabular-nums text-success/90">{c.hits}</td>
+                <td className="px-2 py-1 text-right tabular-nums text-destructive/90">
+                  {c.misses}
+                </td>
                 <td className="px-2 py-1 text-right tabular-nums">
                   {accuracy === null ? (
-                    <span className="text-zinc-500">—</span>
+                    <span className="text-muted-foreground">—</span>
                   ) : (
                     <>
                       {accuracy.toFixed(1)}%
-                      {smallN && <span className="ml-1 text-[10px] text-zinc-500">(small n)</span>}
+                      {smallN && (
+                        <span className="ml-1 text-[10px] text-muted-foreground">(small n)</span>
+                      )}
                     </>
                   )}
                 </td>
@@ -155,30 +159,32 @@ function FalseNegativesList({ entries }: { entries: CalibrationEntry[] }) {
   if (entries.length === 0) {
     return (
       <section>
-        <h3 className="text-xs uppercase tracking-wider text-zinc-500">False-negative recents</h3>
-        <p className="mt-2 text-zinc-500">none</p>
+        <h3 className="text-xs uppercase tracking-wider text-muted-foreground">
+          False-negative recents
+        </h3>
+        <p className="mt-2 text-muted-foreground">none</p>
       </section>
     );
   }
   return (
     <section>
-      <h3 className="text-xs uppercase tracking-wider text-zinc-500">
+      <h3 className="text-xs uppercase tracking-wider text-muted-foreground">
         False-negative recents (newest first)
       </h3>
-      <ul className="mt-2 space-y-1 text-xs text-zinc-300">
+      <ul className="mt-2 space-y-1 text-xs text-foreground">
         {entries.slice(0, 10).map((e) => (
           <li key={`${e.synthesis_pass_id}-${e.note_source}`}>
-            <span className="text-zinc-500">{e.recorded_at.slice(0, 10)}</span>{" "}
-            <code className="text-zinc-200">{e.verdict}</code>{" "}
-            <span className="text-zinc-500">
+            <span className="text-muted-foreground">{e.recorded_at.slice(0, 10)}</span>{" "}
+            <code className="text-foreground">{e.verdict}</code>{" "}
+            <span className="text-muted-foreground">
               {e.confidence} (tier {e.tier_routed})
             </span>{" "}
-            &ldquo;<code className="text-zinc-300">{e.note_source}</code>&rdquo;:{" "}
+            &ldquo;<code className="text-foreground">{e.note_source}</code>&rdquo;:{" "}
             {e.outcome ? <OutcomeSummary outcome={e.outcome} /> : <span>?</span>}
           </li>
         ))}
         {entries.length > 10 && (
-          <li className="text-zinc-500 italic">... and {entries.length - 10} more</li>
+          <li className="text-muted-foreground italic">... and {entries.length - 10} more</li>
         )}
       </ul>
     </section>
@@ -218,22 +224,22 @@ function Tier1Counter({ routed, violations }: { routed: number; violations: Cali
     <section
       className={
         clean
-          ? "rounded-md border border-white/5 bg-white/[0.02] px-4 py-3"
-          : "rounded-md border border-red-500/40 bg-red-950/30 px-4 py-3"
+          ? "rounded-md border border-hairline bg-surface px-4 py-3"
+          : "rounded-md border border-destructive/40 bg-destructive/30 px-4 py-3"
       }
     >
-      <p className="text-xs uppercase tracking-wider text-zinc-500">Tier-1 routings</p>
-      <p className="mt-1 text-zinc-200">
+      <p className="text-xs uppercase tracking-wider text-muted-foreground">Tier-1 routings</p>
+      <p className="mt-1 text-foreground">
         {routed} (violations: {violations.length}{" "}
         {clean ? (
-          <span className="text-emerald-400">✓</span>
+          <span className="text-success">✓</span>
         ) : (
-          <span className="text-red-300">⚠</span>
+          <span className="text-destructive">⚠</span>
         )}
         )
       </p>
       {!clean && (
-        <p className="mt-2 text-xs text-red-300/80">
+        <p className="mt-2 text-xs text-destructive/80">
           Tier-1 violations are zero-tolerance (DR §B.4). Each non-
           <code>escalate</code> verdict routed to tier-1 is either a tier-gate bug or a Producer
           posture failure — review the entries above and decide whether to tighten the gate or the

--- a/clients/react/src/components/calibration/TripwireBanner.tsx
+++ b/clients/react/src/components/calibration/TripwireBanner.tsx
@@ -21,42 +21,42 @@ export function TripwireBanner({ data, onDetailsClick }: TripwireBannerProps) {
   }
   const violations = data.tier1_violations;
   return (
-    <div className="border-b border-red-500/40 bg-red-950/40 px-4 py-2.5">
+    <div className="border-b border-destructive/40 bg-destructive/40 px-4 py-2.5">
       <div className="flex items-start gap-3">
-        <span className="text-lg leading-none text-red-300">⚡</span>
+        <span className="text-lg leading-none text-destructive">⚡</span>
         <div className="flex-1 text-sm">
-          <div className="font-semibold text-red-200">
+          <div className="font-semibold text-destructive">
             TIER-1 TRIPWIRE TRIGGERED{" "}
-            <span className="font-normal text-red-300/70">
+            <span className="font-normal text-destructive/70">
               ({violations.length} violation{violations.length === 1 ? "" : "s"} on{" "}
-              <code className="text-red-200/90">{data.unit}</code>)
+              <code className="text-destructive/90">{data.unit}</code>)
             </span>
           </div>
-          <p className="mt-1 text-xs text-red-300/80">
+          <p className="mt-1 text-xs text-destructive/80">
             Tier-1 is human-gated only (<code>escalate</code> is the only valid verdict). Each item
             below is a non-<code>escalate</code> verdict routed to tier-1 — review whether the
             tier-1 grade was wrong (tighten the tier-gate) or the Producer&apos;s posture was wrong
             (tighten the posture). DR §B.4: zero tolerance.
           </p>
-          <ul className="mt-2 space-y-1 text-xs text-red-200/90">
+          <ul className="mt-2 space-y-1 text-xs text-destructive/90">
             {violations.slice(0, 5).map((v) => (
               <li key={`${v.synthesis_pass_id}-${v.note_source}`}>
-                <code className="text-red-200">{v.note_source}</code>{" "}
-                <span className="text-red-300/70">
+                <code className="text-destructive">{v.note_source}</code>{" "}
+                <span className="text-destructive/70">
                   ({v.verdict}, confidence {v.confidence})
                 </span>{" "}
                 — {v.rationale}
               </li>
             ))}
             {violations.length > 5 && (
-              <li className="text-red-300/60 italic">... and {violations.length - 5} more</li>
+              <li className="text-destructive/60 italic">... and {violations.length - 5} more</li>
             )}
           </ul>
           {onDetailsClick && (
             <button
               type="button"
               onClick={onDetailsClick}
-              className="mt-2 text-xs text-red-300/80 underline-offset-2 hover:underline hover:text-red-200"
+              className="mt-2 text-xs text-destructive/80 underline-offset-2 hover:underline hover:text-destructive"
             >
               Open calibration panel →
             </button>

--- a/clients/react/src/components/calibration/__tests__/CalibrationChip.test.tsx
+++ b/clients/react/src/components/calibration/__tests__/CalibrationChip.test.tsx
@@ -41,7 +41,7 @@ describe("CalibrationChip", () => {
     );
     const btn = screen.getByRole("button");
     expect(btn.textContent).toContain("cal 2");
-    expect(btn.className).toContain("zinc"); // muted, not red
+    expect(btn.className).toContain("muted-foreground"); // muted, not destructive
   });
 
   it("renders the urgent ⚡N chip when tier-1 tripwire violations exist", () => {
@@ -65,6 +65,6 @@ describe("CalibrationChip", () => {
     render(<CalibrationChip data={tripped} onClick={vi.fn()} />);
     const btn = screen.getByRole("button");
     expect(btn.textContent ?? "").toMatch(/⚡\s*1/);
-    expect(btn.className).toContain("red");
+    expect(btn.className).toContain("destructive");
   });
 });

--- a/clients/react/src/components/markdown/MarkdownPanel.tsx
+++ b/clients/react/src/components/markdown/MarkdownPanel.tsx
@@ -105,9 +105,9 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
   const fileTree = (
     <>
       {loading ? (
-        <div className="px-3 py-2 text-xs text-zinc-500">Loading...</div>
+        <div className="px-3 py-2 text-xs text-muted-foreground">Loading...</div>
       ) : tree.length === 0 ? (
-        <div className="px-3 py-2 text-xs text-zinc-500">No markdown files</div>
+        <div className="px-3 py-2 text-xs text-muted-foreground">No markdown files</div>
       ) : (
         <TreeNode entries={tree} selectedFile={selectedFile} onSelect={loadFile} depth={0} />
       )}
@@ -117,13 +117,13 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
   return (
     <div className="flex flex-1 flex-col overflow-hidden">
       {/* Header */}
-      <div className="glass shrink-0 border-b border-white/5 px-4 py-3">
+      <div className="glass shrink-0 border-b border-hairline px-4 py-3">
         <div className="flex items-center gap-3">
           {/* Mobile: toggle file tree button */}
           <button
             type="button"
             onClick={() => setTreeOpen((v) => !v)}
-            className="touch-target flex items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-white/10 hover:text-zinc-300 md:hidden"
+            className="touch-target flex items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground md:hidden"
             title="Toggle file list"
             aria-label="Toggle file list"
           >
@@ -147,7 +147,7 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
             height="20"
             viewBox="0 0 16 16"
             fill="none"
-            className="hidden shrink-0 text-blue-400 md:block"
+            className="hidden shrink-0 text-info md:block"
             role="img"
             aria-label="Document icon"
           >
@@ -190,8 +190,8 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
               opacity="0.5"
             />
           </svg>
-          <h2 className="truncate text-base font-semibold text-zinc-100">{projectName}</h2>
-          <span className="shrink-0 text-xs text-zinc-500">Markdown</span>
+          <h2 className="truncate text-base font-semibold text-foreground">{projectName}</h2>
+          <span className="shrink-0 text-xs text-muted-foreground">Markdown</span>
         </div>
       </div>
 
@@ -202,42 +202,42 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
             {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop tap to close */}
             {/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop tap to close */}
             <div
-              className="absolute inset-0 z-10 bg-black/50 md:hidden"
+              className="absolute inset-0 z-10 bg-background md:hidden"
               onClick={() => setTreeOpen(false)}
             />
-            <div className="absolute inset-y-0 left-0 z-20 w-56 overflow-y-auto border-r border-white/5 bg-zinc-950 py-2 md:hidden animate-slide-in-left">
+            <div className="absolute inset-y-0 left-0 z-20 w-56 overflow-y-auto border-r border-hairline bg-surface-strong py-2 md:hidden animate-slide-in-left">
               {fileTree}
             </div>
           </>
         )}
 
         {/* Desktop: file tree as persistent sidebar */}
-        <div className="hidden w-56 shrink-0 overflow-y-auto border-r border-white/5 bg-black/10 py-2 md:block">
+        <div className="hidden w-56 shrink-0 overflow-y-auto border-r border-hairline bg-background py-2 md:block">
           {fileTree}
         </div>
 
         {/* Right: Preview / Editor */}
         <div className="flex flex-1 flex-col overflow-auto">
           {!selectedFile ? (
-            <div className="flex items-center justify-center py-20 text-sm text-zinc-500">
+            <div className="flex items-center justify-center py-20 text-sm text-muted-foreground">
               {treeOpen ? null : "Select a file to preview"}
             </div>
           ) : fileLoading ? (
-            <div className="flex items-center justify-center py-20 text-sm text-zinc-500">
+            <div className="flex items-center justify-center py-20 text-sm text-muted-foreground">
               Loading...
             </div>
           ) : editing ? (
             <div className="flex flex-1 flex-col h-full">
               {/* Editor toolbar */}
-              <div className="flex items-center gap-2 border-b border-white/5 px-4 py-2">
-                <span className="text-xs text-zinc-400 font-mono truncate flex-1">
+              <div className="flex items-center gap-2 border-b border-hairline px-4 py-2">
+                <span className="text-xs text-muted-foreground font-mono truncate flex-1">
                   {selectedFile.split("/").pop()}
                 </span>
                 <button
                   type="button"
                   onClick={handleSave}
                   disabled={saving}
-                  className="touch-target-sm rounded bg-blue-500/20 px-3 py-1 text-xs text-blue-400 hover:bg-blue-500/30 disabled:opacity-50"
+                  className="touch-target-sm rounded bg-info/20 px-3 py-1 text-xs text-info hover:bg-info/30 disabled:opacity-50"
                 >
                   {saving ? "Saving..." : "Save"}
                 </button>
@@ -248,40 +248,40 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
                     setEditContent(content);
                     setSaveError(null);
                   }}
-                  className="touch-target-sm rounded bg-white/5 px-3 py-1 text-xs text-zinc-400 hover:bg-white/10"
+                  className="touch-target-sm rounded bg-surface px-3 py-1 text-xs text-muted-foreground hover:bg-surface-strong"
                 >
                   Cancel
                 </button>
               </div>
               {saveError && (
-                <div className="border-b border-red-500/20 bg-red-500/5 px-4 py-1 text-xs text-red-400">
+                <div className="border-b border-destructive/20 bg-destructive/5 px-4 py-1 text-xs text-destructive">
                   {saveError}
                 </div>
               )}
               <textarea
                 value={editContent}
                 onChange={(e) => setEditContent(e.target.value)}
-                className="flex-1 resize-none bg-transparent px-4 py-4 font-mono text-sm text-zinc-200 outline-none md:px-6"
+                className="flex-1 resize-none bg-transparent px-4 py-4 font-mono text-sm text-foreground outline-none md:px-6"
                 spellCheck={false}
               />
             </div>
           ) : (
             <div className="flex flex-1 flex-col h-full">
               {/* Preview toolbar */}
-              <div className="flex items-center gap-2 border-b border-white/5 px-4 py-2">
-                <span className="text-xs text-zinc-400 font-mono truncate flex-1">
+              <div className="flex items-center gap-2 border-b border-hairline px-4 py-2">
+                <span className="text-xs text-muted-foreground font-mono truncate flex-1">
                   {selectedFile.split("/").pop()}
                 </span>
                 {editable ? (
                   <button
                     type="button"
                     onClick={() => setEditing(true)}
-                    className="touch-target-sm rounded bg-white/5 px-3 py-1 text-xs text-zinc-400 hover:bg-white/10 hover:text-zinc-200"
+                    className="touch-target-sm rounded bg-surface px-3 py-1 text-xs text-muted-foreground hover:bg-surface-strong hover:text-foreground"
                   >
                     Edit
                   </button>
                 ) : (
-                  <span className="text-[10px] text-zinc-600">read-only</span>
+                  <span className="text-[10px] text-subtle-foreground">read-only</span>
                 )}
               </div>
               {/* Content: markdown preview or code view */}
@@ -289,17 +289,17 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
                 {selectedFile.endsWith(".md") ? (
                   <div
                     className="prose prose-invert prose-sm max-w-none
-                    prose-headings:text-zinc-100 prose-headings:font-semibold
-                    prose-p:text-zinc-300 prose-p:leading-relaxed
-                    prose-a:text-blue-400 prose-a:no-underline hover:prose-a:underline
-                    prose-strong:text-zinc-200
-                    prose-code:text-cyan-400 prose-code:bg-white/5 prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:before:content-none prose-code:after:content-none
-                    prose-pre:bg-zinc-900/50 prose-pre:border prose-pre:border-white/5 prose-pre:rounded-lg prose-pre:overflow-x-auto
-                    prose-li:text-zinc-300
-                    prose-th:text-zinc-300 prose-th:border-white/10
-                    prose-td:text-zinc-400 prose-td:border-white/10
-                    prose-hr:border-white/10
-                    prose-blockquote:border-blue-500/30 prose-blockquote:text-zinc-400
+                    prose-headings:text-foreground prose-headings:font-semibold
+                    prose-p:text-foreground prose-p:leading-relaxed
+                    prose-a:text-info prose-a:no-underline hover:prose-a:underline
+                    prose-strong:text-foreground
+                    prose-code:text-primary prose-code:bg-surface prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:before:content-none prose-code:after:content-none
+                    prose-pre:bg-surface-strong/50 prose-pre:border prose-pre:border-hairline prose-pre:rounded-lg prose-pre:overflow-x-auto
+                    prose-li:text-foreground
+                    prose-th:text-foreground prose-th:border-hairline-strong
+                    prose-td:text-muted-foreground prose-td:border-hairline-strong
+                    prose-hr:border-hairline-strong
+                    prose-blockquote:border-info/30 prose-blockquote:text-muted-foreground
                   "
                   >
                     <Markdown remarkPlugins={[remarkGfm]} components={markdownComponents}>
@@ -307,7 +307,7 @@ export function MarkdownPanel({ projectPath, projectName }: MarkdownPanelProps) 
                     </Markdown>
                   </div>
                 ) : (
-                  <pre className="text-xs text-zinc-300 font-mono whitespace-pre-wrap break-words select-text leading-relaxed">
+                  <pre className="text-xs text-foreground font-mono whitespace-pre-wrap break-words select-text leading-relaxed">
                     {content}
                   </pre>
                 )}
@@ -376,7 +376,7 @@ function TreeNode({
                     return next;
                   })
                 }
-                className="flex w-full items-center gap-1 py-1.5 text-left text-[11px] text-zinc-500 hover:text-zinc-300 transition-colors"
+                className="flex w-full items-center gap-1 py-1.5 text-left text-[11px] text-muted-foreground hover:text-foreground transition-colors"
                 style={{ paddingLeft: 8 + depth * 12, paddingRight: 8 }}
               >
                 <span className="text-[9px]">{isCollapsed ? "\u25B8" : "\u25BE"}</span>
@@ -401,16 +401,20 @@ function TreeNode({
             onClick={() => onSelect(entry.path)}
             className={`flex w-full items-center gap-1.5 py-1.5 text-left text-[11px] transition-colors ${
               isSelected
-                ? "bg-blue-500/10 text-blue-400"
+                ? "bg-info/10 text-info"
                 : entry.openable
-                  ? "text-zinc-400 hover:bg-white/5 hover:text-zinc-200"
-                  : "text-zinc-600 hover:bg-white/[0.03] hover:text-zinc-400"
+                  ? "text-muted-foreground hover:bg-surface hover:text-foreground"
+                  : "text-subtle-foreground hover:bg-surface hover:text-muted-foreground"
             }`}
             style={{ paddingLeft: 8 + depth * 12, paddingRight: 8 }}
           >
             <span
               className={`shrink-0 text-[10px] ${
-                isSelected ? "text-blue-500" : entry.openable ? "text-zinc-500" : "text-zinc-700"
+                isSelected
+                  ? "text-info"
+                  : entry.openable
+                    ? "text-muted-foreground"
+                    : "text-subtle-foreground"
               }`}
             >
               {extLabel(entry.name)}

--- a/clients/react/src/components/markdown/MermaidBlock.tsx
+++ b/clients/react/src/components/markdown/MermaidBlock.tsx
@@ -70,7 +70,7 @@ export function MermaidBlock({ source }: MermaidBlockProps) {
   }
 
   if (!svg) {
-    return <div className="px-2 py-3 text-xs text-zinc-500">Rendering diagram…</div>;
+    return <div className="px-2 py-3 text-xs text-muted-foreground">Rendering diagram…</div>;
   }
 
   return (

--- a/clients/react/src/lib/__tests__/no-raw-palette.test.ts
+++ b/clients/react/src/lib/__tests__/no-raw-palette.test.ts
@@ -26,6 +26,8 @@ const MIGRATED = [
   "components/producer-console",
   "components/agent",
   "components/layout",
+  "components/calibration",
+  "components/markdown",
 ];
 
 // A raw Tailwind palette colour utility: <prefix>-<family>[-<shade>][/<alpha>].


### PR DESCRIPTION
**PR G of the semantic-token migration** (follows #703).

## Migration

- **`components/calibration/`** (3 files) + **`components/markdown/`** (2 files): ~130 codemod substitutions, **zero residual** raw palette, **zero collapsed-ternary** artifacts (guard green). className strings only.
- Markdown's many `prose-*:` Tailwind-Typography modifiers re-skin correctly — the codemod's boundary look-around maps `prose-headings:text-zinc-200` → `prose-headings:text-foreground`, `prose-code:text-cyan-…` → `…text-primary`, etc. Structural modifiers (`prose-invert`, `prose-sm`, bare `prose-code`) are untouched.
- No codemod-dictionary or token-vocabulary change this PR — all colour families were already covered.
- Regression guard allowlist: **+ `components/calibration`, `components/markdown`** (now covers settings + worktree + producer-console + agent + layout + calibration + markdown).

## Test follow-through

`CalibrationChip.test.tsx` had two assertions that read the **real** component `className` and checked raw palette names; updated to the migrated semantic tokens: muted chip `zinc` → `muted-foreground`, tripped chip `red` → `destructive` (verified against the migrated component).

## Gate

`pnpm build && pnpm lint && pnpm test` — green (64 files, **506 passed**, 2 pre-existing skips).

Browser-verify still deferred (vite-on-WSL crash risk + no backend) — recommended at review or on request. Next: PR H (remaining `ui/` etc.), then PR I (repo-wide lint lock + promote `light` to a selectable theme).

🤖 Generated with [Claude Code](https://claude.com/claude-code)