### PR TITLE
chore(gen): sync generated spec + types from tmai-core@966543e

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -1592,6 +1592,10 @@
           "minimum": 0,
           "type": "integer"
         },
+        "producer_reviewed": {
+          "description": "`true` when the Producer has **delivered** its contract-anchored\nΔ-brief for this PR — the soft-valve unlock condition of dev-loop\nDR `2026-05-16-dev-loop-completes-in-tmai` §E (approach\n`2026-05-17-producer-review-gated-in-tmai-merge`).\n\n**Delivered, NOT approved.** A neutral delivered-marker: it states\nonly that the brief reached the operator, never that the Producer\napproves/blocks the merge or judges it merge-worthy (§E load-bearing\nboundary — the Producer's opinion is *content of the brief*, never\nthis bit; the merge decision stays wholly the operator's). The react\nhalf consumes this to make the reviewed merge path frictionless\n(dialog / colour / dismissible override) — that button state machine\nis a separate dispatch; core only exposes the bit, it never blocks a\nmerge on it. Not a `PrInfo` field: it is overlaid from the transient\n[`AppState::producer_reviewed_prs`](crate::state::AppState) in\n[`build_unit_prs_response`], so it resets on engine restart (the\nProducer re-briefs).\n\n`default` + `skip_serializing_if` keep it optional with the exact\n#404 `is_producer` discipline: the field is absent on the wire when\n`false`, and a payload omitting it deserializes to `false` — a\nclient omitting it stays lockstep-free.",
+          "type": "boolean"
+        },
         "review_decision": {
           "description": "Raw `gh` review-decision string (`\"APPROVED\"` / `\"CHANGES_REQUESTED\"`\n/ `\"REVIEW_REQUIRED\"`), or `null` when GitHub reports none.",
           "type": [

--- a/api-spec/mcp-tools.json
+++ b/api-spec/mcp-tools.json
@@ -478,6 +478,34 @@
     }
   },
   {
+    "description": "Mark the Producer's Δ-brief as DELIVERED for a PR (dev-loop soft-valve unlock — a neutral delivered-marker, NOT a merge approval; idempotent)",
+    "name": "mark_pr_reviewed",
+    "parameters_schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "pr_number": {
+          "description": "Pull request number whose Producer Δ-brief has been delivered",
+          "format": "uint64",
+          "minimum": 0,
+          "type": "integer"
+        },
+        "repo": {
+          "default": null,
+          "description": "Repository path (optional, defaults to first registered project)",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "required": [
+        "pr_number"
+      ],
+      "title": "MarkPrReviewedParams",
+      "type": "object"
+    }
+  },
+  {
     "description": "Merge a pull request (checks CI first, then squash/merge/rebase with optional branch and worktree cleanup)",
     "name": "merge_pr",
     "parameters_schema": {

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -102,6 +102,24 @@
         }
       }
     },
+    "/api/github/pr/producer-reviewed": {
+      "post": {
+        "tags": [
+          "prs"
+        ],
+        "summary": "Documentation stub for `POST /api/github/pr/producer-reviewed`.",
+        "description": "dev-loop DR `2026-05-16-dev-loop-completes-in-tmai` §E (approach\n`2026-05-17-producer-review-gated-in-tmai-merge`): mark the Producer's\ncontract-anchored Δ-brief as *delivered* for a PR. Idempotent. Sets a\ntransient, in-memory delivered-marker only — a **neutral bit, NOT a\nmerge approval** (the Producer's opinion is *content of the brief*,\nnever this flag). Core never blocks a merge on it; the soft-valve\ndialog / colour / dismissible override are the react half's, a separate\ndispatch. Vendor-neutral. The marker surfaces on\n`GET /api/units/{unit}/prs` as `PrSummaryWire.producer_reviewed`.",
+        "operationId": "mark_pr_producer_reviewed_doc",
+        "responses": {
+          "200": {
+            "description": "Δ-brief marked delivered for the PR (idempotent)"
+          },
+          "404": {
+            "description": "Repository not found"
+          }
+        }
+      }
+    },
     "/api/task-meta": {
       "get": {
         "tags": [
@@ -3097,6 +3115,10 @@
             "type": "integer",
             "format": "int64",
             "minimum": 0
+          },
+          "producer_reviewed": {
+            "type": "boolean",
+            "description": "`true` when the Producer has **delivered** its contract-anchored\nΔ-brief for this PR — the soft-valve unlock condition of dev-loop\nDR `2026-05-16-dev-loop-completes-in-tmai` §E (approach\n`2026-05-17-producer-review-gated-in-tmai-merge`).\n\n**Delivered, NOT approved.** A neutral delivered-marker: it states\nonly that the brief reached the operator, never that the Producer\napproves/blocks the merge or judges it merge-worthy (§E load-bearing\nboundary — the Producer's opinion is *content of the brief*, never\nthis bit; the merge decision stays wholly the operator's). The react\nhalf consumes this to make the reviewed merge path frictionless\n(dialog / colour / dismissible override) — that button state machine\nis a separate dispatch; core only exposes the bit, it never blocks a\nmerge on it. Not a `PrInfo` field: it is overlaid from the transient\n[`AppState::producer_reviewed_prs`](crate::state::AppState) in\n[`build_unit_prs_response`], so it resets on engine restart (the\nProducer re-briefs).\n\n`default` + `skip_serializing_if` keep it optional with the exact\n#404 `is_producer` discipline: the field is absent on the wire when\n`false`, and a payload omitting it deserializes to `false` — a\nclient omitting it stays lockstep-free."
           },
           "review_decision": {
             "type": [

--- a/clients/ratatui/src/types/generated/pr_summary_wire.rs
+++ b/clients/ratatui/src/types/generated/pr_summary_wire.rs
@@ -24,6 +24,8 @@ pub struct PrSummaryWire {
     pub merge_commit_sha: Option<Value>,
     pub number: i64,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub producer_reviewed: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub review_decision: Option<Value>,
     pub reviews: i64,
     pub state: String,

--- a/clients/react/src/types/generated/PrSummaryWire.ts
+++ b/clients/react/src/types/generated/PrSummaryWire.ts
@@ -33,4 +33,29 @@ check_status: string | null, is_draft: boolean, additions: bigint, deletions: bi
  * Set only for merged PRs (the unit list is open-only, so this is
  * `null` in practice — kept for shape parity with `PrInfo`).
  */
-merge_commit_sha: string | null, };
+merge_commit_sha: string | null, 
+/**
+ * `true` when the Producer has **delivered** its contract-anchored
+ * Δ-brief for this PR — the soft-valve unlock condition of dev-loop
+ * DR `2026-05-16-dev-loop-completes-in-tmai` §E (approach
+ * `2026-05-17-producer-review-gated-in-tmai-merge`).
+ *
+ * **Delivered, NOT approved.** A neutral delivered-marker: it states
+ * only that the brief reached the operator, never that the Producer
+ * approves/blocks the merge or judges it merge-worthy (§E load-bearing
+ * boundary — the Producer's opinion is *content of the brief*, never
+ * this bit; the merge decision stays wholly the operator's). The react
+ * half consumes this to make the reviewed merge path frictionless
+ * (dialog / colour / dismissible override) — that button state machine
+ * is a separate dispatch; core only exposes the bit, it never blocks a
+ * merge on it. Not a `PrInfo` field: it is overlaid from the transient
+ * [`AppState::producer_reviewed_prs`](crate::state::AppState) in
+ * [`build_unit_prs_response`], so it resets on engine restart (the
+ * Producer re-briefs).
+ *
+ * `default` + `skip_serializing_if` keep it optional with the exact
+ * #404 `is_producer` discipline: the field is absent on the wire when
+ * `false`, and a payload omitting it deserializes to `false` — a
+ * client omitting it stays lockstep-free.
+ */
+producer_reviewed?: boolean, };


### PR DESCRIPTION
Manual Producer **hand-mirror** of the generated wire contract — `gen-spec-pr` is billing-dead, so per the standing convention the Producer regenerates + mirrors by hand on wire changes.

**Mirrors** `tmai-core@966543e` = **#406** (dev-loop Stage-2 wire foundation, `2026-05-16-dev-loop-completes-in-tmai` §E):
- `PrSummaryWire.producer_reviewed` — new **optional, serde-defaulted** field (`#[serde(default, skip_serializing_if = Not::not)]`, exact #404 `is_producer` discipline; lockstep-free)
- `POST /api/github/pr/producer-reviewed` — the set-affordance endpoint
- MCP tool `mark_pr_reviewed` (mcp-tools.json 32 → 33)

### Verbatim `tmai-xtask` output — NO hand edits
- `api-spec/openapi.json` (+22), `corevents.schema.json` (+4), `mcp-tools.json` (+28)
- `clients/react/src/types/generated/PrSummaryWire.ts` (+27/-1), `clients/ratatui/src/types/generated/pr_summary_wire.rs` (+2)
- Other generated files byte-identical (no churn). `versions.toml` `api_spec` stays `3.0.1`.

### Trust
- Regenerated from post-#406 tmai-core `966543e` via the exact pipeline the dead `gen-spec-pr` ran; tmai-core `ci-local.sh` "rust-types generation" green at `966543e`.
- `bot/` branch prefix exempts the no-hand-edits guard; **public CI is the real signal**. Operator merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * PR に対する Producer のレビュー完了状態をマークできるようになりました。
  * PR レビュー状態を管理するための新しい API エンドポイントが追加されました。
  * PR サマリーで Producer レビュー状態の表示に対応しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/711?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->