### PR TITLE
chore(gen): sync generated spec + types — RepoPrsWire.billing_dead (from tmai-core@82ffde2)

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -1850,6 +1850,10 @@
     "RepoPrsWire": {
       "description": "One repo's slice of the unit-scoped PR list. `repo_label` is the stable\ndirectory basename (e.g. `\"tmai-core\"`) — the same scheme\n[`crate::config::ResolvedUnit::from_dir`] uses for unit names; `repo_path`\nis the absolute path the diff/merge endpoints take as their `repo` param.",
       "properties": {
+        "billing_dead": {
+          "description": "`true` when `[github.<repo>] billing_dead = true` is set for this\nrepo (`Settings::repo_billing_dead`). Surfaced so the react UI can\ndecide *where* to show the billing-dead CI-gate override affordance\n(approach `2026-05-20-billing-dead-ci-safe-override`, O1-b) — the\naffordance belongs only on a repo the operator has flagged. This is\na read-only projection of operator config; the backend\n(`validate_billing_dead_override`) is the enforcing gate, never this\nbit. Overlaid in [`build_unit_prs_response`] from an injected\npredicate, so the function stays pure / IO-free.\n\n`default` + `skip_serializing_if` keep it optional with the exact\n#404 `is_producer` discipline: absent on the wire when `false`, and a\npayload omitting it deserializes to `false` — clients stay lockstep-free.",
+          "type": "boolean"
+        },
         "primary": {
           "description": "`true` for the unit's primary repo (where the Producer is launched).",
           "type": "boolean"

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -3365,6 +3365,10 @@
           "prs"
         ],
         "properties": {
+          "billing_dead": {
+            "type": "boolean",
+            "description": "`true` when `[github.<repo>] billing_dead = true` is set for this\nrepo (`Settings::repo_billing_dead`). Surfaced so the react UI can\ndecide *where* to show the billing-dead CI-gate override affordance\n(approach `2026-05-20-billing-dead-ci-safe-override`, O1-b) — the\naffordance belongs only on a repo the operator has flagged. This is\na read-only projection of operator config; the backend\n(`validate_billing_dead_override`) is the enforcing gate, never this\nbit. Overlaid in [`build_unit_prs_response`] from an injected\npredicate, so the function stays pure / IO-free.\n\n`default` + `skip_serializing_if` keep it optional with the exact\n#404 `is_producer` discipline: absent on the wire when `false`, and a\npayload omitting it deserializes to `false` — clients stay lockstep-free."
+          },
           "primary": {
             "type": "boolean",
             "description": "`true` for the unit's primary repo (where the Producer is launched)."

--- a/clients/react/src/types/generated/RepoPrsWire.ts
+++ b/clients/react/src/types/generated/RepoPrsWire.ts
@@ -15,4 +15,20 @@ primary: boolean,
 /**
  * Open PRs in this repo, newest first (descending PR number).
  */
-prs: Array<PrSummaryWire>, };
+prs: Array<PrSummaryWire>, 
+/**
+ * `true` when `[github.<repo>] billing_dead = true` is set for this
+ * repo (`Settings::repo_billing_dead`). Surfaced so the react UI can
+ * decide *where* to show the billing-dead CI-gate override affordance
+ * (approach `2026-05-20-billing-dead-ci-safe-override`, O1-b) — the
+ * affordance belongs only on a repo the operator has flagged. This is
+ * a read-only projection of operator config; the backend
+ * (`validate_billing_dead_override`) is the enforcing gate, never this
+ * bit. Overlaid in [`build_unit_prs_response`] from an injected
+ * predicate, so the function stays pure / IO-free.
+ *
+ * `default` + `skip_serializing_if` keep it optional with the exact
+ * #404 `is_producer` discipline: absent on the wire when `false`, and a
+ * payload omitting it deserializes to `false` — clients stay lockstep-free.
+ */
+billing_dead?: boolean, };


### PR DESCRIPTION
Manual Producer gen-spec mirror from `tmai-core@82ffde2` (#431) — the gen-spec-pr workflow is dead per the private-CI billing exhaustion (`project-tmai-core-local-ci-mode`).

Brings the per-repo `billing_dead` flag #431 added to `RepoPrsWire` into the public contract:
- `clients/react/src/types/generated/RepoPrsWire.ts` — `billing_dead?: boolean` (lockstep-free)
- `api-spec/openapi.json` — matching component schema
- `api-spec/corevents.schema.json` — `$defs` propagation

**Phase-B precondition**: the react override UI consumes `repo.billing_dead` to decide where to show the billing-dead CI-gate override affordance. `mcp-tools.json` unchanged (`pull_producer_feed` already landed via #717).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * APIレスポンスに、リポジトリごとの請求ステータス情報が追加されました。このフィールドはオプショナルで、リポジトリの請求設定に基づいて返されます。既存のクライアントとの互換性が保たれています。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/718?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->