### PR TITLE
fix(webui): stale test fixture is_orchestrator → is_producer (rename follow-up)

### DIFF
--- a/clients/react/src/components/agent/__tests__/PreviewPanel-queue.test.tsx
+++ b/clients/react/src/components/agent/__tests__/PreviewPanel-queue.test.tsx
@@ -56,7 +56,7 @@ const QUEUED: QueuedPrompt[] = [
     id: "q1",
     prompt: "run the tests",
     queued_at: "2026-04-20T10:00:00Z",
-    origin: { kind: "Agent", id: "main:0.0", is_orchestrator: true, cwd: null },
+    origin: { kind: "Agent", id: "main:0.0", is_producer: true, cwd: null },
   },
 ];
 


### PR DESCRIPTION
One-line cleanup: `agent/__tests__/PreviewPanel-queue.test.tsx` used `origin.is_orchestrator`, removed in the orchestrator→producer wire rename (now `is_producer?: boolean`).

## Why a standalone PR

This is a pre-existing branch-base `tsc -b` error (TS2353) that:
- fails `tsc -b` and `pnpm build` repo-wide on `main`, and
- is the **sole** cause of the red CI on the dependabot PR **#714** (not the npm bump itself), and
- blocked the in-flight Stage-2 merge-valve worker's gate (its own change is provably clean — stash-verified).

It is logically independent of both the npm bump (#714) and any feature work — a minimal rename-follow-up, kept as its own PR for clean separation of concerns. After merge: `gh pr update-branch` on #714 turns its CI green, and the Stage-2 worker rebases and ships clean.

## Verification

- `pnpm -C clients/react exec tsc -b` → exit 0 (was 1 × TS2353 before).
- vitest unaffected (the runtime value of the fixture didn't change; only the field name).

No behaviour change; test-fixture-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

このプルリクエストは主に内部テストの更新であり、ユーザー向けの新機能や変更はありません。

* **テスト**
  * テスト データの検証ロジックを更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/715?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->