### PR TITLE
feat(producer-console): operator delta-check button (producer-feed trigger)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -13,6 +13,7 @@ import { HandoffRitualFailureDialog } from "@/components/producer-console/Handof
 import { HandoffRitualOverlay } from "@/components/producer-console/HandoffRitualOverlay";
 import { ProducerConsole } from "@/components/producer-console/ProducerConsole";
 import { ProducerConversationHeader } from "@/components/producer-console/ProducerConversationHeader";
+import { ProducerFeedChip } from "@/components/producer-feed/ProducerFeedChip";
 import { SecurityPanel } from "@/components/settings/SecurityPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import { TerminalList } from "@/components/terminal/TerminalList";
@@ -170,18 +171,19 @@ export function App() {
   const { data: calibrationData } = useCalibration(unitName);
   const { data: producerFeedData } = useProducerFeed(unitName);
 
-  // Operator delta-pull trigger forwarded to the Producer console's
-  // "Check deltas ▸" button. Fires a payload-zero "pull pending" ping to
-  // the unit's live Producer; a 404 just means no live Producer occupies
-  // the unit, so we swallow/log rather than crash the action row (the
-  // button gates on a live producer anyway — see ProducerConsoleActions).
-  const triggerProducerFeed = useCallback(async (unit: string) => {
-    try {
-      await api.triggerProducerFeed(unit);
-    } catch (e) {
+  // Single operator delta-pull trigger, shared by BOTH surfaces (the
+  // top-bar ProducerFeedChip and the Producer console's "Check deltas ▸"
+  // button) — closes over `unitName` so both call it arg-free. Fires a
+  // payload-zero "pull pending" ping to the unit's live Producer; a 404
+  // just means no live Producer occupies the unit, so we swallow/log
+  // rather than crash the caller (the button also gates on a live
+  // producer — see ProducerConsoleActions).
+  const handleTriggerProducerFeed = useCallback(() => {
+    if (unitName === null) return;
+    void api.triggerProducerFeed(unitName).catch((e) => {
       console.warn("producer-feed delta-pull trigger failed", e);
-    }
-  }, []);
+    });
+  }, [unitName]);
 
   // ── Producer handoff-and-restart ritual (lifted to App level) ──
   //
@@ -598,7 +600,12 @@ export function App() {
             onSecurityClick={() => {
               toggleSecurity();
             }}
-            indicatorSlot={<CalibrationChip data={calibrationData} onClick={openCalibration} />}
+            indicatorSlot={
+              <>
+                <ProducerFeedChip data={producerFeedData} onClick={handleTriggerProducerFeed} />
+                <CalibrationChip data={calibrationData} onClick={openCalibration} />
+              </>
+            }
             onReturnToConsole={
               selection !== null || mainPanel !== "agents" ? returnToConsole : undefined
             }
@@ -727,7 +734,7 @@ export function App() {
                 unitName={unitName}
                 calibrationData={calibrationData}
                 producerFeedData={producerFeedData}
-                onTriggerDeltaPull={triggerProducerFeed}
+                onTriggerDeltaPull={handleTriggerProducerFeed}
                 onOpenProducerTerminal={openProducerTerminal}
                 onOpenCalibration={openCalibration}
                 trigger={triggerHandoff}

--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -26,6 +26,7 @@ import { useHandoffRitual } from "@/hooks/useHandoffRitual";
 import { useIdleNotification } from "@/hooks/useIdleNotification";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useNotificationConfig } from "@/hooks/useNotificationConfig";
+import { useProducerFeed } from "@/hooks/useProducerFeed";
 import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
 import { useSplitPane } from "@/hooks/useSplitPane";
 import { useWorktrees } from "@/hooks/useWorktrees";
@@ -167,6 +168,20 @@ export function App() {
     return currentProject.split("/").filter(Boolean).pop() ?? null;
   }, [currentProject]);
   const { data: calibrationData } = useCalibration(unitName);
+  const { data: producerFeedData } = useProducerFeed(unitName);
+
+  // Operator delta-pull trigger forwarded to the Producer console's
+  // "Check deltas ▸" button. Fires a payload-zero "pull pending" ping to
+  // the unit's live Producer; a 404 just means no live Producer occupies
+  // the unit, so we swallow/log rather than crash the action row (the
+  // button gates on a live producer anyway — see ProducerConsoleActions).
+  const triggerProducerFeed = useCallback(async (unit: string) => {
+    try {
+      await api.triggerProducerFeed(unit);
+    } catch (e) {
+      console.warn("producer-feed delta-pull trigger failed", e);
+    }
+  }, []);
 
   // ── Producer handoff-and-restart ritual (lifted to App level) ──
   //
@@ -711,6 +726,8 @@ export function App() {
                 currentProjectPath={currentProject}
                 unitName={unitName}
                 calibrationData={calibrationData}
+                producerFeedData={producerFeedData}
+                onTriggerDeltaPull={triggerProducerFeed}
                 onOpenProducerTerminal={openProducerTerminal}
                 onOpenCalibration={openCalibration}
                 trigger={triggerHandoff}

--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -55,8 +55,10 @@ interface ProducerConsoleProps {
    *  button on `has_pending_delta`. */
   producerFeedData: ProducerFeedStatus | null;
   /** Operator delta-pull trigger forwarded to the "Check deltas ▸"
-   *  button — pings the unit's live Producer to pull pending deltas. */
-  onTriggerDeltaPull: (unit: string) => Promise<void>;
+   *  button — pings the unit's live Producer to pull pending deltas.
+   *  Arg-free: the App-level handler closes over the unit name and is
+   *  shared with the top-bar ProducerFeedChip. */
+  onTriggerDeltaPull: () => void;
   onOpenProducerTerminal: () => void;
   /** Phase B polish v3: invoked from the DirBrowser path when the
    *  operator hasn't selected a project yet. `path` is a repo root;

--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -24,7 +24,11 @@
 
 import { useAgents } from "@/hooks/useAgents";
 import { useHandover } from "@/hooks/useHandover";
-import type { CalibrationResponse, TriggerHandoffRitualRequest } from "@/lib/api";
+import type {
+  CalibrationResponse,
+  ProducerFeedStatus,
+  TriggerHandoffRitualRequest,
+} from "@/lib/api";
 import { ProducerConsoleActions } from "./ProducerConsoleActions";
 import { ProducerCtxHeader } from "./ProducerCtxHeader";
 import { ActiveApproachesSection } from "./sections/ActiveApproachesSection";
@@ -46,6 +50,13 @@ interface ProducerConsoleProps {
   /** Calibration response from the parent (App.tsx already polls);
    *  reused here for the footer's calibration-jump badge. */
   calibrationData: CalibrationResponse | null;
+  /** Producer-feed status from the parent (App.tsx polls in lockstep
+   *  with calibration); gates + badges the footer's "Check deltas ▸"
+   *  button on `has_pending_delta`. */
+  producerFeedData: ProducerFeedStatus | null;
+  /** Operator delta-pull trigger forwarded to the "Check deltas ▸"
+   *  button — pings the unit's live Producer to pull pending deltas. */
+  onTriggerDeltaPull: (unit: string) => Promise<void>;
   onOpenProducerTerminal: () => void;
   /** Phase B polish v3: invoked from the DirBrowser path when the
    *  operator hasn't selected a project yet. `path` is a repo root;
@@ -78,6 +89,8 @@ export function ProducerConsole({
   currentProjectPath,
   unitName,
   calibrationData,
+  producerFeedData,
+  onTriggerDeltaPull,
   onOpenProducerTerminal,
   onLaunchProducerAt,
   onOpenCalibration,
@@ -140,6 +153,8 @@ export function ProducerConsole({
         currentProjectPath={currentProjectPath}
         agents={agents}
         calibrationData={calibrationData}
+        producerFeedData={producerFeedData}
+        onTriggerDeltaPull={onTriggerDeltaPull}
         onOpenProducerTerminal={onOpenProducerTerminal}
         onLaunchProducerAt={onLaunchProducerAt}
         onOpenCalibration={onOpenCalibration}

--- a/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
@@ -56,10 +56,11 @@ interface ProducerConsoleActionsProps {
   /** Producer-feed status (App.tsx polls it next to calibration). Gates
    *  + badges the "Check deltas ▸" button on `has_pending_delta`. */
   producerFeedData: ProducerFeedStatus | null;
-  /** Operator delta-pull trigger. The button calls this with the unit
-   *  name; it fires a payload-zero "pull pending" ping to the unit's
-   *  live Producer (App.tsx owns the call + error swallow). */
-  onTriggerDeltaPull: (unit: string) => Promise<void>;
+  /** Operator delta-pull trigger. Arg-free — the App-level handler
+   *  closes over the unit name (and is shared with the top-bar
+   *  ProducerFeedChip), firing a payload-zero "pull pending" ping to the
+   *  unit's live Producer (App.tsx owns the call + error swallow). */
+  onTriggerDeltaPull: () => void;
   /** Spawn the Producer using the already-selected project. */
   onOpenProducerTerminal: () => void;
   /** Spawn the Producer at an explicit repo root — used after the
@@ -122,7 +123,7 @@ export function ProducerConsoleActions({
   // means no live Producer occupies the unit), so the row never crashes.
   const handleDeltaCheckClick = useCallback(() => {
     if (unitName === null || producer === null || !hasPendingDelta) return;
-    void onTriggerDeltaPull(unitName);
+    onTriggerDeltaPull();
   }, [unitName, producer, hasPendingDelta, onTriggerDeltaPull]);
 
   // Same pattern as NewAgentLauncher: pull `[general] default_project_

--- a/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
@@ -36,6 +36,7 @@ import {
   type AgentSnapshot,
   api,
   type CalibrationResponse,
+  type ProducerFeedStatus,
   type TriggerHandoffRitualRequest,
 } from "@/lib/api";
 import { findProducerForUnit } from "@/lib/producer";
@@ -52,6 +53,13 @@ interface ProducerConsoleActionsProps {
    *  live Producer exists for this unit. */
   agents: AgentSnapshot[];
   calibrationData: CalibrationResponse | null;
+  /** Producer-feed status (App.tsx polls it next to calibration). Gates
+   *  + badges the "Check deltas ▸" button on `has_pending_delta`. */
+  producerFeedData: ProducerFeedStatus | null;
+  /** Operator delta-pull trigger. The button calls this with the unit
+   *  name; it fires a payload-zero "pull pending" ping to the unit's
+   *  live Producer (App.tsx owns the call + error swallow). */
+  onTriggerDeltaPull: (unit: string) => Promise<void>;
   /** Spawn the Producer using the already-selected project. */
   onOpenProducerTerminal: () => void;
   /** Spawn the Producer at an explicit repo root — used after the
@@ -75,6 +83,8 @@ export function ProducerConsoleActions({
   currentProjectPath,
   agents,
   calibrationData,
+  producerFeedData,
+  onTriggerDeltaPull,
   onOpenProducerTerminal,
   onLaunchProducerAt,
   onOpenCalibration,
@@ -89,6 +99,9 @@ export function ProducerConsoleActions({
   const [defaultRoot, setDefaultRoot] = useState<string | null>(null);
   const tripwireCount = calibrationData?.tier1_violations.length ?? 0;
   const calCount = calibrationData?.total_in_window ?? 0;
+  // `has_pending_delta` is optional/absent on the wire when false (#404
+  // lockstep-free bool), so treat `undefined` as `false`.
+  const hasPendingDelta = producerFeedData?.has_pending_delta === true;
 
   const producer = useMemo(
     () => findProducerForUnit(agents, currentProjectPath),
@@ -103,6 +116,14 @@ export function ProducerConsoleActions({
     if (!ok) return;
     void trigger(unitName, { trigger: "manual" });
   }, [producer, unitName, trigger]);
+
+  // Lightweight idempotent ping — unlike Handoff there is no
+  // `window.confirm`. App.tsx owns the call + error swallow (a 404 just
+  // means no live Producer occupies the unit), so the row never crashes.
+  const handleDeltaCheckClick = useCallback(() => {
+    if (unitName === null || producer === null || !hasPendingDelta) return;
+    void onTriggerDeltaPull(unitName);
+  }, [unitName, producer, hasPendingDelta, onTriggerDeltaPull]);
 
   // Same pattern as NewAgentLauncher: pull `[general] default_project_
   // root` lazily on open so an edit in GeneralSection flips the picker
@@ -187,6 +208,30 @@ export function ProducerConsoleActions({
           )}
           {tripwireCount === 0 && calCount > 0 && (
             <span className="ml-1.5 text-[10px] text-muted-foreground">{calCount}</span>
+          )}
+        </button>
+
+        <button
+          type="button"
+          onClick={handleDeltaCheckClick}
+          disabled={unitName === null || producer === null || !hasPendingDelta}
+          className="rounded-md bg-surface px-3 py-1.5 text-xs text-foreground transition-colors hover:bg-surface disabled:cursor-not-allowed disabled:opacity-50"
+          title={
+            unitName === null
+              ? "No unit resolved yet — launch the Producer (or pick a project) first"
+              : producer === null
+                ? "No live Producer for this unit — launch one first via Open Producer terminal"
+                : hasPendingDelta
+                  ? "Ping the Producer to pull pending feed deltas"
+                  : "No pending deltas"
+          }
+        >
+          Check deltas ▸
+          {hasPendingDelta && (
+            <span
+              className="ml-1.5 inline-block h-1.5 w-1.5 rounded-full bg-primary align-middle"
+              aria-hidden="true"
+            />
           )}
         </button>
 

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
@@ -88,6 +88,8 @@ function makeProps(
     currentProjectPath: null,
     unitName: null,
     calibrationData: null,
+    producerFeedData: null,
+    onTriggerDeltaPull: vi.fn(),
     onOpenProducerTerminal: vi.fn(),
     onLaunchProducerAt: vi.fn(),
     onOpenCalibration: vi.fn(),

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
@@ -515,8 +515,8 @@ describe("ProducerConsoleActions — Check deltas button", () => {
     expect(btn).toHaveProperty("disabled", true);
   });
 
-  it("calls onTriggerDeltaPull with the unit name when the enabled button is clicked", () => {
-    const onTriggerDeltaPull = vi.fn().mockResolvedValue(undefined);
+  it("calls onTriggerDeltaPull (arg-free; handler closes over the unit) when the enabled button is clicked", () => {
+    const onTriggerDeltaPull = vi.fn();
     render(
       <ProducerConsoleActions
         {...makeProps({
@@ -530,6 +530,6 @@ describe("ProducerConsoleActions — Check deltas button", () => {
     );
 
     fireEvent.click(screen.getByRole("button", { name: /Check deltas/ }));
-    expect(onTriggerDeltaPull).toHaveBeenCalledWith("proj-a");
+    expect(onTriggerDeltaPull).toHaveBeenCalledTimes(1);
   });
 });

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
@@ -9,7 +9,7 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentSnapshot, CalibrationResponse } from "@/lib/api";
+import type { AgentSnapshot, CalibrationResponse, ProducerFeedStatus } from "@/lib/api";
 import { ProducerConsoleActions } from "../ProducerConsoleActions";
 
 vi.mock("@/components/project/NewAgentLauncher", () => ({
@@ -60,6 +60,8 @@ function makeProps(
     currentProjectPath: null,
     agents: [],
     calibrationData: null,
+    producerFeedData: null,
+    onTriggerDeltaPull: vi.fn(),
     onOpenProducerTerminal: vi.fn(),
     onLaunchProducerAt: vi.fn(),
     onOpenCalibration: vi.fn(),
@@ -113,6 +115,16 @@ function calibrationFixture(overrides: Partial<CalibrationResponse> = {}): Calib
     tier1_routed: overrides.tier1_routed ?? 0,
     tier1_violations: overrides.tier1_violations ?? [],
     recent_false_negatives: overrides.recent_false_negatives ?? [],
+  };
+}
+
+function producerFeedFixture(overrides: Partial<ProducerFeedStatus> = {}): ProducerFeedStatus {
+  return {
+    unit: overrides.unit ?? "test-unit",
+    producer_address: overrides.producer_address ?? "test-unit.producer",
+    tip: overrides.tip ?? 0n,
+    last_served_cursor: overrides.last_served_cursor ?? 0n,
+    has_pending_delta: overrides.has_pending_delta,
   };
 }
 
@@ -438,5 +450,86 @@ describe("ProducerConsoleActions — Handoff & restart button", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Handoff & restart/ }));
     expect(trigger).toHaveBeenCalledWith("proj-a", { trigger: "manual" });
+  });
+});
+
+describe("ProducerConsoleActions — Check deltas button", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // A live Producer at the unit's repo root — the gate also requires
+  // this (matches the Handoff button's `findProducerForUnit` precedent).
+  function liveProducer() {
+    return agent({
+      id: "claude:abc-123",
+      cwd: "/home/u/proj-a",
+      git_common_dir: "/home/u/proj-a/.git",
+      is_worktree: false,
+    });
+  }
+
+  it("is disabled when has_pending_delta is false/undefined even with a live Producer", () => {
+    render(
+      <ProducerConsoleActions
+        {...makeProps({
+          unitName: "proj-a",
+          currentProjectPath: "/home/u/proj-a",
+          agents: [liveProducer()],
+          // `has_pending_delta` left undefined — absent on the wire ⇒ false.
+          producerFeedData: producerFeedFixture(),
+        })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /Check deltas/ });
+    expect(btn).toHaveProperty("disabled", true);
+  });
+
+  it("is enabled when a live Producer exists AND has_pending_delta is true", () => {
+    render(
+      <ProducerConsoleActions
+        {...makeProps({
+          unitName: "proj-a",
+          currentProjectPath: "/home/u/proj-a",
+          agents: [liveProducer()],
+          producerFeedData: producerFeedFixture({ has_pending_delta: true, tip: 3n }),
+        })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /Check deltas/ });
+    expect(btn).toHaveProperty("disabled", false);
+  });
+
+  it("stays disabled with a pending delta but no live Producer", () => {
+    render(
+      <ProducerConsoleActions
+        {...makeProps({
+          unitName: "proj-a",
+          currentProjectPath: "/home/u/proj-a",
+          agents: [],
+          producerFeedData: producerFeedFixture({ has_pending_delta: true }),
+        })}
+      />,
+    );
+    const btn = screen.getByRole("button", { name: /Check deltas/ });
+    expect(btn).toHaveProperty("disabled", true);
+  });
+
+  it("calls onTriggerDeltaPull with the unit name when the enabled button is clicked", () => {
+    const onTriggerDeltaPull = vi.fn().mockResolvedValue(undefined);
+    render(
+      <ProducerConsoleActions
+        {...makeProps({
+          unitName: "proj-a",
+          currentProjectPath: "/home/u/proj-a",
+          agents: [liveProducer()],
+          producerFeedData: producerFeedFixture({ has_pending_delta: true }),
+          onTriggerDeltaPull,
+        })}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Check deltas/ }));
+    expect(onTriggerDeltaPull).toHaveBeenCalledWith("proj-a");
   });
 });

--- a/clients/react/src/components/producer-feed/ProducerFeedChip.tsx
+++ b/clients/react/src/components/producer-feed/ProducerFeedChip.tsx
@@ -1,0 +1,40 @@
+// Top-bar always-on pending-delta indicator.
+//
+// Surfaces the unit's producer-feed delta-gate in one chip:
+//
+// - has_pending_delta === true → informational ⚡ 差分 pill — there is
+//   something for the Producer to pull; clicking pings it.
+// - else (no data, or gate false) → no chip rendered at all
+//
+// Deliberately NOT the destructive-red alarm styling of CalibrationChip:
+// a pending delta is "there's something to pull", not a tier-1 alarm, so
+// it uses the informational `primary` accent. The chip shares the single
+// `handleTriggerProducerFeed` callback with the action-row button (App
+// level) — it is the same idempotent ping from a second surface.
+// Quiet-when-nothing mirrors CalibrationChip returning null on an empty
+// store: no chip, no noise.
+
+import type { ProducerFeedStatus } from "@/lib/api";
+
+interface ProducerFeedChipProps {
+  data: ProducerFeedStatus | null;
+  onClick: () => void;
+}
+
+export function ProducerFeedChip({ data, onClick }: ProducerFeedChipProps) {
+  // `has_pending_delta` is optional/absent on the wire when false (#404
+  // lockstep-free bool); anything other than an explicit `true` is quiet.
+  if (!data || data.has_pending_delta !== true) {
+    return null;
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="rounded-full bg-primary/20 px-2.5 py-0.5 text-[11px] font-semibold text-primary hover:bg-primary/30 transition-colors"
+      title="Pending feed deltas — click to have the Producer pull them"
+    >
+      ⚡ 差分
+    </button>
+  );
+}

--- a/clients/react/src/components/producer-feed/__tests__/ProducerFeedChip.test.tsx
+++ b/clients/react/src/components/producer-feed/__tests__/ProducerFeedChip.test.tsx
@@ -1,0 +1,44 @@
+// @vitest-environment jsdom
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { ProducerFeedStatus } from "@/lib/api";
+import { ProducerFeedChip } from "../ProducerFeedChip";
+
+function makeData(overrides: Partial<ProducerFeedStatus> = {}): ProducerFeedStatus {
+  return {
+    unit: "u",
+    producer_address: "u.producer",
+    tip: 0n,
+    last_served_cursor: 0n,
+    has_pending_delta: undefined,
+    ...overrides,
+  };
+}
+
+describe("ProducerFeedChip", () => {
+  it("renders nothing when there is no data", () => {
+    const { container } = render(<ProducerFeedChip data={null} onClick={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders nothing when has_pending_delta is false/undefined", () => {
+    // Quiet-when-nothing — absent on the wire ⇒ false; no chip, no noise.
+    const { container } = render(<ProducerFeedChip data={makeData()} onClick={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("renders the pill and fires onClick when has_pending_delta is true", () => {
+    const onClick = vi.fn();
+    render(
+      <ProducerFeedChip data={makeData({ has_pending_delta: true, tip: 3n })} onClick={onClick} />,
+    );
+    const btn = screen.getByRole("button");
+    expect(btn.textContent ?? "").toMatch(/⚡\s*差分/);
+    // Informational accent, NOT the destructive alarm styling.
+    expect(btn.className).toContain("text-primary");
+    expect(btn.className).not.toContain("destructive");
+
+    fireEvent.click(btn);
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/react/src/hooks/__tests__/useProducerFeed.test.ts
+++ b/clients/react/src/hooks/__tests__/useProducerFeed.test.ts
@@ -1,19 +1,35 @@
 // @vitest-environment jsdom
 //
 // useProducerFeed — the producer-feed status poller behind the Producer
-// console's "Check deltas ▸" button. We mock `api.producerFeed` so each
-// test drives a deterministic response and asserts the sibling-shaped
-// contract (mirrors useUnitPrs.test): `unit = null` parks (no fetch),
+// console's "Check deltas ▸" button + top-bar chip. We mock
+// `api.producerFeed` so each test drives a deterministic response and
+// asserts the sibling-shaped contract: `unit = null` parks (no fetch),
 // the initial fetch flips `loading`, errors surface without fabricating
 // data, a unit change re-fetches, and the 60s poll keeps the last
 // response visible (anti-flicker).
 //
-// Timers stay real and the poll is exercised by capturing the
-// `window.setInterval` callback directly — `@testing-library`'s
-// `waitFor` cannot make progress under fake timers, and a real 60s wait
-// is not viable in a unit test.
+// IMPORTANT — why this does NOT mirror useUnitPrs.test's call-through
+// `vi.spyOn(window, "setInterval")` + `waitFor`:
+//
+//   A call-through spy schedules a REAL `window.setInterval(fetchOnce,
+//   60_000)`. That timer (and any `fetchOnce` it or `waitFor`'s own
+//   internal polling leaves in flight) can outlive the file's jsdom
+//   environment; when the pending `fetchOnce` resolves AFTER teardown,
+//   its `setLoading(false)` runs against a `window` that no longer
+//   exists → "ReferenceError: window is not defined", which vitest
+//   surfaces as an unhandled rejection → process exit 1 *even though
+//   every assertion passed*. This actually red-lit PR #738's CI (stack:
+//   `fetchOnce src/hooks/useProducerFeed.ts:73`) while the local run —
+//   shorter, so the race didn't trip — looked green.
+//
+//   The invariant is therefore: no real `window.setInterval` may survive
+//   the test, and no `fetchOnce` may be left in flight at teardown. We
+//   mock `setInterval` to *record* the poll callback and return a dummy
+//   id (nothing real scheduled), mock `clearInterval` to a no-op, and
+//   flush the async fetch deterministically with `act` (no `waitFor`,
+//   which itself leans on a real `setInterval`).
 
-import { act, renderHook, waitFor } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/lib/api", () => ({
@@ -36,18 +52,37 @@ function status(unit: string, pending: boolean): ProducerFeedStatus {
   };
 }
 
+// Poll callbacks the hook hands to `window.setInterval`, captured WITHOUT
+// scheduling a real timer (see the file header for why this matters).
+let pollCallbacks: Array<() => void>;
+
+// Drain pending microtasks (the `await api.producerFeed(...)` resolution
+// and the React state update it triggers) inside an `act` boundary, so
+// nothing is left in flight when the test returns.
+const flush = () => act(async () => undefined);
+
+beforeEach(() => {
+  vi.mocked(api.producerFeed).mockReset();
+  pollCallbacks = [];
+  vi.spyOn(window, "setInterval").mockImplementation(((cb: () => void) => {
+    pollCallbacks.push(cb);
+    // Dummy id — no real timer scheduled, so nothing survives teardown.
+    return 1 as unknown as ReturnType<typeof window.setInterval>;
+  }) as typeof window.setInterval);
+  vi.spyOn(window, "clearInterval").mockImplementation(
+    (() => undefined) as typeof window.clearInterval,
+  );
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
 describe("useProducerFeed", () => {
-  beforeEach(() => {
-    vi.mocked(api.producerFeed).mockReset();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
-  });
-
-  it("parks on unit=null — no fetch, not loading", () => {
+  it("parks on unit=null — no fetch, not loading, no timer", () => {
     const { result } = renderHook(() => useProducerFeed(null));
     expect(api.producerFeed).not.toHaveBeenCalled();
+    expect(pollCallbacks).toHaveLength(0);
     expect(result.current.loading).toBe(false);
     expect(result.current.data).toBeNull();
     expect(result.current.error).toBeNull();
@@ -57,10 +92,9 @@ describe("useProducerFeed", () => {
     vi.mocked(api.producerFeed).mockResolvedValue(status("tmai", true));
     const { result } = renderHook(() => useProducerFeed("tmai"));
     expect(result.current.loading).toBe(true);
-    await waitFor(() => {
-      expect(result.current.loading).toBe(false);
-    });
+    await flush();
     expect(api.producerFeed).toHaveBeenCalledWith("tmai");
+    expect(result.current.loading).toBe(false);
     expect(result.current.data?.has_pending_delta).toBe(true);
     expect(result.current.error).toBeNull();
   });
@@ -68,9 +102,8 @@ describe("useProducerFeed", () => {
   it("surfaces a fetch error without fabricating data", async () => {
     vi.mocked(api.producerFeed).mockRejectedValue(new Error("boom"));
     const { result } = renderHook(() => useProducerFeed("tmai"));
-    await waitFor(() => {
-      expect(result.current.error?.message).toBe("boom");
-    });
+    await flush();
+    expect(result.current.error?.message).toBe("boom");
     expect(result.current.data).toBeNull();
   });
 
@@ -81,34 +114,32 @@ describe("useProducerFeed", () => {
     const { result, rerender } = renderHook(({ u }) => useProducerFeed(u), {
       initialProps: { u: "tmai" },
     });
-    await waitFor(() => expect(result.current.data?.unit).toBe("tmai"));
+    await flush();
+    expect(result.current.data?.unit).toBe("tmai");
 
     rerender({ u: "other" });
     // Cleared synchronously on unit change so the old unit's pending flag
     // is never shown under the new unit's context.
     expect(result.current.data).toBeNull();
-    await waitFor(() => expect(result.current.data?.unit).toBe("other"));
+    await flush();
+    expect(result.current.data?.unit).toBe("other");
     expect(result.current.data?.has_pending_delta).toBeUndefined();
   });
 
-  it("keeps the last response visible across the 60s poll", async () => {
-    // Spy only — `vi.spyOn` calls through, so `waitFor`'s own internal
-    // `setInterval` polling still works. We read the captured callback
-    // and fire it by hand instead of waiting a real 60s.
-    const setIntervalSpy = vi.spyOn(window, "setInterval");
-
+  it("keeps the last response visible across a poll (anti-flicker)", async () => {
     vi.mocked(api.producerFeed).mockResolvedValue(status("tmai", true));
     const { result } = renderHook(() => useProducerFeed("tmai"));
-    await waitFor(() => expect(result.current.data?.has_pending_delta).toBe(true));
+    await flush();
+    expect(result.current.data?.has_pending_delta).toBe(true);
 
-    const tick = setIntervalSpy.mock.calls[0]?.[0] as (() => void) | undefined;
-    expect(typeof tick).toBe("function");
-
+    // The hook handed exactly one poll callback to `setInterval`; fire it
+    // by hand (no real 60s wait, no real timer) to exercise the re-poll.
+    expect(pollCallbacks).toHaveLength(1);
     await act(async () => {
-      tick?.();
+      pollCallbacks[0]?.();
     });
-    await waitFor(() => expect(api.producerFeed).toHaveBeenCalledTimes(2));
-    // Last response stays visible (anti-flicker) — never cleared on a poll.
+    expect(api.producerFeed).toHaveBeenCalledTimes(2);
+    // Last response stays visible — never cleared on a poll.
     expect(result.current.data?.has_pending_delta).toBe(true);
   });
 });

--- a/clients/react/src/hooks/__tests__/useProducerFeed.test.ts
+++ b/clients/react/src/hooks/__tests__/useProducerFeed.test.ts
@@ -1,0 +1,114 @@
+// @vitest-environment jsdom
+//
+// useProducerFeed — the producer-feed status poller behind the Producer
+// console's "Check deltas ▸" button. We mock `api.producerFeed` so each
+// test drives a deterministic response and asserts the sibling-shaped
+// contract (mirrors useUnitPrs.test): `unit = null` parks (no fetch),
+// the initial fetch flips `loading`, errors surface without fabricating
+// data, a unit change re-fetches, and the 60s poll keeps the last
+// response visible (anti-flicker).
+//
+// Timers stay real and the poll is exercised by capturing the
+// `window.setInterval` callback directly — `@testing-library`'s
+// `waitFor` cannot make progress under fake timers, and a real 60s wait
+// is not viable in a unit test.
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    producerFeed: vi.fn(),
+  },
+}));
+
+import type { ProducerFeedStatus } from "@/lib/api";
+import { api } from "@/lib/api";
+import { useProducerFeed } from "../useProducerFeed";
+
+function status(unit: string, pending: boolean): ProducerFeedStatus {
+  return {
+    unit,
+    producer_address: `${unit}.producer`,
+    tip: pending ? 3n : 0n,
+    last_served_cursor: 0n,
+    has_pending_delta: pending ? true : undefined,
+  };
+}
+
+describe("useProducerFeed", () => {
+  beforeEach(() => {
+    vi.mocked(api.producerFeed).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parks on unit=null — no fetch, not loading", () => {
+    const { result } = renderHook(() => useProducerFeed(null));
+    expect(api.producerFeed).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetches on a real unit and exposes the response", async () => {
+    vi.mocked(api.producerFeed).mockResolvedValue(status("tmai", true));
+    const { result } = renderHook(() => useProducerFeed("tmai"));
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(api.producerFeed).toHaveBeenCalledWith("tmai");
+    expect(result.current.data?.has_pending_delta).toBe(true);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a fetch error without fabricating data", async () => {
+    vi.mocked(api.producerFeed).mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useProducerFeed("tmai"));
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe("boom");
+    });
+    expect(result.current.data).toBeNull();
+  });
+
+  it("re-fetches when the unit changes and clears the previous status", async () => {
+    vi.mocked(api.producerFeed).mockImplementation((u: string) =>
+      Promise.resolve(status(u, u === "tmai")),
+    );
+    const { result, rerender } = renderHook(({ u }) => useProducerFeed(u), {
+      initialProps: { u: "tmai" },
+    });
+    await waitFor(() => expect(result.current.data?.unit).toBe("tmai"));
+
+    rerender({ u: "other" });
+    // Cleared synchronously on unit change so the old unit's pending flag
+    // is never shown under the new unit's context.
+    expect(result.current.data).toBeNull();
+    await waitFor(() => expect(result.current.data?.unit).toBe("other"));
+    expect(result.current.data?.has_pending_delta).toBeUndefined();
+  });
+
+  it("keeps the last response visible across the 60s poll", async () => {
+    // Spy only — `vi.spyOn` calls through, so `waitFor`'s own internal
+    // `setInterval` polling still works. We read the captured callback
+    // and fire it by hand instead of waiting a real 60s.
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+
+    vi.mocked(api.producerFeed).mockResolvedValue(status("tmai", true));
+    const { result } = renderHook(() => useProducerFeed("tmai"));
+    await waitFor(() => expect(result.current.data?.has_pending_delta).toBe(true));
+
+    const tick = setIntervalSpy.mock.calls[0]?.[0] as (() => void) | undefined;
+    expect(typeof tick).toBe("function");
+
+    await act(async () => {
+      tick?.();
+    });
+    await waitFor(() => expect(api.producerFeed).toHaveBeenCalledTimes(2));
+    // Last response stays visible (anti-flicker) — never cleared on a poll.
+    expect(result.current.data?.has_pending_delta).toBe(true);
+  });
+});

--- a/clients/react/src/hooks/useProducerFeed.ts
+++ b/clients/react/src/hooks/useProducerFeed.ts
@@ -1,0 +1,89 @@
+// Polling hook for the unit's producer-feed status — the mechanical
+// delta-gate the operator "Check deltas ▸" button reads.
+//
+// Per the 2026-05-26 producer-feed amendment §wire, the gate
+// (`has_pending_delta = tip > last_served_cursor`) moves on the
+// timescale of worker activity landing on the unit's feed. A 60-second
+// poll matches the calibration sibling and is plenty for a manual
+// operator affordance; we deliberately do not wire SSE here yet (the
+// button does not need real-time precision, the cache miss on the next
+// session start cleans up any tail).
+//
+// The hook keeps the previous response visible while a re-fetch is in
+// flight (`loading` reflects only the initial fetch) so the button's
+// pending-state badge does not flicker between renders.
+
+import { useEffect, useRef, useState } from "react";
+import { api, type ProducerFeedStatus } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface UseProducerFeedResult {
+  data: ProducerFeedStatus | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Poll the unit's producer-feed status at `POLL_INTERVAL_MS`. Returns
+ * the latest response, an initial-load `loading` flag, and the most
+ * recent error (cleared on a successful fetch).
+ *
+ * `unit = null` parks the hook: no fetch, no interval, no data. Useful
+ * when the UI has no project selected and we want the delta-check
+ * button to sit dormant rather than poll a non-existent unit.
+ */
+export function useProducerFeed(unit: string | null): UseProducerFeedResult {
+  const [data, setData] = useState<ProducerFeedStatus | null>(null);
+  const [loading, setLoading] = useState(unit !== null);
+  const [error, setError] = useState<Error | null>(null);
+  // Track the latest fetch so an in-flight response from a previous unit
+  // cannot stamp over a newer unit's data.
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    if (!unit) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    // Clear on unit *change* (this effect's only re-trigger — dep is
+    // [unit]) so a previous query's pending-badge is never shown under a
+    // new unit's context. The 60s same-query re-poll goes through
+    // fetchOnce, which intentionally keeps the last response visible
+    // (anti-flicker); that path is untouched. Mirrors the same guard in
+    // useCalibration / useApproaches.
+    setData(null);
+    setError(null);
+    setLoading(true);
+
+    const fetchOnce = async () => {
+      try {
+        const res = await api.producerFeed(unit);
+        if (myGen !== generationRef.current) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (myGen !== generationRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (myGen === generationRef.current) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [unit]);
+
+  return { data, loading, error };
+}

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -14,6 +14,8 @@ import type { HandoffRitualEvent } from "@/types/generated/HandoffRitualEvent";
 import type { Outcome } from "@/types/generated/Outcome";
 import type { PermissionMode } from "@/types/generated/PermissionMode";
 import type { PrDiffResponse } from "@/types/generated/PrDiffResponse";
+import type { ProducerFeedStatus } from "@/types/generated/ProducerFeedStatus";
+import type { ProducerPullTrigger } from "@/types/generated/ProducerPullTrigger";
 import type { PrSummaryWire } from "@/types/generated/PrSummaryWire";
 import type { QueueAgentEntry } from "@/types/generated/QueueAgentEntry";
 import type { QueueSnapshot } from "@/types/generated/QueueSnapshot";
@@ -42,6 +44,8 @@ export type {
   Outcome,
   PermissionMode,
   PrDiffResponse,
+  ProducerFeedStatus,
+  ProducerPullTrigger,
   PrSummaryWire,
   QueueAgentEntry,
   QueueSnapshot,
@@ -1484,6 +1488,19 @@ export const api = {
   // the CLI's default.
   calibration: (unit: string, days = 90) =>
     apiFetch<CalibrationResponse>(`/units/${encodeURIComponent(unit)}/calibration?days=${days}`),
+
+  // Producer-feed status + operator delta-pull trigger (2026-05-26
+  // amendment §wire / §1). `producerFeed` reads the mechanical delta-gate
+  // (`has_pending_delta = tip > last_served_cursor`) the WebUI's manual
+  // "Check deltas ▸" button enables on; `triggerProducerFeed` fires a
+  // payload-zero "pull pending" ping to the unit's live Producer (404
+  // when no live Producer occupies the unit).
+  producerFeed: (unit: string) =>
+    apiFetch<ProducerFeedStatus>(`/units/${encodeURIComponent(unit)}/producer-feed`),
+  triggerProducerFeed: (unit: string) =>
+    apiFetch<ProducerPullTrigger>(`/units/${encodeURIComponent(unit)}/producer-feed/trigger`, {
+      method: "POST",
+    }),
 
   // Decisions view — bucketed projection of `compose()`'s Settled section
   // per `2026-05-11-producer-conversation-workbench.md` §1. Returns

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -248,6 +248,11 @@ export const api = {
   // calibration store; no Tauri-specific path needed)
   calibration: (unit: string, days?: number) => httpApi.calibration(unit, days),
 
+  // Producer-feed status + delta-pull trigger (HTTP only — engine-side
+  // feed bookkeeping plus a Producer ping; no Tauri-specific path needed)
+  producerFeed: (unit: string) => httpApi.producerFeed(unit),
+  triggerProducerFeed: (unit: string) => httpApi.triggerProducerFeed(unit),
+
   // Decisions view (HTTP only — on-demand JSON projection of compose()'s
   // Settled section; no Tauri-specific path needed)
   decisions: (unit: string) => httpApi.decisions(unit),


### PR DESCRIPTION
## What this adds

An operator **Check deltas ▸** button in the Producer console action row (right after **Calibration ▸**) that fires a payload-zero "pull pending" ping to the unit's live Producer, so the operator can manually nudge it to pull pending unit-feed deltas.

### Changes (clients/react only — no tmai-core / generated-artifact edits)
- **`src/lib/api-http.ts`** — `producerFeed(unit)` (`GET /units/{unit}/producer-feed`) + `triggerProducerFeed(unit)` (`POST /units/{unit}/producer-feed/trigger`), next to `calibration`. Surfaces the generated `ProducerFeedStatus` / `ProducerPullTrigger` types through the `@/lib/api` re-export block (imported, never redefined).
- **`src/lib/api-tauri.ts`** — both methods delegated to `httpApi`, mirroring `calibration` (HTTP-only).
- **`src/hooks/useProducerFeed.ts`** — new 60s poll hook, a close copy of `useCalibration` (generation-ref guard, anti-flicker keeps prior data, `unit=null` parks).
- **`src/App.tsx`** — `useProducerFeed(unitName)` beside `useCalibration`; threads `producerFeedData` + an `onTriggerDeltaPull` callback (which owns the `api.triggerProducerFeed` call and swallows/logs the 404 = no-live-Producer case) down via `<ProducerConsole>`, exactly as `calibrationData` is threaded.
- **`ProducerConsole.tsx` / `ProducerConsoleActions.tsx`** — props plumbed through; button enabled only when `unitName !== null && producer !== null && has_pending_delta === true`, otherwise disabled with the same `disabled:opacity-50 cursor-not-allowed` styling + an explanatory title. A small pending dot shows when `has_pending_delta` is true. No `window.confirm` (lightweight idempotent ping).
- **Tests** — extend `ProducerConsoleActions.test.tsx` (disabled when no pending / enabled with live Producer + pending / click calls trigger with the unit name, via `fireEvent.click`) and add `useProducerFeed.test.ts` (poll/park, error, unit-change, anti-flicker).

Scope is the manual operator button + its polling status + tests — **no** auto-pull-on-pending, **no** SSE, **no** taxonomy/expand work.

## Local gates (clients/react, all green)
- ✅ `pnpm install`
- ✅ `pnpm lint` (biome check — format + lint)
- ✅ `pnpm exec tsc -b`
- ✅ `pnpm build`
- ✅ `pnpm test` (496 passed | 2 skipped; +29 in the two touched/new files)

Not merging — leaving this for Producer review against the brief, then operator merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)