### PR TITLE
chore(gen): sync generated spec + types from tmai-core@34de0e9

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -7,7 +7,7 @@
           "description": "A human interacting through a UI surface",
           "properties": {
             "cwd": {
-              "description": "Working directory of the UI request, used for project-scope routing (#89).\n\nThe WebUI/TUI passes the cwd from the request body so\n`OrchestratorNotifier::source_project_scope` can scope notifications\nwithout needing the caller to be tracked in `state.agents`.",
+              "description": "Working directory of the UI request, used for project-scope routing (#89).\n\nThe WebUI/TUI passes the cwd from the request body so\n`ProducerKicker::source_project_scope` can scope notifications\nwithout needing the caller to be tracked in `state.agents`.",
               "type": [
                 "string",
                 "null"
@@ -34,7 +34,7 @@
           "description": "An AI agent (orchestrator or worker) via MCP tools",
           "properties": {
             "cwd": {
-              "description": "Caller working directory at origin creation time (MCP loopback only).\n\nSet by `TmaiHttpClient::from_runtime` via `std::env::current_dir()` so\n`OrchestratorNotifier::source_project_scope` can resolve the project\nroot when the MCP agent ID is not tracked in `state.agents` (#75).",
+              "description": "Caller working directory at origin creation time (MCP loopback only).\n\nSet by `TmaiHttpClient::from_runtime` via `std::env::current_dir()` so\n`ProducerKicker::source_project_scope` can resolve the project\nroot when the MCP agent ID is not tracked in `state.agents` (#75).",
               "type": [
                 "string",
                 "null"
@@ -44,8 +44,8 @@
               "description": "Canonical AgentId in `<scheme>:<id>` form (e.g. `\"claude:ea760770-c137-...\"`),\nmatching `AgentSnapshot.id`.",
               "type": "string"
             },
-            "is_orchestrator": {
-              "description": "Whether this agent is the orchestrator",
+            "is_producer": {
+              "description": "Whether this agent is the Producer.\n\nWire field name `is_producer` (DR\n`2026-05-16-producer-identity-and-operator-addressing` §B —\nthe deliberate contract-surface change that #402's neutral\n`is_orchestrator` rename was holding back). `default` +\n`skip_serializing_if` make it optional: an old client that\nomits the field still deserializes (→ `false`) and the field\nis absent on the wire when `false`, so neither side is forced\ninto lockstep.",
               "type": "boolean"
             },
             "kind": {
@@ -57,7 +57,6 @@
           },
           "required": [
             "id",
-            "is_orchestrator",
             "kind"
           ],
           "type": "object"

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -348,7 +348,7 @@
                   "string",
                   "null"
                 ],
-                "description": "Working directory of the UI request, used for project-scope routing (#89).\n\nThe WebUI/TUI passes the cwd from the request body so\n`OrchestratorNotifier::source_project_scope` can scope notifications\nwithout needing the caller to be tracked in `state.agents`."
+                "description": "Working directory of the UI request, used for project-scope routing (#89).\n\nThe WebUI/TUI passes the cwd from the request body so\n`ProducerKicker::source_project_scope` can scope notifications\nwithout needing the caller to be tracked in `state.agents`."
               },
               "interface": {
                 "type": "string",
@@ -367,7 +367,6 @@
             "description": "An AI agent (orchestrator or worker) via MCP tools",
             "required": [
               "id",
-              "is_orchestrator",
               "kind"
             ],
             "properties": {
@@ -376,15 +375,15 @@
                   "string",
                   "null"
                 ],
-                "description": "Caller working directory at origin creation time (MCP loopback only).\n\nSet by `TmaiHttpClient::from_runtime` via `std::env::current_dir()` so\n`OrchestratorNotifier::source_project_scope` can resolve the project\nroot when the MCP agent ID is not tracked in `state.agents` (#75)."
+                "description": "Caller working directory at origin creation time (MCP loopback only).\n\nSet by `TmaiHttpClient::from_runtime` via `std::env::current_dir()` so\n`ProducerKicker::source_project_scope` can resolve the project\nroot when the MCP agent ID is not tracked in `state.agents` (#75)."
               },
               "id": {
                 "type": "string",
                 "description": "Canonical AgentId in `<scheme>:<id>` form (e.g. `\"claude:ea760770-c137-...\"`),\nmatching `AgentSnapshot.id`."
               },
-              "is_orchestrator": {
+              "is_producer": {
                 "type": "boolean",
-                "description": "Whether this agent is the orchestrator"
+                "description": "Whether this agent is the Producer.\n\nWire field name `is_producer` (DR\n`2026-05-16-producer-identity-and-operator-addressing` §B —\nthe deliberate contract-surface change that #402's neutral\n`is_orchestrator` rename was holding back). `default` +\n`skip_serializing_if` make it optional: an old client that\nomits the field still deserializes (→ `false`) and the field\nis absent on the wire when `false`, so neither side is forced\ninto lockstep."
               },
               "kind": {
                 "type": "string",

--- a/clients/react/src/types/generated/ActionOrigin.ts
+++ b/clients/react/src/types/generated/ActionOrigin.ts
@@ -15,7 +15,7 @@ interface: string,
  * Working directory of the UI request, used for project-scope routing (#89).
  *
  * The WebUI/TUI passes the cwd from the request body so
- * `OrchestratorNotifier::source_project_scope` can scope notifications
+ * `ProducerKicker::source_project_scope` can scope notifications
  * without needing the caller to be tracked in `state.agents`.
  */
 cwd?: string | null, } | { "kind": "Agent", 
@@ -25,14 +25,23 @@ cwd?: string | null, } | { "kind": "Agent",
  */
 id: string, 
 /**
- * Whether this agent is the orchestrator
+ * Whether this agent is the Producer.
+ *
+ * Wire field name `is_producer` (DR
+ * `2026-05-16-producer-identity-and-operator-addressing` §B —
+ * the deliberate contract-surface change that #402's neutral
+ * `is_orchestrator` rename was holding back). `default` +
+ * `skip_serializing_if` make it optional: an old client that
+ * omits the field still deserializes (→ `false`) and the field
+ * is absent on the wire when `false`, so neither side is forced
+ * into lockstep.
  */
-is_orchestrator: boolean, 
+is_producer?: boolean, 
 /**
  * Caller working directory at origin creation time (MCP loopback only).
  *
  * Set by `TmaiHttpClient::from_runtime` via `std::env::current_dir()` so
- * `OrchestratorNotifier::source_project_scope` can resolve the project
+ * `ProducerKicker::source_project_scope` can resolve the project
  * root when the MCP agent ID is not tracked in `state.agents` (#75).
  */
 cwd?: string | null, } | { "kind": "System", 


### PR DESCRIPTION
Manual Producer **hand-mirror** of the generated wire contract — the `gen-spec-pr` workflow is billing-dead (tmai-core private Actions quota), so per the standing convention the Producer regenerates and mirrors by hand on wire changes.

**Mirrors** `tmai-core@34de0e9` = **#404** (`producer-identity-and-operator-addressing` §B): the `is_orchestrator` → `is_producer` **derived** wire field (optional, serde-defaulted, lockstep-free). #402's wire-neutral rename was intentionally holding this back; #404 took the deliberate contract-surface change.

### What changed (verbatim `tmai-xtask` output — NO hand edits)
- `api-spec/openapi.json`, `api-spec/corevents.schema.json` — `is_producer` replaces `is_orchestrator`
- `clients/react/src/types/generated/ActionOrigin.ts` — `is_orchestrator: boolean` → `is_producer?: boolean` (optional) + §B doc-comment
- mcp-tools.json / ratatui rust-types / other react ts-types: byte-identical (no churn)
- `versions.toml`: `api_spec` stays `3.0.1` (openapi `info.version` not bumped by the rename)

### Provenance / trust
- Regenerated from post-#404 tmai-core `34de0e9` via `tmai-xtask {openapi,schema,mcp-snapshot,ts-types,rust-types}`, the exact pipeline the dead `gen-spec-pr` workflow ran.
- tmai-core `bash scripts/ci-local.sh` "rust-types generation" gate is green at `34de0e9` → the regen is consistent with the Rust contract layer.
- `bot/` branch prefix exempts the no-hand-edits CI guard; **public CI is the real signal** here (not billing-dead). Operator merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **API更新**
  * エージェント起点情報の識別フィールド名を更新し、スキーマドキュメントを改善
  * アクション起点の参照情報を更新
  * ワイヤプロトコルの動作仕様を明確化し、既存クライアントとの互換性を確保
  * API仕様書を最新化

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/710?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->