### PR TITLE
feat(webui): producer-rooted left panel (addressing surface)

### DIFF
--- a/clients/react/src/components/agent/AgentCard.tsx
+++ b/clients/react/src/components/agent/AgentCard.tsx
@@ -57,6 +57,18 @@ function attentionPill(state: AgentAttention | null): {
   };
 }
 
+// Status-dot colour for the subordinate worker rows of the Producer-rooted
+// roster (DR `2026-05-23-producer-rooted-left-panel.md`). This is the
+// roster's *own* mapping — deliberately NOT the `attentionPill` palette: a
+// worker row is a status glance, not a blocking-pill, so only `halted`
+// gets the alarming destructive colour; `started`/`completed` read as muted
+// transients; `null` ("running normally") gets the calm primary dot.
+function attentionDotClass(state: AgentAttention | null): string {
+  if (state === "halted") return "bg-destructive";
+  if (state === "started" || state === "completed") return "bg-muted-foreground";
+  return "bg-primary";
+}
+
 // Agent type display: short label + color
 function agentTypeLabel(agentType: AgentType): {
   icon: string;
@@ -140,14 +152,26 @@ function ChannelBadge({
   );
 }
 
+// Visual treatment within the Producer-rooted roster (DR
+// `2026-05-23-producer-rooted-left-panel.md`):
+//   • "headline"  — the unit's single live Producer. First-class, "who am
+//     I talking to" legible (PRODUCER badge + accent). Full card.
+//   • "worker"    — a subordinate worker row of the Producer's roster.
+//     Status-oriented + visually muted/smaller (status dot + branch/task).
+//     Still click-selectable: the emergency direct-worker path §A keeps.
+//   • "default"   — flat card with no Producer relationship asserted; used
+//     by the honest degradation path when no single Producer resolves.
+type AgentCardVariant = "headline" | "worker" | "default";
+
 interface AgentCardProps {
   agent: AgentSnapshot;
   selected?: boolean;
   onClick?: () => void;
+  variant?: AgentCardVariant;
 }
 
 // Card displaying a single agent's status and info
-export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
+export function AgentCard({ agent, selected, onClick, variant = "default" }: AgentCardProps) {
   // Decision tmai-core@2026-05-09 Phase 4: the wire enum collapses the
   // dynamic state to four values. Three flag user-blocked states (each
   // with its own pill); `null`/absent renders a muted "Running" chip
@@ -156,6 +180,48 @@ export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
   const hasAttention = attention !== null;
   const typeInfo = agentTypeLabel(agent.agent_type);
   const isAi = isAiAgent(agent.agent_type);
+
+  // Subordinate worker row of the Producer's roster. Deliberately a thin
+  // status glance — status dot + branch/task label — NOT a second copy of
+  // the right attention strip (role split, DR §役割分担). The row stays a
+  // real <button> so the emergency direct-worker path (§A) survives.
+  if (variant === "worker") {
+    const taskLabel =
+      agent.git_branch ?? (isAi ? typeInfo.label : agent.display_name || typeInfo.label);
+    const dotTitle = `${agent.git_branch ? `${agent.is_worktree ? "worktree: " : "branch: "}${agent.git_branch}` : agent.display_cwd} — ${attentionPill(attention).label}`;
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        title={dotTitle}
+        className={cn(
+          "group flex w-full items-center gap-2 rounded-lg px-2 py-1 text-left transition-subtle",
+          "hover:bg-surface",
+          selected && "bg-primary/10",
+        )}
+      >
+        <span
+          className={cn(
+            "h-1.5 w-1.5 shrink-0 rounded-full",
+            attentionDotClass(attention),
+            attention === "halted" && "animate-glow-pulse",
+          )}
+          aria-hidden
+        />
+        <span className="truncate text-xs text-subtle-foreground group-hover:text-foreground transition-subtle">
+          {agent.is_worktree && "🌿"}
+          {taskLabel}
+          {agent.git_dirty && <span className="text-warning">*</span>}
+        </span>
+        <span className="flex-1" />
+        {agent.compaction_count > 0 && (
+          <span className="shrink-0 text-[10px] text-subtle-foreground">
+            ♻{agent.compaction_count}
+          </span>
+        )}
+      </button>
+    );
+  }
 
   // Pill info: every agent gets one. Muted "Running" for null.
   const attentionPillInfo = attentionPill(attention);
@@ -186,6 +252,9 @@ export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
         "glass-card group w-full rounded-xl px-3 py-2 text-left transition-subtle",
         "hover:bg-surface hover:border-hairline-strong",
         agent.is_orchestrator && "!border-primary/20 bg-primary/[0.04]",
+        // Producer headline: accent the unit's "who am I talking to" row so
+        // it reads as first-class above its subordinate worker roster.
+        variant === "headline" && "!border-primary/25 bg-primary/[0.05]",
         selected && "!border-primary/30 !bg-primary/10",
         hasAttention && "!border-warning/30 animate-glow-pulse",
         glow && selected && glow,
@@ -194,6 +263,11 @@ export function AgentCard({ agent, selected, onClick }: AgentCardProps) {
       {/* Row 1: Agent type + status badge */}
       <div className="flex items-center justify-between gap-2">
         <div className="flex items-center gap-1.5 truncate">
+          {variant === "headline" && (
+            <span className="shrink-0 rounded border border-primary/30 bg-primary/10 px-1 py-px text-[9px] font-semibold uppercase tracking-wider text-primary">
+              Producer
+            </span>
+          )}
           {agent.is_orchestrator && (
             <span className="shrink-0 rounded border border-primary/30 bg-primary/10 px-1 py-px text-[9px] font-semibold text-primary">
               ORCH

--- a/clients/react/src/components/agent/AgentList.tsx
+++ b/clients/react/src/components/agent/AgentList.tsx
@@ -17,14 +17,22 @@ interface AgentListProps {
   onSpawned: (sessionId: string) => void;
 }
 
-// Scrollable list of agents grouped by project and worktree.
+// The unit addressing surface (DR `2026-05-23-producer-rooted-left-panel.md`).
 //
-// The per-project branch-graph + markdown-files buttons (and their
-// onSelectProject / onSelectMarkdown / splitPane* prop chain) retired with
-// the git/docs multipane (DR `2026-05-14-react-producer-console-rebuild.md`
-// §Refinement 2026-05-22 Fork B). Cross-unit navigation now lives in the
-// ProducerConsole digest / AttentionStrip cross-unit list, not the sidebar;
-// the sidebar is the legacy direct-agent escape hatch only.
+// This panel re-cast the old flat agent registry into a Producer-rooted
+// hierarchy: one collapsible group per unit, each headed by the unit's live
+// Producer with its workers as a subordinate roster (the per-group structure
+// lives in `ProjectGroup` → `ProducerRoster`). The left answers "who am I
+// talking to / who's under them"; the right AttentionStrip answers "what
+// needs me". The earlier "Operator view (legacy) — bypass the Producer"
+// framing is retired: addressing the Producer IS the primary use here, not a
+// bypass (this DR partially supersedes the console-rebuild's "sidebar =
+// legacy escape hatch" stance — emergency override paths are retained).
+//
+// Direct operator spawn is dispatch's job for the Producer (briefs), so the
+// launcher is folded into the de-emphasized "Advanced / emergency" footer
+// rather than the prominent top slot it used to own. Cross-unit navigation
+// still lives in the ProducerConsole digest / AttentionStrip, not here.
 export function AgentList({
   agents,
   loading,
@@ -45,26 +53,10 @@ export function AgentList({
 
   return (
     <div className="flex flex-1 flex-col overflow-y-auto p-2">
-      {/* Phase B of the Producer-console rebuild
-          (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`)
-          moved the main flow to the Producer console (the empty
-          main-pane view). This sidebar still exists — defaults to
-          collapsed, opt-in via the Operator override panel or the
-          sidebar toggle — so the operator has a direct-agent
-          escape hatch. The label below makes that intent visible. */}
-      <div className="mb-2 border-b border-hairline pb-2">
-        <p className="text-[11px] uppercase tracking-wider text-warning/70">
-          Operator view (legacy)
-        </p>
-        <p className="mt-0.5 text-[10px] leading-tight text-subtle-foreground">
-          Direct agent / project access. The new main flow is the Producer console — use this
-          sidebar only when you need to bypass the Producer.
-        </p>
-      </div>
-      <NewAgentLauncher onSpawned={onSpawned} />
       {projects.length === 0 ? (
         <p className="px-2 py-6 text-center text-xs text-subtle-foreground">
-          No agents — pick a directory above to spawn one.
+          No agents yet — dispatch is the Producer's job. Use Advanced below only for an emergency
+          direct spawn.
         </p>
       ) : (
         projects.map((project) => (
@@ -77,6 +69,19 @@ export function AgentList({
           />
         ))
       )}
+
+      {/* Spawn is an emergency-only affordance: dispatch belongs to the
+          Producer (briefs), so the operator's direct launcher sits behind a
+          de-emphasized, collapsed-by-default disclosure at the bottom rather
+          than the prominent top slot it used to hold. */}
+      <details className="mt-auto border-t border-hairline pt-2">
+        <summary className="cursor-pointer select-none px-2 py-1 text-[10px] uppercase tracking-wider text-subtle-foreground transition-colors hover:text-muted-foreground">
+          Advanced — emergency spawn
+        </summary>
+        <div className="mt-1">
+          <NewAgentLauncher onSpawned={onSpawned} />
+        </div>
+      </details>
     </div>
   );
 }

--- a/clients/react/src/components/agent/__tests__/AgentList.test.tsx
+++ b/clients/react/src/components/agent/__tests__/AgentList.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentSnapshot } from "@/lib/api";
+
+// Stub the per-unit group + spawn launcher: this suite asserts AgentList's
+// own shell (retired legacy framing, spawn folded behind an Advanced
+// disclosure), not the children's internals (covered by ProducerRoster /
+// NewAgentLauncher suites).
+vi.mock("@/components/project/ProjectGroup", () => ({
+  ProjectGroup: ({ project }: { project: { name: string; path: string } }) => (
+    <div data-testid="project-group">{project.name}</div>
+  ),
+}));
+vi.mock("@/components/project/NewAgentLauncher", () => ({
+  NewAgentLauncher: () => <div data-testid="new-agent-launcher">launcher</div>,
+}));
+
+const { AgentList } = await import("@/components/agent/AgentList");
+
+function stubAgent(overrides: Partial<AgentSnapshot> = {}): AgentSnapshot {
+  return {
+    id: "claude:prod-1",
+    target: "claude:prod-1",
+    agent_type: "ClaudeCode",
+    title: "",
+    cwd: "/repo",
+    display_cwd: "/repo",
+    display_name: "claude:prod-1",
+    detection_source: "HttpHook",
+    git_branch: null,
+    git_dirty: false,
+    is_worktree: false,
+    git_common_dir: "/repo/.git",
+    worktree_name: null,
+    worktree_base_branch: null,
+    effort_level: null,
+    active_subagents: 0,
+    compaction_count: 0,
+    pty_session_id: null,
+    send_capability: "PtyInject",
+    is_virtual: false,
+    team_info: null,
+    attention: null,
+    ...overrides,
+  };
+}
+
+describe("AgentList", () => {
+  it("does not render the retired 'Operator view (legacy)' framing", () => {
+    render(
+      <AgentList
+        agents={[stubAgent()]}
+        loading={false}
+        selection={null}
+        onSelectAgent={() => {}}
+        worktrees={[]}
+        onSpawned={() => {}}
+      />,
+    );
+
+    expect(screen.queryByText(/operator view \(legacy\)/i)).toBeNull();
+    expect(screen.queryByText(/bypass the producer/i)).toBeNull();
+  });
+
+  it("renders one Producer-rooted group per unit, above the spawn footer", () => {
+    render(
+      <AgentList
+        agents={[stubAgent()]}
+        loading={false}
+        selection={null}
+        onSelectAgent={() => {}}
+        worktrees={[]}
+        onSpawned={() => {}}
+      />,
+    );
+
+    const group = screen.getByTestId("project-group");
+    const launcher = screen.getByTestId("new-agent-launcher");
+    expect(group.textContent).toBe("repo");
+    // The unit roster renders before the emergency spawn footer.
+    expect(group.compareDocumentPosition(launcher) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("folds the spawn launcher behind a de-emphasized Advanced/emergency disclosure", () => {
+    render(
+      <AgentList
+        agents={[stubAgent()]}
+        loading={false}
+        selection={null}
+        onSelectAgent={() => {}}
+        worktrees={[]}
+        onSpawned={() => {}}
+      />,
+    );
+
+    // The launcher is no longer a prominent top slot — it lives inside a
+    // <details> disclosure whose <summary> is the emergency affordance.
+    const summary = screen.getByText(/advanced — emergency spawn/i);
+    expect(summary.tagName.toLowerCase()).toBe("summary");
+
+    const launcher = screen.getByTestId("new-agent-launcher");
+    const details = launcher.closest("details");
+    expect(details).not.toBeNull();
+    // Default-collapsed: the disclosure is not forced open.
+    expect((details as HTMLDetailsElement).open).toBe(false);
+  });
+
+  it("shows an honest empty state when there are no agents", () => {
+    render(
+      <AgentList
+        agents={[]}
+        loading={false}
+        selection={null}
+        onSelectAgent={() => {}}
+        worktrees={[]}
+        onSpawned={() => {}}
+      />,
+    );
+
+    expect(screen.queryByTestId("project-group")).toBeNull();
+    expect(screen.getByText(/no agents yet/i)).toBeTruthy();
+    // Even with no agents, the emergency spawn affordance is still reachable.
+    expect(screen.getByText(/advanced — emergency spawn/i)).toBeTruthy();
+  });
+
+  it("renders an initializing state while loading", () => {
+    render(
+      <AgentList
+        agents={[]}
+        loading={true}
+        selection={null}
+        onSelectAgent={() => {}}
+        worktrees={[]}
+        onSpawned={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/initializing/i)).toBeTruthy();
+  });
+});

--- a/clients/react/src/components/project/ProducerRoster.tsx
+++ b/clients/react/src/components/project/ProducerRoster.tsx
@@ -1,0 +1,100 @@
+import { AgentCard } from "@/components/agent/AgentCard";
+import type { AgentSnapshot } from "@/lib/api";
+import { findProducerForUnit } from "@/lib/producer";
+
+interface ProducerRosterProps {
+  // All agents that belong to this unit (one project group's agents).
+  agents: AgentSnapshot[];
+  // The unit's repo path (the group key) — feeds `findProducerForUnit`.
+  unitPath: string;
+  // `selection.id` from App; matched against both `id` and `target` since a
+  // selection may have been stored under either (the canonical id re-keys
+  // provisional→canonical, the target is stable across that swap).
+  selectedTarget: string | null;
+  onSelect: (target: string) => void;
+}
+
+// Highlight when the row's agent is the current selection, tolerating
+// either id or target as the stored selection key (cf. App's `selectedAgent`
+// resolver, which also matches on both).
+function isSelected(agent: AgentSnapshot, selectedTarget: string | null): boolean {
+  if (selectedTarget === null) return false;
+  return agent.id === selectedTarget || agent.target === selectedTarget;
+}
+
+// Producer-rooted roster for a single unit (DR
+// `2026-05-23-producer-rooted-left-panel.md`). The left panel is the unit
+// **addressing surface**, not an attention feed:
+//
+//   • Producer = headline. The single live Producer (resolved via
+//     `findProducerForUnit`) is the first-class "who am I talking to" row.
+//     Selecting it addresses the Producer (§A — operator addresses Producer).
+//   • Workers = subordinate children. The unit's other agents render as
+//     muted, status-oriented child rows beneath the Producer — its roster,
+//     not co-equal peers. They stay click-selectable: the emergency
+//     direct-worker path §A explicitly preserves
+//     (`feedback_pty_emergency_terminal_access`).
+//   • No single Producer → degrade honestly (simulated-onboarded posture):
+//     show the agents with a 1-line "no single Producer resolved" note;
+//     never fabricate a headline.
+//
+// Role split: this is "who" (structure/identity). It must NOT grow into an
+// attention feed — the blocked/awaiting + PR/CI lists live in the right
+// AttentionStrip. A per-worker status dot is fine; a full attention list is
+// not. The roster is a dumb structural list (no priority/anomaly re-ranking).
+export function ProducerRoster({
+  agents,
+  unitPath,
+  selectedTarget,
+  onSelect,
+}: ProducerRosterProps) {
+  const producer = findProducerForUnit(agents, unitPath);
+
+  // Degradation: zero or ambiguous Producer. Show the agents flat (still
+  // selectable) under an honest note — no fabricated headline.
+  if (producer === null) {
+    return (
+      <div className="flex flex-col gap-1">
+        <p className="px-2 py-1 text-[10px] leading-tight text-subtle-foreground">
+          No single Producer resolved — showing agents directly.
+        </p>
+        {agents.map((agent) => (
+          <AgentCard
+            key={agent.id}
+            agent={agent}
+            selected={isSelected(agent, selectedTarget)}
+            onClick={() => onSelect(agent.target)}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  // Workers = everything in this unit that isn't the Producer. Structural
+  // order preserved from the caller (no judgment sort, DR §No-judgment).
+  const workers = agents.filter((a) => a.id !== producer.id);
+
+  return (
+    <div className="flex flex-col gap-1">
+      <AgentCard
+        agent={producer}
+        variant="headline"
+        selected={isSelected(producer, selectedTarget)}
+        onClick={() => onSelect(producer.target)}
+      />
+      {workers.length > 0 && (
+        <div className="ml-2 flex flex-col gap-0.5 border-l border-hairline pl-2">
+          {workers.map((worker) => (
+            <AgentCard
+              key={worker.id}
+              agent={worker}
+              variant="worker"
+              selected={isSelected(worker, selectedTarget)}
+              onClick={() => onSelect(worker.target)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/react/src/components/project/ProjectGroup.tsx
+++ b/clients/react/src/components/project/ProjectGroup.tsx
@@ -1,6 +1,6 @@
-import { useCallback, useEffect, useRef, useState } from "react";
-import { AgentCard } from "@/components/agent/AgentCard";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useConfirm } from "@/components/layout/ConfirmDialog";
+import { ProducerRoster } from "@/components/project/ProducerRoster";
 import type { ProjectGroup as ProjectGroupType, Selection, WorktreeGroup } from "@/lib/api";
 import { api } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -12,11 +12,14 @@ interface ProjectGroupProps {
   onSpawned: (sessionId: string) => void;
 }
 
-// Collapsible project group containing worktree sub-groups.
-//
-// The per-project branch-graph + markdown-files buttons retired with the
+// Collapsible unit group, rendered as a Producer-rooted addressing surface
+// (DR `2026-05-23-producer-rooted-left-panel.md`): the unit's single live
+// Producer is the headline, its workers hang beneath as a subordinate
+// roster. The body delegates that hierarchy to `ProducerRoster`; this shell
+// keeps the collapsible header + the per-unit emergency spawn `+`. The
+// per-project branch-graph + markdown-files buttons retired earlier with the
 // git/docs multipane (DR `2026-05-14-react-producer-console-rebuild.md`
-// §Refinement 2026-05-22 Fork B). What's left is agent selection + spawn.
+// §Refinement 2026-05-22 Fork B).
 export function ProjectGroup({ project, selection, onSelectAgent, onSpawned }: ProjectGroupProps) {
   const [collapsed, setCollapsed] = useState(false);
   const [showSpawn, setShowSpawn] = useState(false);
@@ -53,6 +56,15 @@ export function ProjectGroup({ project, selection, onSelectAgent, onSpawned }: P
 
   // Derive selectedTarget for agent card highlighting
   const selectedTarget = selection?.type === "agent" ? selection.id : null;
+
+  // Flatten the worktree sub-groups back into one unit agent list for the
+  // Producer-rooted roster. groupByProject already orders these main-first
+  // then worktrees sorted by name, so this preserves a stable structural
+  // order (no judgment sort — DR §No-judgment).
+  const unitAgents = useMemo(
+    () => project.worktrees.flatMap((wt) => wt.agents),
+    [project.worktrees],
+  );
 
   // Spawn an agent in a specific directory
   const confirm = useConfirm();
@@ -259,54 +271,23 @@ export function ProjectGroup({ project, selection, onSelectAgent, onSpawned }: P
         </div>
       </div>
 
-      {/* Agent sub-groups */}
+      {/* Producer-rooted roster (Producer headline + subordinate workers) */}
       {!collapsed && (
         <div className="ml-1 border-l border-hairline pl-2">
-          {project.worktrees.map((wt) => (
-            <WorktreeSection
-              key={wt.name}
-              worktree={wt}
-              selectedTarget={selectedTarget}
-              onSelect={onSelectAgent}
-            />
-          ))}
-          {isEmpty && (
+          {isEmpty ? (
             <div className="px-2 py-2 text-[11px] text-subtle-foreground">
               No agents — click + to spawn
             </div>
+          ) : (
+            <ProducerRoster
+              agents={unitAgents}
+              unitPath={project.path}
+              selectedTarget={selectedTarget}
+              onSelect={onSelectAgent}
+            />
           )}
         </div>
       )}
-    </div>
-  );
-}
-
-interface WorktreeSectionProps {
-  worktree: WorktreeGroup;
-  selectedTarget: string | null;
-  onSelect: (target: string) => void;
-}
-
-// Sub-section for a worktree (or main) within a project — orchestrator agents pinned to top
-function WorktreeSection({ worktree, selectedTarget, onSelect }: WorktreeSectionProps) {
-  const sortedAgents = [...worktree.agents].sort((a, b) => {
-    if (a.is_orchestrator && !b.is_orchestrator) return -1;
-    if (!a.is_orchestrator && b.is_orchestrator) return 1;
-    return 0;
-  });
-
-  return (
-    <div className="mb-0.5">
-      <div className="flex flex-col gap-1">
-        {sortedAgents.map((agent) => (
-          <AgentCard
-            key={agent.id}
-            agent={agent}
-            selected={agent.id === selectedTarget}
-            onClick={() => onSelect(agent.id)}
-          />
-        ))}
-      </div>
     </div>
   );
 }

--- a/clients/react/src/components/project/__tests__/ProducerRoster.test.tsx
+++ b/clients/react/src/components/project/__tests__/ProducerRoster.test.tsx
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { ProducerRoster } from "@/components/project/ProducerRoster";
+import type { AgentSnapshot } from "@/lib/api";
+
+// Minimal AgentSnapshot stub matching the current wire shape. Only the
+// fields the Producer-rooted roster reads need to be meaningful; the rest
+// are filled with inert defaults.
+function stubAgent(overrides: Partial<AgentSnapshot> = {}): AgentSnapshot {
+  return {
+    id: "claude:agent",
+    target: "claude:agent",
+    agent_type: "ClaudeCode",
+    title: "",
+    cwd: "/repo",
+    display_cwd: "/repo",
+    display_name: "claude:agent",
+    detection_source: "HttpHook",
+    git_branch: null,
+    git_dirty: false,
+    is_worktree: false,
+    git_common_dir: "/repo/.git",
+    worktree_name: null,
+    worktree_base_branch: null,
+    effort_level: null,
+    active_subagents: 0,
+    compaction_count: 0,
+    pty_session_id: null,
+    send_capability: "PtyInject",
+    is_virtual: false,
+    team_info: null,
+    attention: null,
+    ...overrides,
+  };
+}
+
+const UNIT_PATH = "/repo";
+
+// The unit's single live Producer: claude-scheme, repo-root (not a worktree).
+const producer = stubAgent({
+  id: "claude:prod-1",
+  target: "claude:prod-1",
+  is_worktree: false,
+  git_common_dir: "/repo/.git",
+  cwd: "/repo",
+});
+
+// A worker: a worktree clone under the same repo.
+const worker = stubAgent({
+  id: "claude:work-1",
+  target: "claude:work-1",
+  is_worktree: true,
+  git_common_dir: "/repo/.git",
+  cwd: "/repo/.claude/worktrees/feat-x",
+  git_branch: "feat-x",
+});
+
+describe("ProducerRoster", () => {
+  it("renders the unit's Producer as the headline and addresses it on click", () => {
+    const onSelect = vi.fn();
+    render(
+      <ProducerRoster
+        agents={[producer, worker]}
+        unitPath={UNIT_PATH}
+        selectedTarget={null}
+        onSelect={onSelect}
+      />,
+    );
+
+    // The PRODUCER badge makes "who am I talking to" legible.
+    expect(screen.getByText("Producer")).toBeTruthy();
+    // Selecting the headline addresses the Producer (§A) via its target.
+    fireEvent.click(screen.getByRole("button", { name: /Producer/ }));
+    expect(onSelect).toHaveBeenCalledWith("claude:prod-1");
+  });
+
+  it("renders workers as subordinate child rows beneath the Producer", () => {
+    render(
+      <ProducerRoster
+        agents={[producer, worker]}
+        unitPath={UNIT_PATH}
+        selectedTarget={null}
+        onSelect={() => {}}
+      />,
+    );
+
+    const producerBtn = screen.getByRole("button", { name: /Producer/ });
+    const workerBtn = screen.getByRole("button", { name: /feat-x/ });
+    expect(producerBtn).toBeTruthy();
+    expect(workerBtn).toBeTruthy();
+
+    // The worker is NOT a second Producer headline — it carries no badge.
+    expect(workerBtn.textContent).not.toContain("Producer");
+
+    // Document order: the worker row renders *beneath* the Producer headline.
+    expect(
+      producerBtn.compareDocumentPosition(workerBtn) & Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
+  it("keeps a worker row click-selectable (emergency direct-address)", () => {
+    const onSelect = vi.fn();
+    render(
+      <ProducerRoster
+        agents={[producer, worker]}
+        unitPath={UNIT_PATH}
+        selectedTarget={null}
+        onSelect={onSelect}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /feat-x/ }));
+    expect(onSelect).toHaveBeenCalledWith("claude:work-1");
+  });
+
+  it("degrades honestly when no single Producer resolves (zero)", () => {
+    const onSelect = vi.fn();
+    // Only a worktree agent — `findProducerForUnit` resolves nothing.
+    render(
+      <ProducerRoster
+        agents={[worker]}
+        unitPath={UNIT_PATH}
+        selectedTarget={null}
+        onSelect={onSelect}
+      />,
+    );
+
+    // Honest note, no fabricated headline.
+    expect(screen.getByText(/no single producer resolved/i)).toBeTruthy();
+    expect(screen.queryByText("Producer")).toBeNull();
+
+    // The agent is still rendered and click-selectable (no crash).
+    fireEvent.click(screen.getByRole("button", { name: /feat-x/ }));
+    expect(onSelect).toHaveBeenCalledWith("claude:work-1");
+  });
+
+  it("degrades honestly when the Producer is ambiguous (two candidates)", () => {
+    const producerB = stubAgent({
+      id: "claude:prod-2",
+      target: "claude:prod-2",
+      is_worktree: false,
+      git_common_dir: "/repo/.git",
+      cwd: "/repo",
+    });
+    render(
+      <ProducerRoster
+        agents={[producer, producerB]}
+        unitPath={UNIT_PATH}
+        selectedTarget={null}
+        onSelect={() => {}}
+      />,
+    );
+
+    expect(screen.getByText(/no single producer resolved/i)).toBeTruthy();
+    expect(screen.queryByText("Producer")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What & why

Re-structures the left sidebar (`AgentList`) from a **flat agent registry** into a **Producer-rooted hierarchy = unit addressing surface**, implementing `doc/decisions/2026-05-23-producer-rooted-left-panel.md`.

The flat registry predated the inversion: Producer and workers sat as co-equal `AgentCard`s, and the panel was framed as an "Operator view (legacy)" escape hatch. Two foundational decisions had already overtaken it — operator *addresses the Producer* (§A), and identity is the Producer-rooted `<unit>.producer.worker[]` hierarchy (#410). This PR brings the left panel into line.

## Before → after structure

**Before:** `[Operator view (legacy)] → [New agent launcher] → per-project group → flat AgentCards (Producer & workers co-equal)`

**After:** per-unit collapsible group, each:
- **Producer headline** — first-class row with a `PRODUCER` badge ("who am I talking to" legible). Click addresses the Producer (same `onSelectAgent(target)` path as today).
- **Worker roster** — the unit's other agents render as muted, indented, status-oriented child rows beneath the Producer (status dot + branch/task label). The dot uses the roster's own mapping per the DR: `halted`→destructive, `started|completed`→muted, `null`→primary. Worker rows **stay click-selectable** — the emergency direct-worker path §A preserves (`feedback_pty_emergency_terminal_access`).
- **Spawn** folded into a de-emphasized, collapsed-by-default `Advanced — emergency spawn` `<details>` footer (dispatch is the Producer's job via briefs).
- **Honest degradation** (simulated-onboarded posture): when no single Producer resolves (zero or ambiguous), agents render flat under a 1-line *"No single Producer resolved"* note — never a fabricated headline.

## Role split (the redundancy fix)

Left = **who** (addressing roster / structure). Right `AttentionStrip` = **what needs you**. The roster adds a per-worker status dot but **no** attention / PR / CI lists, and does **no judgment/sorting** (dumb structural list). Multi-unit ready: one Producer-rooted tree per unit group (a forest when several); no single-unit hard-coding.

## Implementation

- New presentational `ProducerRoster` owns the per-unit hierarchy (`findProducerForUnit` for root identification). `ProjectGroup` delegates its body to it while keeping the collapsible header + per-unit emergency `+`.
- `AgentCard` gains `headline` / `worker` / `default` variants.
- `AgentList` retires the legacy framing and folds the launcher into the footer disclosure.

## Tests

- `ProducerRoster`: Producer headline, subordinate worker children beneath it, worker click = emergency direct-address, zero & ambiguous Producer degradation.
- `AgentList`: legacy framing gone, spawn behind the Advanced disclosure, empty + loading states.
- Existing suites green (479 passed / 2 pre-existing skips). Gate: `pnpm lint` → `tsc -b` → `build` → `test` all pass.

## Not touched (per scope)

The right `AttentionStrip`, the centre conversation, `ProducerConversationHeader`, the digest, `api-spec/` / generated types, and tmai-core. The hierarchy is derived from the **current** agent snapshot only (`is_worktree` / `git_common_dir` / `claude:` id-scheme); if core lands a `<unit>.producer.worker[]` wire shape, this swaps in cleanly.

## References

- DR: `doc/decisions/2026-05-23-producer-rooted-left-panel.md`
- Partially supersedes the "sidebar = legacy escape hatch" stance in `2026-05-14-react-producer-console-rebuild.md` (emergency override paths retained).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * エージェントカード表示の複数レイアウト変種（ヘッドライン、ワーカー行、デフォルト）に対応しました。
  * プロデューサーを中心とした階層構造でエージェントを整理・表示する新しいロスター表示を導入しました。

* **改善**
  * 左パネルのUIを再構成し、説明文言と配置を更新しました。
  * 新規エージェント起動機能を「高度な機能」セクションに移動し、通常時は隠れた状態になりました。

* **テスト**
  * レイアウト変更の仕様を検証するテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/727?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->