### PR TITLE
feat(webui): drag-resizable attention strip; approaches→briefing; ▶ relabel (P1.1)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -34,7 +34,25 @@ import { useSplitPane } from "@/hooks/useSplitPane";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { api, groupByProject, isAiAgentLoose, type Selection, setCallerCwd } from "@/lib/api";
 import { useSSE } from "@/lib/sse-provider";
+import { ATTENTION_STRIP_WIDTH_DEFAULT, clampAttentionStripWidth } from "@/lib/ui-prefs";
 import { useUIPref } from "@/lib/ui-prefs-provider";
+
+// The attention strip is a right-docked panel, but `useSplitPane` speaks in
+// 0–1 ratios of its container (here the app root, full viewport width). We
+// map the persisted px width to/from that ratio at the seams: a stored width
+// W on a viewport V seeds ratio = 1 − W/V (the strip occupies the right
+// `1 − ratio` of the row); on commit we read the ratio back into px. The hook
+// clamps the ratio to [0.2, 0.8] and `clampAttentionStripWidth` clamps the
+// committed px, so the two guards compose.
+function attentionViewportWidth(): number {
+  return typeof window !== "undefined" && window.innerWidth > 0 ? window.innerWidth : 1440;
+}
+function attentionWidthToRatio(width: number): number {
+  return 1 - width / attentionViewportWidth();
+}
+function attentionRatioToWidth(ratio: number): number {
+  return (1 - ratio) * attentionViewportWidth();
+}
 
 export function App() {
   // Apply the active WebUI theme's css vars to <html> and keep them in
@@ -97,6 +115,10 @@ export function App() {
     () => setAttentionStripCollapsed(!attentionStripCollapsed),
     [attentionStripCollapsed, setAttentionStripCollapsed],
   );
+  // Drag-resizable strip width (P1.1). Persisted in px; the drag itself runs
+  // through the shared useSplitPane engine (ratio-based), so we convert at
+  // the seams. See the attention*Width helpers above.
+  const [attentionStripWidth, setAttentionStripWidth] = useUIPref("attentionStripWidth");
   const showSettings = mainPanel === "settings";
   const showSecurity = mainPanel === "security";
   const showCalibration = mainPanel === "calibration";
@@ -247,6 +269,17 @@ export function App() {
     orientation: "vertical",
     initialRatio: splitRatioV,
     onCommit: setSplitRatioV,
+  });
+  // Attention-strip resize. Its containerRef is attached to the app-root
+  // flex row below; the strip is that row's right-most in-flow child, so a
+  // ratio of `clientX / rowWidth` makes the strip occupy `1 − ratio` of the
+  // row — i.e. dragging its left-edge handle resizes it. Commit clamps the
+  // derived px width to the legal window.
+  const attentionStripSplit = useSplitPane({
+    orientation: "horizontal",
+    initialRatio: attentionWidthToRatio(attentionStripWidth),
+    onCommit: (ratio) =>
+      setAttentionStripWidth(clampAttentionStripWidth(attentionRatioToWidth(ratio))),
   });
   const isNarrowScreen = horizontalSplit.isNarrowScreen;
 
@@ -538,7 +571,7 @@ export function App() {
   );
 
   return (
-    <div className="flex h-screen text-foreground">
+    <div ref={attentionStripSplit.containerRef} className="flex h-screen text-foreground">
       {/* Mobile: overlay backdrop when drawer is open */}
       {isMobileScreen && mobileDrawerOpen && (
         // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop tap to close
@@ -839,6 +872,17 @@ export function App() {
           onSelectProjectByPath={handleSelectProject}
           collapsed={attentionStripCollapsed}
           onToggleCollapsed={toggleAttentionStrip}
+          resize={{
+            width: attentionStripWidth,
+            isResizing: attentionStripSplit.isDragging,
+            ratio: attentionStripSplit.splitRatio,
+            onMouseDown: attentionStripSplit.onDividerMouseDown,
+            // Double-click resets to the default px width (the hook's own
+            // reset snaps the ratio to 0.5 = half the viewport, far too wide
+            // for a strip), then the initialRatio reseed tracks it.
+            onDoubleClick: () => setAttentionStripWidth(ATTENTION_STRIP_WIDTH_DEFAULT),
+            onAdjust: attentionStripSplit.adjustRatio,
+          }}
         />
       )}
 

--- a/clients/react/src/components/producer-console/AttentionStrip.tsx
+++ b/clients/react/src/components/producer-console/AttentionStrip.tsx
@@ -1,6 +1,6 @@
 // Persistent right-hand attention strip — P1 of the L/C/R co-visible
 // re-layout (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`
-// §Refinement 2026-05-22).
+// §Refinement 2026-05-22), refined by §"P1.1 — lived-feedback adjustment".
 //
 // WHY this exists: before P1, selecting an agent (the Producer
 // conversation = PreviewPanel) *replaced* the ProducerConsole digest in
@@ -13,35 +13,66 @@
 // conversation, or the git/docs multipane (P2 retires the latter; P1
 // leaves it in place).
 //
-// Fork A — DUMB SUBSET: the strip is attention-grade status only. It
-// reuses the existing self-contained Producer-console sections in a
-// width-constrained form:
-//   ▶ blocked / awaiting agents   (WhereYouLeftOffSection, attentionOnly)
-//   ▣ verdict-awaiting approaches  (ActiveApproachesSection)
+// Fork A — DUMB SUBSET: the strip is attention-grade status only. P1.1
+// sharpened the rule to "changes-during-session ⇒ strip; read-once-at-
+// start ⇒ briefing", so the slow-moving ▣ verdict-awaiting approaches
+// moved OUT of the strip and back to the centre digest (start-briefing).
+// The strip now reuses three self-contained sections in width-constrained
+// form:
+//   ▶ Blocked / awaiting agents   (WhereYouLeftOffSection, attentionOnly —
+//                                  the strip relabels the ▶ header; the
+//                                  centre digest keeps "Where you left off")
 //   🔀 open PRs + CI               (UnitPrsSection)
 //   ⬢ cross-unit needs-you         (CrossUnitStatusSection)
 // The heavy context (full ⬡ Settled decisions list, ◐ Working-with-this-
-// human / MEMORY) deliberately stays in the on-demand centre digest, not
-// here. Per the pre-producer-dashboard convergence
+// human / MEMORY) and the ▣ approaches deliberately stay in the on-demand
+// centre digest, not here. Per the pre-producer-dashboard convergence
 // (`doc/decisions/2026-05-20-provisional-pre-producer-dashboard.md`) this
 // is a dumb status surface: no priority scalar, no anomaly sort, no
 // re-ranking — the section order below is a fixed reading order, not a
 // judgment. The always-on TripwireBanner lives in `App.tsx` above the
 // centre and is not duplicated here.
+//
+// WIDTH: the expanded strip is drag-resizable (P1.1). The drag itself is
+// driven by the shared `useSplitPane` engine wired in `App.tsx` (which
+// owns the persisted `attentionStripWidth` pref); this component just
+// renders the left-edge handle and applies the width. While dragging we
+// size from the live ratio (a % of the app row) so the edge tracks the
+// cursor; when idle we apply the persisted px width directly. minWidth /
+// maxWidth pin both to the legal window so an extreme drag stops cleanly.
 
 import { useHandover } from "@/hooks/useHandover";
-import { ActiveApproachesSection } from "./sections/ActiveApproachesSection";
+import { makeSplitKeyHandler, RATIO_STEP } from "@/hooks/useSplitPane";
+import { ATTENTION_STRIP_WIDTH_MAX, ATTENTION_STRIP_WIDTH_MIN } from "@/lib/ui-prefs";
 import { CrossUnitStatusSection } from "./sections/CrossUnitStatusSection";
 import { UnitPrsSection } from "./sections/UnitPrsSection";
 import { WhereYouLeftOffSection } from "./sections/WhereYouLeftOffSection";
 
+/** Drag-resize wiring for the expanded strip. App.tsx builds this from the
+ *  shared `useSplitPane` hook + the `attentionStripWidth` pref, so the strip
+ *  stays a pure presentation surface (mirrors how SplitPaneLayout receives
+ *  its divider props from App). */
+export interface AttentionStripResize {
+  /** Persisted px width — applied directly when not mid-drag. */
+  width: number;
+  /** True while the divider is being dragged (live % sizing + active styling). */
+  isResizing: boolean;
+  /** Live split ratio (0–1) of the app row; the strip occupies `1 − ratio`. */
+  ratio: number;
+  onMouseDown: (e: React.MouseEvent) => void;
+  /** Reset to the default width (double-click affordance). */
+  onDoubleClick: () => void;
+  /** Keyboard ratio nudge (arrow keys / Home / End) — wired to adjustRatio. */
+  onAdjust: (delta: number) => void;
+}
+
 interface AttentionStripProps {
   /** Currently focused project (App.tsx's `currentProject`). Scopes the
-   *  ▶ attention list and the unit for the PR / approaches sections. */
+   *  ▶ attention list and the unit for the PR section. */
   currentProjectPath: string | null;
   /** Unit name — basename of `currentProjectPath`. Drives the wire-backed
-   *  PR / approaches sections (`resolve_unit_or_cwd` falls back to the
-   *  basename when no `[[unit]]` table matches). */
+   *  PR section (`resolve_unit_or_cwd` falls back to the basename when no
+   *  `[[unit]]` table matches). */
   unitName: string | null;
   /** Wired to App.tsx's `handleSelectProject` so picking a unit in the
    *  strip matches sidebar / centre-digest selection exactly. */
@@ -51,6 +82,8 @@ interface AttentionStripProps {
    *  UI pref. */
   collapsed: boolean;
   onToggleCollapsed: () => void;
+  /** Drag-resize wiring (only consumed when expanded). */
+  resize: AttentionStripResize;
 }
 
 export function AttentionStrip({
@@ -59,6 +92,7 @@ export function AttentionStrip({
   onSelectProjectByPath,
   collapsed,
   onToggleCollapsed,
+  resize,
 }: AttentionStripProps) {
   const { whereYouLeftOff, crossUnit, missingPreconditions } = useHandover(currentProjectPath);
 
@@ -91,12 +125,53 @@ export function AttentionStrip({
     );
   }
 
+  // While dragging, size from the live ratio so the left edge tracks the
+  // cursor (a % of the app row, since the ratio is row-relative); when idle,
+  // apply the persisted px width directly. min/max pin both forms to the
+  // legal window so the strip can't be dragged to starve the centre.
+  const width = resize.isResizing ? `${(1 - resize.ratio) * 100}%` : `${resize.width}px`;
+  const onHandleKeyDown = makeSplitKeyHandler("horizontal", RATIO_STEP, resize.onAdjust);
+
   return (
     <aside
       data-testid="attention-strip"
       data-collapsed="false"
-      className="glass flex w-80 shrink-0 flex-col border-l border-hairline"
+      className="glass relative flex shrink-0 flex-col border-l border-hairline"
+      style={{
+        width,
+        minWidth: ATTENTION_STRIP_WIDTH_MIN,
+        maxWidth: ATTENTION_STRIP_WIDTH_MAX,
+      }}
     >
+      {/* Left-edge resize handle (same WAI-ARIA Window Splitter pattern as
+          SplitPaneLayout). Absolutely positioned over the left border and
+          nudged half its width outward so the hit target straddles the edge.
+          biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter */}
+      <div
+        role="separator"
+        tabIndex={0}
+        aria-orientation="vertical"
+        aria-label="Resize attention strip"
+        aria-valuenow={Math.round((1 - resize.ratio) * 100)}
+        aria-valuemin={20}
+        aria-valuemax={80}
+        className="group absolute inset-y-0 left-0 z-10 flex w-1.5 -translate-x-1/2 cursor-col-resize items-center justify-center"
+        onMouseDown={resize.onMouseDown}
+        onDoubleClick={resize.onDoubleClick}
+        onKeyDown={onHandleKeyDown}
+      >
+        <div
+          className={`h-full w-px transition-colors ${
+            resize.isResizing ? "bg-primary/50" : "bg-surface group-hover:bg-primary/30"
+          }`}
+        />
+        <div className="absolute flex flex-col gap-1 opacity-0 transition-opacity group-hover:opacity-100">
+          <div className="h-1 w-1 rounded-full bg-muted-foreground" />
+          <div className="h-1 w-1 rounded-full bg-muted-foreground" />
+          <div className="h-1 w-1 rounded-full bg-muted-foreground" />
+        </div>
+      </div>
+
       <header className="flex shrink-0 items-center justify-between border-b border-hairline px-4 py-3">
         <h2 className="text-sm font-semibold text-foreground">Attention</h2>
         <button
@@ -113,7 +188,6 @@ export function AttentionStrip({
 
       <div className="flex-1 space-y-6 overflow-y-auto px-4 py-4 text-sm">
         <WhereYouLeftOffSection data={whereYouLeftOff} attentionOnly />
-        <ActiveApproachesSection unitName={unitName} />
         <UnitPrsSection unitName={unitName} />
         <CrossUnitStatusSection
           data={crossUnit}

--- a/clients/react/src/components/producer-console/__tests__/AttentionStrip.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/AttentionStrip.test.tsx
@@ -2,25 +2,30 @@
 //
 // AttentionStrip — P1 of the L/C/R co-visible re-layout
 // (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`
-// §Refinement 2026-05-22). The strip is the dumb status subset (Fork A)
-// that reuses four self-contained Producer-console sections. We mock the
-// three data hooks (`useHandover` for the client-derived sections,
-// `useUnitPrs` / `useApproaches` for the wire-backed ones) so each render
-// presents a deterministic, network-free shape and we can assert:
-//   - all four attention sections render when expanded;
+// §Refinement 2026-05-22), refined by §"P1.1 — lived-feedback adjustment".
+// The strip is the dumb status subset (Fork A) that reuses three
+// self-contained Producer-console sections. We mock the two data hooks
+// (`useHandover` for the client-derived sections, `useUnitPrs` for the
+// wire-backed one) so each render presents a deterministic, network-free
+// shape and we can assert:
+//   - the three attention sections render when expanded (▣ approaches is
+//     NOT here post-P1.1 — it lives in the centre digest);
+//   - the strip's ▶ header reads "Blocked / awaiting" (the centre digest
+//     keeps "Where you left off");
 //   - `attentionOnly` drops the ambient worktree list (strip ≠ digest);
 //   - the collapsed rail hides the sections and exposes an expand control;
-//   - cross-unit clicks route to onSelectProjectByPath.
+//   - cross-unit clicks route to onSelectProjectByPath;
+//   - the strip is drag-resizable: a left-edge handle drives the resize
+//     wiring, and the applied width follows the persisted px / live ratio.
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { HandoverDigest } from "@/hooks/useHandover";
-import type { ApproachesResponse, PrSummaryWire, UnitPrsResponse } from "@/lib/api";
-import { AttentionStrip } from "../AttentionStrip";
+import type { PrSummaryWire, UnitPrsResponse } from "@/lib/api";
+import { AttentionStrip, type AttentionStripResize } from "../AttentionStrip";
 
 const useHandoverMock = vi.fn();
 const useUnitPrsMock = vi.fn();
-const useApproachesMock = vi.fn();
 
 vi.mock("@/hooks/useHandover", () => ({
   useHandover: (path: string | null) => useHandoverMock(path),
@@ -28,10 +33,6 @@ vi.mock("@/hooks/useHandover", () => ({
 
 vi.mock("@/hooks/useUnitPrs", () => ({
   useUnitPrs: (unit: string | null) => useUnitPrsMock(unit),
-}));
-
-vi.mock("@/hooks/useApproaches", () => ({
-  useApproaches: (unit: string | null) => useApproachesMock(unit),
 }));
 
 function digest(overrides: Partial<HandoverDigest> = {}): HandoverDigest {
@@ -55,26 +56,23 @@ function emptyPrs(): { data: UnitPrsResponse | null; loading: boolean; error: Er
   return { data, loading: false, error: null };
 }
 
-function emptyApproaches(): {
-  data: ApproachesResponse | null;
-  loading: boolean;
-  error: Error | null;
-} {
-  const data: ApproachesResponse = {
-    unit: "stub",
-    composed_at: "2026-05-22T00:00:00Z",
-    repos: [],
-  };
-  return { data, loading: false, error: null };
-}
-
 beforeEach(() => {
   useHandoverMock.mockReset();
   useUnitPrsMock.mockReset();
-  useApproachesMock.mockReset();
   useUnitPrsMock.mockReturnValue(emptyPrs());
-  useApproachesMock.mockReturnValue(emptyApproaches());
 });
+
+function makeResize(overrides: Partial<AttentionStripResize> = {}): AttentionStripResize {
+  return {
+    width: 320,
+    isResizing: false,
+    ratio: 0.5,
+    onMouseDown: vi.fn(),
+    onDoubleClick: vi.fn(),
+    onAdjust: vi.fn(),
+    ...overrides,
+  };
+}
 
 function makeProps(overrides: Partial<Parameters<typeof AttentionStrip>[0]> = {}) {
   return {
@@ -83,21 +81,26 @@ function makeProps(overrides: Partial<Parameters<typeof AttentionStrip>[0]> = {}
     onSelectProjectByPath: vi.fn(),
     collapsed: false,
     onToggleCollapsed: vi.fn(),
+    resize: makeResize(),
     ...overrides,
   };
 }
 
 describe("AttentionStrip", () => {
-  it("renders all four attention sections when expanded", () => {
+  it("renders the three attention sections when expanded (no ▣ approaches)", () => {
     useHandoverMock.mockReturnValue(digest());
 
     render(<AttentionStrip {...makeProps()} />);
 
     expect(screen.getByRole("heading", { name: /Attention/ })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: /Where you left off/ })).toBeTruthy();
-    expect(screen.getByRole("heading", { name: /Active approaches/ })).toBeTruthy();
+    // P1.1: the strip's ▶ header is "Blocked / awaiting", not the digest's
+    // "Where you left off".
+    expect(screen.getByRole("heading", { name: /Blocked \/ awaiting/ })).toBeTruthy();
+    expect(screen.queryByRole("heading", { name: /Where you left off/ })).toBeNull();
     expect(screen.getByRole("heading", { name: /Open PRs/ })).toBeTruthy();
     expect(screen.getByRole("heading", { name: /Cross-unit status/ })).toBeTruthy();
+    // ▣ verdict-awaiting approaches moved OUT of the strip (start-briefing).
+    expect(screen.queryByRole("heading", { name: /Active approaches/ })).toBeNull();
   });
 
   it("shows attention agents but NOT the ambient worktree list (attentionOnly)", () => {
@@ -207,9 +210,10 @@ describe("AttentionStrip", () => {
 
     render(<AttentionStrip {...makeProps({ collapsed: true, onToggleCollapsed: onToggle })} />);
 
-    // Sections are gone in the collapsed rail …
-    expect(screen.queryByRole("heading", { name: /Active approaches/ })).toBeNull();
+    // Sections (and the resize handle) are gone in the collapsed rail …
+    expect(screen.queryByRole("heading", { name: /Blocked \/ awaiting/ })).toBeNull();
     expect(screen.queryByRole("heading", { name: /Open PRs/ })).toBeNull();
+    expect(screen.queryByRole("separator", { name: /Resize attention strip/i })).toBeNull();
 
     // … and the strip stays addressable for the layout test.
     const strip = screen.getByTestId("attention-strip");
@@ -218,5 +222,45 @@ describe("AttentionStrip", () => {
     const expandBtn = screen.getByRole("button", { name: /Expand attention strip/i });
     fireEvent.click(expandBtn);
     expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("is drag-resizable: the left-edge handle drives the resize wiring", () => {
+    useHandoverMock.mockReturnValue(digest());
+    const onMouseDown = vi.fn();
+    const onDoubleClick = vi.fn();
+
+    render(
+      <AttentionStrip {...makeProps({ resize: makeResize({ onMouseDown, onDoubleClick }) })} />,
+    );
+
+    const handle = screen.getByRole("separator", { name: /Resize attention strip/i });
+    expect(handle.getAttribute("aria-orientation")).toBe("vertical");
+
+    fireEvent.mouseDown(handle);
+    expect(onMouseDown).toHaveBeenCalledTimes(1);
+
+    fireEvent.doubleClick(handle);
+    expect(onDoubleClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("applies the persisted px width when idle and the live ratio while dragging", () => {
+    useHandoverMock.mockReturnValue(digest());
+
+    // Idle: width comes straight from the persisted px pref.
+    const { rerender } = render(
+      <AttentionStrip {...makeProps({ resize: makeResize({ width: 420, isResizing: false }) })} />,
+    );
+    let strip = screen.getByTestId("attention-strip");
+    expect(strip.style.width).toBe("420px");
+    expect(strip.style.maxWidth).toBe("560px");
+    expect(strip.style.minWidth).toBe("240px");
+
+    // Dragging: width tracks the live ratio (strip = 1 − ratio of the row).
+    rerender(
+      <AttentionStrip {...makeProps({ resize: makeResize({ ratio: 0.6, isResizing: true }) })} />,
+    );
+    strip = screen.getByTestId("attention-strip");
+    // (1 − 0.6) * 100 = 40%
+    expect(strip.style.width).toBe("40%");
   });
 });

--- a/clients/react/src/components/producer-console/sections/WhereYouLeftOffSection.tsx
+++ b/clients/react/src/components/producer-console/sections/WhereYouLeftOffSection.tsx
@@ -14,7 +14,10 @@ interface WhereYouLeftOffSectionProps {
    *  reuses this section but wants only the *attention part* — blocked /
    *  awaiting agents — not the ambient worktree list. When true, render just
    *  the attention list (which `useHandover` falls back to *all* AI agents
-   *  for when no project is scoped, so the strip still shows what's blocked).
+   *  for when no project is scoped, so the strip still shows what's blocked)
+   *  AND relabel the ▶ header to "Blocked / awaiting" — per P1.1 the strip
+   *  surfaces continuous attention, so its header names that, not the
+   *  start-of-session "where you left off" framing the centre digest keeps.
    *  Default false keeps the centre digest's full ▶ section unchanged. */
   attentionOnly?: boolean;
 }
@@ -29,7 +32,9 @@ export function WhereYouLeftOffSection({
     <section>
       <header className="mb-2 flex items-baseline gap-2">
         <span className="text-base text-primary">▶</span>
-        <h3 className="text-sm font-semibold text-foreground">Where you left off</h3>
+        <h3 className="text-sm font-semibold text-foreground">
+          {attentionOnly ? "Blocked / awaiting" : "Where you left off"}
+        </h3>
         {activeProjectName && (
           <span className="text-xs text-muted-foreground">
             on <code className="text-foreground">{activeProjectName}</code>

--- a/clients/react/src/lib/__tests__/ui-prefs.test.ts
+++ b/clients/react/src/lib/__tests__/ui-prefs.test.ts
@@ -55,6 +55,32 @@ describe("ui-prefs", () => {
     expect(loadUIPrefs().terminalFontSize).toBe(DEFAULT_UI_PREFS.terminalFontSize);
   });
 
+  it("defaults the attention-strip width to 320px and round-trips across reload", () => {
+    // Default matches the pre-P1.1 fixed w-80.
+    expect(loadUIPrefs().attentionStripWidth).toBe(320);
+    // The drag commit persists a px width; a fresh load (= reload) reads it back.
+    saveUIPrefs({ ...DEFAULT_UI_PREFS, attentionStripWidth: 440 });
+    expect(loadUIPrefs().attentionStripWidth).toBe(440);
+  });
+
+  it("clamps an out-of-range / non-numeric attention-strip width", () => {
+    localStorage.setItem(
+      UI_PREFS_STORAGE_KEY,
+      JSON.stringify({ ...DEFAULT_UI_PREFS, attentionStripWidth: 9999 }),
+    );
+    expect(loadUIPrefs().attentionStripWidth).toBe(560); // ATTENTION_STRIP_WIDTH_MAX
+    localStorage.setItem(
+      UI_PREFS_STORAGE_KEY,
+      JSON.stringify({ ...DEFAULT_UI_PREFS, attentionStripWidth: 10 }),
+    );
+    expect(loadUIPrefs().attentionStripWidth).toBe(240); // ATTENTION_STRIP_WIDTH_MIN
+    localStorage.setItem(
+      UI_PREFS_STORAGE_KEY,
+      JSON.stringify({ ...DEFAULT_UI_PREFS, attentionStripWidth: "wide" }),
+    );
+    expect(loadUIPrefs().attentionStripWidth).toBe(DEFAULT_UI_PREFS.attentionStripWidth);
+  });
+
   it("round-trips a saved blob", () => {
     const next: UIPrefs = {
       ...DEFAULT_UI_PREFS,

--- a/clients/react/src/lib/ui-prefs.ts
+++ b/clients/react/src/lib/ui-prefs.ts
@@ -35,7 +35,24 @@ export interface UIPrefs {
   // width when the centre conversation/multipane is busy. Default open so
   // a clean-state user sees the co-visible attention surface immediately.
   attentionStripCollapsed: boolean;
+  // Persistent right-hand attention strip width in px
+  // (same DR, §"P1.1 — lived-feedback adjustment"). The strip is a
+  // right-docked panel, so unlike the splitRatioH/V *ratios* this is an
+  // absolute pixel width: a docked panel reads naturally in px and should
+  // not reflow when the centre pane's content changes. Drag-resized via
+  // the shared useSplitPane drag engine; persisted here so the operator's
+  // chosen width survives reloads / cross-tab. Mirrors the ratio prefs
+  // structurally (clamped numeric field) — see clampAttentionStripWidth.
+  attentionStripWidth: number;
 }
+
+// Attention-strip width bounds (px). Floor keeps the section content
+// (PR rows, cross-unit list) legible; ceiling stops the strip from
+// starving the centre conversation. Default matches the pre-P1.1 fixed
+// `w-80` (20rem = 320px) so existing users see no jump on upgrade.
+export const ATTENTION_STRIP_WIDTH_MIN = 240;
+export const ATTENTION_STRIP_WIDTH_MAX = 560;
+export const ATTENTION_STRIP_WIDTH_DEFAULT = 320;
 
 export const DEFAULT_UI_PREFS: UIPrefs = {
   displayMode: "split-h",
@@ -48,6 +65,7 @@ export const DEFAULT_UI_PREFS: UIPrefs = {
   theme: DEFAULT_THEME_NAME,
   terminalFontSize: 13,
   attentionStripCollapsed: false,
+  attentionStripWidth: ATTENTION_STRIP_WIDTH_DEFAULT,
 };
 
 export const UI_PREFS_STORAGE_KEY = "tmai:ui:prefs";
@@ -72,6 +90,24 @@ function clampRatio(value: unknown, fallback: number): number {
 function clampFontSize(value: unknown, fallback: number): number {
   if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
   return Math.max(TERMINAL_FONT_SIZE_MIN, Math.min(TERMINAL_FONT_SIZE_MAX, Math.round(value)));
+}
+
+// Clamp a candidate strip width to the legal px window, rounding to a whole
+// pixel. Exported so the drag commit path (App.tsx) clamps the committed
+// width with the same rule coercePrefs applies on load — the two guards
+// then compose: the drag can't persist an out-of-range width, and a
+// hand-edited / stale blob is still corrected on read.
+export function clampAttentionStripWidth(value: number): number {
+  if (!Number.isFinite(value)) return ATTENTION_STRIP_WIDTH_DEFAULT;
+  return Math.max(
+    ATTENTION_STRIP_WIDTH_MIN,
+    Math.min(ATTENTION_STRIP_WIDTH_MAX, Math.round(value)),
+  );
+}
+
+function clampStripWidth(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value)) return fallback;
+  return clampAttentionStripWidth(value);
 }
 
 // Validate each field individually so a partially corrupt blob still
@@ -101,6 +137,10 @@ function coercePrefs(raw: unknown): UIPrefs {
       typeof r.attentionStripCollapsed === "boolean"
         ? r.attentionStripCollapsed
         : DEFAULT_UI_PREFS.attentionStripCollapsed,
+    attentionStripWidth: clampStripWidth(
+      r.attentionStripWidth,
+      DEFAULT_UI_PREFS.attentionStripWidth,
+    ),
   };
 }
 


### PR DESCRIPTION
P1.1 lived-feedback refinement of the persistent attention strip from #722, per `doc/decisions/2026-05-14-react-producer-console-rebuild.md` §"P1.1 — lived-feedback adjustment (2026-05-23)". Two frictions surfaced from first use of P1: the strip width was fixed (no drag), and ▣ verdict-awaiting approaches change slowly (start-orientation, not continuous attention).

## Changes
1. **Drag-resizable width.** A left-edge handle on the expanded strip drives the shared `useSplitPane` engine (wired in `App.tsx`; its `containerRef` is attached to the app-root flex row, of which the strip is the right-most in-flow child, so `1 − ratio` of the row = the strip). Width persists as a **new `attentionStripWidth` px UI-pref** (interface + default + `coercePrefs` clamp, mirroring `splitRatioH/V` structurally), clamped 240–560, default 320 (= the old fixed `w-80`). The strip is ratio-sized (live %) while dragging and px-sized when idle; double-click resets to the default width. Collapse-to-rail is unchanged (resizable when expanded, thin rail when collapsed).
2. **Approaches → briefing.** `ActiveApproachesSection` removed from the strip; it still renders in the centre `ProducerConsole` digest (start-briefing). Net: approaches show in the digest, not the persistent strip.
3. **▶ relabel.** The strip's `WhereYouLeftOffSection ... attentionOnly` header now reads **"Blocked / awaiting"** (branch on `attentionOnly`); the centre digest's full `WhereYouLeftOffSection` keeps **"Where you left off"**.

## Scope
Still **additive re P2** — `BranchGraph` / `MarkdownPanel` / the Tabbed/Split/Triple layouts / `useSplitPane` all stay in place (reused, not modified). No changes to `useTerminal.ts` / `globals.css`. Centre digest unchanged except that `ActiveApproaches` remains there.

## Gate (run locally, all green)
- `pnpm lint` (biome) ✓
- `pnpm exec tsc -b` ✓
- `pnpm build` ✓
- `pnpm test` ✓ — 529 passed, 2 skipped (68 files)

Tests added/updated: ui-prefs round-trips + clamps the px width across reload (= persists across reloads); the strip is drag-resizable (handle drives the resize wiring) and applies px-when-idle / live-%-when-dragging; the strip has no ▣ approaches and its ▶ reads "Blocked / awaiting"; the centre digest still has its full ▶ "Where you left off" + ActiveApproaches.

**How the resize width persists:** the drag's final ratio is converted to a pixel width and stored in the `attentionStripWidth` field of the consolidated `tmai:ui:prefs` localStorage blob (via `useUIPref` → `saveUIPrefs`); on reload `loadUIPrefs`/`coercePrefs` reads + clamps it and seeds the split ratio from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 注意ストリップがドラッグで幅を変更できるようになりました
  * ドラッグで調整した幅が自動的に保存されます
  * ダブルクリックでデフォルト幅にリセットできます
  * キーボード操作での幅調整に対応しました
  * 注意ストリップの表示内容を整理しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/723?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->