### PR TITLE
feat(webui): billing-dead-CI safe operator-override (Phase B UI)

### DIFF
--- a/clients/react/src/components/producer-console/sections/UnitPrsSection.tsx
+++ b/clients/react/src/components/producer-console/sections/UnitPrsSection.tsx
@@ -26,7 +26,7 @@
 import { useState } from "react";
 import { DiffViewer } from "@/components/worktree/DiffViewer";
 import { useUnitPrs } from "@/hooks/useUnitPrs";
-import { api, type PrSummaryWire, type RepoPrsWire } from "@/lib/api";
+import { api, type PrMergeOverride, type PrSummaryWire, type RepoPrsWire } from "@/lib/api";
 
 interface UnitPrsSectionProps {
   unitName: string | null;
@@ -128,7 +128,11 @@ function PrList({ repos }: { repos: RepoPrsWire[] }) {
   const multiRepo = repos.length > 1;
   const [merge, setMerge] = useState<Record<string, MergeState>>({});
 
-  const onMerge = async (repoPath: string, pr: PrSummaryWire) => {
+  // `override` (Phase B billing-dead CI-safe path) is threaded straight
+  // through to `api.mergePr` and is sent only when present — the normal
+  // merge call is byte-for-byte unchanged. Both paths share this one
+  // MergeState lifecycle (busy/done/error) per the brief.
+  const onMerge = async (repoPath: string, pr: PrSummaryWire, override?: PrMergeOverride) => {
     const key = prKey(repoPath, pr.number);
     setMerge((m) => ({ ...m, [key]: { ...IDLE_MERGE, busy: true } }));
     try {
@@ -136,6 +140,7 @@ function PrList({ repos }: { repos: RepoPrsWire[] }) {
       await api.mergePr(repoPath, Number(pr.number), {
         method: "squash",
         deleteBranch: true,
+        ...(override ? { override } : {}),
       });
       setMerge((m) => ({ ...m, [key]: { ...IDLE_MERGE, done: true } }));
     } catch (e) {
@@ -166,8 +171,18 @@ function PrList({ repos }: { repos: RepoPrsWire[] }) {
                   key={prKey(repo.repo_path, pr.number)}
                   repoPath={repo.repo_path}
                   pr={pr}
+                  // billing-dead lives on the REPO, not the PR — thread it
+                  // down the same way the rest of the row is mapped from
+                  // `repo.prs`. Absent-when-false ⇒ `=== true`.
+                  billingDead={repo.billing_dead === true}
                   merge={merge[prKey(repo.repo_path, pr.number)] ?? IDLE_MERGE}
                   onMerge={() => onMerge(repo.repo_path, pr)}
+                  onOverrideMerge={(attestation) =>
+                    onMerge(repo.repo_path, pr, {
+                      ci_local_attestation: attestation,
+                      repo_billing_dead_acknowledged: true,
+                    })
+                  }
                   onArmMerge={(armed) =>
                     setMerge((m) => ({
                       ...m,
@@ -221,16 +236,42 @@ function checkBadge(status: string | null): { label: string; cls: string } | nul
 interface PrRowProps {
   repoPath: string;
   pr: PrSummaryWire;
+  /** `repo.billing_dead === true` — the repo (not the PR) is flagged
+   *  billing-dead, so the CI-safe override affordance is offered. */
+  billingDead: boolean;
   merge: MergeState;
   onMerge: () => void;
+  /** Fire the Phase B billing-dead CI-safe override merge with the
+   *  pasted ci-local attestation. */
+  onOverrideMerge: (attestation: string) => void;
   onArmMerge: (armed: boolean) => void;
 }
 
-function PrRow({ repoPath, pr, merge, onMerge, onArmMerge }: PrRowProps) {
+function PrRow({
+  repoPath,
+  pr,
+  billingDead,
+  merge,
+  onMerge,
+  onOverrideMerge,
+  onArmMerge,
+}: PrRowProps) {
   const [diffOpen, setDiffOpen] = useState(false);
   const [patch, setPatch] = useState<string | null>(null);
   const [diffLoading, setDiffLoading] = useState(false);
   const [diffError, setDiffError] = useState<string | null>(null);
+
+  // Phase B billing-dead CI-safe override (approach
+  // `2026-05-20-billing-dead-ci-safe-override`). Distinct from the
+  // Stage-2 producer_reviewed valve below — that valve only governs the
+  // *normal* merge button's friction; this is a separate button + panel
+  // for the narrow case where GitHub CI is red *only because* the repo's
+  // private Actions billing lapsed. The UI just collects + sends the
+  // attestation; the backend re-validates the per-repo `billing_dead`
+  // flag and is the real gate.
+  const [overrideOpen, setOverrideOpen] = useState(false);
+  const [attestation, setAttestation] = useState("");
+  const showOverride = billingDead && pr.check_status === "FAILURE";
 
   // Lazy: fetch the patch on the first open and cache it for the row's
   // lifetime (an open PR's diff is stable enough for a review pass).
@@ -371,7 +412,61 @@ function PrRow({ repoPath, pr, merge, onMerge, onArmMerge }: PrRowProps) {
             </button>
           </span>
         )}
+
+        {/* Phase B billing-dead CI-safe override — a DISTINCT affordance
+            from the merge button(s) above (outlined, not filled, so the
+            two are never confused). Offered only when the repo is flagged
+            billing-dead AND this PR's GitHub CI is red. */}
+        {showOverride && (
+          <button
+            type="button"
+            onClick={() => setOverrideOpen((open) => !open)}
+            disabled={merge.busy}
+            title="GitHub CI is red only because this repo's private Actions billing lapsed. Merge with a pasted ci-local attestation — the backend re-validates the per-repo billing_dead flag and is the real gate."
+            className="rounded border border-warning/50 bg-transparent px-2 py-0.5 text-[11px] font-medium text-warning transition-colors hover:bg-warning/10 disabled:opacity-50"
+          >
+            Override (ci-local attestation)
+          </button>
+        )}
       </div>
+
+      {showOverride && overrideOpen && (
+        <div className="mt-2 rounded border border-warning/40 bg-warning/[0.05] px-2 py-1.5">
+          <p className="text-[10.5px] leading-relaxed text-warning">
+            CI is red only because this repo's private Actions billing is dead. Paste the{" "}
+            <code className="text-foreground">ci-local</code> run summary; the backend re-checks the
+            per-repo <code className="text-foreground">billing_dead</code> flag + attestation before
+            running <code className="text-foreground">gh pr merge --admin</code>.
+          </p>
+          <textarea
+            value={attestation}
+            onChange={(e) => setAttestation(e.target.value)}
+            rows={4}
+            placeholder="Paste the ci-local attestation (e.g. the `bash scripts/ci-local.sh` summary)…"
+            className="mt-1.5 w-full rounded border border-hairline-strong/40 bg-surface px-2 py-1 font-mono text-[10.5px] text-foreground placeholder:text-subtle-foreground"
+          />
+          <div className="mt-1.5 flex items-center gap-1.5">
+            {/* Disabled while empty mirrors the backend min-sanity; the
+                backend stays the real gate (flag + attestation). */}
+            <button
+              type="button"
+              onClick={() => onOverrideMerge(attestation)}
+              disabled={merge.busy || attestation.trim() === ""}
+              className="rounded bg-destructive/20 px-2 py-0.5 text-[11px] font-medium text-destructive transition-colors hover:bg-destructive/30 disabled:opacity-50"
+            >
+              {merge.busy ? "Merging…" : `Override-merge #${Number(pr.number)}`}
+            </button>
+            <button
+              type="button"
+              onClick={() => setOverrideOpen(false)}
+              disabled={merge.busy}
+              className="rounded bg-surface px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong disabled:opacity-50"
+            >
+              Cancel
+            </button>
+          </div>
+        </div>
+      )}
 
       {merge.error && (
         <p className="mt-1 text-[10.5px] text-destructive/80">Merge failed: {merge.error}</p>

--- a/clients/react/src/components/producer-console/sections/__tests__/UnitPrsSection.test.tsx
+++ b/clients/react/src/components/producer-console/sections/__tests__/UnitPrsSection.test.tsx
@@ -263,4 +263,91 @@ describe("UnitPrsSection", () => {
       expect(screen.getByText(/✓ Merged #707/)).toBeTruthy();
     });
   });
+
+  // Phase B billing-dead CI-safe operator override (approach
+  // `2026-05-20-billing-dead-ci-safe-override`). A DISTINCT affordance
+  // from the producer_reviewed valve above: a separate button + panel,
+  // offered ONLY when the repo is flagged billing-dead AND this PR's
+  // GitHub CI is red. The UI just collects + sends the attestation; the
+  // backend (`validate_billing_dead_override`) is the real gate.
+
+  const failingBillingDeadRepo = (): RepoPrsWire => {
+    const repo = repoStub();
+    repo.prs[0].check_status = "FAILURE";
+    repo.billing_dead = true;
+    return repo;
+  };
+
+  const OVERRIDE_BTN = /Override \(ci-local attestation\)/;
+
+  it("does not render the override button when the repo is not billing-dead, even on CI-red", async () => {
+    const repo = repoStub();
+    repo.prs[0].check_status = "FAILURE"; // CI red, but billing_dead absent.
+    unitPrsMock.mockResolvedValue({ unit: "tmai", repos: [repo] });
+    render(<UnitPrsSection unitName="tmai" />);
+    await screen.findByText(/token lock \+ light theme/);
+    expect(screen.queryByRole("button", { name: OVERRIDE_BTN })).toBeNull();
+  });
+
+  it("does not render the override button when CI is not red, even on a billing-dead repo", async () => {
+    const repo = repoStub();
+    repo.billing_dead = true; // billing-dead, but check_status stays SUCCESS.
+    unitPrsMock.mockResolvedValue({ unit: "tmai", repos: [repo] });
+    render(<UnitPrsSection unitName="tmai" />);
+    await screen.findByText(/token lock \+ light theme/);
+    expect(screen.queryByRole("button", { name: OVERRIDE_BTN })).toBeNull();
+  });
+
+  it("renders the override button only when the repo is billing-dead AND CI is red", async () => {
+    unitPrsMock.mockResolvedValue({ unit: "tmai", repos: [failingBillingDeadRepo()] });
+    render(<UnitPrsSection unitName="tmai" />);
+    expect(await screen.findByRole("button", { name: OVERRIDE_BTN })).toBeTruthy();
+  });
+
+  it("opens the override panel and confirms with the exact override payload", async () => {
+    unitPrsMock.mockResolvedValue({ unit: "tmai", repos: [failingBillingDeadRepo()] });
+    mergePrMock.mockResolvedValue({ status: "merged" });
+    render(<UnitPrsSection unitName="tmai" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: OVERRIDE_BTN }));
+
+    const textarea = screen.getByPlaceholderText(/ci-local attestation/i);
+    fireEvent.change(textarea, { target: { value: "ci-local: all green\n42 passed" } });
+
+    fireEvent.click(screen.getByRole("button", { name: /Override-merge #707/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/✓ Merged #707/)).toBeTruthy();
+    });
+    // repo_billing_dead_acknowledged: true + the pasted attestation,
+    // alongside the unchanged squash/delete-branch defaults.
+    expect(mergePrMock).toHaveBeenCalledWith("/home/u/works/tmai", 707, {
+      method: "squash",
+      deleteBranch: true,
+      override: {
+        ci_local_attestation: "ci-local: all green\n42 passed",
+        repo_billing_dead_acknowledged: true,
+      },
+    });
+  });
+
+  it("disables the override Confirm on an empty attestation and Cancel dismisses without calling", async () => {
+    unitPrsMock.mockResolvedValue({ unit: "tmai", repos: [failingBillingDeadRepo()] });
+    render(<UnitPrsSection unitName="tmai" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: OVERRIDE_BTN }));
+
+    const confirm = screen.getByRole("button", {
+      name: /Override-merge #707/,
+    }) as HTMLButtonElement;
+    // Empty textarea ⇒ Confirm disabled (mirrors the backend min-sanity).
+    expect(confirm.disabled).toBe(true);
+
+    // Cancel closes the panel and never touches the API.
+    fireEvent.click(screen.getByRole("button", { name: /^Cancel$/ }));
+    await waitFor(() => {
+      expect(screen.queryByPlaceholderText(/ci-local attestation/i)).toBeNull();
+    });
+    expect(mergePrMock).not.toHaveBeenCalled();
+  });
 });

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -656,6 +656,30 @@ export interface PrMergeStatus {
 export type PrMergeMethod = "squash" | "merge" | "rebase";
 
 /**
+ * Operator override for the billing-dead CI-safe merge path (approach
+ * `2026-05-20-billing-dead-ci-safe-override`, Phase B). Lets the operator
+ * merge a PR whose GitHub CI is red **only because** the repo's private
+ * Actions billing has lapsed.
+ *
+ * Hand-typed here rather than imported from `src/types/generated/`: the
+ * backend type is an inline `Deserialize`-only struct on
+ * `POST /api/github/pr/merge` with no `ToSchema` / `ts_rs::TS` derive, so
+ * there is no generated binding to re-export. Field names MUST byte-match
+ * the backend's serde fields (`validate_billing_dead_override`).
+ *
+ * The UI never enforces — it only collects + sends. The backend is the
+ * real gate: it requires `[github.<repo>] billing_dead = true` server-side
+ * AND a valid attestation before doing `gh pr merge --admin`, posting a PR
+ * comment, and baking the attestation into the merge-commit trailer.
+ */
+export interface PrMergeOverride {
+  /** Pasted `ci-local` run summary attesting the change passed locally. */
+  ci_local_attestation: string;
+  /** Operator's explicit acknowledgement the repo is billing-dead. */
+  repo_billing_dead_acknowledged: boolean;
+}
+
+/**
  * Response of `POST /api/github/pr/merge`.
  *
  * WHY permissive: this endpoint predates the Stage-1 doc stubs and is
@@ -1224,10 +1248,16 @@ export const api = {
   // the operator merges directly, not via a spawned agent. Defaults
   // (squash + delete-branch) match the prompt that path used; cleanup
   // of the head worktree stays off (Stage-1 scope is merge only).
+  //
+  // `opts.override` is the Phase B billing-dead CI-safe override (approach
+  // `2026-05-20-billing-dead-ci-safe-override`): sent only when present,
+  // so an ordinary merge body is byte-for-byte unchanged. The backend
+  // re-validates the per-repo `billing_dead` flag + attestation; the UI
+  // only collects + forwards.
   mergePr: (
     repoPath: string,
     prNumber: number,
-    opts?: { method?: PrMergeMethod; deleteBranch?: boolean },
+    opts?: { method?: PrMergeMethod; deleteBranch?: boolean; override?: PrMergeOverride },
   ) =>
     apiFetch<MergePrResponse>("/github/pr/merge", {
       method: "POST",
@@ -1236,6 +1266,7 @@ export const api = {
         pr_number: prNumber,
         method: opts?.method ?? "squash",
         delete_branch: opts?.deleteBranch ?? true,
+        ...(opts?.override ? { override: opts.override } : {}),
       }),
     }),
   getCiFailureLog: (repoPath: string, runId: number) =>

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -14,6 +14,7 @@ import type {
   NotifyTemplates,
   OrchestratorRules,
   PrMergeMethod,
+  PrMergeOverride,
   PrMonitorScope,
   SpawnRequest,
   SpawnRuntime,
@@ -155,7 +156,7 @@ export const api = {
   mergePr: (
     repoPath: string,
     prNumber: number,
-    opts?: { method?: PrMergeMethod; deleteBranch?: boolean },
+    opts?: { method?: PrMergeMethod; deleteBranch?: boolean; override?: PrMergeOverride },
   ) => httpApi.mergePr(repoPath, prNumber, opts),
   getCiFailureLog: (repoPath: string, runId: number) => httpApi.getCiFailureLog(repoPath, runId),
   rerunFailedChecks: (repoPath: string, runId: number) =>


### PR DESCRIPTION
## What this does

Adds the React affordance that collects + sends an operator override for merging a PR whose **GitHub CI is red only because the repo's private Actions billing has lapsed** (approach `2026-05-20-billing-dead-ci-safe-override`, **Phase B UI**). Phase A backend (PRs #428/#431) + the `billing_dead` wire field (synced in #718) are already merged.

- Shows an **"Override (ci-local attestation)"** button on a PR row **only when `repo.billing_dead === true && pr.check_status === "FAILURE"`**. `billing_dead` lives on the repo (`RepoPrsWire`), so it's threaded down as a `billingDead` prop from `PrList` → `PrRow`, the same way the row is already mapped from `repo.prs`.
- Distinct styling/label from the normal merge button (outlined, not filled) so the two are never confused.
- Click → an inline panel: a `<textarea>` to paste the ci-local run summary + Confirm/Cancel. Confirm is disabled while the textarea is empty (mirrors the backend min-sanity; the backend stays the real gate). Cancel closes it with no call.
- Confirm → `api.mergePr(repoPath, Number(pr.number), { method: "squash", deleteBranch: true, override: { ci_local_attestation: <textarea>, repo_billing_dead_acknowledged: true } })`, reusing the existing `MergeState` busy/done/error lifecycle. A backend 4xx (flag not set / bad attestation) surfaces via the existing `Merge failed:` text — never a fabricated success.

## Orthogonality with the producer_reviewed valve

The override is a **distinct affordance** from the Stage-2 `producer_reviewed` Δ-brief valve. They are orthogonal: the valve governs the *normal* merge button's friction (frictionless vs arm/confirm); the override is a separate button + panel for the narrow billing-dead-CI case. The valve logic is untouched — its existing tests pass unchanged.

## Hand-typed `PrMergeOverride`

`PrMergeOverride` is **not** a generated type: the backend struct is an inline `Deserialize`-only type on `POST /api/github/pr/merge` with no `ToSchema` / `ts_rs::TS` derive, so there's no generated binding to re-export. It is hand-typed in `api-http.ts` next to `mergePr`, with field names byte-matching the backend's serde fields (`ci_local_attestation`, `repo_billing_dead_acknowledged`). `override` is added to the POST body **only when present**, so an ordinary merge body is byte-for-byte unchanged. The `api-tauri.ts` `mergePr` wrapper's opts type is widened identically (it forwards opts verbatim).

## Gate (run in `clients/react/`, mirrors `.github/workflows/build-react.yml`)

| command | result |
| --- | --- |
| `pnpm install --frozen-lockfile` | ✅ Done |
| `pnpm tsc --noEmit` | ✅ exit 0 |
| `pnpm lint` (biome check src/) | ✅ No fixes applied |
| `pnpm test` (vitest run) | ✅ 515 passed, 2 skipped (66 files) |
| `pnpm build` (tsc -b && vite build) | ✅ built (pre-existing chunk-size/Tauri warnings only) |

(`pnpm audit --prod --audit-level high` is deps-only; no deps were added.)

## Scope

scope: only the 4 files above — `UnitPrsSection.tsx`, `UnitPrsSection.test.tsx`, `api-http.ts`, `api-tauri.ts`. No tmai-core, generated-type, or producer_reviewed-valve edits; no new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * PR マージ時にビリング死亡状態での CI-safe オーバーライドが可能になりました。CI チェック失敗時にローカル認証情報を入力することでマージを確認できます。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/719?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->