### PR TITLE
feat(webui): migrate remaining areas + App.tsx (PR H)

### DIFF
--- a/clients/react/scripts/theme-codemod.mjs
+++ b/clients/react/scripts/theme-codemod.mjs
@@ -65,6 +65,12 @@ const RULES = [
   [/(?<![\w-])border-white\/5(?!\d)/g, "border-hairline"],
   [/(?<![\w-])border-white\/(?:10|15|20|30)(?!\d)/g, "border-hairline-strong"],
   [/(?<![\w-])border-white(?![\w/[-])/g, "border-hairline-strong"],
+  // Divider lines (`divide-*`) follow the same hairline mapping as
+  // borders (the utility sets border-color on between-children).
+  [/(?<![\w-])divide-white\/\[[0-9.]+\](?![\w-])/g, "divide-hairline"],
+  [/(?<![\w-])divide-white\/5(?!\d)/g, "divide-hairline"],
+  [/(?<![\w-])divide-white\/(?:10|15|20|30)(?!\d)/g, "divide-hairline-strong"],
+  [/(?<![\w-])divide-white(?![\w/[-])/g, "divide-hairline-strong"],
   // Ring overlays → the strong hairline. (A resting-vs-focus pair that
   // collapses to the same ring is a deliberate manual-fixup point: the
   // focus ring is upgraded to ring-primary by hand, matching this
@@ -115,9 +121,16 @@ const RULES = [
   [/(?<![\w-])bg-black(?:\/(?:\[[0-9.]+\]|[0-9]{1,3}))?(?![\w-])/g, "bg-background"],
 ];
 
-function* walk(dir) {
-  for (const entry of readdirSync(dir)) {
-    const p = join(dir, entry);
+// Yields source files under `target` — accepts a directory OR a single
+// file path (e.g. `src/App.tsx`), so the migration's final stretch can
+// target loose top-level files too.
+function* walk(target) {
+  if (statSync(target).isFile()) {
+    if (/\.(tsx|ts)$/.test(target) && !/\.test\.(tsx|ts)$/.test(target)) yield target;
+    return;
+  }
+  for (const entry of readdirSync(target)) {
+    const p = join(target, entry);
     const st = statSync(p);
     if (st.isDirectory()) {
       if (entry === "__tests__" || entry === "node_modules") continue;

--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -527,13 +527,13 @@ export function App() {
   );
 
   return (
-    <div className="flex h-screen text-zinc-100">
+    <div className="flex h-screen text-foreground">
       {/* Mobile: overlay backdrop when drawer is open */}
       {isMobileScreen && mobileDrawerOpen && (
         // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop tap to close
         // biome-ignore lint/a11y/noStaticElementInteractions: backdrop tap to close
         <div
-          className="fixed inset-0 z-40 bg-black/60 animate-fade-in"
+          className="fixed inset-0 z-40 bg-background animate-fade-in"
           onClick={closeMobileDrawer}
         />
       )}
@@ -541,18 +541,18 @@ export function App() {
       {/* Mobile drawer (off-canvas) */}
       {isMobileScreen && (
         <div
-          className={`fixed inset-y-0 left-0 z-50 flex w-80 flex-col glass border-r border-white/5 transition-transform duration-300 ease-out safe-top safe-bottom ${
+          className={`fixed inset-y-0 left-0 z-50 flex w-80 flex-col glass border-r border-hairline transition-transform duration-300 ease-out safe-top safe-bottom ${
             mobileDrawerOpen ? "translate-x-0" : "-translate-x-full"
           }`}
         >
-          <div className="flex items-center justify-between border-b border-white/5 px-4 py-3">
-            <span className="bg-gradient-to-r from-cyan-400 to-blue-400 bg-clip-text text-sm font-bold tracking-wide text-transparent">
+          <div className="flex items-center justify-between border-b border-hairline px-4 py-3">
+            <span className="bg-gradient-to-r from-[var(--brand-from)] to-[var(--brand-to)] bg-clip-text text-sm font-bold tracking-wide text-transparent">
               tmai
             </span>
             <button
               type="button"
               onClick={closeMobileDrawer}
-              className="touch-target flex items-center justify-center rounded-lg text-zinc-500 transition-colors hover:bg-white/10 hover:text-zinc-300"
+              className="touch-target flex items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
               title="Close navigation"
               aria-label="Close navigation"
             >
@@ -608,8 +608,8 @@ export function App() {
                   onClick={() => handleSelectAgent(agent.target)}
                   className={`h-8 w-8 rounded-lg text-[10px] transition-colors ${
                     selectedTarget === agent.target
-                      ? "bg-cyan-500/20 text-cyan-400"
-                      : "text-zinc-500 hover:bg-white/10 hover:text-zinc-300"
+                      ? "bg-primary/20 text-primary"
+                      : "text-muted-foreground hover:bg-surface-strong hover:text-foreground"
                   }`}
                   title={agent.target}
                 >
@@ -743,7 +743,7 @@ export function App() {
             const split = displayMode === "split-v" ? verticalSplit : horizontalSplit;
             return (
               <div className="flex flex-1 flex-col overflow-hidden">
-                <div className="flex shrink-0 items-center justify-end gap-2 border-b border-white/[0.06] px-3 py-1">
+                <div className="flex shrink-0 items-center justify-end gap-2 border-b border-hairline px-3 py-1">
                   <DisplayModeSelector mode={displayMode} onChange={setDisplayMode} />
                 </div>
                 <AgentActions agent={selectedAgent} passthrough />

--- a/clients/react/src/components/project/DirBrowser.tsx
+++ b/clients/react/src/components/project/DirBrowser.tsx
@@ -60,7 +60,7 @@ export function DirBrowser({ onSelect, onCancel, startPath, actionSlot }: DirBro
     // Backdrop
     <div
       role="dialog"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-black/60"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background"
       onClick={onCancel}
       onKeyDown={(e) => {
         if (e.key === "Escape") onCancel();
@@ -70,40 +70,40 @@ export function DirBrowser({ onSelect, onCancel, startPath, actionSlot }: DirBro
       {/* biome-ignore lint/a11y/noStaticElementInteractions: stops click propagation to close backdrop */}
       <div
         role="presentation"
-        className="glass mx-4 flex w-full max-w-lg flex-col rounded-2xl border border-white/10 shadow-2xl"
+        className="glass mx-4 flex w-full max-w-lg flex-col rounded-2xl border border-hairline-strong shadow-2xl"
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => e.stopPropagation()}
       >
         {/* Header */}
-        <div className="flex items-center justify-between border-b border-white/5 px-5 py-3">
-          <h3 className="text-sm font-semibold text-zinc-200">Select Directory</h3>
+        <div className="flex items-center justify-between border-b border-hairline px-5 py-3">
+          <h3 className="text-sm font-semibold text-foreground">Select Directory</h3>
           <button
             type="button"
             onClick={onCancel}
-            className="rounded px-2 py-0.5 text-xs text-zinc-500 transition-colors hover:bg-white/10 hover:text-zinc-300"
+            className="rounded px-2 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
           >
             Cancel
           </button>
         </div>
 
         {/* Path bar */}
-        <div className="flex items-center gap-2 border-b border-white/5 px-5 py-2">
+        <div className="flex items-center gap-2 border-b border-hairline px-5 py-2">
           <button
             type="button"
             onClick={goUp}
             disabled={!currentPath || currentPath === "/"}
-            className="shrink-0 rounded px-1.5 py-0.5 text-xs text-zinc-400 transition-colors hover:bg-white/10 hover:text-zinc-200 disabled:opacity-30"
+            className="shrink-0 rounded px-1.5 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground disabled:opacity-30"
           >
             ..
           </button>
-          <span className="flex-1 truncate text-xs text-zinc-500" title={currentPath}>
+          <span className="flex-1 truncate text-xs text-muted-foreground" title={currentPath}>
             {currentPath || "~"}
           </span>
           {!actionSlot && (
             <button
               type="button"
               onClick={() => onSelect?.(currentPath)}
-              className="shrink-0 rounded-md bg-cyan-500/20 px-3 py-1 text-xs text-cyan-400 transition-colors hover:bg-cyan-500/30"
+              className="shrink-0 rounded-md bg-primary/20 px-3 py-1 text-xs text-primary transition-colors hover:bg-primary/30"
             >
               Select this
             </button>
@@ -111,15 +111,19 @@ export function DirBrowser({ onSelect, onCancel, startPath, actionSlot }: DirBro
         </div>
 
         {actionSlot && (
-          <div className="border-b border-white/5 px-5 py-2">{actionSlot(currentPath)}</div>
+          <div className="border-b border-hairline px-5 py-2">{actionSlot(currentPath)}</div>
         )}
 
         {/* Directory listing */}
         <div className="max-h-80 overflow-y-auto">
-          {loading && <div className="px-5 py-6 text-center text-xs text-zinc-600">Loading...</div>}
-          {error && <div className="px-5 py-6 text-center text-xs text-red-400">{error}</div>}
+          {loading && (
+            <div className="px-5 py-6 text-center text-xs text-subtle-foreground">Loading...</div>
+          )}
+          {error && <div className="px-5 py-6 text-center text-xs text-destructive">{error}</div>}
           {!loading && !error && entries.length === 0 && (
-            <div className="px-5 py-6 text-center text-xs text-zinc-600">No subdirectories</div>
+            <div className="px-5 py-6 text-center text-xs text-subtle-foreground">
+              No subdirectories
+            </div>
           )}
           {!loading &&
             !error &&
@@ -130,20 +134,20 @@ export function DirBrowser({ onSelect, onCancel, startPath, actionSlot }: DirBro
                 onClick={() => loadDir(entry.path)}
                 onDoubleClick={actionSlot ? undefined : () => onSelect?.(entry.path)}
                 className={cn(
-                  "flex w-full items-center gap-2 px-5 py-1.5 text-left text-xs transition-colors hover:bg-white/5",
-                  entry.is_git ? "text-cyan-400" : "text-zinc-400",
+                  "flex w-full items-center gap-2 px-5 py-1.5 text-left text-xs transition-colors hover:bg-surface",
+                  entry.is_git ? "text-primary" : "text-muted-foreground",
                 )}
               >
                 <span className="shrink-0 text-[10px]">{entry.is_git ? "●" : "▸"}</span>
                 <span className="flex-1 truncate">{entry.name}</span>
-                {entry.is_git && <span className="shrink-0 text-[9px] text-cyan-600">git</span>}
+                {entry.is_git && <span className="shrink-0 text-[9px] text-primary">git</span>}
               </button>
             ))}
         </div>
 
         {/* Footer hint */}
-        <div className="border-t border-white/5 px-5 py-2">
-          <p className="text-[10px] text-zinc-600">
+        <div className="border-t border-hairline px-5 py-2">
+          <p className="text-[10px] text-subtle-foreground">
             {actionSlot
               ? "Click to navigate, then pick a runtime to spawn here"
               : "Click to navigate, double-click to select"}

--- a/clients/react/src/components/project/NewAgentLauncher.tsx
+++ b/clients/react/src/components/project/NewAgentLauncher.tsx
@@ -80,7 +80,7 @@ export function NewAgentLauncher({ onSpawned }: NewAgentLauncherProps) {
         type="button"
         onClick={() => void handleOpenBrowser()}
         disabled={spawning}
-        className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-white/10 bg-white/[0.02] px-3 py-2 text-xs text-zinc-400 transition-colors hover:border-cyan-500/30 hover:bg-cyan-500/5 hover:text-cyan-300 disabled:opacity-50"
+        className="flex w-full items-center justify-center gap-1.5 rounded-lg border border-dashed border-hairline-strong bg-surface px-3 py-2 text-xs text-muted-foreground transition-colors hover:border-primary/30 hover:bg-primary/5 hover:text-primary disabled:opacity-50"
       >
         <span className="text-sm leading-none">+</span>
         <span>New agent</span>
@@ -101,7 +101,7 @@ export function NewAgentLauncher({ onSpawned }: NewAgentLauncherProps) {
                     disabled={spawning || !currentPath}
                     className={cn(
                       "flex-1 rounded px-2 py-1 text-center text-[11px] transition-colors",
-                      "text-zinc-300 hover:bg-cyan-500/10 hover:text-cyan-400 disabled:opacity-50",
+                      "text-foreground hover:bg-primary/10 hover:text-primary disabled:opacity-50",
                     )}
                   >
                     {rt}
@@ -109,7 +109,7 @@ export function NewAgentLauncher({ onSpawned }: NewAgentLauncherProps) {
                 ))}
               </div>
               {error && (
-                <p role="alert" aria-live="assertive" className="text-[11px] text-red-400">
+                <p role="alert" aria-live="assertive" className="text-[11px] text-destructive">
                   {error}
                 </p>
               )}

--- a/clients/react/src/components/project/ProjectGroup.tsx
+++ b/clients/react/src/components/project/ProjectGroup.tsx
@@ -136,7 +136,7 @@ export function ProjectGroup({
   return (
     <div className="mb-1">
       {/* Project header */}
-      <div className="flex w-full items-center gap-1 rounded-lg px-2 py-1.5 transition-colors hover:bg-white/5">
+      <div className="flex w-full items-center gap-1 rounded-lg px-2 py-1.5 transition-colors hover:bg-surface">
         <button
           type="button"
           onClick={() => setCollapsed((v) => !v)}
@@ -144,7 +144,7 @@ export function ProjectGroup({
         >
           <span
             className={cn(
-              "text-[10px] text-zinc-600 transition-transform shrink-0",
+              "text-[10px] text-subtle-foreground transition-transform shrink-0",
               collapsed && "-rotate-90",
             )}
           >
@@ -154,7 +154,7 @@ export function ProjectGroup({
             <span
               className={cn(
                 "block truncate text-xs font-semibold",
-                isEmpty ? "text-zinc-500" : "text-zinc-300",
+                isEmpty ? "text-muted-foreground" : "text-foreground",
               )}
             >
               {project.name}
@@ -162,16 +162,16 @@ export function ProjectGroup({
             {/* Branch info under project name */}
             <div className="flex items-center gap-1.5 mt-0.5">
               {mainBranch && (
-                <span className="truncate text-[10px] text-zinc-500">
+                <span className="truncate text-[10px] text-muted-foreground">
                   {mainBranch}
-                  {mainDirty && <span className="text-amber-500">*</span>}
+                  {mainDirty && <span className="text-warning">*</span>}
                 </span>
               )}
               {worktreeCount > 0 && (
-                <span className="flex items-center gap-0.5 text-[10px] text-emerald-600">
+                <span className="flex items-center gap-0.5 text-[10px] text-success">
                   <span>🌿</span>
                   <span>×{worktreeCount}</span>
-                  {worktreesDirty && <span className="text-amber-500">*</span>}
+                  {worktreesDirty && <span className="text-warning">*</span>}
                 </span>
               )}
             </div>
@@ -179,10 +179,10 @@ export function ProjectGroup({
         </button>
         <div className="flex items-center gap-1.5">
           {project.totalAgents > 0 && (
-            <span className="text-[10px] text-zinc-600">{project.totalAgents}</span>
+            <span className="text-[10px] text-subtle-foreground">{project.totalAgents}</span>
           )}
           {project.attentionAgents > 0 && (
-            <span className="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[10px] text-amber-400">
+            <span className="rounded-full bg-warning/15 px-1.5 py-0.5 text-[10px] text-warning">
               {project.attentionAgents}
             </span>
           )}
@@ -193,8 +193,8 @@ export function ProjectGroup({
             className={cn(
               "rounded px-1 py-0.5 transition-colors",
               isProjectSelected
-                ? "text-emerald-400 bg-emerald-500/10"
-                : "text-zinc-600 hover:text-emerald-400 hover:bg-emerald-500/10",
+                ? "text-success bg-success/10"
+                : "text-subtle-foreground hover:text-success hover:bg-success/10",
             )}
             title="Branch graph"
           >
@@ -225,8 +225,8 @@ export function ProjectGroup({
             className={cn(
               "rounded px-1 py-0.5 transition-colors",
               isMarkdownSelected
-                ? "text-blue-400 bg-blue-500/10"
-                : "text-zinc-600 hover:text-blue-400 hover:bg-blue-500/10",
+                ? "text-info bg-info/10"
+                : "text-subtle-foreground hover:text-info hover:bg-info/10",
             )}
             title="Markdown files"
           >
@@ -268,13 +268,13 @@ export function ProjectGroup({
               type="button"
               onClick={() => setShowSpawn((v) => !v)}
               disabled={spawning}
-              className="rounded px-1 py-0.5 text-xs text-zinc-500 transition-colors hover:bg-white/10 hover:text-cyan-400 disabled:opacity-50"
+              className="rounded px-1 py-0.5 text-xs text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary disabled:opacity-50"
               title="Spawn agent"
             >
               +
             </button>
             {showSpawn && (
-              <div className="absolute right-0 top-full z-10 mt-1 flex flex-col gap-0.5 rounded-lg border border-white/10 bg-zinc-900 p-1 shadow-lg min-w-[140px]">
+              <div className="absolute right-0 top-full z-10 mt-1 flex flex-col gap-0.5 rounded-lg border border-hairline-strong bg-surface-strong p-1 shadow-lg min-w-[140px]">
                 {/* Orchestrator option (shown when enabled for this project) */}
                 {orchEnabled && (
                   <>
@@ -285,8 +285,8 @@ export function ProjectGroup({
                       className={cn(
                         "whitespace-nowrap rounded px-3 py-1 text-left text-xs transition-colors",
                         hasRunningOrchestrator
-                          ? "text-zinc-600 cursor-not-allowed"
-                          : "text-cyan-400 hover:bg-white/10 hover:text-cyan-300",
+                          ? "text-subtle-foreground cursor-not-allowed"
+                          : "text-primary hover:bg-surface-strong hover:text-primary",
                       )}
                       title={
                         hasRunningOrchestrator
@@ -296,10 +296,10 @@ export function ProjectGroup({
                     >
                       Orchestrator
                       {hasRunningOrchestrator && (
-                        <span className="ml-1 text-[10px] text-zinc-600">(active)</span>
+                        <span className="ml-1 text-[10px] text-subtle-foreground">(active)</span>
                       )}
                     </button>
-                    <div className="mx-1 border-t border-white/5" />
+                    <div className="mx-1 border-t border-hairline" />
                   </>
                 )}
                 {hasMultipleTargets
@@ -308,11 +308,11 @@ export function ProjectGroup({
                       const hasAgent = target.agents.length > 0;
                       return (
                         <div key={target.name}>
-                          <div className="px-2 py-0.5 text-[10px] text-zinc-500 truncate">
+                          <div className="px-2 py-0.5 text-[10px] text-muted-foreground truncate">
                             {target.isWorktree ? "🌿 " : ""}
                             {target.branch || target.name}
                             {hasAgent && (
-                              <span className="ml-1 text-amber-500" title="Agent active">
+                              <span className="ml-1 text-warning" title="Agent active">
                                 ●
                               </span>
                             )}
@@ -323,7 +323,7 @@ export function ProjectGroup({
                                 type="button"
                                 key={`${target.name}-${cmd}`}
                                 onClick={() => spawn(cmd, target.path, hasAgent)}
-                                className="flex-1 whitespace-nowrap rounded px-2 py-0.5 text-center text-[11px] text-zinc-400 transition-colors hover:bg-white/10 hover:text-cyan-400"
+                                className="flex-1 whitespace-nowrap rounded px-2 py-0.5 text-center text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
                               >
                                 {cmd}
                               </button>
@@ -340,7 +340,7 @@ export function ProjectGroup({
                           type="button"
                           key={cmd}
                           onClick={() => spawn(cmd, spawnTargets[0].path, hasAgent)}
-                          className="whitespace-nowrap rounded px-3 py-1 text-left text-xs text-zinc-300 transition-colors hover:bg-white/10 hover:text-cyan-400"
+                          className="whitespace-nowrap rounded px-3 py-1 text-left text-xs text-foreground transition-colors hover:bg-surface-strong hover:text-primary"
                         >
                           {cmd}
                         </button>
@@ -354,7 +354,7 @@ export function ProjectGroup({
 
       {/* Agent sub-groups */}
       {!collapsed && (
-        <div className="ml-1 border-l border-white/5 pl-2">
+        <div className="ml-1 border-l border-hairline pl-2">
           {project.worktrees.map((wt) => (
             <WorktreeSection
               key={wt.name}
@@ -364,7 +364,9 @@ export function ProjectGroup({
             />
           ))}
           {isEmpty && (
-            <div className="px-2 py-2 text-[11px] text-zinc-600">No agents — click + to spawn</div>
+            <div className="px-2 py-2 text-[11px] text-subtle-foreground">
+              No agents — click + to spawn
+            </div>
           )}
         </div>
       )}

--- a/clients/react/src/components/teams/TeamsPanel.tsx
+++ b/clients/react/src/components/teams/TeamsPanel.tsx
@@ -46,12 +46,12 @@ export function TeamsPanel({ onClose }: TeamsPanelProps) {
   return (
     <div className="glass-deep flex flex-1 flex-col overflow-hidden rounded-lg">
       {/* Header */}
-      <div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
-        <h2 className="text-lg font-semibold text-zinc-100">Teams</h2>
+      <div className="flex items-center justify-between border-b border-hairline-strong px-6 py-4">
+        <h2 className="text-lg font-semibold text-foreground">Teams</h2>
         <button
           type="button"
           onClick={onClose}
-          className="text-zinc-500 hover:text-zinc-300 transition-subtle"
+          className="text-muted-foreground hover:text-foreground transition-subtle"
         >
           ✕
         </button>
@@ -62,11 +62,11 @@ export function TeamsPanel({ onClose }: TeamsPanelProps) {
         {/* Teams List */}
         <div className="w-64 shrink-0 overflow-y-auto">
           {loading ? (
-            <div className="text-zinc-500">Loading teams...</div>
+            <div className="text-muted-foreground">Loading teams...</div>
           ) : error ? (
-            <div className="text-red-500 text-sm">{error}</div>
+            <div className="text-destructive text-sm">{error}</div>
           ) : teams.length === 0 ? (
-            <div className="text-zinc-500">No teams found</div>
+            <div className="text-muted-foreground">No teams found</div>
           ) : (
             <div className="space-y-2">
               {teams.map((team) => (
@@ -76,12 +76,12 @@ export function TeamsPanel({ onClose }: TeamsPanelProps) {
                   onClick={() => setSelectedTeam(team.name)}
                   className={`glass-card w-full rounded-lg px-3 py-2 text-left transition-subtle text-sm ${
                     selectedTeam === team.name
-                      ? "!border-cyan-500/30 !bg-cyan-500/10"
-                      : "hover:bg-white/[0.05]"
+                      ? "!border-primary/30 !bg-primary/10"
+                      : "hover:bg-surface"
                   }`}
                 >
-                  <div className="font-medium text-zinc-200">{team.name}</div>
-                  <div className="text-xs text-zinc-500 mt-1">
+                  <div className="font-medium text-foreground">{team.name}</div>
+                  <div className="text-xs text-muted-foreground mt-1">
                     {team.member_count} members • {team.task_done}/{team.task_total} done
                   </div>
                 </button>
@@ -96,11 +96,13 @@ export function TeamsPanel({ onClose }: TeamsPanelProps) {
             <div className="space-y-4">
               {/* Team Info */}
               <div className="glass-card rounded-lg px-4 py-3">
-                <h3 className="font-semibold text-zinc-100 text-base">{selectedTeamData.name}</h3>
+                <h3 className="font-semibold text-foreground text-base">{selectedTeamData.name}</h3>
                 {selectedTeamData.description && (
-                  <p className="text-sm text-zinc-400 mt-1">{selectedTeamData.description}</p>
+                  <p className="text-sm text-muted-foreground mt-1">
+                    {selectedTeamData.description}
+                  </p>
                 )}
-                <div className="text-xs text-zinc-500 mt-2 space-y-1">
+                <div className="text-xs text-muted-foreground mt-2 space-y-1">
                   <div>Members: {selectedTeamData.member_count}</div>
                   <div>
                     Progress: {selectedTeamData.task_done}/{selectedTeamData.task_total} tasks
@@ -111,32 +113,36 @@ export function TeamsPanel({ onClose }: TeamsPanelProps) {
 
               {/* Tasks */}
               <div>
-                <h4 className="text-sm font-semibold text-zinc-300 mb-2">Tasks</h4>
+                <h4 className="text-sm font-semibold text-foreground mb-2">Tasks</h4>
                 {teamTasks.length === 0 ? (
-                  <div className="text-zinc-600 text-sm">No tasks</div>
+                  <div className="text-subtle-foreground text-sm">No tasks</div>
                 ) : (
                   <div className="space-y-2">
                     {teamTasks.map((task) => (
                       <div key={task.id} className="glass-card rounded-lg px-3 py-2 text-sm">
                         <div className="flex items-center justify-between gap-2">
                           <div className="flex-1">
-                            <div className="font-medium text-zinc-200">{task.subject}</div>
-                            <div className="text-xs text-zinc-600 mt-0.5">{task.description}</div>
+                            <div className="font-medium text-foreground">{task.subject}</div>
+                            <div className="text-xs text-subtle-foreground mt-0.5">
+                              {task.description}
+                            </div>
                           </div>
                           <div
                             className={`px-2 py-1 rounded text-xs font-medium shrink-0 ${
                               task.status === "completed"
-                                ? "bg-emerald-500/20 text-emerald-400"
+                                ? "bg-success/20 text-success"
                                 : task.status === "in_progress"
-                                  ? "bg-cyan-500/20 text-cyan-400"
-                                  : "bg-zinc-500/20 text-zinc-400"
+                                  ? "bg-primary/20 text-primary"
+                                  : "bg-muted-foreground/20 text-muted-foreground"
                             }`}
                           >
                             {task.status}
                           </div>
                         </div>
                         {task.owner && (
-                          <div className="text-xs text-zinc-500 mt-1">Owner: {task.owner}</div>
+                          <div className="text-xs text-muted-foreground mt-1">
+                            Owner: {task.owner}
+                          </div>
                         )}
                       </div>
                     ))}
@@ -145,7 +151,7 @@ export function TeamsPanel({ onClose }: TeamsPanelProps) {
               </div>
             </div>
           ) : (
-            <div className="text-zinc-500">Select a team</div>
+            <div className="text-muted-foreground">Select a team</div>
           )}
         </div>
       </div>

--- a/clients/react/src/components/terminal/TerminalList.tsx
+++ b/clients/react/src/components/terminal/TerminalList.tsx
@@ -12,8 +12,8 @@ export function TerminalList({ terminals, selectedTarget, onSelect }: TerminalLi
   if (terminals.length === 0) return null;
 
   return (
-    <div className="border-t border-white/5 px-2 pb-2 pt-1">
-      <div className="px-1 py-1 text-[10px] font-medium uppercase tracking-wider text-zinc-600">
+    <div className="border-t border-hairline px-2 pb-2 pt-1">
+      <div className="px-1 py-1 text-[10px] font-medium uppercase tracking-wider text-subtle-foreground">
         Terminals
       </div>
       <div className="flex flex-col gap-0.5">
@@ -38,18 +38,20 @@ export function TerminalList({ terminals, selectedTarget, onSelect }: TerminalLi
               className={cn(
                 "flex items-center justify-between rounded-md px-2 py-1 text-left text-xs transition-colors",
                 selected
-                  ? "bg-cyan-500/10 text-cyan-400"
-                  : "text-zinc-400 hover:bg-white/5 hover:text-zinc-300",
+                  ? "bg-primary/10 text-primary"
+                  : "text-muted-foreground hover:bg-surface hover:text-foreground",
               )}
             >
               <div className="flex items-center gap-1.5 truncate">
-                <span className="text-zinc-600">{">"}</span>
+                <span className="text-subtle-foreground">{">"}</span>
                 <span className="truncate">{name}</span>
               </div>
               <span
                 className={cn(
                   "shrink-0 text-[10px]",
-                  status === "Active" || status === "—" ? "text-zinc-600" : "text-zinc-500",
+                  status === "Active" || status === "—"
+                    ? "text-subtle-foreground"
+                    : "text-muted-foreground",
                 )}
               >
                 {status}

--- a/clients/react/src/components/terminal/TerminalPanel.tsx
+++ b/clients/react/src/components/terminal/TerminalPanel.tsx
@@ -88,8 +88,8 @@ export function TerminalPanel({ agentId }: TerminalPanelProps) {
           : "shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)]"
       }`}
     >
-      <div className="flex items-center justify-between border-b border-zinc-800 px-3 py-1.5">
-        <span className="text-xs text-zinc-500">{agentIdShort(agentId)}</span>
+      <div className="flex items-center justify-between border-b border-hairline-strong px-3 py-1.5">
+        <span className="text-xs text-muted-foreground">{agentIdShort(agentId)}</span>
       </div>
       {/* biome-ignore lint/a11y/noStaticElementInteractions: terminal container needs pointer events for selection mode */}
       <div
@@ -113,7 +113,7 @@ export function TerminalPanel({ agentId }: TerminalPanelProps) {
       />
 
       {/* Footer status bar */}
-      <div className="flex items-center gap-2 border-t border-white/5 px-3 py-1.5">
+      <div className="flex items-center gap-2 border-t border-hairline px-3 py-1.5">
         <ModeToggleButton
           inputMode={inputMode}
           onToggle={inputMode ? enterSelectMode : enterInputMode}

--- a/clients/react/src/components/terminal/controls.tsx
+++ b/clients/react/src/components/terminal/controls.tsx
@@ -19,7 +19,7 @@ export function ModeToggleButton({ inputMode, onToggle }: ModeToggleButtonProps)
       onMouseDown={(e) => e.preventDefault()}
       onClick={onToggle}
       className={`touch-target-sm rounded px-2 py-1 text-xs transition-colors ${
-        inputMode ? "bg-cyan-500/20 text-cyan-400" : "bg-amber-500/20 text-amber-400"
+        inputMode ? "bg-primary/20 text-primary" : "bg-warning/20 text-warning"
       }`}
       title={
         inputMode
@@ -45,7 +45,9 @@ export function AutoScrollToggleButton({ autoScroll, onToggle }: AutoScrollToggl
       onMouseDown={(e) => e.preventDefault()}
       onClick={onToggle}
       className={`touch-target-sm rounded px-2 py-1 text-xs transition-colors ${
-        autoScroll ? "bg-cyan-500/15 text-cyan-400" : "bg-white/5 text-zinc-600 hover:text-zinc-400"
+        autoScroll
+          ? "bg-primary/15 text-primary"
+          : "bg-surface text-subtle-foreground hover:text-muted-foreground"
       }`}
       title={autoScroll ? "Auto-scroll: ON" : "Auto-scroll: OFF"}
     >
@@ -60,7 +62,7 @@ export function AutoScrollToggleButton({ autoScroll, onToggle }: AutoScrollToggl
  */
 export function ModeHint({ inputMode }: { inputMode: boolean }) {
   return (
-    <span className="hidden text-[10px] text-zinc-600 sm:block">
+    <span className="hidden text-[10px] text-subtle-foreground sm:block">
       {inputMode ? "click to select" : "Enter or click ⌨ to input"}
     </span>
   );

--- a/clients/react/src/components/ui/QueueBadge.tsx
+++ b/clients/react/src/components/ui/QueueBadge.tsx
@@ -15,7 +15,7 @@ export function QueueBadge({ count, onClick, icon = "✉", title }: QueueBadgePr
       type="button"
       onMouseDown={(e) => e.preventDefault()}
       onClick={onClick}
-      className="rounded px-1.5 py-0.5 text-[10px] transition-colors bg-amber-500/20 text-amber-400 hover:bg-amber-500/30"
+      className="rounded px-1.5 py-0.5 text-[10px] transition-colors bg-warning/20 text-warning hover:bg-warning/30"
       title={title ?? `${count} item${count !== 1 ? "s" : ""} queued — click to view`}
     >
       {icon} {count}

--- a/clients/react/src/components/ui/QueuePopover.tsx
+++ b/clients/react/src/components/ui/QueuePopover.tsx
@@ -38,27 +38,27 @@ export function QueuePopover<T extends { id: string }>({
   return (
     <div
       ref={ref}
-      className="absolute bottom-full left-0 z-50 mb-1 w-80 rounded-lg border border-white/10 bg-[#1a1a1a] shadow-xl"
+      className="absolute bottom-full left-0 z-50 mb-1 w-80 rounded-lg border border-hairline-strong bg-popover shadow-xl"
     >
-      <div className="flex items-center justify-between border-b border-white/10 px-3 py-2">
-        <span className="text-[11px] font-medium text-zinc-300">{title}</span>
+      <div className="flex items-center justify-between border-b border-hairline-strong px-3 py-2">
+        <span className="text-[11px] font-medium text-foreground">{title}</span>
         <button
           type="button"
           onClick={onClose}
-          className="text-[10px] text-zinc-500 hover:text-zinc-300 transition-colors"
+          className="text-[10px] text-muted-foreground hover:text-foreground transition-colors"
           aria-label="Close"
         >
           ✕
         </button>
       </div>
-      <ul className="max-h-60 divide-y divide-white/5 overflow-y-auto">
+      <ul className="max-h-60 divide-y divide-hairline overflow-y-auto">
         {items.map((item) => (
           <li key={item.id} className="flex items-start gap-2 px-3 py-2">
             <div className="min-w-0 flex-1">{renderItem(item)}</div>
             <button
               type="button"
               onClick={() => onCancel(item.id)}
-              className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-red-400 transition-colors hover:bg-red-500/20"
+              className="shrink-0 rounded px-1.5 py-0.5 text-[10px] text-destructive transition-colors hover:bg-destructive/20"
               aria-label="Cancel queued prompt"
             >
               Cancel

--- a/clients/react/src/components/usage/UsagePanel.tsx
+++ b/clients/react/src/components/usage/UsagePanel.tsx
@@ -4,16 +4,16 @@ import { useSSE } from "@/lib/sse-provider";
 
 // Color class based on usage percentage
 function meterColor(percent: number): string {
-  if (percent >= 80) return "text-red-400";
-  if (percent >= 50) return "text-amber-400";
-  return "text-cyan-400";
+  if (percent >= 80) return "text-destructive";
+  if (percent >= 50) return "text-warning";
+  return "text-primary";
 }
 
 // Bar gradient class based on usage percentage
 function barGradient(percent: number): string {
-  if (percent >= 80) return "from-red-500 to-red-400";
-  if (percent >= 50) return "from-amber-500 to-amber-400";
-  return "from-cyan-500 to-blue-500";
+  if (percent >= 80) return "from-destructive to-destructive";
+  if (percent >= 50) return "from-warning to-warning";
+  return "from-primary to-info";
 }
 
 // Format "fetched_at" as relative time
@@ -58,14 +58,16 @@ export function UsagePanel() {
   const hasData = usage && usage.meters.length > 0;
 
   return (
-    <div className="border-t border-white/5">
+    <div className="border-t border-hairline">
       {/* Header row */}
       <button
         type="button"
         onClick={() => setExpanded((v) => !v)}
-        className="flex w-full items-center gap-2 px-4 py-2 text-left transition-colors hover:bg-white/5"
+        className="flex w-full items-center gap-2 px-4 py-2 text-left transition-colors hover:bg-surface"
       >
-        <span className="text-[10px] font-semibold tracking-wider text-zinc-500">USAGE</span>
+        <span className="text-[10px] font-semibold tracking-wider text-muted-foreground">
+          USAGE
+        </span>
 
         {/* Collapsed: show top 2 meters as badges */}
         {!expanded && hasData && (
@@ -78,7 +80,9 @@ export function UsagePanel() {
           </div>
         )}
 
-        {!expanded && !hasData && <span className="flex-1 text-[11px] text-zinc-600">—</span>}
+        {!expanded && !hasData && (
+          <span className="flex-1 text-[11px] text-subtle-foreground">—</span>
+        )}
 
         {/* Refresh button */}
         <button
@@ -87,7 +91,7 @@ export function UsagePanel() {
             e.stopPropagation();
             handleFetch();
           }}
-          className={`text-xs text-zinc-500 transition-colors hover:text-zinc-300 ${
+          className={`text-xs text-muted-foreground transition-colors hover:text-foreground ${
             fetching ? "animate-spin" : ""
           }`}
         >
@@ -103,13 +107,13 @@ export function UsagePanel() {
               {usage.meters.map((m) => (
                 <div key={m.label} className="space-y-1">
                   <div className="flex items-baseline justify-between">
-                    <span className="text-[11px] text-zinc-400">{m.label}</span>
+                    <span className="text-[11px] text-muted-foreground">{m.label}</span>
                     <span className={`text-[11px] font-medium ${meterColor(m.percent)}`}>
                       {m.percent}%
                     </span>
                   </div>
                   {/* Progress bar */}
-                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-white/5">
+                  <div className="h-1.5 w-full overflow-hidden rounded-full bg-surface">
                     <div
                       className={`h-full rounded-full bg-gradient-to-r ${barGradient(m.percent)} transition-all duration-500`}
                       style={{ width: `${Math.min(m.percent, 100)}%` }}
@@ -117,7 +121,7 @@ export function UsagePanel() {
                   </div>
                   {/* Reset info / spending */}
                   {(m.reset_info || m.spending) && (
-                    <p className="text-[10px] text-zinc-600">
+                    <p className="text-[10px] text-subtle-foreground">
                       {m.spending && <span>{m.spending}</span>}
                       {m.spending && m.reset_info && <span> · </span>}
                       {m.reset_info && <span>{m.reset_info}</span>}
@@ -126,15 +130,17 @@ export function UsagePanel() {
                 </div>
               ))}
               {/* Updated timestamp */}
-              <p className="text-[10px] text-zinc-600">Updated {timeAgo(usage.fetched_at)}</p>
+              <p className="text-[10px] text-subtle-foreground">
+                Updated {timeAgo(usage.fetched_at)}
+              </p>
             </>
           ) : (
-            <p className="text-[11px] text-zinc-600">
+            <p className="text-[11px] text-subtle-foreground">
               {fetching ? "Fetching usage..." : "Click ↻ to fetch usage data"}
             </p>
           )}
 
-          {usage?.error && <p className="text-[10px] text-red-400/70">{usage.error}</p>}
+          {usage?.error && <p className="text-[10px] text-destructive/70">{usage.error}</p>}
         </div>
       )}
     </div>

--- a/clients/react/src/lib/__tests__/no-raw-palette.test.ts
+++ b/clients/react/src/lib/__tests__/no-raw-palette.test.ts
@@ -28,6 +28,12 @@ const MIGRATED = [
   "components/layout",
   "components/calibration",
   "components/markdown",
+  "components/project",
+  "components/teams",
+  "components/terminal",
+  "components/ui",
+  "components/usage",
+  "App.tsx",
 ];
 
 // A raw Tailwind palette colour utility: <prefix>-<family>[-<shade>][/<alpha>].
@@ -43,6 +49,11 @@ const RAW_PALETTE = new RegExp(
 );
 
 function* walk(dir: string): Generator<string> {
+  // Accept a single-file area (e.g. "App.tsx") as well as a directory.
+  if (statSync(dir).isFile()) {
+    if (/\.tsx?$/.test(dir) && !/\.test\.tsx?$/.test(dir)) yield dir;
+    return;
+  }
   for (const entry of readdirSync(dir)) {
     const p = join(dir, entry);
     if (statSync(p).isDirectory()) {


### PR DESCRIPTION
**PR H of the semantic-token migration** (follows #704). This **completes the component-tree migration** — the entire `src/components` tree **and** `App.tsx` are now free of raw Tailwind palette classes.

## Migration

- 11 files, ~170 codemod substitutions, **zero residual** raw palette, **zero collapsed-ternary** artifacts (guard green): `App.tsx`, `components/project/` (3), `components/teams/` (1), `components/terminal/` (3), `components/ui/` (2), `components/usage/` (1).
- Regression guard allowlist: **+ project, teams, terminal, ui, usage, App.tsx** — the guard now covers the whole tree.

## Manual fixups (codemod can't decide)

- `App.tsx` mobile-drawer **"tmai" brand wordmark** → brand fx vars `from-[var(--brand-from)] to-[var(--brand-to)]` (same call as the StatusBar fix in #703), applied before the codemod.
- `QueuePopover.tsx` `bg-[#1a1a1a]` (an arbitrary-hex popover surface) → `bg-popover` (themed: `zinc` ~identical, `light` a proper light popover).

## Canonical codemod / guard hardening

- `walk()` (codemod **and** guard) now accepts a single **file** target (e.g. `src/App.tsx`), not just directories — needed for loose top-level files and for PR I's repo-wide lock.
- `divide-white/<alpha>` → `divide-hairline` / `divide-hairline-strong` (mirrors the `border-white` hairline mapping; the `divide` utility sets border-color between children). `UsagePanel`'s percent-based bar gradients (`from-red/amber/cyan`) map correctly via the existing status rules.

## Gate

`pnpm build && pnpm lint && pnpm test` — green (64 files, **518 passed**, 2 pre-existing skips).

Browser-verify still deferred (vite-on-WSL crash risk + no backend) — recommended at review or on request. **Next: PR I** — flip the regression lint repo-wide (scan all of `components` + `App.tsx`, drop the allowlist) and **promote `light` into the selectable themes** (the proof the migration landed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)