### PR TITLE
feat(webui): compact the Producer conversation into a single bar

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -673,23 +673,28 @@ export function App() {
           // sidebar drops into the conversation; clearing the selection
           // (returnToConsole) returns to the digest.
           <div className="flex flex-1 flex-col overflow-hidden">
-            {selectedAgent && <AgentActions agent={selectedAgent} passthrough />}
-            {/* Conversation-view header: the ctx% readout + Handoff &
-                restart trigger, co-visible ABOVE the terminal so the
-                operator conversing with the Producer can reach the
-                ritual without returning to the digest (fixes the
-                manual-kill trap, lived friction 2026-05-23). Renders
-                ONLY when the selected agent IS this unit's Producer;
-                when talking to a worker it stays hidden. */}
-            {selectedAgent && selectedAgent.id === producerForUnit?.id && (
-              <ProducerConversationHeader
-                agents={agents}
-                currentProjectPath={currentProject}
-                unitName={unitName}
-                trigger={triggerHandoff}
-                onOpenSettings={openSettingsFromOverride}
-              />
-            )}
+            {/* One bar above the conversation. For the Producer it is the
+                merged ProducerConversationHeader — status dot + name +
+                Kill (subsuming AgentActions) PLUS the ctx% readout and
+                the Handoff & restart trigger, co-visible ABOVE the
+                terminal so the operator conversing with the Producer can
+                reach the ritual without returning to the digest (fixes
+                the manual-kill trap, lived friction 2026-05-23) and
+                without three stacked bars eating the conversation height
+                (density refinement 2026-05-23). For a worker we keep the
+                plain AgentActions bar UNCHANGED. */}
+            {selectedAgent &&
+              (selectedAgent.id === producerForUnit?.id ? (
+                <ProducerConversationHeader
+                  agents={agents}
+                  currentProjectPath={currentProject}
+                  unitName={unitName}
+                  trigger={triggerHandoff}
+                  onOpenSettings={openSettingsFromOverride}
+                />
+              ) : (
+                <AgentActions agent={selectedAgent} passthrough />
+              ))}
             {sessionId && selectedAgent ? (
               <div key={sessionId} className="flex-1 overflow-hidden animate-fade-in">
                 <TerminalPanel agentId={selectedAgent.target} />

--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -684,7 +684,7 @@ export function App() {
                 (density refinement 2026-05-23). For a worker we keep the
                 plain AgentActions bar UNCHANGED. */}
             {selectedAgent &&
-              (selectedAgent.id === producerForUnit?.id ? (
+              (selectedAgent.target === producerForUnit?.target ? (
                 <ProducerConversationHeader
                   agents={agents}
                   currentProjectPath={currentProject}

--- a/clients/react/src/__tests__/App.handoff.test.tsx
+++ b/clients/react/src/__tests__/App.handoff.test.tsx
@@ -76,7 +76,11 @@ vi.mock("@/components/producer-console/ProducerConversationHeader", () => ({
 vi.mock("@/components/agent/PreviewPanel", () => ({
   PreviewPanel: () => <div data-testid="preview-stub">preview</div>,
 }));
-vi.mock("@/components/agent/AgentActions", () => ({ AgentActions: () => null }));
+// Observable stub so we can assert the Producer conversation renders the
+// MERGED bar (no separate AgentActions) while a worker still gets one.
+vi.mock("@/components/agent/AgentActions", () => ({
+  AgentActions: () => <div data-testid="agent-actions-stub">actions</div>,
+}));
 vi.mock("@/components/terminal/TerminalPanel", () => ({
   TerminalPanel: () => <div data-testid="terminal-stub">terminal</div>,
 }));
@@ -191,6 +195,9 @@ describe("App — handoff ritual wiring", () => {
 
     expect(screen.getByTestId("preview-stub")).toBeTruthy();
     expect(screen.getByTestId("conversation-header-stub")).toBeTruthy();
+    // The merged bar subsumes AgentActions for the Producer — no separate
+    // AgentActions bar (density refinement 2026-05-23).
+    expect(screen.queryByTestId("agent-actions-stub")).toBeNull();
   });
 
   it("does NOT mount the conversation header when the selected agent is a worker", () => {
@@ -213,6 +220,8 @@ describe("App — handoff ritual wiring", () => {
 
     expect(screen.getByTestId("preview-stub")).toBeTruthy();
     expect(screen.queryByTestId("conversation-header-stub")).toBeNull();
+    // A worker keeps the plain AgentActions bar UNCHANGED.
+    expect(screen.getByTestId("agent-actions-stub")).toBeTruthy();
   });
 
   it("renders the in-progress overlay at App level — co-visible with the conversation view", () => {

--- a/clients/react/src/components/producer-console/ProducerConversationHeader.tsx
+++ b/clients/react/src/components/producer-console/ProducerConversationHeader.tsx
@@ -1,27 +1,40 @@
-// Conversation-view header for the active Producer.
+// Conversation-view header for the active Producer — a SINGLE compact bar.
 //
 // Co-visible affordance (DR `2026-05-14-react-producer-console-rebuild.md`
 // — the L/C/R co-visible principle): when the operator is *conversing*
 // with the Producer in the centre pane, the digest's Handoff & restart
 // trigger and ctx% readout used to be unreachable (they lived only in
 // the hand-over digest), which trapped the operator into a manual kill
-// (lived friction 2026-05-23). This strip lifts both into the
-// conversation, ABOVE the terminal.
+// (lived friction 2026-05-23). #725 lifted both into the conversation,
+// ABOVE the terminal.
+//
+// Density refinement (lived friction 2026-05-23, operator at the
+// screen): the Producer conversation stacked THREE bars — AgentActions
+// (name + status pill + Kill), this ctx% strip, and the TerminalPanel id
+// row. This bar now subsumes AgentActions for the Producer too: it
+// carries the status dot + name + Kill alongside the ctx% readout and
+// the Handoff trigger, so the conversation pane gets the height back.
+// App renders ONLY this bar for the Producer (no separate AgentActions);
+// the slim `provisional:…` id row beneath belongs to TerminalPanel.
 //
 // It renders ONLY when the selected agent IS this unit's Producer; the
 // gate lives in `App.tsx` (`selectedAgent.id === producerForUnit?.id`),
 // so when the operator is talking to a worker this component is never
-// mounted.
+// mounted (workers keep their `<AgentActions>` bar).
 //
-// The ctx% readout reuses `ProducerCtxHeader` verbatim (same
-// `formatThousands` / `renderBar` / `thresholdColorClass`); the
-// `Handoff & restart ▸` button rides in its `actionSlot`. The button
-// fires the App-level lifted ritual via the `trigger` prop — there is
-// exactly one `useHandoffRitual` instance, in App.
+// The ctx readout reuses `ProducerCtxHeader`'s exported helpers
+// (`formatThousands` / `renderBar` / `thresholdColorClass`) and the same
+// threshold fetch (`getOrchestratorSettings`); the digest keeps the
+// full-form `ProducerCtxHeader`. The status dot reuses AgentActions'
+// `attention`→colour/label mapping. The Handoff button fires the
+// App-level lifted ritual via `trigger` — there is exactly one
+// `useHandoffRitual` instance, in App.
 
-import type { AgentSnapshot, TriggerHandoffRitualRequest } from "@/lib/api";
+import { useEffect, useState } from "react";
+import { type AgentSnapshot, api, type TriggerHandoffRitualRequest } from "@/lib/api";
 import { findProducerForUnit } from "@/lib/producer";
-import { ProducerCtxHeader } from "./ProducerCtxHeader";
+import { cn } from "@/lib/utils";
+import { formatThousands, renderBar, thresholdColorClass } from "./ProducerCtxHeader";
 
 interface ProducerConversationHeaderProps {
   agents: AgentSnapshot[];
@@ -47,14 +60,66 @@ export function ProducerConversationHeader({
   onOpenSettings,
 }: ProducerConversationHeaderProps) {
   // Resolve the single live Producer via the shared resolver — the same
-  // one the digest button and the ctx readout use, so all three agree.
+  // one the digest button and the ctx readout use, so all surfaces agree.
   const producer = findProducerForUnit(agents, currentProjectPath);
+  const ctx = producer?.ctx_usage ?? null;
+  const disabled = producer === null || unitName === null;
+
+  // Status dot — reuse AgentActions' flat `attention` enum mapping
+  // (tmai-core@2026-05-09 Phase 4): `"halted"` → destructive (at a
+  // permission prompt), `"started"|"completed"` → muted (waiting on the
+  // operator), `null` → primary (running). The word rides in the dot's
+  // title so the colour stays glanceable without a separate pill.
+  const attention = producer?.attention ?? null;
+  const statusWord =
+    attention === "halted"
+      ? "Halted"
+      : attention === "completed"
+        ? "Done"
+        : attention === "started"
+          ? "Started"
+          : "Active";
+  const dotColor =
+    attention === "halted"
+      ? "text-destructive"
+      : attention === "started" || attention === "completed"
+        ? "text-muted-foreground"
+        : "text-primary";
+
+  const [threshold, setThreshold] = useState<number | null>(null);
+
+  // One-shot fetch on mount, re-fetched on currentProjectPath change —
+  // same contract as ProducerCtxHeader (threshold edits aren't on the
+  // SSE fanout; the next mount picks up a new value).
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getOrchestratorSettings(currentProjectPath ?? undefined)
+      .then((s) => {
+        if (!cancelled) setThreshold(s.auto_handoff_threshold_pct);
+      })
+      .catch(() => {
+        if (!cancelled) setThreshold(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentProjectPath]);
+
+  const effectiveThreshold = threshold ?? 0;
+  const thresholdLabel =
+    threshold === null
+      ? "auto@—"
+      : effectiveThreshold === 0
+        ? "auto: off"
+        : `auto@${effectiveThreshold}%`;
+  const readoutColor = thresholdColorClass(ctx?.pct ?? null, effectiveThreshold);
 
   const handleHandoffClick = () => {
     // Defensive: App only mounts this header when a Producer is
     // resolved, but keep the guard so the confirm can't fire with no
     // target.
-    if (producer === null || unitName === null) return;
+    if (disabled) return;
     const ok = window.confirm(
       "Kill the current Producer and start a fresh one bridged via hand-off?",
     );
@@ -62,26 +127,74 @@ export function ProducerConversationHeader({
     void trigger(unitName, { trigger: "manual" });
   };
 
+  // Best-effort kill — reuses AgentActions' handler shape (swallow the
+  // error: an already-dead agent shouldn't throw to the operator).
+  const handleKill = async () => {
+    if (producer === null) return;
+    try {
+      await api.killAgent(producer.target);
+    } catch (_e) {}
+  };
+
   return (
-    <ProducerCtxHeader
-      agents={agents}
-      currentProjectPath={currentProjectPath}
-      onOpenSettings={onOpenSettings}
-      actionSlot={
+    <div className="flex flex-wrap items-center gap-2 border-b border-hairline bg-surface px-3 py-1.5 text-xs">
+      <span className={cn("shrink-0 text-sm leading-none", dotColor)} title={statusWord}>
+        ●
+      </span>
+      <span className="truncate text-sm font-medium text-foreground">
+        {producer?.display_name ?? "Producer"}
+      </span>
+
+      {ctx ? (
+        <span
+          className="flex items-center gap-1.5 font-mono"
+          title={`ctx: ${formatThousands(ctx.used)} / ${formatThousands(ctx.total)} (${ctx.pct}%)`}
+        >
+          <span className="text-foreground">{ctx.pct}%</span>
+          <span className="text-muted-foreground" aria-hidden="true">
+            {renderBar(ctx.pct).chars}
+          </span>
+        </span>
+      ) : (
+        <span className="font-mono text-subtle-foreground" title="ctx: — / —">
+          —
+        </span>
+      )}
+      <span className={cn("font-mono", readoutColor)}>{thresholdLabel}</span>
+
+      <div className="ml-auto flex items-center gap-2">
         <button
           type="button"
           onClick={handleHandoffClick}
-          disabled={producer === null || unitName === null}
-          className="rounded-md bg-surface px-3 py-1 text-xs text-foreground transition-colors hover:bg-surface-strong disabled:cursor-not-allowed disabled:opacity-50"
+          disabled={disabled}
+          className="rounded-md bg-surface-strong px-3 py-1 text-xs text-foreground transition-colors hover:bg-surface-strong/70 disabled:cursor-not-allowed disabled:opacity-50"
           title={
-            producer === null || unitName === null
+            disabled
               ? "No live Producer for this unit"
               : "Kill the current Producer and start a fresh one, bridged via a hand-off file"
           }
         >
           Handoff &amp; restart ▸
         </button>
-      }
-    />
+        <button
+          type="button"
+          onClick={handleKill}
+          disabled={producer === null}
+          className="touch-target-sm rounded-md px-2 py-1 text-xs text-subtle-foreground transition-colors hover:text-destructive disabled:cursor-not-allowed disabled:opacity-50"
+          title="Kill agent"
+        >
+          Kill
+        </button>
+        <button
+          type="button"
+          onClick={onOpenSettings}
+          aria-label="Open settings — auto-handoff threshold"
+          title="Open settings — auto-handoff threshold"
+          className="rounded text-muted-foreground transition-colors hover:text-foreground"
+        >
+          ⚙
+        </button>
+      </div>
+    </div>
   );
 }

--- a/clients/react/src/components/producer-console/ProducerConversationHeader.tsx
+++ b/clients/react/src/components/producer-console/ProducerConversationHeader.tsx
@@ -18,9 +18,11 @@
 // the slim `provisional:…` id row beneath belongs to TerminalPanel.
 //
 // It renders ONLY when the selected agent IS this unit's Producer; the
-// gate lives in `App.tsx` (`selectedAgent.id === producerForUnit?.id`),
-// so when the operator is talking to a worker this component is never
-// mounted (workers keep their `<AgentActions>` bar).
+// gate lives in `App.tsx` (`selectedAgent.target === producerForUnit?.target`
+// — compared on the stable PTY `target`, not `id`, since `id` can re-key
+// provisional→canonical and momentarily mis-classify the Producer as a
+// worker at that boundary), so when the operator is talking to a worker
+// this component is never mounted (workers keep their `<AgentActions>` bar).
 //
 // The ctx readout reuses `ProducerCtxHeader`'s exported helpers
 // (`formatThousands` / `renderBar` / `thresholdColorClass`) and the same
@@ -138,7 +140,15 @@ export function ProducerConversationHeader({
 
   return (
     <div className="flex flex-wrap items-center gap-2 border-b border-hairline bg-surface px-3 py-1.5 text-xs">
-      <span className={cn("shrink-0 text-sm leading-none", dotColor)} title={statusWord}>
+      <span
+        // `role="img"` so the colour-coded glyph announces its state to
+        // screen readers via `aria-label` (colour + `title` alone aren't
+        // reliably announced).
+        role="img"
+        className={cn("shrink-0 text-sm leading-none", dotColor)}
+        title={statusWord}
+        aria-label={statusWord}
+      >
         ●
       </span>
       <span className="truncate text-sm font-medium text-foreground">

--- a/clients/react/src/components/producer-console/__tests__/ProducerConversationHeader.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConversationHeader.test.tsx
@@ -1,10 +1,15 @@
 // @vitest-environment jsdom
 //
-// ProducerConversationHeader — the co-visible ctx% readout + Handoff &
-// restart trigger shown ABOVE the terminal while conversing with the
-// Producer. It reuses ProducerCtxHeader for the readout (which fetches
-// the orchestrator settings), so we mock that fetch; the button fires
-// the App-level lifted `trigger` after a confirm.
+// ProducerConversationHeader — the SINGLE compact bar shown ABOVE the
+// terminal while conversing with the Producer. Density refinement
+// (2026-05-23): it merges what used to be three stacked bars, so it now
+// carries a status dot (from `attention`) + name + Kill (subsuming
+// AgentActions) alongside the compact ctx% readout (no `ctx:` label, no
+// `used / total` text — those move to a title tooltip) and the Handoff &
+// restart trigger. The ctx readout reuses ProducerCtxHeader's helpers
+// and fetches the orchestrator settings, so we mock that fetch; the
+// Handoff button fires the App-level lifted `trigger` after a confirm,
+// and Kill calls `api.killAgent`.
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -12,10 +17,11 @@ import type { AgentSnapshot } from "@/lib/api";
 import { ProducerConversationHeader } from "../ProducerConversationHeader";
 
 const getOrchestratorSettingsMock = vi.fn();
+const killAgentMock = vi.fn();
 
 // Preserve the actual module (the shared `findProducerForUnit` resolver
 // reaches `normalizeGitDir` through it) and override only the fetch the
-// ctx readout makes on mount.
+// ctx readout makes on mount and the kill the Kill button fires.
 vi.mock("@/lib/api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
   return {
@@ -23,6 +29,7 @@ vi.mock("@/lib/api", async () => {
     api: {
       ...actual.api,
       getOrchestratorSettings: (project?: string) => getOrchestratorSettingsMock(project),
+      killAgent: (target: string) => killAgentMock(target),
     },
   };
 });
@@ -78,6 +85,8 @@ function orchestratorFixture(threshold: number) {
 beforeEach(() => {
   getOrchestratorSettingsMock.mockReset();
   getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+  killAgentMock.mockReset();
+  killAgentMock.mockResolvedValue(undefined);
 });
 
 // Restore any `vi.spyOn(window, "confirm")` after each test so a failing
@@ -87,11 +96,13 @@ afterEach(() => {
 });
 
 describe("ProducerConversationHeader", () => {
-  it("renders the ctx% readout and an enabled Handoff button when a Producer is resolved", () => {
+  it("renders the status dot, name, compact ctx% + bar, auto@N%, Kill, ⚙ and an enabled Handoff button", async () => {
     const producer = agent({
       id: "claude:abc",
+      display_name: "tmai",
       cwd: "/home/u/proj",
       git_common_dir: "/home/u/proj/.git",
+      attention: "halted",
       ctx_usage: {
         used: 142_000n,
         total: 200_000n,
@@ -109,13 +120,45 @@ describe("ProducerConversationHeader", () => {
       />,
     );
 
-    expect(screen.getByText(/ctx:/)).toBeTruthy();
+    // Status dot — coloured + word-in-title from `attention`.
+    expect(screen.getByTitle("Halted")).toBeTruthy();
+    // Name.
+    expect(screen.getByText("tmai")).toBeTruthy();
+    // Compact ctx readout: percent + bar, no `ctx:` label / used-total text.
     expect(screen.getByText("71%")).toBeTruthy();
+    expect(screen.queryByText(/ctx:\s*142k/)).toBeNull();
+    // The full used/total rides in a title tooltip instead.
+    expect(screen.getByTitle("ctx: 142k / 200k (71%)")).toBeTruthy();
+    // Compact threshold readout — resolves after the orchestrator-settings fetch.
+    expect(await screen.findByText("auto@75%")).toBeTruthy();
+    // Kill + settings + Handoff.
+    expect(screen.getByRole("button", { name: "Kill" })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Open settings/ })).toBeTruthy();
     const btn = screen.getByRole("button", { name: /Handoff & restart/ });
     expect(btn).toHaveProperty("disabled", false);
   });
 
-  it("disables the Handoff button when no Producer matches the unit", () => {
+  it("defaults the status dot to Active when attention is null", () => {
+    const producer = agent({
+      id: "claude:abc",
+      cwd: "/home/u/proj",
+      git_common_dir: "/home/u/proj/.git",
+      attention: null,
+    });
+    render(
+      <ProducerConversationHeader
+        agents={[producer]}
+        currentProjectPath="/home/u/proj"
+        unitName="proj"
+        trigger={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByTitle("Active")).toBeTruthy();
+  });
+
+  it("disables Handoff and Kill when no Producer matches the unit", () => {
     render(
       <ProducerConversationHeader
         agents={[]}
@@ -126,8 +169,11 @@ describe("ProducerConversationHeader", () => {
       />,
     );
 
-    const btn = screen.getByRole("button", { name: /Handoff & restart/ });
-    expect(btn).toHaveProperty("disabled", true);
+    expect(screen.getByRole("button", { name: /Handoff & restart/ })).toHaveProperty(
+      "disabled",
+      true,
+    );
+    expect(screen.getByRole("button", { name: "Kill" })).toHaveProperty("disabled", true);
   });
 
   it("fires window.confirm + trigger(unit, manual) when the Handoff button is accepted", () => {
@@ -174,5 +220,26 @@ describe("ProducerConversationHeader", () => {
     fireEvent.click(screen.getByRole("button", { name: /Handoff & restart/ }));
     expect(confirmSpy).toHaveBeenCalledTimes(1);
     expect(trigger).not.toHaveBeenCalled();
+  });
+
+  it("calls api.killAgent(producer.target) when Kill is clicked", () => {
+    const producer = agent({
+      id: "claude:abc",
+      target: "claude:abc",
+      cwd: "/home/u/proj",
+      git_common_dir: "/home/u/proj/.git",
+    });
+    render(
+      <ProducerConversationHeader
+        agents={[producer]}
+        currentProjectPath="/home/u/proj"
+        unitName="proj"
+        trigger={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Kill" }));
+    expect(killAgentMock).toHaveBeenCalledWith("claude:abc");
   });
 });


### PR DESCRIPTION
## What

Compacts the **Producer conversation view** chrome from three stacked top bars into one, giving the conversation pane back its height. Lived friction (operator at the screen, 2026-05-23): while conversing with the Producer, three rows stacked above the terminal.

This is an additive **density** refinement on the co-visible conversation surface (governed by `clients/react/doc/decisions/2026-05-14-react-producer-console-rebuild.md`). It removes **no** capability — only merges redundant chrome. No DR amendment needed.

## Before → after

**Before** (three bars):
```
display_name        [status pill]        [Kill]      ← AgentActions
ctx: 370k / 1000k (37%) ▮▮▮░ │ auto-handoff at 65% ⚙  [Handoff & restart ▸]   ← ProducerConversationHeader
provisional:a32a943c                                 ← TerminalPanel id row
```

**After** (one merged bar + the panel's own slim id row, unchanged):
```
● tmai  37% ▮▮▮░  auto@65%        [Handoff & restart ▸] [Kill] ⚙   ← merged bar
provisional:a32a943c                                                ← TerminalPanel id row (unchanged)
```

## The merged bar (`ProducerConversationHeader`)

A single compact row (`py-1.5`, `flex-wrap`), L→R:
- **status dot** `●` coloured from `agent.attention` (reusing AgentActions' mapping: `halted`→destructive, `started`/`completed`→muted, `null`→primary); status word ("Halted"/"Started"/"Done"/"Active") in its `title`.
- agent **name** (`display_name`, truncated).
- **compact ctx readout**: `{pct}% ▮▮▮░` — the `ctx:` label and the `used / total` text move into a `title` tooltip. Reuses the exported `formatThousands` / `renderBar` / `thresholdColorClass` from `ProducerCtxHeader` (threshold colour-banding kept), same `getOrchestratorSettings` fetch.
- `auto@{threshold}%` (compact form of `auto-handoff at N%`; `auto: off` when disabled, `auto@—` before the fetch resolves).
- spacer, then `[Handoff & restart ▸]` (same `window.confirm` + `trigger(unit, {trigger:"manual"})`), `[Kill]` (`api.killAgent(producer.target)`), and the `⚙` settings deep-link.

## Wiring (`App.tsx`)

In the conversation branch: when `selectedAgent.id === producerForUnit?.id`, render **only** the merged `ProducerConversationHeader` (it now subsumes AgentActions' name/status/Kill for the Producer). Otherwise render `<AgentActions agent={selectedAgent} passthrough />` exactly as today.

## Non-Producer unchanged

Worker / non-Producer agents render `<AgentActions passthrough>` with no behavioural change. `ProducerCtxHeader`'s full-form digest header (in `ProducerConsole`) is untouched. The handoff ritual contract (confirm text, trigger payload, App-level overlay) is unchanged. No `api-spec/` / generated-types / tmai-core changes.

## Tests

- `ProducerConversationHeader.test.tsx` updated for the merged shape: status dot by `attention`, name, compact ctx (`%` + bar, full used/total in tooltip), `auto@N%`, Handoff (confirm + trigger), Kill (`api.killAgent`), disabled state when no Producer resolves.
- `App.handoff.test.tsx`: Producer conversation renders **one** merged bar (no `AgentActions`); a worker still renders `AgentActions`.

## Gate (from `clients/react/`)

`pnpm install` → `pnpm lint` ✓ → `pnpm tsc -b` ✓ → `pnpm build` ✓ → `pnpm test` ✓ (469 passed, 2 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * プロデューサー会話ヘッダーをコンパクトな単一バーに統一し、ステータス表示・ctx%・自動ハンドオフ閾値・操作（ハンドオフ＆再起動、停止、設定）を一箇所で利用可能にしました。

* **改善**
  * プロデューサー選択時は従来のアクション領域がヘッダーに統合され、ワーカー選択時は従来どおりの表示を維持します。

* **テスト**
  * ヘッダー表示と各操作の表示・挙動を検証するテストを更新・拡充しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/726?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->