### PR TITLE
feat(webui): pre-fill billing-dead override from Producer ci-local attestation (Phase B)

### DIFF
--- a/clients/react/src/components/producer-console/sections/UnitPrsSection.tsx
+++ b/clients/react/src/components/producer-console/sections/UnitPrsSection.tsx
@@ -23,7 +23,7 @@
 // as a failure with a `gh`/github.com fallback hint, never a fabricated
 // empty list.
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { DiffViewer } from "@/components/worktree/DiffViewer";
 import { useUnitPrs } from "@/hooks/useUnitPrs";
 import { api, type PrMergeOverride, type PrSummaryWire, type RepoPrsWire } from "@/lib/api";
@@ -242,7 +242,8 @@ interface PrRowProps {
   merge: MergeState;
   onMerge: () => void;
   /** Fire the Phase B billing-dead CI-safe override merge with the
-   *  pasted ci-local attestation. */
+   *  ci-local attestation in the textarea (pre-filled from the Producer's
+   *  stored attestation, or hand-pasted when absent). */
   onOverrideMerge: (attestation: string) => void;
   onArmMerge: (armed: boolean) => void;
 }
@@ -270,7 +271,28 @@ function PrRow({
   // attestation; the backend re-validates the per-repo `billing_dead`
   // flag and is the real gate.
   const [overrideOpen, setOverrideOpen] = useState(false);
-  const [attestation, setAttestation] = useState("");
+  // Pre-fill the override textarea from the Producer's stored ci-local
+  // attestation (`PrSummaryWire.ci_local_attestation`, approach
+  // `2026-05-26-producer-supplied-override-attestation`) so the operator
+  // need not hand-paste it. The field stays editable — what's sent is the
+  // textarea content, pre-filled or typed. `?? ""` because the wire field
+  // is optional/nullable; absent ⇒ "" keeps the manual-paste fallback.
+  const prefill = pr.ci_local_attestation ?? "";
+  const hasPrefill = prefill !== "";
+  const [attestation, setAttestation] = useState(prefill);
+  // Whether the operator has touched the textarea since it was (re)armed.
+  // A later 60s poll can bring a changed `prefill`; we adopt it ONLY while
+  // the field is still clean, never clobbering an operator's edit (the
+  // brief's load-bearing line). Cancel re-arms it so a reopen re-syncs.
+  const [attestationEdited, setAttestationEdited] = useState(false);
+  // Re-sync to a newly-polled attestation while the field is clean. Keyed
+  // on `prefill` so it fires only when the prop value actually changes;
+  // the `attestationEdited` guard makes the operator's edit sticky.
+  useEffect(() => {
+    if (!attestationEdited) {
+      setAttestation(prefill);
+    }
+  }, [prefill, attestationEdited]);
   const showOverride = billingDead && pr.check_status === "FAILURE";
 
   // Lazy: fetch the patch on the first open and cache it for the row's
@@ -432,15 +454,28 @@ function PrRow({
 
       {showOverride && overrideOpen && (
         <div className="mt-2 rounded border border-warning/40 bg-warning/[0.05] px-2 py-1.5">
-          <p className="text-[10.5px] leading-relaxed text-warning">
-            CI is red only because this repo's private Actions billing is dead. Paste the{" "}
-            <code className="text-foreground">ci-local</code> run summary; the backend re-checks the
-            per-repo <code className="text-foreground">billing_dead</code> flag + attestation before
-            running <code className="text-foreground">gh pr merge --admin</code>.
-          </p>
+          {hasPrefill ? (
+            <p className="text-[10.5px] leading-relaxed text-warning">
+              CI is red only because this repo's private Actions billing is dead. The Producer's{" "}
+              <code className="text-foreground">ci-local</code> summary is pre-filled below —
+              review/edit it, then confirm. The backend re-checks the per-repo{" "}
+              <code className="text-foreground">billing_dead</code> flag + attestation before
+              running <code className="text-foreground">gh pr merge --admin</code>.
+            </p>
+          ) : (
+            <p className="text-[10.5px] leading-relaxed text-warning">
+              CI is red only because this repo's private Actions billing is dead. Paste the{" "}
+              <code className="text-foreground">ci-local</code> run summary; the backend re-checks
+              the per-repo <code className="text-foreground">billing_dead</code> flag + attestation
+              before running <code className="text-foreground">gh pr merge --admin</code>.
+            </p>
+          )}
           <textarea
             value={attestation}
-            onChange={(e) => setAttestation(e.target.value)}
+            onChange={(e) => {
+              setAttestation(e.target.value);
+              setAttestationEdited(true);
+            }}
             rows={4}
             aria-label="CI-local attestation for billing-dead override"
             placeholder="Paste the ci-local attestation (e.g. the `bash scripts/ci-local.sh` summary)…"
@@ -460,8 +495,12 @@ function PrRow({
             <button
               type="button"
               onClick={() => {
+                // Discard edits and re-arm the prop sync: reopening shows
+                // the latest Producer prefill (or "" when absent), never a
+                // stale paste.
                 setOverrideOpen(false);
-                setAttestation("");
+                setAttestation(prefill);
+                setAttestationEdited(false);
               }}
               disabled={merge.busy}
               className="rounded bg-surface px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong disabled:opacity-50"

--- a/clients/react/src/components/producer-console/sections/__tests__/UnitPrsSection.test.tsx
+++ b/clients/react/src/components/producer-console/sections/__tests__/UnitPrsSection.test.tsx
@@ -13,7 +13,7 @@
 //   posture: pick-a-project on null unit (no fetch); honest error; no
 //      fabricated empty list.
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { RepoPrsWire } from "@/lib/api";
 
@@ -366,5 +366,116 @@ describe("UnitPrsSection", () => {
     fireEvent.click(screen.getByRole("button", { name: OVERRIDE_BTN }));
     const reopened = screen.getByLabelText(/CI-local attestation/i) as HTMLTextAreaElement;
     expect(reopened.value).toBe("");
+  });
+
+  // Phase B prefill (approach `2026-05-26-producer-supplied-override-
+  // attestation`, O2-d wire `PrSummaryWire.ci_local_attestation`). When
+  // the Producer stored a ci-local attestation alongside the delivered
+  // marker, the override textarea is pre-filled with it (editable) so the
+  // operator need not hand-paste; absence keeps the manual-paste fallback.
+  // It is evidence-of-verification, never an approval — the panel copy
+  // stays at "pre-filled / review/edit", and the backend is still the gate.
+
+  const attestedBillingDeadRepo = (attestation: string): RepoPrsWire => {
+    const repo = failingBillingDeadRepo();
+    repo.prs[0].ci_local_attestation = attestation;
+    return repo;
+  };
+
+  it("pre-fills the override textarea from the Producer's ci-local attestation when present", async () => {
+    unitPrsMock.mockResolvedValue({
+      unit: "tmai",
+      repos: [attestedBillingDeadRepo("ci-local — PASS, all gates green")],
+    });
+    render(<UnitPrsSection unitName="tmai" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: OVERRIDE_BTN }));
+    const ta = screen.getByLabelText(/CI-local attestation/i) as HTMLTextAreaElement;
+    expect(ta.value).toBe("ci-local — PASS, all gates green");
+    // Pre-fill messaging — review/edit, never "approved".
+    expect(screen.getByText(/pre-filled below/i)).toBeTruthy();
+  });
+
+  it("keeps the empty manual-paste fallback when no attestation is present", async () => {
+    unitPrsMock.mockResolvedValue({ unit: "tmai", repos: [failingBillingDeadRepo()] });
+    render(<UnitPrsSection unitName="tmai" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: OVERRIDE_BTN }));
+    const ta = screen.getByLabelText(/CI-local attestation/i) as HTMLTextAreaElement;
+    expect(ta.value).toBe("");
+    // The absent path keeps the original "paste the summary" copy.
+    expect(screen.getByText(/Paste the/i)).toBeTruthy();
+    expect(screen.queryByText(/pre-filled below/i)).toBeNull();
+  });
+
+  it("override-merges the pre-filled attestation unchanged when the operator does not edit it", async () => {
+    unitPrsMock.mockResolvedValue({
+      unit: "tmai",
+      repos: [attestedBillingDeadRepo("ci-local — PASS")],
+    });
+    mergePrMock.mockResolvedValue({ status: "merged" });
+    render(<UnitPrsSection unitName="tmai" />);
+
+    fireEvent.click(await screen.findByRole("button", { name: OVERRIDE_BTN }));
+    // Pre-filled ⇒ non-empty ⇒ Confirm is enabled without any typing.
+    fireEvent.click(screen.getByRole("button", { name: /Override-merge #707/ }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/✓ Merged #707/)).toBeTruthy();
+    });
+    // The send shape is unchanged: the textarea content (here the
+    // pre-fill) is sent verbatim, same as a hand-paste.
+    expect(mergePrMock).toHaveBeenCalledWith("/home/u/works/tmai", 707, {
+      method: "squash",
+      deleteBranch: true,
+      override: {
+        ci_local_attestation: "ci-local — PASS",
+        repo_billing_dead_acknowledged: true,
+      },
+    });
+  });
+
+  // Prop-update behavior across a 60s poll (the brief's load-bearing
+  // line): a clean textarea adopts a newer attestation, but an operator's
+  // edit is never clobbered. Fake timers drive the real `useUnitPrs`
+  // interval; `findBy`/`waitFor` don't auto-advance vitest fake timers, so
+  // each fetch is flushed manually inside `act`.
+  it("adopts a newer attestation on a clean poll but never clobbers an operator's edit", async () => {
+    vi.useFakeTimers();
+    try {
+      unitPrsMock
+        .mockResolvedValueOnce({ unit: "tmai", repos: [attestedBillingDeadRepo("ci-local v1")] })
+        .mockResolvedValueOnce({
+          unit: "tmai",
+          repos: [attestedBillingDeadRepo("ci-local v2 (newer)")],
+        })
+        .mockResolvedValue({ unit: "tmai", repos: [attestedBillingDeadRepo("ci-local v3")] });
+
+      render(<UnitPrsSection unitName="tmai" />);
+      // Flush the initial (microtask) fetch — advancing 1ms cannot reach
+      // the 60s interval, but drains the pending promise.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1);
+      });
+
+      fireEvent.click(screen.getByRole("button", { name: OVERRIDE_BTN }));
+      const ta = () => screen.getByLabelText(/CI-local attestation/i) as HTMLTextAreaElement;
+      expect(ta().value).toBe("ci-local v1");
+
+      // Clean (un-edited) → a later poll adopts the newer attestation.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(ta().value).toBe("ci-local v2 (newer)");
+
+      // Operator edits → subsequent polls must NOT clobber the edit.
+      fireEvent.change(ta(), { target: { value: "operator hand-edit" } });
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(60_000);
+      });
+      expect(ta().value).toBe("operator hand-edit");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });


### PR DESCRIPTION
## What

Pre-fill the billing-dead **override** panel's textarea from the Producer's stored ci-local attestation so the operator no longer hand-pastes the summary. Reads the wire field `PrSummaryWire.ci_local_attestation` (added in tmai-core #449) — the neutral *evidence-of-verification* the Producer attached via `mark_pr_reviewed`. When the field is absent, the panel keeps the existing empty-textarea **manual-paste fallback** unchanged.

Scope is strictly `clients/react`: only `UnitPrsSection.tsx` + its test. No backend / wire-type / normal-merge / `producer_reviewed`-valve changes.

## Behavior

1. **Initial value** = `pr.ci_local_attestation ?? ""` — pre-filled when present, empty when absent. Stays **editable**.
2. **Copy switches** on presence: "The Producer's `ci-local` summary is pre-filled below — review/edit it, then confirm." when present; the original "Paste the `ci-local` run summary…" when absent.
3. **Send shape unchanged**: `onOverrideMerge(attestation)` sends the textarea content verbatim (pre-filled or typed). The `api.mergePr` override payload (`ci_local_attestation` + `repo_billing_dead_acknowledged: true`) and the backend contract are untouched.
4. **Prop updates across the 60s poll**: a *clean* textarea re-syncs to a newly-polled attestation, but once the operator edits, subsequent polls **never clobber** the edit (sticky-after-edit guard; Cancel discards edits and re-arms the sync).

## Invariants kept

- The override stays a **distinct affordance** from the normal merge button and the `producer_reviewed` "Δ-brief ✓" valve — not conflated.
- Attestation is **evidence, not approval**: UI wording stays at "attestation / pre-filled / review-edit", never "approved".
- **Manual-paste fallback preserved** (empty textarea when no attestation).
- Scope limited to the **billing-dead override** only.

## Tests added (`UnitPrsSection.test.tsx`)

- pre-fills the textarea from `ci_local_attestation` when present (+ asserts the "pre-filled below" copy);
- keeps the empty manual-paste fallback + original copy when absent;
- override-merges the pre-filled attestation **unchanged** when the operator does not edit it (exact payload asserted);
- across a 60s poll: adopts a newer attestation on a clean textarea, but **never clobbers** an operator's edit (real `useUnitPrs` interval driven by fake timers).

All pre-existing Phase B tests (empty-attestation disable, Cancel-clears-on-reopen, payload shape) still pass unchanged.

## Gate (clients/react)

- `pnpm lint` (biome) ✓
- `pnpm build` (`tsc -b` + vite) ✓
- `pnpm test` ✓ — 493 passed | 2 skipped (pre-existing)

No scope deviation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * プロデューサ提供のアテステーション値がUI上で自動プリフィルされるようになりました
  * ポーリング更新時に、編集されていない場合のみ最新値に自動同期されます
  * キャンセル操作が最新プリフィル値へのリセットに対応しました

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/734?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->