### PR TITLE
feat(webui): group the left panel by unit, not repo path (#439)

### DIFF
--- a/clients/react/src/lib/__tests__/group-by-project.test.ts
+++ b/clients/react/src/lib/__tests__/group-by-project.test.ts
@@ -1,0 +1,227 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { type AgentSnapshot, groupByProject } from "../api-http";
+
+// Minimal AgentSnapshot stub — only the fields `groupByProject` reads
+// (unit, git_common_dir, cwd, is_worktree, worktree_name, git_branch,
+// git_dirty, attention) need to be meaningful; the rest are inert.
+function stubAgent(overrides: Partial<AgentSnapshot> = {}): AgentSnapshot {
+  return {
+    id: "claude:agent",
+    target: "claude:agent",
+    agent_type: "ClaudeCode",
+    title: "",
+    cwd: "/home/u/works/tmai",
+    display_cwd: "/home/u/works/tmai",
+    display_name: "claude:agent",
+    detection_source: "HttpHook",
+    git_branch: null,
+    git_dirty: false,
+    is_worktree: false,
+    git_common_dir: "/home/u/works/tmai/.git",
+    worktree_name: null,
+    worktree_base_branch: null,
+    effort_level: null,
+    active_subagents: 0,
+    compaction_count: 0,
+    pty_session_id: null,
+    send_capability: "PtyInject",
+    is_virtual: false,
+    team_info: null,
+    attention: null,
+    ...overrides,
+  };
+}
+
+describe("groupByProject — unit grouping (#439)", () => {
+  it("collapses agents sharing a unit but with different git_common_dir into ONE group", () => {
+    // The multi-repo unit `tmai` = repos `tmai` + `tmai-core`. Two agents,
+    // two repos, one unit — the whole point of #439.
+    const tmaiAgent = stubAgent({
+      id: "claude:prod",
+      target: "claude:prod",
+      unit: "tmai",
+      git_common_dir: "/home/u/works/tmai/.git",
+      cwd: "/home/u/works/tmai",
+    });
+    const coreAgent = stubAgent({
+      id: "claude:core",
+      target: "claude:core",
+      unit: "tmai",
+      git_common_dir: "/home/u/works/tmai-core/.git",
+      cwd: "/home/u/works/tmai-core",
+    });
+
+    const groups = groupByProject([tmaiAgent, coreAgent]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].totalAgents).toBe(2);
+    // Display the unit name…
+    expect(groups[0].name).toBe("tmai");
+    // …but `path` is a REAL repo dir (the primary repo, basename === unit),
+    // never the bare unit name — App treats it as a filesystem path.
+    expect(groups[0].path).toBe("/home/u/works/tmai");
+  });
+
+  it("preserves the within-unit worktree/main sub-structure", () => {
+    const main = stubAgent({
+      id: "claude:prod",
+      target: "claude:prod",
+      unit: "tmai",
+      git_common_dir: "/home/u/works/tmai/.git",
+      cwd: "/home/u/works/tmai",
+      is_worktree: false,
+      git_branch: "main",
+    });
+    const worktree = stubAgent({
+      id: "claude:worker",
+      target: "claude:worker",
+      unit: "tmai",
+      git_common_dir: "/home/u/works/tmai/.git",
+      cwd: "/home/u/works/tmai/.claude/worktrees/feat-x",
+      is_worktree: true,
+      worktree_name: "feat-x",
+      git_branch: "feat-x",
+    });
+
+    const groups = groupByProject([main, worktree]);
+
+    expect(groups).toHaveLength(1);
+    const [group] = groups;
+    // main first, then worktrees sorted by name.
+    expect(group.worktrees.map((wt) => wt.name)).toEqual(["main", "feat-x"]);
+
+    const mainWt = group.worktrees.find((wt) => !wt.isWorktree);
+    expect(mainWt?.agents.map((a) => a.id)).toEqual(["claude:prod"]);
+
+    const featWt = group.worktrees.find((wt) => wt.name === "feat-x");
+    expect(featWt?.isWorktree).toBe(true);
+    expect(featWt?.agents.map((a) => a.id)).toEqual(["claude:worker"]);
+  });
+
+  it("collapses a multi-repo unit AND keeps its worktree sub-structure", () => {
+    // tmai main + a tmai worktree + a tmai-core worker, all unit `tmai`.
+    const tmaiMain = stubAgent({
+      id: "claude:prod",
+      target: "claude:prod",
+      unit: "tmai",
+      git_common_dir: "/home/u/works/tmai/.git",
+      cwd: "/home/u/works/tmai",
+      is_worktree: false,
+      git_branch: "main",
+    });
+    const tmaiWorktree = stubAgent({
+      id: "claude:worker",
+      target: "claude:worker",
+      unit: "tmai",
+      git_common_dir: "/home/u/works/tmai/.git",
+      cwd: "/home/u/works/tmai/.claude/worktrees/feat-x",
+      is_worktree: true,
+      worktree_name: "feat-x",
+      git_branch: "feat-x",
+    });
+    const coreWorker = stubAgent({
+      id: "claude:core",
+      target: "claude:core",
+      unit: "tmai",
+      git_common_dir: "/home/u/works/tmai-core/.git",
+      cwd: "/home/u/works/tmai-core",
+      is_worktree: false,
+    });
+
+    const groups = groupByProject([tmaiMain, tmaiWorktree, coreWorker]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].totalAgents).toBe(3);
+    expect(groups[0].path).toBe("/home/u/works/tmai");
+    // The worktree sub-structure still distinguishes the feat-x worktree
+    // from the (collapsed) repo roots.
+    expect(groups[0].worktrees.map((wt) => wt.name)).toEqual(["main", "feat-x"]);
+  });
+
+  it("falls back to git_common_dir grouping when `unit` is absent", () => {
+    // No `unit` → the pre-#439 behavior: one group per repo dir.
+    const foo = stubAgent({
+      id: "claude:foo",
+      target: "claude:foo",
+      git_common_dir: "/home/u/works/foo/.git",
+      cwd: "/home/u/works/foo",
+    });
+    const bar = stubAgent({
+      id: "claude:bar",
+      target: "claude:bar",
+      git_common_dir: "/home/u/works/bar/.git",
+      cwd: "/home/u/works/bar",
+    });
+
+    const groups = groupByProject([foo, bar]);
+
+    // Different repos, no unit → two separate groups (NOT collapsed).
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.path)).toEqual(["/home/u/works/bar", "/home/u/works/foo"]);
+    expect(groups.map((g) => g.name)).toEqual(["bar", "foo"]);
+  });
+
+  it("treats an empty-string `unit` as absent (fallback)", () => {
+    const agent = stubAgent({
+      unit: "",
+      git_common_dir: "/home/u/works/foo/.git",
+      cwd: "/home/u/works/foo",
+    });
+
+    const groups = groupByProject([agent]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].path).toBe("/home/u/works/foo");
+    expect(groups[0].name).toBe("foo");
+  });
+
+  it("keeps unit and unit-less agents in separate groups during the transition", () => {
+    // Per-agent fallback: a unit-bearing agent and a unit-less one at a
+    // different repo do not merge. Namespacing (`unit:` prefix) guarantees a
+    // bare unit name can't collide with an absolute repo-dir key.
+    const withUnit = stubAgent({
+      id: "claude:u",
+      target: "claude:u",
+      unit: "tmai",
+      git_common_dir: "/home/u/works/tmai/.git",
+      cwd: "/home/u/works/tmai",
+    });
+    const withoutUnit = stubAgent({
+      id: "claude:n",
+      target: "claude:n",
+      git_common_dir: "/home/u/works/other/.git",
+      cwd: "/home/u/works/other",
+    });
+
+    const groups = groupByProject([withUnit, withoutUnit]);
+
+    expect(groups).toHaveLength(2);
+    expect(groups.map((g) => g.path).sort()).toEqual(["/home/u/works/other", "/home/u/works/tmai"]);
+  });
+
+  it("picks the first repo dir when no member's basename matches the unit name", () => {
+    // A unit whose name matches none of its repos' basenames still resolves
+    // to a real repo dir (the first member), never the bare unit name.
+    const a = stubAgent({
+      id: "claude:a",
+      target: "claude:a",
+      unit: "myproject",
+      git_common_dir: "/home/u/works/frontend/.git",
+      cwd: "/home/u/works/frontend",
+    });
+    const b = stubAgent({
+      id: "claude:b",
+      target: "claude:b",
+      unit: "myproject",
+      git_common_dir: "/home/u/works/backend/.git",
+      cwd: "/home/u/works/backend",
+    });
+
+    const groups = groupByProject([a, b]);
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].name).toBe("myproject");
+    expect(groups[0].path).toBe("/home/u/works/frontend");
+  });
+});

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -197,6 +197,16 @@ export interface AgentSnapshot {
   git_dirty: boolean | null;
   is_worktree: boolean | null;
   git_common_dir: string | null;
+  /** Unit name this agent belongs to (tmai-core #443 — wire half of #439).
+   *  A `[[unit]]` can span several repos, so two agents with *different*
+   *  `git_common_dir` may share one `unit`; that is exactly what the
+   *  unit-grouped left panel collapses into a single Producer-rooted group.
+   *  Optional here not because the contract is loose but because the field
+   *  only appears once the engine is rebuilt to serve it: a not-yet-rebuilt
+   *  engine omits it, and `groupByProject` falls back to `git_common_dir`
+   *  grouping for that transition window. Once the engine serves it the
+   *  field is always present. */
+  unit?: string;
   worktree_name: string | null;
   worktree_base_branch: string | null;
   effort_level: EffortLevel | null;
@@ -279,13 +289,18 @@ export interface WorktreeGroup {
   agents: AgentSnapshot[];
 }
 
-// A project group: one git repository (main + worktrees)
+// A unit group: one `[[unit]]` (which may span several repos), rendered as
+// the Producer-rooted addressing surface. Named `ProjectGroup` for history;
+// the grouping key is the unit (#439), not the repo.
 export interface ProjectGroup {
-  // Display name derived from path (last dir component)
+  // Display name — the unit name when grouped by unit, else the repo's last
+  // path component (the back-compat fallback).
   name: string;
-  // Full path (git_common_dir or cwd)
+  // A real repo path representing the unit (the primary repo, where the
+  // Producer runs). NOT the unit name: App's currentProject / setCallerCwd /
+  // findProducerForUnit / spawn cwd all treat this as a filesystem path.
   path: string;
-  // Worktrees within this project (main first, then worktrees sorted)
+  // Worktrees within this unit (main first, then worktrees sorted)
   worktrees: WorktreeGroup[];
   // Aggregate counts
   totalAgents: number;
@@ -316,8 +331,35 @@ export function normalizeGitDir(dir: string): string {
   return cleaned.slice(0, end);
 }
 
-// Group agents by project (git_common_dir) and worktree.
-// When worktreeSnapshots is provided, agent-less worktrees are also shown.
+// Resolve an agent's normalized repo directory: prefer `git_common_dir`,
+// then a cwd→git_common_dir prefix match, then the cwd itself. Factored
+// out of the grouping loop so unit-grouping (for the representative repo
+// path) and the back-compat git_common_dir grouping share one resolver.
+function resolveRepoDir(agent: AgentSnapshot, cwdToGitDir: Map<string, string>): string {
+  if (agent.git_common_dir) return normalizeGitDir(agent.git_common_dir);
+  // Try to match this cwd to a known git dir via prefix
+  let matched = cwdToGitDir.get(agent.cwd);
+  if (!matched) {
+    for (const [cwd, gitDir] of cwdToGitDir) {
+      if (agent.cwd.startsWith(cwd) || cwd.startsWith(agent.cwd)) {
+        matched = gitDir;
+        break;
+      }
+    }
+  }
+  return matched || agent.cwd;
+}
+
+// Group agents into the left-panel unit groups and their worktree
+// sub-structure. When worktreeSnapshots is provided, agent-less worktrees
+// are also shown.
+//
+// Top-level key (#439, served by tmai-core #443): `agent.unit`. A `[[unit]]`
+// can span several repos, so all agents sharing a `unit` collapse into ONE
+// group even when their `git_common_dir` differs — the whole point of #439.
+// When `unit` is absent/empty (an engine not yet rebuilt to serve the field),
+// each agent falls back to its repo dir, reproducing the pre-#439 grouping so
+// the panel keeps working during the transition window.
 export function groupByProject(
   agents: AgentSnapshot[],
   worktreeSnapshots: WorktreeSnapshot[] = [],
@@ -334,23 +376,13 @@ export function groupByProject(
   }
 
   for (const agent of agents) {
-    // Prefer git_common_dir, then lookup from cwd, then fallback to cwd itself
-    let key: string;
-    if (agent.git_common_dir) {
-      key = normalizeGitDir(agent.git_common_dir);
-    } else {
-      // Try to match this cwd to a known git dir via prefix
-      let matched = cwdToGitDir.get(agent.cwd);
-      if (!matched) {
-        for (const [cwd, gitDir] of cwdToGitDir) {
-          if (agent.cwd.startsWith(cwd) || cwd.startsWith(agent.cwd)) {
-            matched = gitDir;
-            break;
-          }
-        }
-      }
-      key = matched || agent.cwd;
-    }
+    // Group key: the unit identity when the wire serves it, else the repo
+    // dir (back-compat). Unit keys are namespaced (`unit:`) so a bare unit
+    // name can never collide with an absolute repo-dir key.
+    const key =
+      agent.unit && agent.unit.length > 0
+        ? `unit:${agent.unit}`
+        : resolveRepoDir(agent, cwdToGitDir);
 
     const group = projectMap.get(key);
     if (group) {
@@ -362,7 +394,22 @@ export function groupByProject(
 
   const projects: ProjectGroup[] = [];
 
-  for (const [path, groupAgents] of projectMap) {
+  for (const [key, groupAgents] of projectMap) {
+    // A unit group shares one `unit` across all its agents; a fallback group
+    // has none. Either way `path` is a REAL repo dir (never the unit name):
+    // for a multi-repo unit it resolves to the primary repo — the one whose
+    // basename matches the unit name, where the Producer runs — falling back
+    // to the first agent's repo dir. In the back-compat case the key already
+    // IS the repo dir.
+    const unit =
+      groupAgents[0]?.unit && groupAgents[0].unit.length > 0 ? groupAgents[0].unit : null;
+    let path: string;
+    if (unit !== null) {
+      const dirs = groupAgents.map((a) => resolveRepoDir(a, cwdToGitDir));
+      path = dirs.find((d) => projectName(d) === unit) ?? dirs[0] ?? key;
+    } else {
+      path = key;
+    }
     // Sub-group by worktree
     const worktreeMap = new Map<string, AgentSnapshot[]>();
 
@@ -446,7 +493,8 @@ export function groupByProject(
     const attentionCount = groupAgents.filter((a) => a.attention != null).length;
 
     projects.push({
-      name: projectName(path),
+      // Display the unit name when grouped by unit; else the repo basename.
+      name: unit ?? projectName(path),
       path,
       worktrees,
       totalAgents: groupAgents.length,


### PR DESCRIPTION
## What

WebUI half of #439: make the left panel group by **unit** so a multi-repo unit (e.g. unit `tmai` = repos `tmai` + `tmai-core`) collapses its agents under ONE Producer-rooted group instead of splitting one group per repo.

The wire half landed in tmai-core #443: `/api/agents` `AgentSnapshot` now carries a `unit` field (the unit name).

## Changes

- **`AgentSnapshot.unit?: string`** — added to the hand-written TS type in `clients/react/src/lib/api-http.ts`, mirroring the new wire field. Typed optional (not because the contract is loose) because the field only appears once the engine is rebuilt to serve it; this also matches the file's existing convention for transitional wire fields and keeps the back-compat fallback type-safe.
- **`groupByProject` keys on `agent.unit`** when present, so all agents sharing a unit form ONE group even when their `git_common_dir` differs (the point of #439). The repo-dir resolution is factored into a `resolveRepoDir` helper shared by both paths.
- **Back-compat fallback**: when `agent.unit` is absent/empty (an engine not yet rebuilt), each agent falls back to the pre-#439 `git_common_dir` grouping per-agent, so the panel does not break during the transition window. Unit keys are namespaced (`unit:`) so a bare unit name can't collide with an absolute repo-dir key.
- **`ProjectGroup.path` stays a real repo dir** — the unit's *primary* repo (the member whose basename matches the unit name, where the Producer runs; else the first member). This is deliberate: App's `currentProject` / `setCallerCwd` / `findProducerForUnit` / spawn cwd all treat `path` as a filesystem path, so it must never become the bare unit name. `ProjectGroup.name` now shows the unit name.
- **Preserved unchanged**: the within-unit worktree/main sub-structure and the Producer-rooted roster (`ProjectGroup`/`ProducerRoster`, per DR `2026-05-23-producer-rooted-left-panel.md`) — Producer = headline, workers = subordinate children.

## Tests

New `clients/react/src/lib/__tests__/group-by-project.test.ts` (mocked agents, no live engine):
- (a) two agents, same `unit`, different `git_common_dir` → collapse into one group;
- (b) within-unit worktree/main sub-structure preserved (and a multi-repo + worktree combined case);
- (c) `unit` absent → falls back to `git_common_dir` grouping;
- plus: empty-string `unit` → fallback; per-agent unit/unit-less split during transition; primary-repo path selection when no basename matches the unit name.

## Gate (local, all green)

```
##### pnpm lint #####
Checked 164 files in 148ms. No fixes applied.

##### pnpm build #####  (tsc -b && vite build)
dist/assets/index-CZAf60zS.js   945.04 kB │ gzip: 257.79 kB
✓ built in 577ms

##### pnpm test #####  (vitest run)
 Test Files  65 passed (65)
      Tests  489 passed | 2 skipped (491)
```

(The vite chunk-size and Tauri dynamic-import warnings are pre-existing and unrelated.)

## Out of scope

The tmai-core wire (#443); `GET /api/units`; live-engine verification (a later engine rebuild — tests use mocked agents); the handoff work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## テスト
* エージェントグループ化機能の包括的なテストケースを追加

## 新機能
* エージェントをユニット単位でグループ化可能に
* 複数リポジトリを単一のサイドバーグループに集約できるように改善
* ユニット情報が欠落した場合のフォールバック動作に対応

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/729?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->