### PR TITLE
chore(gen): sync generated spec + types from tmai-core@9827a29943

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -1298,7 +1298,7 @@
           "type": "object"
         },
         {
-          "description": "`HANDOFF READY` literal observed + `active.md` validated (§C steps 3-4).",
+          "description": "`active.md` baton landed fresh + validated (§C steps 3-4).",
           "properties": {
             "phase": {
               "enum": [
@@ -1358,7 +1358,7 @@
           "type": "object"
         },
         {
-          "description": "Failure path; `reason` is a machine-readable code per DR §D failure\ninventory (`no_active_producer`, `multiple_producers`, `timeout`,\n`missing_handoff_ready`, `malformed_handoff`, `kill_failed`,\n`spawn_failed`). Consumers route every variant to the same operator\ndialog (§E).",
+          "description": "Failure path; `reason` is a machine-readable code per DR §D failure\ninventory (`no_active_producer`, `multiple_producers`,\n`prompt_send_failed`, `timeout`, `malformed_handoff`, `kill_failed`,\n`spawn_failed`). Consumers route every variant to the same operator\ndialog (§E).",
           "properties": {
             "phase": {
               "enum": [
@@ -1585,6 +1585,13 @@
         },
         "check_status": {
           "description": "Raw rolled-up check status (`\"SUCCESS\"` / `\"FAILURE\"` / `\"PENDING\"`),\nor `null` when there are no checks.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "ci_local_attestation": {
+          "description": "The ci-local attestation the Producer stored alongside the delivered\nmarker, if any (approach `2026-05-26-producer-supplied-override-\nattestation.md`, O2-d). `Some` only when `producer_reviewed` is true\nAND the Producer supplied an attestation via `mark_pr_reviewed`.\n\nNeutral evidence-of-verification, **not** an approval — same §E\nboundary as `producer_reviewed`. The react half (Phase B) reads it to\npre-fill the billing-dead override textarea so the operator need not\nhand-paste the ci-local summary; absence simply means the operator\nfalls back to the manual paste (the O2-a path). The backend consumes\nthe *stored* copy directly — this wire field is for the UI, not the\nauthoritative override input.\n\nOptional / serde-default with the same lockstep-free discipline as\n`producer_reviewed`: absent on the wire when `None`, and a payload\nomitting it deserializes to `None`.",
           "type": [
             "string",
             "null"

--- a/api-spec/mcp-tools.json
+++ b/api-spec/mcp-tools.json
@@ -483,6 +483,14 @@
     "parameters_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
+        "ci_local_attestation": {
+          "default": null,
+          "description": "Optional ci-local attestation: the PASS/FAIL summary from\n`bash scripts/ci-local.sh` the Producer verified at brief time\n(approach `2026-05-26-producer-supplied-override-attestation.md`,\nO2-d). When present it is stored on the delivered marker so a\nbilling-dead override merge can consume it WITHOUT the operator\nhand-pasting. Omitting it keeps the marker a bare neutral\ndelivered-marker (unchanged behavior). Neutral evidence, never an\napproval.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "pr_number": {
           "description": "Pull request number whose Producer Δ-brief has been delivered",
           "format": "uint64",

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -2806,7 +2806,7 @@
           },
           {
             "type": "object",
-            "description": "`HANDOFF READY` literal observed + `active.md` validated (§C steps 3-4).",
+            "description": "`active.md` baton landed fresh + validated (§C steps 3-4).",
             "required": [
               "phase"
             ],
@@ -2866,7 +2866,7 @@
           },
           {
             "type": "object",
-            "description": "Failure path; `reason` is a machine-readable code per DR §D failure\ninventory (`no_active_producer`, `multiple_producers`, `timeout`,\n`missing_handoff_ready`, `malformed_handoff`, `kill_failed`,\n`spawn_failed`). Consumers route every variant to the same operator\ndialog (§E).",
+            "description": "Failure path; `reason` is a machine-readable code per DR §D failure\ninventory (`no_active_producer`, `multiple_producers`,\n`prompt_send_failed`, `timeout`, `malformed_handoff`, `kill_failed`,\n`spawn_failed`). Consumers route every variant to the same operator\ndialog (§E).",
             "required": [
               "reason",
               "phase"
@@ -3113,6 +3113,13 @@
               "null"
             ],
             "description": "Raw rolled-up check status (`\"SUCCESS\"` / `\"FAILURE\"` / `\"PENDING\"`),\nor `null` when there are no checks."
+          },
+          "ci_local_attestation": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "The ci-local attestation the Producer stored alongside the delivered\nmarker, if any (approach `2026-05-26-producer-supplied-override-\nattestation.md`, O2-d). `Some` only when `producer_reviewed` is true\nAND the Producer supplied an attestation via `mark_pr_reviewed`.\n\nNeutral evidence-of-verification, **not** an approval — same §E\nboundary as `producer_reviewed`. The react half (Phase B) reads it to\npre-fill the billing-dead override textarea so the operator need not\nhand-paste the ci-local summary; absence simply means the operator\nfalls back to the manual paste (the O2-a path). The backend consumes\nthe *stored* copy directly — this wire field is for the UI, not the\nauthoritative override input.\n\nOptional / serde-default with the same lockstep-free discipline as\n`producer_reviewed`: absent on the wire when `None`, and a payload\nomitting it deserializes to `None`."
           },
           "comments": {
             "type": "integer",

--- a/clients/ratatui/src/types/generated/pr_summary_wire.rs
+++ b/clients/ratatui/src/types/generated/pr_summary_wire.rs
@@ -15,6 +15,8 @@ pub struct PrSummaryWire {
     pub base_branch: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub check_status: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub ci_local_attestation: Option<Value>,
     pub comments: i64,
     pub deletions: i64,
     pub head_branch: String,

--- a/clients/react/src/types/generated/PrSummaryWire.ts
+++ b/clients/react/src/types/generated/PrSummaryWire.ts
@@ -58,4 +58,23 @@ merge_commit_sha: string | null,
  * `false`, and a payload omitting it deserializes to `false` — a
  * client omitting it stays lockstep-free.
  */
-producer_reviewed?: boolean, };
+producer_reviewed?: boolean, 
+/**
+ * The ci-local attestation the Producer stored alongside the delivered
+ * marker, if any (approach `2026-05-26-producer-supplied-override-
+ * attestation.md`, O2-d). `Some` only when `producer_reviewed` is true
+ * AND the Producer supplied an attestation via `mark_pr_reviewed`.
+ *
+ * Neutral evidence-of-verification, **not** an approval — same §E
+ * boundary as `producer_reviewed`. The react half (Phase B) reads it to
+ * pre-fill the billing-dead override textarea so the operator need not
+ * hand-paste the ci-local summary; absence simply means the operator
+ * falls back to the manual paste (the O2-a path). The backend consumes
+ * the *stored* copy directly — this wire field is for the UI, not the
+ * authoritative override input.
+ *
+ * Optional / serde-default with the same lockstep-free discipline as
+ * `producer_reviewed`: absent on the wire when `None`, and a payload
+ * omitting it deserializes to `None`.
+ */
+ci_local_attestation?: string | null, };


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@9827a299436784be85ce65b4f1902ca89c7887d8

**Manual gen-spec mirror.** The tmai-core `gen-spec-pr` workflow is billing-dead (private Actions allotment exhausted), so the Producer regenerated the contract artifacts via `tmai-xtask` and opened this bot PR by hand. The `bot/` branch prefix exempts it from the no-hand-edits guard; **public CI (types-drift / build-react / build-ratatui / validate-spec) is the real signal.**

Regenerated from **tmai-core #449** (producer-supplied ci-local attestation, O2-d): `PrSummaryWire` gains an optional `ci_local_attestation`; the `mark_pr_reviewed` MCP param + openapi/schema reflect it. `versions.toml` unchanged (core / api_spec both 3.0.1).

Do not hand-edit these files — regenerated from Rust contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/corevents.schema.json                      | 11 +++++++++--
 api-spec/mcp-tools.json                             |  8 ++++++++
 api-spec/openapi.json                               | 11 +++++++++--
 .../ratatui/src/types/generated/pr_summary_wire.rs  |  2 ++
 clients/react/src/types/generated/PrSummaryWire.ts  | 21 ++++++++++++++++++++-
 5 files changed, 48 insertions(+), 5 deletions(-)
```

</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **新機能**
  * ローカルCI検証の結果をプルリクエストレビュー時に供給できるようになりました。

* **改善**
  * ハンドオフプロセスの説明文言を更新しました。
  * ハンドオフ失敗時の理由コードを更新しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/733?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->