### PR TITLE
chore(gen): sync mcp-tools.json — pull_producer_feed marker (from tmai-core@d1b3e0c)

### DIFF
--- a/api-spec/mcp-tools.json
+++ b/api-spec/mcp-tools.json
@@ -557,6 +557,35 @@
     }
   },
   {
+    "description": "Pull this unit's delta feed: bare state-change facts since your cursor (or the full compose() baseline on first-pull / cursor-loss). Facts, not instructions — you judge. Pass the returned cursor back next turn.",
+    "name": "pull_producer_feed",
+    "parameters_schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "cursor": {
+          "default": null,
+          "description": "Opaque cursor returned by your previous `pull_producer_feed` call.\nOMIT it on your first pull of a session and after any restart: the\nserver then returns the full `compose()` baseline plus a fresh\ncursor. Pass it back verbatim every subsequent turn to receive only\nthe bare state-change facts observed since it.",
+          "format": "uint64",
+          "minimum": 0,
+          "type": [
+            "integer",
+            "null"
+          ]
+        },
+        "repo": {
+          "default": null,
+          "description": "Repository path (optional, defaults to cwd or first registered\nproject). Used only to resolve the owning unit's `<unit>.producer`\nfeed address — mirrors the `repo` param of `dispatch_issue` /\n`tmai_handoff_write`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      },
+      "title": "PullProducerFeedParams",
+      "type": "object"
+    }
+  },
+  {
     "description": "Rerun failed CI checks",
     "name": "rerun_ci",
     "parameters_schema": {


### PR DESCRIPTION
Manual Producer gen-spec mirror from `tmai-core@d1b3e0c` (the gen-spec-pr workflow is dead per the private-CI billing exhaustion — `project-tmai-core-local-ci-mode`).

## Material diff: 1 file, +29 lines

`api-spec/mcp-tools.json` — adds the `pull_producer_feed` MCP tool registered in tmai-core **#412 / #413** (the unit delta feed). This is a lag from the post-#412 era that had not been mirrored to public yet; not new to tmai-core@d1b3e0c.

## Regen result for the other 4 artifacts

- `api-spec/openapi.json` — byte-identical, no diff
- `api-spec/corevents.schema.json` — byte-identical, no diff
- `clients/react/src/types/generated/*.ts` (76 files) — byte-identical, no diff
- `clients/ratatui/src/types/generated/*.rs` — byte-identical, no diff

That tmai-core@d1b3e0c's Phase A (`PrMergeOverride` wire) produces no schema diff is **by design**: `PrMergeOverride` in `src/web/api.rs` follows the existing api.rs hand-typed convention (`Deserialize`-only, no `utoipa::ToSchema`), like `MergePrRequest` / `PrMergeMethod` before it. Phase B (react UI, separate later worker) will hand-type its TS interface in `clients/react/src/lib/api-http.ts`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プロデューサーフィード取得の効率化を実現。前回取得時点以降の状態変更情報のみを取得でき、リソース効率が向上します。リポジトリ指定により検索範囲も制御可能になりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/717?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->