### PR TITLE
fix(webui): override panel — clear attestation on Cancel + textarea aria-label (#719 follow-up)

### DIFF
--- a/clients/react/src/components/producer-console/sections/UnitPrsSection.tsx
+++ b/clients/react/src/components/producer-console/sections/UnitPrsSection.tsx
@@ -442,6 +442,7 @@ function PrRow({
             value={attestation}
             onChange={(e) => setAttestation(e.target.value)}
             rows={4}
+            aria-label="CI-local attestation for billing-dead override"
             placeholder="Paste the ci-local attestation (e.g. the `bash scripts/ci-local.sh` summary)…"
             className="mt-1.5 w-full rounded border border-hairline-strong/40 bg-surface px-2 py-1 font-mono text-[10.5px] text-foreground placeholder:text-subtle-foreground"
           />
@@ -458,7 +459,10 @@ function PrRow({
             </button>
             <button
               type="button"
-              onClick={() => setOverrideOpen(false)}
+              onClick={() => {
+                setOverrideOpen(false);
+                setAttestation("");
+              }}
               disabled={merge.busy}
               className="rounded bg-surface px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong disabled:opacity-50"
             >

--- a/clients/react/src/components/producer-console/sections/__tests__/UnitPrsSection.test.tsx
+++ b/clients/react/src/components/producer-console/sections/__tests__/UnitPrsSection.test.tsx
@@ -350,4 +350,21 @@ describe("UnitPrsSection", () => {
     });
     expect(mergePrMock).not.toHaveBeenCalled();
   });
+
+  it("clears the pasted attestation on Cancel (fresh on reopen) and labels the textarea for a11y", async () => {
+    unitPrsMock.mockResolvedValue({ unit: "tmai", repos: [failingBillingDeadRepo()] });
+    render(<UnitPrsSection unitName="tmai" />);
+
+    // `getByLabelText` resolves only via the textarea's aria-label.
+    fireEvent.click(await screen.findByRole("button", { name: OVERRIDE_BTN }));
+    const ta = screen.getByLabelText(/CI-local attestation/i) as HTMLTextAreaElement;
+    fireEvent.change(ta, { target: { value: "ci-local summary\n  ✓ all" } });
+    expect(ta.value).toBe("ci-local summary\n  ✓ all");
+
+    // Cancel must clear, so reopening shows a fresh textarea, not the stale paste.
+    fireEvent.click(screen.getByRole("button", { name: /^Cancel$/ }));
+    fireEvent.click(screen.getByRole("button", { name: OVERRIDE_BTN }));
+    const reopened = screen.getByLabelText(/CI-local attestation/i) as HTMLTextAreaElement;
+    expect(reopened.value).toBe("");
+  });
 });


### PR DESCRIPTION
## What

Two small follow-ups to #719 (billing-dead override UI), addressing the CodeRabbit nitpicks:

1. **Cancel clears the attestation** — `Cancel` now resets `attestation` alongside closing the panel, so reopening shows a fresh textarea rather than the previous paste.
2. **textarea `aria-label`** — adds `aria-label="CI-local attestation for billing-dead override"` for screen-reader users.

## Tests

New test asserts the textarea is reachable by its aria-label and that Cancel clears the value (empty on reopen). Full clients/react gate green locally: `tsc --noEmit`, `pnpm lint` (biome), `pnpm test` (516 passed / 2 skipped), `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * プロデューサーコンソールの Override パネルで、キャンセル操作後に入力フィールドが正しくリセットされるよう改善しました。

* **アクセシビリティ改善**
  * テキスト入力フィールドのアクセシビリティを向上させました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/720?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->