### PR TITLE
feat(webui): repo-wide token lock + promote light theme (PR I — final)

### DIFF
--- a/clients/react/src/components/settings/__tests__/ThemeSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/ThemeSection.test.tsx
@@ -10,20 +10,35 @@ describe("ThemeSection", () => {
     localStorage.clear();
   });
 
-  it("shows Tokyo Night selected by default", () => {
+  it("shows Tokyo Night selected by default, with Zinc and the Day theme available", () => {
     renderWithProviders(<ThemeSection />);
-    expect(screen.getByRole("button", { name: /Tokyo Night/ }).getAttribute("aria-pressed")).toBe(
+    // Exact-anchored so it doesn't also match "Tokyo Night Day".
+    expect(screen.getByRole("button", { name: /^Tokyo Night$/ }).getAttribute("aria-pressed")).toBe(
       "true",
     );
     expect(screen.getByRole("button", { name: /Zinc/ }).getAttribute("aria-pressed")).toBe("false");
+    expect(
+      screen.getByRole("button", { name: /Tokyo Night Day/ }).getAttribute("aria-pressed"),
+    ).toBe("false");
   });
 
-  it("persists the selection to the ui-prefs blob and reflects it", () => {
+  it("persists a Zinc selection to the ui-prefs blob and reflects it", () => {
     renderWithProviders(<ThemeSection />);
 
     fireEvent.click(screen.getByRole("button", { name: /Zinc/ }));
 
     expect(screen.getByRole("button", { name: /Zinc/ }).getAttribute("aria-pressed")).toBe("true");
     expect(JSON.parse(localStorage.getItem(UI_PREFS_STORAGE_KEY) ?? "{}").theme).toBe("zinc");
+  });
+
+  it("the migration landed: the light theme is selectable and persists", () => {
+    renderWithProviders(<ThemeSection />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Tokyo Night Day/ }));
+
+    expect(
+      screen.getByRole("button", { name: /Tokyo Night Day/ }).getAttribute("aria-pressed"),
+    ).toBe("true");
+    expect(JSON.parse(localStorage.getItem(UI_PREFS_STORAGE_KEY) ?? "{}").theme).toBe("light");
   });
 });

--- a/clients/react/src/lib/__tests__/no-raw-palette.test.ts
+++ b/clients/react/src/lib/__tests__/no-raw-palette.test.ts
@@ -1,16 +1,21 @@
-// Regression guard for the WebUI semantic-token migration.
+// Repo-wide regression lock for the WebUI semantic-token migration.
 //
-// Once an area has been migrated off the hardcoded Tailwind palette
-// classes (`text-zinc-300`, `bg-white/10`, `text-cyan-400`, …) onto the
-// semantic theme tokens, it must STAY migrated — otherwise the theme
-// silently stops applying there again. This test fails if any raw
-// palette utility reappears in a migrated directory.
+// The migration (PRs A–H) moved the entire component tree off the
+// hardcoded Tailwind palette classes (`text-zinc-300`, `bg-white/10`,
+// `text-cyan-400`, …) onto the semantic theme tokens, so every surface
+// re-skins with the active theme (including the `light` theme). This
+// guard makes that permanent: if a raw palette utility reappears
+// ANYWHERE under `src/` it fails, so the theme can never silently stop
+// applying again.
 //
-// `MIGRATED` is the allowlist that grows one entry per area PR. The
-// remaining (not-yet-migrated) directories are intentionally NOT scanned
-// — they still hardcode palette classes by design until their PR lands.
-// The migration's final PR scans `components` wholesale and deletes this
-// comment's caveat.
+// (Earlier PRs used a growing `MIGRATED` allowlist; the final PR drops
+// it and scans the whole tree.)
+//
+// Excluded, by design:
+//   • `__tests__` dirs and `*.test.*` — test fixtures/strings.
+//   • `types/generated/**` — generated wire types, not styled.
+//   • `lib/theme.ts` — the single source of truth; it legitimately
+//     holds colour *values* (hex/oklch), never Tailwind palette classes.
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, join, relative, resolve } from "node:path";
@@ -19,22 +24,8 @@ import { describe, expect, it } from "vitest";
 
 const SRC = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
 
-// Directories (relative to src/) that have completed the migration.
-const MIGRATED = [
-  "components/settings",
-  "components/worktree",
-  "components/producer-console",
-  "components/agent",
-  "components/layout",
-  "components/calibration",
-  "components/markdown",
-  "components/project",
-  "components/teams",
-  "components/terminal",
-  "components/ui",
-  "components/usage",
-  "App.tsx",
-];
+// Paths (relative to src/) excluded from the scan.
+const EXCLUDED = new Set(["types/generated", "lib/theme.ts"]);
 
 // A raw Tailwind palette colour utility: <prefix>-<family>[-<shade>][/<alpha>].
 // Semantic tokens (foreground / surface / primary / hairline / …) do not
@@ -49,13 +40,10 @@ const RAW_PALETTE = new RegExp(
 );
 
 function* walk(dir: string): Generator<string> {
-  // Accept a single-file area (e.g. "App.tsx") as well as a directory.
-  if (statSync(dir).isFile()) {
-    if (/\.tsx?$/.test(dir) && !/\.test\.tsx?$/.test(dir)) yield dir;
-    return;
-  }
   for (const entry of readdirSync(dir)) {
     const p = join(dir, entry);
+    const rel = relative(SRC, p);
+    if (EXCLUDED.has(rel)) continue;
     if (statSync(p).isDirectory()) {
       if (entry === "__tests__") continue;
       yield* walk(p);
@@ -69,48 +57,47 @@ function* walk(dir: string): Generator<string> {
 // `cond ? "text-muted-foreground" : "text-muted-foreground"`. The
 // codemod collapses shade ranges (zinc-400 & zinc-500 → muted-foreground),
 // which can silently turn a meaningful "dimmer-when-disabled" branch into
-// a no-op conditional that drops a UX cue. Catch it here so every future
-// area PR fixes it (restore the distinction with a different token, e.g.
-// subtle-foreground, or simplify) instead of relying on a human reviewer.
+// a no-op conditional that drops a UX cue. Restore the distinction with a
+// different token (e.g. subtle-foreground) or simplify to a single class.
 const IDENTICAL_TERNARY = /\?\s*("(?:[^"\\]|\\.)*")\s*:\s*("(?:[^"\\]|\\.)*")/g;
 
-describe("semantic-token migration regression guard", () => {
-  for (const area of MIGRATED) {
-    it(`'${area}' stays free of raw Tailwind palette classes`, () => {
-      const violations: string[] = [];
-      for (const file of walk(join(SRC, area))) {
-        const text = readFileSync(file, "utf8");
-        text.split("\n").forEach((line, i) => {
-          const hits = line.match(RAW_PALETTE);
-          if (hits) {
-            violations.push(`${relative(SRC, file)}:${i + 1}  ${[...new Set(hits)].join(" ")}`);
-          }
-        });
-      }
-      expect(
-        violations,
-        `Raw palette classes found in a migrated area — run scripts/theme-codemod.mjs ` +
-          `and map any leftovers to semantic tokens:\n${violations.join("\n")}`,
-      ).toEqual([]);
-    });
+describe("semantic-token migration — repo-wide lock", () => {
+  it("src/ is free of raw Tailwind palette classes", () => {
+    const violations: string[] = [];
+    for (const file of walk(SRC)) {
+      const text = readFileSync(file, "utf8");
+      text.split("\n").forEach((line, i) => {
+        const hits = line.match(RAW_PALETTE);
+        if (hits) {
+          violations.push(`${relative(SRC, file)}:${i + 1}  ${[...new Set(hits)].join(" ")}`);
+        }
+      });
+    }
+    expect(
+      violations,
+      `Raw Tailwind palette classes found — the WebUI is fully migrated to ` +
+        `semantic theme tokens. Run scripts/theme-codemod.mjs on the file(s) ` +
+        `and map any leftovers to semantic tokens:\n${violations.join("\n")}`,
+    ).toEqual([]);
+  });
 
-    it(`'${area}' has no codemod-collapsed (identical-branch) class ternaries`, () => {
-      const violations: string[] = [];
-      for (const file of walk(join(SRC, area))) {
-        const text = readFileSync(file, "utf8");
-        for (const m of text.matchAll(IDENTICAL_TERNARY)) {
-          if (m[1] === m[2]) {
-            const ln = text.slice(0, m.index).split("\n").length;
-            violations.push(`${relative(SRC, file)}:${ln}  ${m[1]}`);
-          }
+  it("src/ has no codemod-collapsed (identical-branch) class ternaries", () => {
+    const violations: string[] = [];
+    for (const file of walk(SRC)) {
+      const text = readFileSync(file, "utf8");
+      for (const m of text.matchAll(IDENTICAL_TERNARY)) {
+        if (m[1] === m[2]) {
+          const ln = text.slice(0, m.index).split("\n").length;
+          violations.push(`${relative(SRC, file)}:${ln}  ${m[1]}`);
         }
       }
-      expect(
-        violations,
-        `Both ternary branches resolve to the same class (the codemod collapsed a ` +
-          `distinction). Restore it with a different token (e.g. subtle-foreground for ` +
-          `the disabled/inactive branch) or simplify to a single class:\n${violations.join("\n")}`,
-      ).toEqual([]);
-    });
-  }
+    }
+    expect(
+      violations,
+      `Both ternary branches resolve to the same class (a collapsed ` +
+        `distinction). Restore it with a different token (e.g. ` +
+        `subtle-foreground for the disabled/inactive branch) or simplify ` +
+        `to a single class:\n${violations.join("\n")}`,
+    ).toEqual([]);
+  });
 });

--- a/clients/react/src/lib/__tests__/theme.test.ts
+++ b/clients/react/src/lib/__tests__/theme.test.ts
@@ -3,7 +3,6 @@ import { beforeEach, describe, expect, it } from "vitest";
 import {
   applyThemeToDocument,
   DEFAULT_THEME_NAME,
-  REGISTERED_THEME_NAMES,
   resolveTheme,
   SEMANTIC_TOKENS,
   THEME_NAMES,
@@ -32,14 +31,12 @@ describe("theme registry", () => {
     expect(DEFAULT_THEME_NAME).toBe("tokyonight");
   });
 
-  it("resolves the registry-only `light` theme but keeps it un-selectable", () => {
-    // Resolvable now (acceptance-test theme for the token migration)…
+  it("exposes `light` as a first-class selectable theme (migration complete)", () => {
     expect(resolveTheme("light")).toBe(THEMES.light);
-    expect(REGISTERED_THEME_NAMES).toContain("light");
-    // …but NOT user-selectable (Settings switcher + ui-prefs validation
-    // both key off THEME_NAMES) until the component tree consumes tokens.
-    expect(THEME_NAMES as readonly string[]).not.toContain("light");
-    expect(THEME_NAMES as readonly string[]).toEqual(["tokyonight", "zinc"]);
+    // Graduated into the selectable set once the component tree finished
+    // migrating onto semantic tokens (Settings switcher + ui-prefs
+    // validation both key off THEME_NAMES).
+    expect(THEME_NAMES as readonly string[]).toEqual(["tokyonight", "zinc", "light"]);
   });
 });
 
@@ -152,11 +149,13 @@ describe("themeCssVars / applyThemeToDocument — the CSS-var surface", () => {
     expect(lt["--color-background"]).toBe("#e1e2e7");
   });
 
-  it("PR-A inert invariant: glow vars match the pre-theme literals for the selectable themes", () => {
-    // The globals.css `.glow-*` / glowPulse rewrite only stays visually
-    // identical if every SELECTABLE theme keeps the original cyan/amber/
-    // red literals. (light may differ — it isn't selectable yet.)
-    for (const name of THEME_NAMES) {
+  it("PR-A inert invariant: the dark themes keep the pre-theme glow literals", () => {
+    // The globals.css `.glow-*` / glowPulse rewrite stayed visually
+    // identical for the pre-existing dark themes only by keeping the
+    // original cyan/amber/red literals. `light` is a new theme and
+    // legitimately retunes the glow for a light backdrop, so it is
+    // intentionally excluded from this invariant.
+    for (const name of ["tokyonight", "zinc"] as const) {
       const v = themeCssVars(THEMES[name]);
       expect(v["--glow-accent"]).toBe("34 211 238");
       expect(v["--glow-warning"]).toBe("245 158 11");

--- a/clients/react/src/lib/theme.ts
+++ b/clients/react/src/lib/theme.ts
@@ -25,19 +25,14 @@
 
 import type { ITheme } from "@xterm/xterm";
 
-// User-SELECTABLE themes — drives the Settings switcher and ui-prefs
-// validation. `light` is intentionally NOT here yet: it is fully defined
-// (below) and resolvable so it can serve as the acceptance test for the
-// semantic-token migration, but until the component tree actually
-// consumes the tokens it would render broken, so it stays unreachable
-// from the UI until the migration's final PR promotes it into this list.
-export const THEME_NAMES = ["tokyonight", "zinc"] as const;
+// User-selectable themes — drives the Settings switcher, ui-prefs
+// validation, the registry and `resolveTheme`. `light` (Tokyo Night
+// Day) graduated here once the component tree finished migrating onto
+// semantic tokens (PRs A–H): the whole UI now genuinely re-skins under
+// a light theme, so it is a first-class choice. (Earlier it was held in
+// a separate registry-only list until the migration could back it.)
+export const THEME_NAMES = ["tokyonight", "zinc", "light"] as const;
 export type ThemeName = (typeof THEME_NAMES)[number];
-
-// All themes in the registry (selectable + not-yet-selectable). Used by
-// `resolveTheme` and `THEMES` so `light` exists and is testable now.
-export const REGISTERED_THEME_NAMES = ["tokyonight", "zinc", "light"] as const;
-export type RegisteredThemeName = (typeof REGISTERED_THEME_NAMES)[number];
 
 // New installs default to Tokyo Night so the WebUI matches the operator's
 // tmux out of the box.
@@ -184,7 +179,7 @@ export interface ThemePalette {
 }
 
 export interface Theme {
-  name: RegisteredThemeName;
+  name: ThemeName;
   label: string;
   palette: ThemePalette;
 }
@@ -505,7 +500,7 @@ const LIGHT: Theme = {
   },
 };
 
-export const THEMES: Record<RegisteredThemeName, Theme> = Object.freeze({
+export const THEMES: Record<ThemeName, Theme> = Object.freeze({
   tokyonight: TOKYONIGHT,
   zinc: ZINC,
   light: LIGHT,
@@ -514,12 +509,10 @@ export const THEMES: Record<RegisteredThemeName, Theme> = Object.freeze({
 // Resolve a (possibly untrusted / persisted) name to a Theme. Returns a
 // stable singleton per name — callers can safely use the result as a
 // React effect dependency; identity only changes when the name changes.
-// Resolves any REGISTERED theme (incl. the not-yet-selectable `light`)
-// so tests and the migration's final PR can reach it; ui-prefs still
-// validates persisted values against the selectable THEME_NAMES.
+// Unknown / nullish names fall back to the default theme.
 export function resolveTheme(name: string | null | undefined): Theme {
-  if (name && (REGISTERED_THEME_NAMES as readonly string[]).includes(name)) {
-    return THEMES[name as RegisteredThemeName];
+  if (name && (THEME_NAMES as readonly string[]).includes(name)) {
+    return THEMES[name as ThemeName];
   }
   return THEMES[DEFAULT_THEME_NAME];
 }


### PR DESCRIPTION
**Final PR of the semantic-token migration.** The component tree is fully migrated (PRs A–H, #698–#705); this makes it permanent and ships the proof.

## Repo-wide lock

The regression guard is now a **repo-wide lock**. The growing per-area `MIGRATED` allowlist is dropped — the guard scans **all of `src/`**, excluding only:
- `__tests__/` and `*.test.*` (fixtures/strings),
- `types/generated/**` (generated wire types),
- `lib/theme.ts` (the single source of truth — it legitimately holds colour *values*, never palette classes).

Any raw Tailwind palette class reappearing **anywhere**, plus any collapsed identical-branch class ternary, now fails the test suite. The theme can never silently stop applying again.

## `light` promoted (the proof)

`light` (Tokyo Night Day) is now a **first-class selectable theme**. The `THEME_NAMES` / `REGISTERED_THEME_NAMES` split was migration scaffolding — it let `light` be defined and tested while staying unreachable from the UI as long as components still hardcoded palette. Collapsed back to a single `THEME_NAMES = [tokyonight, zinc, light]`; `Theme.name` / `THEMES` / `resolveTheme` retyped to `ThemeName`; `RegisteredThemeName` / `REGISTERED_THEME_NAMES` removed (no remaining refs). `ThemeSection` now offers all three — selecting **Tokyo Night Day** re-skins the entire UI light, which is the end-to-end proof the migration landed.

## Tests

- `theme.test`: `light` selectable; the PR-A glow inert-invariant is pinned to the dark themes only (`light` legitimately retunes the glow for a light backdrop).
- `ThemeSection.test`: 3-theme selectors, anchored so `/^Tokyo Night$/` doesn't also match "Tokyo Night Day"; new test asserting the light theme is selectable and persists.

## Scope note

The lock covers **all of `src/`**, not just `components` + `App.tsx` as originally planned — a full `src` sweep showed zero raw palette outside the migrated tree, so the stronger guarantee costs nothing.

## Gate

`pnpm build && pnpm lint && pnpm test` — green (64 files, **495 passed**, 2 pre-existing skips; guard collapsed from ~26 per-area cases to 2 repo-wide ones).

## Migration complete

A `feat(webui): theme system` (#696) → … → this. The WebUI is fully theme-driven: terminal + chrome + every component re-skin with the active theme, locked against regression, with a working light theme as the acceptance proof. Browser-verify across the themes is still recommended at review (vite-on-WSL crash risk meant it was deferred throughout — structural correctness is covered by build + the repo-wide guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)