### PR TITLE
feat(webui): reach handoff trigger + ctx% from the Producer conversation

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -9,7 +9,10 @@ import { HelpOverlay } from "@/components/layout/HelpOverlay";
 import { StatusBar } from "@/components/layout/StatusBar";
 import { ToastContainer, useToast } from "@/components/layout/ToastContainer";
 import { AttentionStrip } from "@/components/producer-console/AttentionStrip";
+import { HandoffRitualFailureDialog } from "@/components/producer-console/HandoffRitualFailureDialog";
+import { HandoffRitualOverlay } from "@/components/producer-console/HandoffRitualOverlay";
 import { ProducerConsole } from "@/components/producer-console/ProducerConsole";
+import { ProducerConversationHeader } from "@/components/producer-console/ProducerConversationHeader";
 import { SecurityPanel } from "@/components/settings/SecurityPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import { TerminalList } from "@/components/terminal/TerminalList";
@@ -19,6 +22,7 @@ import { useApplyTheme } from "@/hooks/useActiveTheme";
 import { useAgentSelectionFallback } from "@/hooks/useAgentSelectionFallback";
 import { useAgents } from "@/hooks/useAgents";
 import { useCalibration } from "@/hooks/useCalibration";
+import { useHandoffRitual } from "@/hooks/useHandoffRitual";
 import { useIdleNotification } from "@/hooks/useIdleNotification";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useNotificationConfig } from "@/hooks/useNotificationConfig";
@@ -26,6 +30,7 @@ import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
 import { useSplitPane } from "@/hooks/useSplitPane";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { api, groupByProject, isAiAgentLoose, type Selection, setCallerCwd } from "@/lib/api";
+import { findProducerForUnit } from "@/lib/producer";
 import { useSSE } from "@/lib/sse-provider";
 import { ATTENTION_STRIP_WIDTH_DEFAULT, clampAttentionStripWidth } from "@/lib/ui-prefs";
 import { useUIPref } from "@/lib/ui-prefs-provider";
@@ -162,6 +167,68 @@ export function App() {
     return currentProject.split("/").filter(Boolean).pop() ?? null;
   }, [currentProject]);
   const { data: calibrationData } = useCalibration(unitName);
+
+  // ── Producer handoff-and-restart ritual (lifted to App level) ──
+  //
+  // Exactly ONE `useHandoffRitual` instance for the whole app. The
+  // trigger flows down to BOTH trigger sites (the digest's `Handoff &
+  // restart` button via ProducerConsole, and the conversation header),
+  // while the in-progress overlay / failure dialog / ready-toast render
+  // HERE as App-level siblings of TripwireBanner / ToastContainer — so
+  // they stay co-visible regardless of which centre view is shown
+  // (digest, Producer conversation, Settings, …). It used to live inside
+  // the digest-only ProducerConsoleActions, which left the trigger
+  // unreachable while conversing with the Producer (lived friction
+  // 2026-05-23). Two hook instances would mean two overlays, so this
+  // MUST remain the only one.
+  const {
+    state: ritualState,
+    trigger: triggerHandoff,
+    retry: retryHandoff,
+    dismiss: dismissHandoff,
+    retryCount: handoffRetryCount,
+    retryRefused: handoffRetryRefused,
+  } = useHandoffRitual();
+
+  // The single live Producer for the focused unit. Drives the
+  // conversation-header gate (only show it when the selected agent IS
+  // this Producer), the failure dialog's Force-kill target, and its
+  // Resume-in-CC id. Shares the `findProducerForUnit` resolver with the
+  // digest button and the ctx readout so all surfaces agree.
+  const producerForUnit = useMemo(
+    () => findProducerForUnit(agents, currentProject),
+    [agents, currentProject],
+  );
+
+  // Auto-dismiss `ready` with a brief success toast (handoff-lifecycle
+  // DR §E overlay spec). Moved up from ProducerConsoleActions with the
+  // rest of the ritual UI.
+  const [handoffReadyToastVisible, setHandoffReadyToastVisible] = useState(false);
+  useEffect(() => {
+    if (ritualState.kind !== "ready") return;
+    setHandoffReadyToastVisible(true);
+    const t = setTimeout(() => {
+      setHandoffReadyToastVisible(false);
+      dismissHandoff();
+    }, 2500);
+    return () => clearTimeout(t);
+  }, [ritualState.kind, dismissHandoff]);
+
+  const handleHandoffRetry = useCallback(() => {
+    if (unitName === null) return;
+    void retryHandoff(unitName, { trigger: "manual" });
+  }, [retryHandoff, unitName]);
+
+  const handleHandoffForceKill = useCallback(async () => {
+    if (producerForUnit === null) return;
+    try {
+      await api.killAgent(producerForUnit.target);
+    } catch {
+      // Best-effort — if the kill fails (already dead, etc.) we still
+      // dismiss; the dialog already surfaced the upstream failure.
+    }
+    dismissHandoff();
+  }, [producerForUnit, dismissHandoff]);
 
   // "Open Producer terminal" affordance from <ProducerConsole>.
   //
@@ -607,6 +674,22 @@ export function App() {
           // (returnToConsole) returns to the digest.
           <div className="flex flex-1 flex-col overflow-hidden">
             {selectedAgent && <AgentActions agent={selectedAgent} passthrough />}
+            {/* Conversation-view header: the ctx% readout + Handoff &
+                restart trigger, co-visible ABOVE the terminal so the
+                operator conversing with the Producer can reach the
+                ritual without returning to the digest (fixes the
+                manual-kill trap, lived friction 2026-05-23). Renders
+                ONLY when the selected agent IS this unit's Producer;
+                when talking to a worker it stays hidden. */}
+            {selectedAgent && selectedAgent.id === producerForUnit?.id && (
+              <ProducerConversationHeader
+                agents={agents}
+                currentProjectPath={currentProject}
+                unitName={unitName}
+                trigger={triggerHandoff}
+                onOpenSettings={openSettingsFromOverride}
+              />
+            )}
             {sessionId && selectedAgent ? (
               <div key={sessionId} className="flex-1 overflow-hidden animate-fade-in">
                 <TerminalPanel agentId={selectedAgent.target} />
@@ -625,6 +708,7 @@ export function App() {
                 calibrationData={calibrationData}
                 onOpenProducerTerminal={openProducerTerminal}
                 onOpenCalibration={openCalibration}
+                trigger={triggerHandoff}
                 onSelectProjectByPath={handleSelectProject}
                 onLaunchProducerAt={launchProducerAt}
                 onOverrideSpawned={handleSpawned}
@@ -672,6 +756,45 @@ export function App() {
 
       {/* Toast notifications */}
       <ToastContainer toasts={toast.toasts} onRemove={toast.removeToast} />
+
+      {/* Handoff-and-restart ritual UI — App-level single instance so it
+          stays co-visible regardless of the active centre view (digest,
+          Producer conversation, Settings, …). The ordered phases, the
+          4-choice failure dialog, the retry budget (max 2, 3rd refused)
+          and the confirm text are the unchanged handoff-lifecycle DR §E
+          contract; this only RELOCATES the surface up from the digest. */}
+      {(ritualState.kind === "dispatching" || ritualState.kind === "in_progress") &&
+        unitName !== null && (
+          <HandoffRitualOverlay
+            unitName={unitName}
+            ritualId={ritualState.kind === "in_progress" ? ritualState.ritualId : null}
+            phases={ritualState.kind === "in_progress" ? ritualState.phases : []}
+          />
+        )}
+
+      {ritualState.kind === "escalated" && unitName !== null && (
+        <HandoffRitualFailureDialog
+          unitName={unitName}
+          reason={ritualState.reason}
+          message={ritualState.message}
+          producerAgentId={producerForUnit?.id ?? null}
+          retryCount={handoffRetryCount}
+          retryRefused={handoffRetryRefused}
+          onForceKill={() => void handleHandoffForceKill()}
+          onRetry={handleHandoffRetry}
+          onDismiss={dismissHandoff}
+        />
+      )}
+
+      {handoffReadyToastVisible && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-4 right-4 z-40 rounded-md border border-success/30 bg-surface-strong px-4 py-2 text-xs text-success shadow-lg"
+        >
+          Handoff complete — fresh Producer is ready.
+        </div>
+      )}
     </div>
   );
 }

--- a/clients/react/src/__tests__/App.attention-strip.test.tsx
+++ b/clients/react/src/__tests__/App.attention-strip.test.tsx
@@ -82,6 +82,15 @@ vi.mock("@/components/producer-console/ProducerConsole", () => ({
     </div>
   ),
 }));
+// The conversation header mounts above the terminal whenever the
+// selected agent is the unit's Producer; it pulls orchestrator settings
+// through ProducerCtxHeader. Stub it — this is a layout test, the
+// header's content is covered by ProducerConversationHeader.test.tsx.
+vi.mock("@/components/producer-console/ProducerConversationHeader", () => ({
+  ProducerConversationHeader: () => (
+    <div data-testid="conversation-header-stub">conversation-header</div>
+  ),
+}));
 vi.mock("@/components/agent/PreviewPanel", () => ({
   PreviewPanel: () => <div data-testid="preview-stub">preview</div>,
 }));

--- a/clients/react/src/__tests__/App.handoff.test.tsx
+++ b/clients/react/src/__tests__/App.handoff.test.tsx
@@ -1,0 +1,241 @@
+// @vitest-environment jsdom
+//
+// App-level handoff-ritual wiring test. After the ritual was lifted out
+// of the digest-only ProducerConsoleActions up to App
+// (`doc/decisions/2026-05-14-react-producer-console-rebuild.md` — the
+// L/C/R co-visible principle; lived friction 2026-05-23), App owns the
+// single `useHandoffRitual` instance and is responsible for:
+//
+//   1. mounting <ProducerConversationHeader> ABOVE the conversation ONLY
+//      when the selected agent IS the unit's Producer (not for workers);
+//   2. rendering the in-progress overlay at App level so it stays
+//      co-visible with ANY centre view — including the conversation that
+//      previously couldn't reach it.
+//
+// We stub the conversation header (its content is covered by its own
+// test) and observe the App gate via the stub's presence; the overlay is
+// the REAL component so we assert on its phase rows. `useHandoffRitual`
+// is mocked so we can drive `state` deterministically.
+
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentSnapshot } from "@/lib/api";
+import { renderWithProviders } from "@/test/render";
+
+// ── hook mocks ──
+const useAgentsMock = vi.fn();
+const useResponsiveLayoutMock = vi.fn();
+const useSplitPaneMock = vi.fn();
+const useHandoffRitualMock = vi.fn();
+
+vi.mock("@/lib/sse-provider", () => ({
+  useSSE: () => undefined,
+  useSSEContext: () => ({
+    cache: { agents: [], worktrees: [], queueEntries: [], loading: false },
+    refreshCache: vi.fn(),
+    subscribe: vi.fn(),
+  }),
+}));
+vi.mock("@/hooks/useActiveTheme", () => ({ useApplyTheme: () => undefined }));
+vi.mock("@/hooks/useAgents", () => ({ useAgents: () => useAgentsMock() }));
+vi.mock("@/hooks/useWorktrees", () => ({
+  useWorktrees: () => ({ worktrees: [], loading: false, refresh: vi.fn() }),
+}));
+vi.mock("@/hooks/useCalibration", () => ({
+  useCalibration: () => ({ data: null, loading: false, error: null }),
+}));
+vi.mock("@/hooks/useNotificationConfig", () => ({ useNotificationConfig: () => ({}) }));
+vi.mock("@/hooks/useIdleNotification", () => ({
+  useIdleNotification: () => ({ handleAgentStopped: vi.fn() }),
+}));
+vi.mock("@/hooks/useResponsiveLayout", () => ({
+  useResponsiveLayout: () => useResponsiveLayoutMock(),
+}));
+vi.mock("@/hooks/useSplitPane", () => ({ useSplitPane: () => useSplitPaneMock() }));
+vi.mock("@/hooks/useAgentSelectionFallback", () => ({
+  useAgentSelectionFallback: () => undefined,
+}));
+vi.mock("@/hooks/useKeyboardShortcuts", () => ({ useKeyboardShortcuts: () => undefined }));
+vi.mock("@/hooks/useHandoffRitual", () => ({ useHandoffRitual: () => useHandoffRitualMock() }));
+
+// ── component stubs ──
+vi.mock("@/components/producer-console/AttentionStrip", () => ({
+  AttentionStrip: () => <div data-testid="attention-strip-stub">strip</div>,
+}));
+vi.mock("@/components/producer-console/ProducerConsole", () => ({
+  ProducerConsole: () => <div data-testid="producer-console-stub">digest</div>,
+}));
+// Stub the conversation header so the App gate
+// (`selectedAgent.id === producerForUnit?.id`) is observable without
+// rendering the real ctx readout (which fetches orchestrator settings).
+vi.mock("@/components/producer-console/ProducerConversationHeader", () => ({
+  ProducerConversationHeader: () => (
+    <div data-testid="conversation-header-stub">conversation-header</div>
+  ),
+}));
+vi.mock("@/components/agent/PreviewPanel", () => ({
+  PreviewPanel: () => <div data-testid="preview-stub">preview</div>,
+}));
+vi.mock("@/components/agent/AgentActions", () => ({ AgentActions: () => null }));
+vi.mock("@/components/terminal/TerminalPanel", () => ({
+  TerminalPanel: () => <div data-testid="terminal-stub">terminal</div>,
+}));
+vi.mock("@/components/agent/AgentList", () => ({ AgentList: () => null }));
+vi.mock("@/components/terminal/TerminalList", () => ({ TerminalList: () => null }));
+vi.mock("@/components/usage/UsagePanel", () => ({ UsagePanel: () => null }));
+vi.mock("@/components/settings/SettingsPanel", () => ({ SettingsPanel: () => null }));
+vi.mock("@/components/settings/SecurityPanel", () => ({ SecurityPanel: () => null }));
+vi.mock("@/components/calibration/CalibrationPanel", () => ({ CalibrationPanel: () => null }));
+
+import { App } from "@/App";
+
+function agent(overrides: {
+  id: string;
+  cwd?: string;
+  gitCommonDir?: string | null;
+  isWorktree?: boolean;
+}): AgentSnapshot {
+  const id = overrides.id;
+  const cwd = overrides.cwd ?? "/p/alpha";
+  return {
+    id,
+    target: id,
+    agent_type: "ClaudeCode",
+    title: id,
+    cwd,
+    display_cwd: cwd,
+    display_name: id,
+    detection_source: "HttpHook",
+    git_branch: null,
+    git_dirty: null,
+    is_worktree: overrides.isWorktree ?? false,
+    git_common_dir: overrides.gitCommonDir === undefined ? "/p/alpha/.git" : overrides.gitCommonDir,
+    worktree_name: overrides.isWorktree ? "feat-x" : null,
+    worktree_base_branch: null,
+    effort_level: null,
+    active_subagents: 0,
+    compaction_count: 0,
+    pty_session_id: null,
+    send_capability: "None",
+    is_virtual: false,
+    team_info: null,
+    is_orchestrator: false,
+    attention: null,
+  } as AgentSnapshot;
+}
+
+function responsive(overrides: Record<string, unknown> = {}) {
+  return {
+    sidebarCollapsed: true,
+    toggleSidebar: vi.fn(),
+    actionPanelCollapsed: true,
+    toggleActionPanel: vi.fn(),
+    isNarrowScreen: false,
+    isMobileScreen: false,
+    mobileDrawerOpen: false,
+    toggleMobileDrawer: vi.fn(),
+    closeMobileDrawer: vi.fn(),
+    ...overrides,
+  };
+}
+
+function splitPane(isNarrowScreen = false) {
+  return {
+    splitRatio: 0.5,
+    isDragging: false,
+    containerRef: { current: null },
+    onDividerMouseDown: vi.fn(),
+    onDividerDoubleClick: vi.fn(),
+    adjustRatio: vi.fn(),
+    isNarrowScreen,
+  };
+}
+
+function idleRitual() {
+  return {
+    state: { kind: "idle" as const },
+    trigger: vi.fn(),
+    retry: vi.fn(),
+    dismiss: vi.fn(),
+    retryCount: 0,
+    retryRefused: false,
+  };
+}
+
+beforeEach(() => {
+  useAgentsMock.mockReset();
+  useResponsiveLayoutMock.mockReset();
+  useSplitPaneMock.mockReset();
+  useHandoffRitualMock.mockReset();
+  useResponsiveLayoutMock.mockReturnValue(responsive());
+  useSplitPaneMock.mockReturnValue(splitPane(false));
+  useHandoffRitualMock.mockReturnValue(idleRitual());
+});
+
+describe("App — handoff ritual wiring", () => {
+  it("mounts the conversation header when the selected agent IS the unit's Producer", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [agent({ id: "claude:prod" })],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+
+    renderWithProviders(<App />);
+
+    // No selection yet → digest, no conversation header.
+    expect(screen.queryByTestId("conversation-header-stub")).toBeNull();
+
+    // Select the Producer (collapsed sidebar renders one button per agent).
+    fireEvent.click(screen.getByTitle("claude:prod"));
+
+    expect(screen.getByTestId("preview-stub")).toBeTruthy();
+    expect(screen.getByTestId("conversation-header-stub")).toBeTruthy();
+  });
+
+  it("does NOT mount the conversation header when the selected agent is a worker", () => {
+    // A non-worktree Producer + a worktree worker, both under /p/alpha.
+    // The unit's Producer resolves to the non-worktree one; selecting the
+    // worktree worker must leave the header unmounted.
+    useAgentsMock.mockReturnValue({
+      agents: [
+        agent({ id: "claude:prod", cwd: "/p/alpha", isWorktree: false }),
+        agent({ id: "claude:work", cwd: "/p/alpha/.worktrees/feat-x", isWorktree: true }),
+      ],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+
+    renderWithProviders(<App />);
+
+    fireEvent.click(screen.getByTitle("claude:work"));
+
+    expect(screen.getByTestId("preview-stub")).toBeTruthy();
+    expect(screen.queryByTestId("conversation-header-stub")).toBeNull();
+  });
+
+  it("renders the in-progress overlay at App level — co-visible with the conversation view", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [agent({ id: "claude:prod" })],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+    useHandoffRitualMock.mockReturnValue({
+      ...idleRitual(),
+      state: { kind: "in_progress", ritualId: "r-1", phases: [] },
+    });
+
+    renderWithProviders(<App />);
+
+    // Overlay is present in the digest view …
+    expect(screen.getByTestId("phase-row-prompted")).toBeTruthy();
+
+    // … and STILL present after switching to the Producer conversation —
+    // the trap that forced manual-kill (overlay only in the digest) is gone.
+    fireEvent.click(screen.getByTitle("claude:prod"));
+    expect(screen.getByTestId("preview-stub")).toBeTruthy();
+    expect(screen.getByTestId("phase-row-prompted")).toBeTruthy();
+  });
+});

--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -24,7 +24,7 @@
 
 import { useAgents } from "@/hooks/useAgents";
 import { useHandover } from "@/hooks/useHandover";
-import type { CalibrationResponse } from "@/lib/api";
+import type { CalibrationResponse, TriggerHandoffRitualRequest } from "@/lib/api";
 import { ProducerConsoleActions } from "./ProducerConsoleActions";
 import { ProducerCtxHeader } from "./ProducerCtxHeader";
 import { ActiveApproachesSection } from "./sections/ActiveApproachesSection";
@@ -53,6 +53,11 @@ interface ProducerConsoleProps {
    *  `tmai producer` there. */
   onLaunchProducerAt: (path: string) => void;
   onOpenCalibration: () => void;
+  /** The App-level lifted handoff-ritual trigger, forwarded to the
+   *  digest's `Handoff & restart ▸` button. The ritual hook itself
+   *  lives in App (single instance); the overlay / failure dialog /
+   *  ready-toast render at App level. */
+  trigger: (unit: string, body: TriggerHandoffRitualRequest) => Promise<void>;
   /** Click handler for the cross-unit list — wired to App.tsx's
    *  `handleSelectProject` so unit selection here matches sidebar
    *  selection there. */
@@ -76,6 +81,7 @@ export function ProducerConsole({
   onOpenProducerTerminal,
   onLaunchProducerAt,
   onOpenCalibration,
+  trigger,
   onSelectProjectByPath,
   onOverrideSpawned,
   onOpenSidebar,
@@ -137,6 +143,7 @@ export function ProducerConsole({
         onOpenProducerTerminal={onOpenProducerTerminal}
         onLaunchProducerAt={onLaunchProducerAt}
         onOpenCalibration={onOpenCalibration}
+        trigger={trigger}
         onOverrideSpawned={onOverrideSpawned}
         onOpenSidebar={onOpenSidebar}
         sidebarCollapsed={sidebarCollapsed}

--- a/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
@@ -32,10 +32,13 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { DirBrowser } from "@/components/project/DirBrowser";
 import { NewAgentLauncher } from "@/components/project/NewAgentLauncher";
-import { useHandoffRitual } from "@/hooks/useHandoffRitual";
-import { type AgentSnapshot, api, type CalibrationResponse, normalizeGitDir } from "@/lib/api";
-import { HandoffRitualFailureDialog } from "./HandoffRitualFailureDialog";
-import { HandoffRitualOverlay } from "./HandoffRitualOverlay";
+import {
+  type AgentSnapshot,
+  api,
+  type CalibrationResponse,
+  type TriggerHandoffRitualRequest,
+} from "@/lib/api";
+import { findProducerForUnit } from "@/lib/producer";
 
 interface ProducerConsoleActionsProps {
   unitName: string | null;
@@ -45,9 +48,8 @@ interface ProducerConsoleActionsProps {
    *  to operate on. */
   currentProjectPath: string | null;
   /** Live agent list (already flowing through SSEProvider). Used by the
-   *  Handoff & restart button to (1) gate enablement on whether a live
-   *  Producer exists for this unit and (2) expose the Producer's
-   *  canonical agent id to the Force-kill / Resume-in-CC paths. */
+   *  Handoff & restart button to gate enablement on whether a single
+   *  live Producer exists for this unit. */
   agents: AgentSnapshot[];
   calibrationData: CalibrationResponse | null;
   /** Spawn the Producer using the already-selected project. */
@@ -56,46 +58,16 @@ interface ProducerConsoleActionsProps {
    *  DirBrowser picks a path. */
   onLaunchProducerAt: (path: string) => void;
   onOpenCalibration: () => void;
+  /** The App-level lifted handoff-ritual trigger. The button does the
+   *  `window.confirm` then calls this; the overlay / failure dialog /
+   *  ready-toast all render at App level off the single `useHandoffRitual`
+   *  instance, so they stay co-visible from any view. */
+  trigger: (unit: string, body: TriggerHandoffRitualRequest) => Promise<void>;
   /** Spawn callback for the operator-override NewAgentLauncher. */
   onOverrideSpawned: (sessionId: string) => void;
   onOpenSidebar: () => void;
   sidebarCollapsed: boolean;
   onOpenSettings: () => void;
-}
-
-// Canonical AgentId scheme that marks a Producer-eligible Claude
-// session. Per DR `2026-05-14-react-producer-console-rebuild.md`
-// polish v4, the Producer is launched as `bash -c "tmai producer
-// <unit>"` so `agent_type` is `Custom("bash")` — but the canonical
-// `id` is still `claude:UUID` once the L2 promotion lands. We pin to
-// the id scheme rather than `agent_type` for the same reason
-// `useHandover` does.
-const PRODUCER_ID_SCHEME = "claude:";
-
-/** Find the single live Producer for this unit, if any.
- *
- *  Filter rules (DR §E + scoping pattern from `useHandover`):
- *   1. `id` starts with `claude:` (canonical scheme)
- *   2. `!is_worktree` — Producer runs at the repo root, not in a
- *      worktree clone (worktree Producers would be Worker agents)
- *   3. cwd / `git_common_dir` resolves to the unit's repo path
- *
- *  If zero or more than one candidate exists, the button stays disabled
- *  — the spec is explicit that the handoff ritual operates on a *single*
- *  Producer; we never guess. */
-function findProducerForUnit(
-  agents: AgentSnapshot[],
-  unitRepoPath: string | null,
-): AgentSnapshot | null {
-  if (unitRepoPath === null) return null;
-  const targetPath = normalizeGitDir(unitRepoPath);
-  const candidates = agents.filter((a) => {
-    if (!a.id.startsWith(PRODUCER_ID_SCHEME)) return false;
-    if (a.is_worktree === true) return false;
-    const agentRepo = a.git_common_dir ? normalizeGitDir(a.git_common_dir) : a.cwd;
-    return agentRepo === targetPath;
-  });
-  return candidates.length === 1 ? (candidates[0] ?? null) : null;
 }
 
 export function ProducerConsoleActions({
@@ -106,6 +78,7 @@ export function ProducerConsoleActions({
   onOpenProducerTerminal,
   onLaunchProducerAt,
   onOpenCalibration,
+  trigger,
   onOverrideSpawned,
   onOpenSidebar,
   sidebarCollapsed,
@@ -114,7 +87,6 @@ export function ProducerConsoleActions({
   const [overrideOpen, setOverrideOpen] = useState(false);
   const [browsing, setBrowsing] = useState(false);
   const [defaultRoot, setDefaultRoot] = useState<string | null>(null);
-  const [readyToastVisible, setReadyToastVisible] = useState(false);
   const tripwireCount = calibrationData?.tier1_violations.length ?? 0;
   const calCount = calibrationData?.total_in_window ?? 0;
 
@@ -122,21 +94,6 @@ export function ProducerConsoleActions({
     () => findProducerForUnit(agents, currentProjectPath),
     [agents, currentProjectPath],
   );
-
-  const ritual = useHandoffRitual();
-  const { state: ritualState, trigger, retry, dismiss } = ritual;
-
-  // Auto-dismiss `ready` with a brief success toast — per the issue
-  // body's overlay spec.
-  useEffect(() => {
-    if (ritualState.kind !== "ready") return;
-    setReadyToastVisible(true);
-    const t = setTimeout(() => {
-      setReadyToastVisible(false);
-      dismiss();
-    }, 2500);
-    return () => clearTimeout(t);
-  }, [ritualState.kind, dismiss]);
 
   const handleHandoffClick = useCallback(() => {
     if (producer === null || unitName === null) return;
@@ -146,22 +103,6 @@ export function ProducerConsoleActions({
     if (!ok) return;
     void trigger(unitName, { trigger: "manual" });
   }, [producer, unitName, trigger]);
-
-  const handleRetry = useCallback(() => {
-    if (unitName === null) return;
-    void retry(unitName, { trigger: "manual" });
-  }, [retry, unitName]);
-
-  const handleForceKill = useCallback(async () => {
-    if (producer === null) return;
-    try {
-      await api.killAgent(producer.target);
-    } catch {
-      // Best-effort — if the kill fails (already dead, etc.) we still
-      // dismiss; the dialog already surfaced the upstream failure.
-    }
-    dismiss();
-  }, [producer, dismiss]);
 
   // Same pattern as NewAgentLauncher: pull `[general] default_project_
   // root` lazily on open so an edit in GeneralSection flips the picker
@@ -301,39 +242,6 @@ export function ProducerConsoleActions({
               </span>
             </button>
           </div>
-        </div>
-      )}
-
-      {(ritualState.kind === "dispatching" || ritualState.kind === "in_progress") &&
-        unitName !== null && (
-          <HandoffRitualOverlay
-            unitName={unitName}
-            ritualId={ritualState.kind === "in_progress" ? ritualState.ritualId : null}
-            phases={ritualState.kind === "in_progress" ? ritualState.phases : []}
-          />
-        )}
-
-      {ritualState.kind === "escalated" && unitName !== null && (
-        <HandoffRitualFailureDialog
-          unitName={unitName}
-          reason={ritualState.reason}
-          message={ritualState.message}
-          producerAgentId={producer?.id ?? null}
-          retryCount={ritual.retryCount}
-          retryRefused={ritual.retryRefused}
-          onForceKill={() => void handleForceKill()}
-          onRetry={handleRetry}
-          onDismiss={dismiss}
-        />
-      )}
-
-      {readyToastVisible && (
-        <div
-          role="status"
-          aria-live="polite"
-          className="fixed bottom-4 right-4 z-40 rounded-md border border-success/30 bg-surface-strong px-4 py-2 text-xs text-success shadow-lg"
-        >
-          Handoff complete — fresh Producer is ready.
         </div>
       )}
 

--- a/clients/react/src/components/producer-console/ProducerConversationHeader.tsx
+++ b/clients/react/src/components/producer-console/ProducerConversationHeader.tsx
@@ -1,0 +1,87 @@
+// Conversation-view header for the active Producer.
+//
+// Co-visible affordance (DR `2026-05-14-react-producer-console-rebuild.md`
+// — the L/C/R co-visible principle): when the operator is *conversing*
+// with the Producer in the centre pane, the digest's Handoff & restart
+// trigger and ctx% readout used to be unreachable (they lived only in
+// the hand-over digest), which trapped the operator into a manual kill
+// (lived friction 2026-05-23). This strip lifts both into the
+// conversation, ABOVE the terminal.
+//
+// It renders ONLY when the selected agent IS this unit's Producer; the
+// gate lives in `App.tsx` (`selectedAgent.id === producerForUnit?.id`),
+// so when the operator is talking to a worker this component is never
+// mounted.
+//
+// The ctx% readout reuses `ProducerCtxHeader` verbatim (same
+// `formatThousands` / `renderBar` / `thresholdColorClass`); the
+// `Handoff & restart ▸` button rides in its `actionSlot`. The button
+// fires the App-level lifted ritual via the `trigger` prop — there is
+// exactly one `useHandoffRitual` instance, in App.
+
+import type { AgentSnapshot, TriggerHandoffRitualRequest } from "@/lib/api";
+import { findProducerForUnit } from "@/lib/producer";
+import { ProducerCtxHeader } from "./ProducerCtxHeader";
+
+interface ProducerConversationHeaderProps {
+  agents: AgentSnapshot[];
+  /** Repo root for the currently focused unit — drives the ctx readout
+   *  and the single-Producer resolution. */
+  currentProjectPath: string | null;
+  /** Unit name (basename of `currentProjectPath`) — the handoff ritual
+   *  endpoint keys on it. */
+  unitName: string | null;
+  /** The App-level lifted ritual trigger. The button does the confirm
+   *  then calls this; the overlay / failure dialog / ready-toast all
+   *  render at App level off the same single hook instance. */
+  trigger: (unit: string, body: TriggerHandoffRitualRequest) => Promise<void>;
+  /** ⚙ deep-link into Settings (auto-handoff threshold lives there). */
+  onOpenSettings: () => void;
+}
+
+export function ProducerConversationHeader({
+  agents,
+  currentProjectPath,
+  unitName,
+  trigger,
+  onOpenSettings,
+}: ProducerConversationHeaderProps) {
+  // Resolve the single live Producer via the shared resolver — the same
+  // one the digest button and the ctx readout use, so all three agree.
+  const producer = findProducerForUnit(agents, currentProjectPath);
+
+  const handleHandoffClick = () => {
+    // Defensive: App only mounts this header when a Producer is
+    // resolved, but keep the guard so the confirm can't fire with no
+    // target.
+    if (producer === null || unitName === null) return;
+    const ok = window.confirm(
+      "Kill the current Producer and start a fresh one bridged via hand-off?",
+    );
+    if (!ok) return;
+    void trigger(unitName, { trigger: "manual" });
+  };
+
+  return (
+    <ProducerCtxHeader
+      agents={agents}
+      currentProjectPath={currentProjectPath}
+      onOpenSettings={onOpenSettings}
+      actionSlot={
+        <button
+          type="button"
+          onClick={handleHandoffClick}
+          disabled={producer === null || unitName === null}
+          className="rounded-md bg-surface px-3 py-1 text-xs text-foreground transition-colors hover:bg-surface-strong disabled:cursor-not-allowed disabled:opacity-50"
+          title={
+            producer === null || unitName === null
+              ? "No live Producer for this unit"
+              : "Kill the current Producer and start a fresh one, bridged via a hand-off file"
+          }
+        >
+          Handoff &amp; restart ▸
+        </button>
+      }
+    />
+  );
+}

--- a/clients/react/src/components/producer-console/ProducerCtxHeader.tsx
+++ b/clients/react/src/components/producer-console/ProducerCtxHeader.tsx
@@ -10,14 +10,16 @@
 // .auto_handoff_threshold_pct`), so the operator can predict
 // the trigger instead of being surprised by it.
 //
-// Producer scoping matches the `Handoff & restart` button
-// (`ProducerConsoleActions.findProducerForUnit`): `claude:` id-scheme
-// + `!is_worktree` + cwd resolves to the unit's repo path. The header
-// always renders (fixed-height row) so swapping projects / waiting
-// for the first statusline payload doesn't make the layout jump.
+// Producer scoping matches the `Handoff & restart` button via the
+// shared `findProducerForUnit` resolver (`@/lib/producer`): `claude:`
+// id-scheme + `!is_worktree` + cwd resolves to the unit's repo path.
+// The header always renders (fixed-height row) so swapping projects /
+// waiting for the first statusline payload doesn't make the layout jump.
 
+import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
-import { type AgentSnapshot, api, normalizeGitDir } from "@/lib/api";
+import { type AgentSnapshot, api } from "@/lib/api";
+import { findProducerForUnit } from "@/lib/producer";
 
 interface ProducerCtxHeaderProps {
   agents: AgentSnapshot[];
@@ -25,26 +27,11 @@ interface ProducerCtxHeaderProps {
    *  can be resolved and the row renders its placeholder. */
   currentProjectPath: string | null;
   onOpenSettings: () => void;
-}
-
-const PRODUCER_ID_SCHEME = "claude:";
-
-// Same filter rules as `ProducerConsoleActions.findProducerForUnit`,
-// kept inline to avoid widening that module's export surface for what
-// is essentially a one-call helper.
-function findProducerForUnit(
-  agents: AgentSnapshot[],
-  unitRepoPath: string | null,
-): AgentSnapshot | null {
-  if (unitRepoPath === null) return null;
-  const targetPath = normalizeGitDir(unitRepoPath);
-  const candidates = agents.filter((a) => {
-    if (!a.id.startsWith(PRODUCER_ID_SCHEME)) return false;
-    if (a.is_worktree === true) return false;
-    const agentRepo = a.git_common_dir ? normalizeGitDir(a.git_common_dir) : a.cwd;
-    return agentRepo === targetPath;
-  });
-  return candidates.length === 1 ? (candidates[0] ?? null) : null;
+  /** Optional trailing affordance, right-aligned in the row. The
+   *  conversation header (`ProducerConversationHeader`) passes the
+   *  `Handoff & restart ▸` button here so the ctx% readout and the
+   *  trigger share one strip; the digest passes nothing. */
+  actionSlot?: ReactNode;
 }
 
 // CC's statusline reports `total` and `used` as bigints (200_000-ish);
@@ -89,6 +76,7 @@ export function ProducerCtxHeader({
   agents,
   currentProjectPath,
   onOpenSettings,
+  actionSlot,
 }: ProducerCtxHeaderProps) {
   const producer = findProducerForUnit(agents, currentProjectPath);
   const ctx = producer?.ctx_usage ?? null;
@@ -158,6 +146,7 @@ export function ProducerCtxHeader({
         >
           ⚙
         </button>
+        {actionSlot && <div className="ml-auto flex items-center">{actionSlot}</div>}
       </div>
     </div>
   );

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
@@ -91,6 +91,7 @@ function makeProps(
     onOpenProducerTerminal: vi.fn(),
     onLaunchProducerAt: vi.fn(),
     onOpenCalibration: vi.fn(),
+    trigger: vi.fn(),
     onSelectProjectByPath: vi.fn(),
     onOverrideSpawned: vi.fn(),
     onOpenSidebar: vi.fn(),

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
@@ -34,26 +34,20 @@ vi.mock("@/components/project/DirBrowser", () => ({
 }));
 
 // `@/lib/api` exports both runtime helpers and `normalizeGitDir` —
-// the new Handoff & restart filter calls `normalizeGitDir`, so we
-// preserve the actual module and override only the `api` namespace.
+// the shared `findProducerForUnit` resolver (`@/lib/producer`) calls
+// `normalizeGitDir`, so we preserve the actual module and override only
+// the `api` namespace. Only `getGeneralSettings` is exercised here now
+// (the handoff ritual hook was lifted to App level — the button just
+// calls the injected `trigger` prop).
 vi.mock("@/lib/api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
   return {
     ...actual,
     api: {
       getGeneralSettings: vi.fn().mockResolvedValue({ default_project_root: null }),
-      killAgent: vi.fn().mockResolvedValue(undefined),
-      triggerHandoffRitual: vi.fn().mockResolvedValue({ ritual_id: "r-stub" }),
     },
   };
 });
-
-// `useSSE` would throw because tests don't wrap in SSEProvider — stub
-// it to a no-op. `useHandoffRitual` lives inside ProducerConsoleActions
-// and registers an onEvent handler; we just need it to silently accept.
-vi.mock("@/lib/sse-provider", () => ({
-  useSSE: vi.fn(),
-}));
 
 import type { ComponentProps } from "react";
 
@@ -68,6 +62,7 @@ function makeProps(
     onOpenProducerTerminal: vi.fn(),
     onLaunchProducerAt: vi.fn(),
     onOpenCalibration: vi.fn(),
+    trigger: vi.fn(),
     onOverrideSpawned: vi.fn(),
     onOpenSidebar: vi.fn(),
     sidebarCollapsed: false,
@@ -391,9 +386,8 @@ describe("ProducerConsoleActions — Handoff & restart button", () => {
     expect(btn).toHaveProperty("disabled", true);
   });
 
-  it("calls window.confirm and does NOT POST when confirmation is denied", async () => {
-    const { api } = await import("@/lib/api");
-    vi.mocked(api.triggerHandoffRitual).mockClear();
+  it("calls window.confirm and does NOT fire the trigger when confirmation is denied", () => {
+    const trigger = vi.fn();
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
     const producer = agent({
       id: "claude:abc-123",
@@ -406,20 +400,20 @@ describe("ProducerConsoleActions — Handoff & restart button", () => {
           unitName: "proj-a",
           currentProjectPath: "/home/u/proj-a",
           agents: [producer],
+          trigger,
         })}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: /Handoff & restart/ }));
     expect(confirmSpy).toHaveBeenCalledTimes(1);
-    expect(vi.mocked(api.triggerHandoffRitual)).not.toHaveBeenCalled();
+    expect(trigger).not.toHaveBeenCalled();
 
     confirmSpy.mockRestore();
   });
 
-  it("fires the ritual when confirmation is accepted", async () => {
-    const { api } = await import("@/lib/api");
-    vi.mocked(api.triggerHandoffRitual).mockClear();
+  it("fires the lifted trigger prop when confirmation is accepted", () => {
+    const trigger = vi.fn();
     const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
     const producer = agent({
       id: "claude:abc-123",
@@ -432,14 +426,13 @@ describe("ProducerConsoleActions — Handoff & restart button", () => {
           unitName: "proj-a",
           currentProjectPath: "/home/u/proj-a",
           agents: [producer],
+          trigger,
         })}
       />,
     );
 
     fireEvent.click(screen.getByRole("button", { name: /Handoff & restart/ }));
-    expect(vi.mocked(api.triggerHandoffRitual)).toHaveBeenCalledWith("proj-a", {
-      trigger: "manual",
-    });
+    expect(trigger).toHaveBeenCalledWith("proj-a", { trigger: "manual" });
 
     confirmSpy.mockRestore();
   });

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
@@ -8,7 +8,7 @@
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentSnapshot, CalibrationResponse } from "@/lib/api";
 import { ProducerConsoleActions } from "../ProducerConsoleActions";
 
@@ -44,6 +44,7 @@ vi.mock("@/lib/api", async () => {
   return {
     ...actual,
     api: {
+      ...actual.api,
       getGeneralSettings: vi.fn().mockResolvedValue({ default_project_root: null }),
     },
   };
@@ -313,6 +314,12 @@ describe("ProducerConsoleActions — Handoff & restart button", () => {
     vi.clearAllMocks();
   });
 
+  // Restore any `vi.spyOn(window, "confirm")` (and other spies) after each
+  // test so a failing assertion can't leak the confirm stub into later tests.
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
   it("is disabled when no Producer agent matches the unit", () => {
     render(<ProducerConsoleActions {...makeProps({ unitName: "tmai", agents: [] })} />);
     const btn = screen.getByRole("button", { name: /Handoff & restart/ });
@@ -408,13 +415,11 @@ describe("ProducerConsoleActions — Handoff & restart button", () => {
     fireEvent.click(screen.getByRole("button", { name: /Handoff & restart/ }));
     expect(confirmSpy).toHaveBeenCalledTimes(1);
     expect(trigger).not.toHaveBeenCalled();
-
-    confirmSpy.mockRestore();
   });
 
   it("fires the lifted trigger prop when confirmation is accepted", () => {
     const trigger = vi.fn();
-    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    vi.spyOn(window, "confirm").mockReturnValue(true);
     const producer = agent({
       id: "claude:abc-123",
       cwd: "/home/u/proj-a",
@@ -433,7 +438,5 @@ describe("ProducerConsoleActions — Handoff & restart button", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Handoff & restart/ }));
     expect(trigger).toHaveBeenCalledWith("proj-a", { trigger: "manual" });
-
-    confirmSpy.mockRestore();
   });
 });

--- a/clients/react/src/components/producer-console/__tests__/ProducerConversationHeader.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConversationHeader.test.tsx
@@ -1,0 +1,176 @@
+// @vitest-environment jsdom
+//
+// ProducerConversationHeader — the co-visible ctx% readout + Handoff &
+// restart trigger shown ABOVE the terminal while conversing with the
+// Producer. It reuses ProducerCtxHeader for the readout (which fetches
+// the orchestrator settings), so we mock that fetch; the button fires
+// the App-level lifted `trigger` after a confirm.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentSnapshot } from "@/lib/api";
+import { ProducerConversationHeader } from "../ProducerConversationHeader";
+
+const getOrchestratorSettingsMock = vi.fn();
+
+// Preserve the actual module (the shared `findProducerForUnit` resolver
+// reaches `normalizeGitDir` through it) and override only the fetch the
+// ctx readout makes on mount.
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getOrchestratorSettings: (project?: string) => getOrchestratorSettingsMock(project),
+    },
+  };
+});
+
+function agent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot {
+  return {
+    id: partial.id,
+    target: partial.target ?? partial.id,
+    agent_type: partial.agent_type ?? "ClaudeCode",
+    title: partial.title ?? partial.id,
+    cwd: partial.cwd ?? "/home/u/proj",
+    display_cwd: partial.display_cwd ?? "proj",
+    display_name: partial.display_name ?? partial.id,
+    detection_source: partial.detection_source ?? "IpcSocket",
+    git_branch: partial.git_branch ?? "main",
+    git_dirty: partial.git_dirty ?? false,
+    is_worktree: partial.is_worktree ?? false,
+    git_common_dir: partial.git_common_dir ?? "/home/u/proj/.git",
+    worktree_name: partial.worktree_name ?? null,
+    worktree_base_branch: partial.worktree_base_branch ?? null,
+    effort_level: partial.effort_level ?? null,
+    active_subagents: partial.active_subagents ?? 0,
+    compaction_count: partial.compaction_count ?? 0,
+    pty_session_id: partial.pty_session_id ?? null,
+    send_capability: partial.send_capability ?? "Ipc",
+    is_virtual: partial.is_virtual ?? false,
+    team_info: partial.team_info ?? null,
+    attention: partial.attention ?? null,
+    is_orchestrator: partial.is_orchestrator,
+    ctx_usage: partial.ctx_usage,
+  };
+}
+
+function orchestratorFixture(threshold: number) {
+  return {
+    enabled: true,
+    role: "",
+    rules: { branch: "", merge: "", review: "", custom: "" },
+    notify: {},
+    guardrails: { max_ci_retries: 0, max_review_loops: 0, escalate_to_human_after: 0 },
+    auto_action_templates: {},
+    pr_monitor_enabled: false,
+    pr_monitor_interval_secs: 60,
+    pr_monitor_exclude_authors: [],
+    pr_monitor_scope: "current_project",
+    inject_state_snapshot: false,
+    auto_handoff_threshold_pct: threshold,
+    is_project_override: false,
+    dispatch: {},
+  };
+}
+
+beforeEach(() => {
+  getOrchestratorSettingsMock.mockReset();
+  getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+});
+
+describe("ProducerConversationHeader", () => {
+  it("renders the ctx% readout and an enabled Handoff button when a Producer is resolved", () => {
+    const producer = agent({
+      id: "claude:abc",
+      cwd: "/home/u/proj",
+      git_common_dir: "/home/u/proj/.git",
+      ctx_usage: {
+        used: 142_000n,
+        total: 200_000n,
+        pct: 71,
+        updated_at: "2026-05-15T00:00:00Z",
+      },
+    });
+    render(
+      <ProducerConversationHeader
+        agents={[producer]}
+        currentProjectPath="/home/u/proj"
+        unitName="proj"
+        trigger={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText(/ctx:/)).toBeTruthy();
+    expect(screen.getByText("71%")).toBeTruthy();
+    const btn = screen.getByRole("button", { name: /Handoff & restart/ });
+    expect(btn).toHaveProperty("disabled", false);
+  });
+
+  it("disables the Handoff button when no Producer matches the unit", () => {
+    render(
+      <ProducerConversationHeader
+        agents={[]}
+        currentProjectPath="/home/u/proj"
+        unitName="proj"
+        trigger={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    const btn = screen.getByRole("button", { name: /Handoff & restart/ });
+    expect(btn).toHaveProperty("disabled", true);
+  });
+
+  it("fires window.confirm + trigger(unit, manual) when the Handoff button is accepted", () => {
+    const trigger = vi.fn();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const producer = agent({
+      id: "claude:abc",
+      cwd: "/home/u/proj",
+      git_common_dir: "/home/u/proj/.git",
+    });
+    render(
+      <ProducerConversationHeader
+        agents={[producer]}
+        currentProjectPath="/home/u/proj"
+        unitName="proj"
+        trigger={trigger}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Handoff & restart/ }));
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(trigger).toHaveBeenCalledWith("proj", { trigger: "manual" });
+
+    confirmSpy.mockRestore();
+  });
+
+  it("does NOT fire the trigger when the confirm is denied", () => {
+    const trigger = vi.fn();
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(false);
+    const producer = agent({
+      id: "claude:abc",
+      cwd: "/home/u/proj",
+      git_common_dir: "/home/u/proj/.git",
+    });
+    render(
+      <ProducerConversationHeader
+        agents={[producer]}
+        currentProjectPath="/home/u/proj"
+        unitName="proj"
+        trigger={trigger}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Handoff & restart/ }));
+    expect(confirmSpy).toHaveBeenCalledTimes(1);
+    expect(trigger).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+});

--- a/clients/react/src/components/producer-console/__tests__/ProducerConversationHeader.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConversationHeader.test.tsx
@@ -7,7 +7,7 @@
 // the App-level lifted `trigger` after a confirm.
 
 import { fireEvent, render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentSnapshot } from "@/lib/api";
 import { ProducerConversationHeader } from "../ProducerConversationHeader";
 
@@ -80,6 +80,12 @@ beforeEach(() => {
   getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
 });
 
+// Restore any `vi.spyOn(window, "confirm")` after each test so a failing
+// assertion can't leak the confirm stub into later tests.
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("ProducerConversationHeader", () => {
   it("renders the ctx% readout and an enabled Handoff button when a Producer is resolved", () => {
     const producer = agent({
@@ -145,8 +151,6 @@ describe("ProducerConversationHeader", () => {
     fireEvent.click(screen.getByRole("button", { name: /Handoff & restart/ }));
     expect(confirmSpy).toHaveBeenCalledTimes(1);
     expect(trigger).toHaveBeenCalledWith("proj", { trigger: "manual" });
-
-    confirmSpy.mockRestore();
   });
 
   it("does NOT fire the trigger when the confirm is denied", () => {
@@ -170,7 +174,5 @@ describe("ProducerConversationHeader", () => {
     fireEvent.click(screen.getByRole("button", { name: /Handoff & restart/ }));
     expect(confirmSpy).toHaveBeenCalledTimes(1);
     expect(trigger).not.toHaveBeenCalled();
-
-    confirmSpy.mockRestore();
   });
 });

--- a/clients/react/src/lib/producer.ts
+++ b/clients/react/src/lib/producer.ts
@@ -1,0 +1,44 @@
+// Shared Producer resolver.
+//
+// Both the Producer console digest and the conversation view need to
+// pin "the single live Producer for this unit" from the live agent
+// list — for the ctx% readout, the Handoff & restart trigger gate, and
+// (App-level) the failure-dialog's Force-kill target. This used to be
+// copy-pasted verbatim across `ProducerConsoleActions` and
+// `ProducerCtxHeader`; it lives here once so every consumer agrees.
+
+import { type AgentSnapshot, normalizeGitDir } from "@/lib/api";
+
+// Canonical AgentId scheme that marks a Producer-eligible Claude
+// session. Per DR `2026-05-14-react-producer-console-rebuild.md`
+// polish v4, the Producer is launched as `bash -c "tmai producer
+// <unit>"` so `agent_type` is `Custom("bash")` — but the canonical
+// `id` is still `claude:UUID` once the L2 promotion lands. We pin to
+// the id scheme rather than `agent_type` for the same reason
+// `useHandover` does.
+export const PRODUCER_ID_SCHEME = "claude:";
+
+/** Find the single live Producer for this unit, if any.
+ *
+ *  Filter rules (DR §E + scoping pattern from `useHandover`):
+ *   1. `id` starts with `claude:` (canonical scheme)
+ *   2. `!is_worktree` — Producer runs at the repo root, not in a
+ *      worktree clone (worktree Producers would be Worker agents)
+ *   3. cwd / `git_common_dir` resolves to the unit's repo path
+ *
+ *  If zero or more than one candidate exists, returns `null` — the
+ *  handoff ritual operates on a *single* Producer; we never guess. */
+export function findProducerForUnit(
+  agents: AgentSnapshot[],
+  unitRepoPath: string | null,
+): AgentSnapshot | null {
+  if (unitRepoPath === null) return null;
+  const targetPath = normalizeGitDir(unitRepoPath);
+  const candidates = agents.filter((a) => {
+    if (!a.id.startsWith(PRODUCER_ID_SCHEME)) return false;
+    if (a.is_worktree === true) return false;
+    const agentRepo = a.git_common_dir ? normalizeGitDir(a.git_common_dir) : a.cwd;
+    return agentRepo === targetPath;
+  });
+  return candidates.length === 1 ? (candidates[0] ?? null) : null;
+}

--- a/clients/react/src/lib/producer.ts
+++ b/clients/react/src/lib/producer.ts
@@ -37,7 +37,10 @@ export function findProducerForUnit(
   const candidates = agents.filter((a) => {
     if (!a.id.startsWith(PRODUCER_ID_SCHEME)) return false;
     if (a.is_worktree === true) return false;
-    const agentRepo = a.git_common_dir ? normalizeGitDir(a.git_common_dir) : a.cwd;
+    // Normalize both branches: a raw `cwd` fallback would otherwise be
+    // compared against an already-normalized `targetPath` and could miss
+    // (trailing slash / `.git` suffix).
+    const agentRepo = normalizeGitDir(a.git_common_dir ?? a.cwd);
     return agentRepo === targetPath;
   });
   return candidates.length === 1 ? (candidates[0] ?? null) : null;


### PR DESCRIPTION
## Why

The Producer **handoff-and-restart** trigger, the live **ctx%** readout, and the ritual **overlay / failure dialog / ready-toast** all lived inside the digest-only `ProducerConsole`. While the operator is *conversing* with the Producer in the centre pane, none of these were reachable — which trapped the operator into a **manual kill** (lived friction 2026-05-23). This makes the trigger + ctx% co-visible from the conversation and lifts the ritual UI to App level so it is reachable from any view.

This is an **additive co-visible affordance** fully consistent with the L/C/R co-visible principle of `clients/react/doc/decisions/2026-05-14-react-producer-console-rebuild.md` — it removes nothing.

## What

- **Lift `useHandoffRitual` to `App.tsx` as the single instance.** The in-progress overlay, the 4-choice failure dialog and the ready-toast now render at App level (siblings of the tripwire banner / toasts), so they stay co-visible regardless of which centre view is shown. The force-kill handler, the retry handler and the ready-toast auto-dismiss move up with it. **The ritual contract is unchanged** — ordered phases, failure-dialog choices, retry budget (max 2, 3rd refused) and the `confirm()` text are only **relocated**, never altered. There is exactly **one** `useHandoffRitual` instance in the app.
- **New `ProducerConversationHeader`**, rendered above the terminal in the conversation branch **only when the selected agent IS the unit's Producer** (`selectedAgent.id === producerForUnit?.id`); never for a worker. It reuses `ProducerCtxHeader` for the ctx% readout via a new optional `actionSlot` prop carrying the `Handoff & restart ▸` button; the button fires the lifted `trigger` after the same `window.confirm`.
- **De-dup the Producer resolver.** `findProducerForUnit` (previously copy-pasted verbatim in `ProducerConsoleActions` and `ProducerCtxHeader`) is extracted once to `src/lib/producer.ts` and consumed by App, both headers and the actions row — logic identical.
- **Digest behaviour unchanged.** The digest's `Handoff & restart ▸` button stays and now calls the lifted `trigger` via a prop instead of owning the hook; its overlay/dialog/toast JSX is removed (now at App level). `ProducerCtxHeader` is unchanged in the digest (passes no `actionSlot`).

## Tests

- `ProducerConversationHeader.test.tsx` — renders ctx% + Handoff button for a resolved Producer; disabled with no Producer; fires `confirm` + `trigger(unit, { trigger: "manual" })`; no trigger when confirm is denied.
- `App.handoff.test.tsx` — App mounts the conversation header only when the selected agent is the Producer (not a worktree worker); the in-progress overlay renders at App level co-visible with the conversation view.
- Updated `ProducerConsoleActions.test.tsx` (overlay/dialog moved out → assert the injected `trigger` prop), `ProducerConsole.test.tsx` (+`trigger` prop), `App.attention-strip.test.tsx` (stub the new header).

## Gate (from `clients/react/`)

`pnpm install` → `pnpm lint` → `pnpm tsc -b` → `pnpm build` → `pnpm test` — all green (467 passing, 2 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Producer の会話ビューに「Handoff & restart」ボタンを追加
  * アプリ全体でハンドオフ儀式のオーバーレイを一貫表示
  * ハンドオフ完了時に成功通知を表示
  * ハンドオフ失敗時に再試行とフォースキルオプションを提供

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/725?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->