### PR TITLE
chore(gen): sync generated spec + types from tmai-core@21d8b4b (PrReviewFeedback.branch)

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -3434,6 +3434,10 @@
     {
       "description": "A PR received review feedback (changes requested)",
       "properties": {
+        "branch": {
+          "description": "Head branch name. Carried so the unit-delta-feed writer can run\nthe *same* dispatched-worker gate it runs for `PrCreated`\n(`pr_branch_attribution` + `dispatch_project_root_for_branch`).\n`#[serde(default)]` keeps the field backward-compatible on the\nwire, matching `PrCreated`/`PrClosed` which already carry `branch`.",
+          "type": "string"
+        },
         "comments_summary": {
           "description": "Summary of review comments",
           "type": "string"

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -1480,6 +1480,10 @@
               "type"
             ],
             "properties": {
+              "branch": {
+                "type": "string",
+                "description": "Head branch name. Carried so the unit-delta-feed writer can run\nthe *same* dispatched-worker gate it runs for `PrCreated`\n(`pr_branch_attribution` + `dispatch_project_root_for_branch`).\n`#[serde(default)]` keeps the field backward-compatible on the\nwire, matching `PrCreated`/`PrClosed` which already carry `branch`."
+              },
               "comments_summary": {
                 "type": "string",
                 "description": "Summary of review comments"

--- a/clients/ratatui/src/types/generated/core_event.rs
+++ b/clients/ratatui/src/types/generated/core_event.rs
@@ -99,6 +99,8 @@ pub enum CoreEvent {
         title: String,
     },
     PrReviewFeedback {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        branch: Option<String>,
         comments_summary: String,
         pr_number: i64,
         #[serde(skip_serializing_if = "Option::is_none")]

--- a/clients/react/src/types/generated/CoreEvent.ts
+++ b/clients/react/src/types/generated/CoreEvent.ts
@@ -235,7 +235,15 @@ comments_summary: string,
  * can dedupe on `(pr_number, review_count)` instead of
  * collapsing distinct rounds into one entry.
  */
-review_count: bigint, } | { "type": "PrClosed", 
+review_count: bigint, 
+/**
+ * Head branch name. Carried so the unit-delta-feed writer can run
+ * the *same* dispatched-worker gate it runs for `PrCreated`
+ * (`pr_branch_attribution` + `dispatch_project_root_for_branch`).
+ * `#[serde(default)]` keeps the field backward-compatible on the
+ * wire, matching `PrCreated`/`PrClosed` which already carry `branch`.
+ */
+branch: string, } | { "type": "PrClosed", 
 /**
  * PR number
  */


### PR DESCRIPTION
Generated-artifact mirror for **tmai-core #457** (edge-A expansion). The gen-spec-pr workflow is billing-dead, so the Producer mirrors manually (bot/ branch prefix is exempt from the no-hand-edits check).

`CoreEvent::PrReviewFeedback` now carries `branch` (non-breaking optional field) so the unit-delta-feed writer can run the same dispatched-worker gate it runs for `PrCreated`. Regenerated via `cargo xtask {openapi,schema,mcp-snapshot,ts-types,rust-types}`:

- `api-spec/openapi.json` — +branch on PrReviewFeedback
- `api-spec/corevents.schema.json` — +branch on PrReviewFeedback
- `clients/react/src/types/generated/CoreEvent.ts` — +branch
- `clients/ratatui/src/types/generated/core_event.rs` — +branch

Non-breaking: optional field, api-spec version unchanged. mcp-tools.json unchanged (CoreEvent change doesn't touch MCP tools).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * PR受け取り時のレビューフィードバックイベントにブランチ名フィールドが追加されました。このフィールドはオプショナルであり、PR作成・終了などの他のPRイベントと同様にブランチ情報がイベントに含まれるようになります。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/739?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->