### PR TITLE
chore(gen): sync generated spec + types from tmai-core@256333f (ApproachStatus planned/partial)

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -100,8 +100,10 @@
       "type": "string"
     },
     "ApproachStatus": {
-      "description": "Lifecycle position of an approach record.\n\nUnlike [`super::decision::DecisionStatus`], the approach lifecycle resolves\noutward (`active → validated / rejected / replaced`) rather than through a\nsupersede chain. A validated / rejected approach is preserved as the\naudit-trail record of *what we tried and what happened*; a follow-up\ndecision (if any) is authored separately rather than in-place.",
+      "description": "Lifecycle position of an approach record.\n\nUnlike [`super::decision::DecisionStatus`], the approach lifecycle resolves\noutward (`planned → partial → active → validated / rejected / replaced`)\nrather than through a supersede chain. The two pre-active states split what\n`active` used to overload: the boundary is **whether `success-signal` can\nfire yet (is the approach evaluable?)** — a single binary point, not a\npercent-complete continuum. A validated / rejected approach is preserved as\nthe audit-trail record of *what we tried and what happened*; a follow-up\ndecision (if any) is authored separately rather than in-place.\n\nSee `doc/approaches/2026-05-27-approach-lifecycle-planned-and-partial-states.md`.",
       "enum": [
+        "planned",
+        "partial",
         "active",
         "validated",
         "rejected",

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -524,8 +524,10 @@
       },
       "ApproachStatus": {
         "type": "string",
-        "description": "Lifecycle position of an approach record.\n\nUnlike [`super::decision::DecisionStatus`], the approach lifecycle resolves\noutward (`active → validated / rejected / replaced`) rather than through a\nsupersede chain. A validated / rejected approach is preserved as the\naudit-trail record of *what we tried and what happened*; a follow-up\ndecision (if any) is authored separately rather than in-place.",
+        "description": "Lifecycle position of an approach record.\n\nUnlike [`super::decision::DecisionStatus`], the approach lifecycle resolves\noutward (`planned → partial → active → validated / rejected / replaced`)\nrather than through a supersede chain. The two pre-active states split what\n`active` used to overload: the boundary is **whether `success-signal` can\nfire yet (is the approach evaluable?)** — a single binary point, not a\npercent-complete continuum. A validated / rejected approach is preserved as\nthe audit-trail record of *what we tried and what happened*; a follow-up\ndecision (if any) is authored separately rather than in-place.\n\nSee `doc/approaches/2026-05-27-approach-lifecycle-planned-and-partial-states.md`.",
         "enum": [
+          "planned",
+          "partial",
           "active",
           "validated",
           "rejected",

--- a/clients/ratatui/src/types/generated/approach_status.rs
+++ b/clients/ratatui/src/types/generated/approach_status.rs
@@ -10,6 +10,8 @@ use std::collections::HashMap;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum ApproachStatus {
+    planned,
+    partial,
     active,
     validated,
     rejected,

--- a/clients/react/src/types/generated/ApproachStatus.ts
+++ b/clients/react/src/types/generated/ApproachStatus.ts
@@ -4,9 +4,14 @@
  * Lifecycle position of an approach record.
  *
  * Unlike [`super::decision::DecisionStatus`], the approach lifecycle resolves
- * outward (`active → validated / rejected / replaced`) rather than through a
- * supersede chain. A validated / rejected approach is preserved as the
- * audit-trail record of *what we tried and what happened*; a follow-up
+ * outward (`planned → partial → active → validated / rejected / replaced`)
+ * rather than through a supersede chain. The two pre-active states split what
+ * `active` used to overload: the boundary is **whether `success-signal` can
+ * fire yet (is the approach evaluable?)** — a single binary point, not a
+ * percent-complete continuum. A validated / rejected approach is preserved as
+ * the audit-trail record of *what we tried and what happened*; a follow-up
  * decision (if any) is authored separately rather than in-place.
+ *
+ * See `doc/approaches/2026-05-27-approach-lifecycle-planned-and-partial-states.md`.
  */
-export type ApproachStatus = "active" | "validated" | "rejected" | "replaced";
+export type ApproachStatus = "planned" | "partial" | "active" | "validated" | "rejected" | "replaced";


### PR DESCRIPTION
## Summary

Generated-artifact mirror for **tmai-core #458** (approach-lifecycle Phase 1). The gen-spec-pr workflow is billing-dead, so the Producer mirrors manually (bot/ branch prefix is exempt from no-hand-edits).

`ApproachStatus` gains `planned` and `partial` variants (non-breaking enum additions, ordered before `active`). Regenerated via `cargo xtask {openapi,schema,mcp-snapshot,ts-types,rust-types}`:

- `api-spec/openapi.json` / `api-spec/corevents.schema.json` — +planned/+partial
- `clients/react/src/types/generated/ApproachStatus.ts` — +planned/+partial
- `clients/ratatui/src/types/generated/approach_status.rs` — +Planned/+Partial

Non-breaking; api-spec version unchanged. mcp-tools.json unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * アプローチのステータスに「計画中」と「部分的」の新しい状態を追加しました。アプローチのライフサイクルが拡張され、より詳細な進捗追跡が可能になりました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/740?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->