### PR TITLE
feat(webui): persistent right attention strip co-visible with conversation (P1)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -13,6 +13,7 @@ import { TabbedPaneLayout } from "@/components/layout/TabbedPaneLayout";
 import { ToastContainer, useToast } from "@/components/layout/ToastContainer";
 import { TriplePaneLayout } from "@/components/layout/TriplePaneLayout";
 import { MarkdownPanel } from "@/components/markdown/MarkdownPanel";
+import { AttentionStrip } from "@/components/producer-console/AttentionStrip";
 import { ProducerConsole } from "@/components/producer-console/ProducerConsole";
 import { SecurityPanel } from "@/components/settings/SecurityPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
@@ -86,6 +87,16 @@ export function App() {
   const [tabsActive, setTabsActive] = useUIPref("tabsActive");
   const [splitRatioH, setSplitRatioH] = useUIPref("splitRatioH");
   const [splitRatioV, setSplitRatioV] = useUIPref("splitRatioV");
+  // Persistent right attention strip
+  // (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`
+  // §Refinement 2026-05-22 — L/C/R co-visible layout). Collapsed state
+  // lives in the WebUI prefs store so it survives reloads / cross-tab.
+  const [attentionStripCollapsed, setAttentionStripCollapsed] =
+    useUIPref("attentionStripCollapsed");
+  const toggleAttentionStrip = useCallback(
+    () => setAttentionStripCollapsed(!attentionStripCollapsed),
+    [attentionStripCollapsed, setAttentionStripCollapsed],
+  );
   const showSettings = mainPanel === "settings";
   const showSecurity = mainPanel === "security";
   const showCalibration = mainPanel === "calibration";
@@ -812,6 +823,24 @@ export function App() {
           </div>
         )}
       </main>
+
+      {/* Persistent right attention strip — third flex column, sibling of
+          <main> and OUTSIDE the selection switch above, so it stays
+          co-visible with whatever the centre shows (Producer conversation,
+          digest, or git/docs multipane). DR
+          `2026-05-14-react-producer-console-rebuild.md` §Refinement
+          2026-05-22 (Fork A / Fork C P1). Hidden on narrow / mobile —
+          same threshold as `canShowMultiPane` — so it never crowds a small
+          viewport; folds to a thin rail otherwise. */}
+      {!isNarrowScreen && !isMobileScreen && (
+        <AttentionStrip
+          currentProjectPath={currentProject}
+          unitName={unitName}
+          onSelectProjectByPath={handleSelectProject}
+          collapsed={attentionStripCollapsed}
+          onToggleCollapsed={toggleAttentionStrip}
+        />
+      )}
 
       {/* Help overlay */}
       <HelpOverlay isOpen={showHelp} onClose={() => setShowHelp(false)} />

--- a/clients/react/src/__tests__/App.attention-strip.test.tsx
+++ b/clients/react/src/__tests__/App.attention-strip.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+//
+// App layout test for P1 of the L/C/R co-visible re-layout
+// (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`
+// §Refinement 2026-05-22). This is a *layout* test: it asserts WHERE the
+// AttentionStrip sits in App's flex tree and WHEN it shows — not the
+// strip's internals (those are covered by AttentionStrip.test.tsx). So we
+// stub the strip (and every heavy panel) and drive App's selection /
+// breakpoint state through mocked hooks.
+//
+// The load-bearing assertions:
+//   1. with no agent selected, the centre shows the digest AND the strip
+//      is present;
+//   2. after selecting an agent the centre swaps to the agent view but the
+//      strip STAYS present — co-visibility kills the digest↔conversation
+//      screen-switch;
+//   3. on a narrow viewport the strip is gone (same threshold as the
+//      centre multipane gate) so it never crowds a small screen.
+
+import { fireEvent, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentSnapshot } from "@/lib/api";
+import { renderWithProviders } from "@/test/render";
+
+// ── hook mocks ──
+const useAgentsMock = vi.fn();
+const useResponsiveLayoutMock = vi.fn();
+const useSplitPaneMock = vi.fn();
+
+vi.mock("@/lib/sse-provider", () => ({
+  useSSE: () => undefined,
+  useSSEContext: () => ({
+    cache: { agents: [], worktrees: [], queueEntries: [], loading: false },
+    refreshCache: vi.fn(),
+    subscribe: vi.fn(),
+  }),
+}));
+vi.mock("@/hooks/useActiveTheme", () => ({ useApplyTheme: () => undefined }));
+vi.mock("@/hooks/useAgents", () => ({ useAgents: () => useAgentsMock() }));
+vi.mock("@/hooks/useWorktrees", () => ({
+  useWorktrees: () => ({ worktrees: [], loading: false, refresh: vi.fn() }),
+}));
+vi.mock("@/hooks/useCalibration", () => ({
+  useCalibration: () => ({ data: null, loading: false, error: null }),
+}));
+vi.mock("@/hooks/useNotificationConfig", () => ({ useNotificationConfig: () => ({}) }));
+vi.mock("@/hooks/useIdleNotification", () => ({
+  useIdleNotification: () => ({ handleAgentStopped: vi.fn() }),
+}));
+vi.mock("@/hooks/useResponsiveLayout", () => ({
+  useResponsiveLayout: () => useResponsiveLayoutMock(),
+}));
+vi.mock("@/hooks/useSplitPane", () => ({ useSplitPane: () => useSplitPaneMock() }));
+vi.mock("@/hooks/useAgentSelectionFallback", () => ({
+  useAgentSelectionFallback: () => undefined,
+}));
+vi.mock("@/hooks/useKeyboardShortcuts", () => ({ useKeyboardShortcuts: () => undefined }));
+
+// ── component stubs (everything heavy / networked) ──
+vi.mock("@/components/producer-console/AttentionStrip", () => ({
+  AttentionStrip: () => <div data-testid="attention-strip-stub">strip</div>,
+}));
+vi.mock("@/components/producer-console/ProducerConsole", () => ({
+  ProducerConsole: () => <div data-testid="producer-console-stub">digest</div>,
+}));
+vi.mock("@/components/agent/PreviewPanel", () => ({
+  PreviewPanel: () => <div data-testid="preview-stub">preview</div>,
+}));
+vi.mock("@/components/agent/AgentActions", () => ({ AgentActions: () => null }));
+vi.mock("@/components/terminal/TerminalPanel", () => ({
+  TerminalPanel: () => <div data-testid="terminal-stub">terminal</div>,
+}));
+vi.mock("@/components/worktree/BranchGraph", () => ({ BranchGraph: () => null }));
+vi.mock("@/components/markdown/MarkdownPanel", () => ({ MarkdownPanel: () => null }));
+vi.mock("@/components/worktree/WorktreePanel", () => ({ WorktreePanel: () => null }));
+vi.mock("@/components/layout/SplitPaneLayout", () => ({
+  SplitPaneLayout: ({ left }: { left: ReactNode }) => <div>{left}</div>,
+}));
+vi.mock("@/components/layout/TabbedPaneLayout", () => ({
+  TabbedPaneLayout: ({ preview }: { preview: ReactNode }) => <div>{preview}</div>,
+}));
+vi.mock("@/components/layout/TriplePaneLayout", () => ({
+  TriplePaneLayout: ({ preview }: { preview: ReactNode }) => <div>{preview}</div>,
+}));
+vi.mock("@/components/layout/DisplayModeSelector", () => ({
+  DisplayModeSelector: () => null,
+}));
+vi.mock("@/components/agent/AgentList", () => ({ AgentList: () => null }));
+vi.mock("@/components/terminal/TerminalList", () => ({ TerminalList: () => null }));
+vi.mock("@/components/usage/UsagePanel", () => ({ UsagePanel: () => null }));
+vi.mock("@/components/settings/SettingsPanel", () => ({ SettingsPanel: () => null }));
+vi.mock("@/components/settings/SecurityPanel", () => ({ SecurityPanel: () => null }));
+vi.mock("@/components/calibration/CalibrationPanel", () => ({ CalibrationPanel: () => null }));
+
+import { App } from "@/App";
+
+function agent(target: string, cwd: string): AgentSnapshot {
+  return {
+    id: target,
+    target,
+    agent_type: "ClaudeCode",
+    title: target,
+    cwd,
+    display_cwd: cwd,
+    display_name: target,
+    detection_source: "HttpHook",
+    git_branch: null,
+    git_dirty: null,
+    is_worktree: null,
+    git_common_dir: null,
+    worktree_name: null,
+    worktree_base_branch: null,
+    effort_level: null,
+    active_subagents: 0,
+    compaction_count: 0,
+    pty_session_id: null,
+    send_capability: "None",
+    is_virtual: false,
+    team_info: null,
+    is_orchestrator: false,
+    attention: null,
+  } as AgentSnapshot;
+}
+
+function responsive(overrides: Record<string, unknown> = {}) {
+  return {
+    sidebarCollapsed: true,
+    toggleSidebar: vi.fn(),
+    actionPanelCollapsed: true,
+    toggleActionPanel: vi.fn(),
+    isNarrowScreen: false,
+    isMobileScreen: false,
+    mobileDrawerOpen: false,
+    toggleMobileDrawer: vi.fn(),
+    closeMobileDrawer: vi.fn(),
+    ...overrides,
+  };
+}
+
+function splitPane(isNarrowScreen = false) {
+  return {
+    splitRatio: 0.5,
+    isDragging: false,
+    containerRef: { current: null },
+    onDividerMouseDown: vi.fn(),
+    onDividerDoubleClick: vi.fn(),
+    adjustRatio: vi.fn(),
+    isNarrowScreen,
+  };
+}
+
+beforeEach(() => {
+  useAgentsMock.mockReset();
+  useResponsiveLayoutMock.mockReset();
+  useSplitPaneMock.mockReset();
+  useAgentsMock.mockReturnValue({
+    agents: [agent("claude:abc", "/p/alpha")],
+    attentionCount: 0,
+    loading: false,
+    refresh: vi.fn(),
+  });
+  useResponsiveLayoutMock.mockReturnValue(responsive());
+  useSplitPaneMock.mockReturnValue(splitPane(false));
+});
+
+describe("App — persistent attention strip layout", () => {
+  it("shows the digest in the centre AND the strip on the right with no selection", () => {
+    renderWithProviders(<App />);
+    expect(screen.getByTestId("producer-console-stub")).toBeTruthy();
+    expect(screen.getByTestId("attention-strip-stub")).toBeTruthy();
+  });
+
+  it("keeps the strip co-visible after an agent is selected (centre swaps, strip stays)", () => {
+    renderWithProviders(<App />);
+
+    // Collapsed sidebar renders one button per AI agent (title = target).
+    const agentBtn = screen.getByTitle("claude:abc");
+    fireEvent.click(agentBtn);
+
+    // Centre swapped away from the digest to the agent conversation …
+    expect(screen.queryByTestId("producer-console-stub")).toBeNull();
+    expect(screen.getByTestId("preview-stub")).toBeTruthy();
+    // … and the attention strip is STILL there — no screen-switch.
+    expect(screen.getByTestId("attention-strip-stub")).toBeTruthy();
+  });
+
+  it("hides the strip on a narrow viewport (same threshold as the centre multipane)", () => {
+    useResponsiveLayoutMock.mockReturnValue(responsive({ isNarrowScreen: true }));
+    useSplitPaneMock.mockReturnValue(splitPane(true));
+
+    renderWithProviders(<App />);
+
+    expect(screen.queryByTestId("attention-strip-stub")).toBeNull();
+  });
+
+  it("hides the strip on mobile", () => {
+    useResponsiveLayoutMock.mockReturnValue(responsive({ isMobileScreen: true }));
+
+    renderWithProviders(<App />);
+
+    expect(screen.queryByTestId("attention-strip-stub")).toBeNull();
+  });
+});

--- a/clients/react/src/components/producer-console/AttentionStrip.tsx
+++ b/clients/react/src/components/producer-console/AttentionStrip.tsx
@@ -1,0 +1,127 @@
+// Persistent right-hand attention strip — P1 of the L/C/R co-visible
+// re-layout (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`
+// §Refinement 2026-05-22).
+//
+// WHY this exists: before P1, selecting an agent (the Producer
+// conversation = PreviewPanel) *replaced* the ProducerConsole digest in
+// the single `<main>`, and `returnToConsole` was the only way back. So
+// the operator could not read the attention surface and converse at the
+// same time — the digest↔conversation screen-switch the refinement set
+// out to kill. This strip is mounted in `App.tsx` as a sibling of
+// `<main>` (a third flex column), OUTSIDE the `selection` switch, so it
+// stays co-visible with whatever the centre shows — digest, Producer
+// conversation, or the git/docs multipane (P2 retires the latter; P1
+// leaves it in place).
+//
+// Fork A — DUMB SUBSET: the strip is attention-grade status only. It
+// reuses the existing self-contained Producer-console sections in a
+// width-constrained form:
+//   ▶ blocked / awaiting agents   (WhereYouLeftOffSection, attentionOnly)
+//   ▣ verdict-awaiting approaches  (ActiveApproachesSection)
+//   🔀 open PRs + CI               (UnitPrsSection)
+//   ⬢ cross-unit needs-you         (CrossUnitStatusSection)
+// The heavy context (full ⬡ Settled decisions list, ◐ Working-with-this-
+// human / MEMORY) deliberately stays in the on-demand centre digest, not
+// here. Per the pre-producer-dashboard convergence
+// (`doc/decisions/2026-05-20-provisional-pre-producer-dashboard.md`) this
+// is a dumb status surface: no priority scalar, no anomaly sort, no
+// re-ranking — the section order below is a fixed reading order, not a
+// judgment. The always-on TripwireBanner lives in `App.tsx` above the
+// centre and is not duplicated here.
+
+import { useHandover } from "@/hooks/useHandover";
+import { ActiveApproachesSection } from "./sections/ActiveApproachesSection";
+import { CrossUnitStatusSection } from "./sections/CrossUnitStatusSection";
+import { UnitPrsSection } from "./sections/UnitPrsSection";
+import { WhereYouLeftOffSection } from "./sections/WhereYouLeftOffSection";
+
+interface AttentionStripProps {
+  /** Currently focused project (App.tsx's `currentProject`). Scopes the
+   *  ▶ attention list and the unit for the PR / approaches sections. */
+  currentProjectPath: string | null;
+  /** Unit name — basename of `currentProjectPath`. Drives the wire-backed
+   *  PR / approaches sections (`resolve_unit_or_cwd` falls back to the
+   *  basename when no `[[unit]]` table matches). */
+  unitName: string | null;
+  /** Wired to App.tsx's `handleSelectProject` so picking a unit in the
+   *  strip matches sidebar / centre-digest selection exactly. */
+  onSelectProjectByPath: (path: string, name: string) => void;
+  /** Collapsed = folded to a thin rail (operator reclaims width when the
+   *  centre is busy). Persisted by App.tsx via the `attentionStripCollapsed`
+   *  UI pref. */
+  collapsed: boolean;
+  onToggleCollapsed: () => void;
+}
+
+export function AttentionStrip({
+  currentProjectPath,
+  unitName,
+  onSelectProjectByPath,
+  collapsed,
+  onToggleCollapsed,
+}: AttentionStripProps) {
+  const { whereYouLeftOff, crossUnit, missingPreconditions } = useHandover(currentProjectPath);
+
+  if (collapsed) {
+    return (
+      <aside
+        data-testid="attention-strip"
+        data-collapsed="true"
+        className="glass flex w-9 shrink-0 flex-col items-center border-l border-hairline py-2"
+      >
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          title="Expand attention strip"
+          aria-label="Expand attention strip"
+          aria-expanded={false}
+          className="flex h-8 w-8 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+        >
+          ‹
+        </button>
+        {/* Vertical label so the rail still reads as the attention surface
+            even when folded. `writing-mode` keeps it on one rotated line. */}
+        <span
+          className="mt-2 select-none text-[10px] uppercase tracking-widest text-subtle-foreground"
+          style={{ writingMode: "vertical-rl" }}
+        >
+          Attention
+        </span>
+      </aside>
+    );
+  }
+
+  return (
+    <aside
+      data-testid="attention-strip"
+      data-collapsed="false"
+      className="glass flex w-80 shrink-0 flex-col border-l border-hairline"
+    >
+      <header className="flex shrink-0 items-center justify-between border-b border-hairline px-4 py-3">
+        <h2 className="text-sm font-semibold text-foreground">Attention</h2>
+        <button
+          type="button"
+          onClick={onToggleCollapsed}
+          title="Collapse attention strip"
+          aria-label="Collapse attention strip"
+          aria-expanded={true}
+          className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+        >
+          ›
+        </button>
+      </header>
+
+      <div className="flex-1 space-y-6 overflow-y-auto px-4 py-4 text-sm">
+        <WhereYouLeftOffSection data={whereYouLeftOff} attentionOnly />
+        <ActiveApproachesSection unitName={unitName} />
+        <UnitPrsSection unitName={unitName} />
+        <CrossUnitStatusSection
+          data={crossUnit}
+          activePath={currentProjectPath}
+          onSelectUnit={onSelectProjectByPath}
+          preconditions={missingPreconditions}
+        />
+      </div>
+    </aside>
+  );
+}

--- a/clients/react/src/components/producer-console/__tests__/AttentionStrip.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/AttentionStrip.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment jsdom
+//
+// AttentionStrip — P1 of the L/C/R co-visible re-layout
+// (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`
+// §Refinement 2026-05-22). The strip is the dumb status subset (Fork A)
+// that reuses four self-contained Producer-console sections. We mock the
+// three data hooks (`useHandover` for the client-derived sections,
+// `useUnitPrs` / `useApproaches` for the wire-backed ones) so each render
+// presents a deterministic, network-free shape and we can assert:
+//   - all four attention sections render when expanded;
+//   - `attentionOnly` drops the ambient worktree list (strip ≠ digest);
+//   - the collapsed rail hides the sections and exposes an expand control;
+//   - cross-unit clicks route to onSelectProjectByPath.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HandoverDigest } from "@/hooks/useHandover";
+import type { ApproachesResponse, PrSummaryWire, UnitPrsResponse } from "@/lib/api";
+import { AttentionStrip } from "../AttentionStrip";
+
+const useHandoverMock = vi.fn();
+const useUnitPrsMock = vi.fn();
+const useApproachesMock = vi.fn();
+
+vi.mock("@/hooks/useHandover", () => ({
+  useHandover: (path: string | null) => useHandoverMock(path),
+}));
+
+vi.mock("@/hooks/useUnitPrs", () => ({
+  useUnitPrs: (unit: string | null) => useUnitPrsMock(unit),
+}));
+
+vi.mock("@/hooks/useApproaches", () => ({
+  useApproaches: (unit: string | null) => useApproachesMock(unit),
+}));
+
+function digest(overrides: Partial<HandoverDigest> = {}): HandoverDigest {
+  return {
+    whereYouLeftOff: overrides.whereYouLeftOff ?? {
+      activeProjectPath: null,
+      activeProjectName: null,
+      worktrees: [],
+      attentionAgents: [],
+    },
+    crossUnit: overrides.crossUnit ?? { units: [] },
+    missingPreconditions: overrides.missingPreconditions ?? {
+      noLiveAgents: true,
+      singleUnitOnly: false,
+    },
+  };
+}
+
+function emptyPrs(): { data: UnitPrsResponse | null; loading: boolean; error: Error | null } {
+  const data: UnitPrsResponse = { unit: "stub", repos: [] };
+  return { data, loading: false, error: null };
+}
+
+function emptyApproaches(): {
+  data: ApproachesResponse | null;
+  loading: boolean;
+  error: Error | null;
+} {
+  const data: ApproachesResponse = {
+    unit: "stub",
+    composed_at: "2026-05-22T00:00:00Z",
+    repos: [],
+  };
+  return { data, loading: false, error: null };
+}
+
+beforeEach(() => {
+  useHandoverMock.mockReset();
+  useUnitPrsMock.mockReset();
+  useApproachesMock.mockReset();
+  useUnitPrsMock.mockReturnValue(emptyPrs());
+  useApproachesMock.mockReturnValue(emptyApproaches());
+});
+
+function makeProps(overrides: Partial<Parameters<typeof AttentionStrip>[0]> = {}) {
+  return {
+    currentProjectPath: "/p/alpha",
+    unitName: "alpha",
+    onSelectProjectByPath: vi.fn(),
+    collapsed: false,
+    onToggleCollapsed: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe("AttentionStrip", () => {
+  it("renders all four attention sections when expanded", () => {
+    useHandoverMock.mockReturnValue(digest());
+
+    render(<AttentionStrip {...makeProps()} />);
+
+    expect(screen.getByRole("heading", { name: /Attention/ })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Where you left off/ })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Active approaches/ })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Open PRs/ })).toBeTruthy();
+    expect(screen.getByRole("heading", { name: /Cross-unit status/ })).toBeTruthy();
+  });
+
+  it("shows attention agents but NOT the ambient worktree list (attentionOnly)", () => {
+    useHandoverMock.mockReturnValue(
+      digest({
+        whereYouLeftOff: {
+          activeProjectPath: "/p/alpha",
+          activeProjectName: "alpha",
+          // A worktree the centre digest would show — the strip must not.
+          worktrees: [
+            {
+              name: "feature-xyz",
+              branch: "feat/xyz",
+              path: "/p/alpha-wt",
+              isMain: false,
+              dirty: true,
+              agentCount: 1,
+            },
+          ],
+          attentionAgents: [
+            {
+              target: "claude:1",
+              displayName: "halted-agent",
+              attention: "halted",
+              cwd: "/p/alpha",
+              isOrchestrator: false,
+            },
+          ],
+        },
+      }),
+    );
+
+    render(<AttentionStrip {...makeProps()} />);
+
+    // The blocked agent is surfaced …
+    expect(screen.getByText("halted-agent")).toBeTruthy();
+    // … but the worktree row is not (worktrees are ambient, not attention).
+    expect(screen.queryByText("feature-xyz")).toBeNull();
+  });
+
+  it("renders an open PR row in the strip (reuses UnitPrsSection)", () => {
+    useHandoverMock.mockReturnValue(digest());
+    const pr: PrSummaryWire = {
+      number: 707n,
+      title: "token lock + light theme",
+      state: "OPEN",
+      head_branch: "feat/tokens",
+      head_sha: "abc1234",
+      base_branch: "main",
+      url: "https://example.test/pr/707",
+      review_decision: "APPROVED",
+      check_status: "SUCCESS",
+      is_draft: false,
+      additions: 120n,
+      deletions: 7n,
+      comments: 2n,
+      reviews: 1n,
+      author: "trust-delta",
+      merge_commit_sha: null,
+    };
+    const data: UnitPrsResponse = {
+      unit: "alpha",
+      repos: [{ repo_path: "/p/alpha", repo_label: "alpha", primary: true, prs: [pr] }],
+    };
+    useUnitPrsMock.mockReturnValue({ data, loading: false, error: null });
+
+    render(<AttentionStrip {...makeProps()} />);
+
+    expect(screen.getByText(/token lock \+ light theme/)).toBeTruthy();
+    expect(screen.getByText("CI ✓")).toBeTruthy();
+  });
+
+  it("routes a cross-unit click to onSelectProjectByPath", () => {
+    const onSelect = vi.fn();
+    useHandoverMock.mockReturnValue(
+      digest({
+        crossUnit: {
+          units: [
+            {
+              path: "/p/alpha",
+              name: "alpha",
+              state: "needs-you",
+              agentCount: 2,
+              attentionCount: 1,
+            },
+            { path: "/p/beta", name: "beta", state: "quiet", agentCount: 0, attentionCount: 0 },
+          ],
+        },
+      }),
+    );
+
+    const { container } = render(
+      <AttentionStrip {...makeProps({ onSelectProjectByPath: onSelect })} />,
+    );
+
+    const betaButton = Array.from(container.querySelectorAll("button")).find((b) =>
+      b.textContent?.includes("beta"),
+    );
+    expect(betaButton).toBeTruthy();
+    betaButton?.click();
+    expect(onSelect).toHaveBeenCalledWith("/p/beta", "beta");
+  });
+
+  it("collapses to a rail that hides the sections and exposes an expand control", () => {
+    useHandoverMock.mockReturnValue(digest());
+    const onToggle = vi.fn();
+
+    render(<AttentionStrip {...makeProps({ collapsed: true, onToggleCollapsed: onToggle })} />);
+
+    // Sections are gone in the collapsed rail …
+    expect(screen.queryByRole("heading", { name: /Active approaches/ })).toBeNull();
+    expect(screen.queryByRole("heading", { name: /Open PRs/ })).toBeNull();
+
+    // … and the strip stays addressable for the layout test.
+    const strip = screen.getByTestId("attention-strip");
+    expect(strip.getAttribute("data-collapsed")).toBe("true");
+
+    const expandBtn = screen.getByRole("button", { name: /Expand attention strip/i });
+    fireEvent.click(expandBtn);
+    expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/react/src/components/producer-console/sections/WhereYouLeftOffSection.tsx
+++ b/clients/react/src/components/producer-console/sections/WhereYouLeftOffSection.tsx
@@ -9,9 +9,20 @@ import type { AttentionAgentBrief, WhereYouLeftOff, WorktreeBrief } from "@/hook
 
 interface WhereYouLeftOffSectionProps {
   data: WhereYouLeftOff;
+  /** Strip mode (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`
+   *  §Refinement 2026-05-22 — Fork A): the persistent right attention strip
+   *  reuses this section but wants only the *attention part* — blocked /
+   *  awaiting agents — not the ambient worktree list. When true, render just
+   *  the attention list (which `useHandover` falls back to *all* AI agents
+   *  for when no project is scoped, so the strip still shows what's blocked).
+   *  Default false keeps the centre digest's full ▶ section unchanged. */
+  attentionOnly?: boolean;
 }
 
-export function WhereYouLeftOffSection({ data }: WhereYouLeftOffSectionProps) {
+export function WhereYouLeftOffSection({
+  data,
+  attentionOnly = false,
+}: WhereYouLeftOffSectionProps) {
   const { activeProjectName, worktrees, attentionAgents } = data;
 
   return (
@@ -26,7 +37,11 @@ export function WhereYouLeftOffSection({ data }: WhereYouLeftOffSectionProps) {
         )}
       </header>
 
-      {!activeProjectName ? (
+      {attentionOnly ? (
+        <div className="pl-6">
+          <AttentionAgentsList agents={attentionAgents} />
+        </div>
+      ) : !activeProjectName ? (
         <EmptyProject />
       ) : (
         <div className="space-y-3 pl-6">

--- a/clients/react/src/lib/ui-prefs.ts
+++ b/clients/react/src/lib/ui-prefs.ts
@@ -28,6 +28,13 @@ export interface UIPrefs {
   // xterm font size (px). Presentation-only, browser-side; replaces the
   // old hardcoded `fontSize: 13` in useTerminal.
   terminalFontSize: number;
+  // Persistent right-hand attention strip collapse state
+  // (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`
+  // §Refinement 2026-05-22 — L/C/R co-visible layout). Presentation-only,
+  // browser-side: the operator can fold the strip to a rail to reclaim
+  // width when the centre conversation/multipane is busy. Default open so
+  // a clean-state user sees the co-visible attention surface immediately.
+  attentionStripCollapsed: boolean;
 }
 
 export const DEFAULT_UI_PREFS: UIPrefs = {
@@ -40,6 +47,7 @@ export const DEFAULT_UI_PREFS: UIPrefs = {
   tripleInnerRatio: 0.5,
   theme: DEFAULT_THEME_NAME,
   terminalFontSize: 13,
+  attentionStripCollapsed: false,
 };
 
 export const UI_PREFS_STORAGE_KEY = "tmai:ui:prefs";
@@ -89,6 +97,10 @@ function coercePrefs(raw: unknown): UIPrefs {
       ? (r.theme as ThemeName)
       : DEFAULT_UI_PREFS.theme,
     terminalFontSize: clampFontSize(r.terminalFontSize, DEFAULT_UI_PREFS.terminalFontSize),
+    attentionStripCollapsed:
+      typeof r.attentionStripCollapsed === "boolean"
+        ? r.attentionStripCollapsed
+        : DEFAULT_UI_PREFS.attentionStripCollapsed,
   };
 }
 


### PR DESCRIPTION
## P1 — persistent right attention strip, co-visible with the Producer conversation

Implements **P1** of the L/C/R co-visible re-layout in
`doc/decisions/2026-05-14-react-producer-console-rebuild.md`
(§ "Refinement 2026-05-22 — L/C/R co-visible layout", Fork A + Fork C P1).

### Problem
In-tmai merge killed the github.com round-trip; the next attention tax is the
**digest↔conversation screen-switch**. Today `ProducerConsole` (the hand-over
digest) only occupies `<main>` when no agent is selected; selecting an agent
(the Producer conversation = `PreviewPanel`/terminal) **replaces** it, and
`returnToConsole` is the only way back. Digest and conversation are never
co-visible.

### What this does
Adds a persistent **right** column — the *attention strip* — as a third flex
child of `App.tsx`'s layout, a sibling of `<main>` and **outside** the
`selection` switch. It therefore stays visible regardless of `selection`: when
an agent / Producer conversation is in the centre, the strip stays on the right.

**How it stays co-visible:** the strip is not inside the `selection`-driven
view swap in `<main>`; it is mounted next to `<main>` in the top-level
`flex h-screen` row. The view swap only changes the *centre*; the strip is
untouched by it. (Verified by an App-level test: with an agent selected the
centre swaps away from the digest but the strip remains.)

### Strip contents (Fork A — dumb status subset)
Width-constrained reuse of the existing self-contained Producer-console sections:
- **▶ blocked / awaiting agents** — `WhereYouLeftOffSection` with a new
  additive `attentionOnly` prop (drops the ambient worktree list; the centre
  digest's full section is unchanged).
- **▣ verdict-awaiting approaches** — `ActiveApproachesSection`.
- **🔀 open PRs + CI** — `UnitPrsSection`.
- **⬢ cross-unit needs-you** — `CrossUnitStatusSection`.

No judgment creep: no priority scalar, no anomaly sort, no re-ranking — a fixed
reading order, a dumb status surface (per
`2026-05-20-provisional-pre-producer-dashboard`). The always-on `TripwireBanner`
stays hoisted in `<main>` (not duplicated). The **full** ProducerConsole digest
(settled-decisions list, working-with-human/MEMORY) is kept as the centre
no-selection view / on-demand briefing.

### Scope discipline (P1 is additive)
- Does **not** retire the git/docs multipane (`BranchGraph`, `MarkdownPanel`,
  Tabbed/Split/Triple, `useSplitPane`) — that's P2.
- Does **not** remove worktree-delete / issue-start-work actions — P2.
- Does **not** touch `useTerminal.ts` / `globals.css` (separate workpiece).
- Strip folds to a rail (persisted via a new browser-side `attentionStripCollapsed`
  UI pref) and hides on narrow/mobile (same threshold as `canShowMultiPane`).

### Gate (run locally; public CI is the real signal)
- `pnpm lint` (biome check) — clean
- `pnpm exec tsc -b` — exit 0
- `pnpm build` — exit 0
- `pnpm test` — **525 passed / 2 skipped**, 68 files

New tests: `AttentionStrip.test.tsx` (renders 4 sections; `attentionOnly`
hides worktrees; reuses `UnitPrsSection`; cross-unit click routing; collapsed
rail). `App.attention-strip.test.tsx` (strip co-visible with no selection AND
after selecting an agent; hidden on narrow; hidden on mobile).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 右側に永続的な Attention ストリップを追加しました。折りたたみ・展開状態が自動的に保存されます。
  * 広い画面では常に表示され、作業中に注意関連情報へすばやくアクセス可能になります。
  * モバイル・狭い画面では自動的に非表示になります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/722?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->