### PR TITLE
feat(react): consume units wire — cross-repo Producer resolver + dormant-unit reconciliation (#439)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -30,6 +30,7 @@ import { useNotificationConfig } from "@/hooks/useNotificationConfig";
 import { useProducerFeed } from "@/hooks/useProducerFeed";
 import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
 import { useSplitPane } from "@/hooks/useSplitPane";
+import { useUnits } from "@/hooks/useUnits";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import { api, groupByProject, isAiAgentLoose, type Selection, setCallerCwd } from "@/lib/api";
 import { findProducerForUnit } from "@/lib/producer";
@@ -170,6 +171,16 @@ export function App() {
   }, [currentProject]);
   const { data: calibrationData } = useCalibration(unitName);
   const { data: producerFeedData } = useProducerFeed(unitName);
+  // Configured-unit membership (tmai-core #460 — wire half of #439).
+  // Threaded into `findProducerForUnit` below so multi-repo units
+  // resolve their Producer against the primary repo specifically,
+  // not against whichever repo `currentProject` happens to point at.
+  // `useHandover` consumes the same wire for cross-unit reconciliation.
+  const { data: unitsData } = useUnits();
+  const unitReposForCurrent = useMemo(() => {
+    if (unitName === null) return null;
+    return unitsData?.units.find((u) => u.name === unitName)?.repos ?? null;
+  }, [unitsData, unitName]);
 
   // Single operator delta-pull trigger, shared by BOTH surfaces (the
   // top-bar ProducerFeedChip and the Producer console's "Check deltas ▸"
@@ -212,9 +223,16 @@ export function App() {
   // this Producer), the failure dialog's Force-kill target, and its
   // Resume-in-CC id. Shares the `findProducerForUnit` resolver with the
   // digest button and the ctx readout so all surfaces agree.
+  //
+  // Cross-repo aware: when the units wire has resolved this unit's
+  // membership, we pass the full `UnitRepoWire[]` so the resolver can
+  // pin the Producer to the unit's PRIMARY repo even if `currentProject`
+  // happens to point at a non-primary repo. The single-path fallback
+  // keeps the resolver working pre-wire-load and for cwd-synthesized
+  // units that the units endpoint doesn't enumerate.
   const producerForUnit = useMemo(
-    () => findProducerForUnit(agents, currentProject),
-    [agents, currentProject],
+    () => findProducerForUnit(agents, unitReposForCurrent ?? currentProject),
+    [agents, unitReposForCurrent, currentProject],
   );
 
   // Auto-dismiss `ready` with a brief success toast (handoff-lifecycle

--- a/clients/react/src/components/producer-console/__tests__/AttentionStrip.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/AttentionStrip.test.tsx
@@ -46,7 +46,6 @@ function digest(overrides: Partial<HandoverDigest> = {}): HandoverDigest {
     crossUnit: overrides.crossUnit ?? { units: [] },
     missingPreconditions: overrides.missingPreconditions ?? {
       noLiveAgents: true,
-      singleUnitOnly: false,
     },
   };
 }

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
@@ -74,7 +74,6 @@ function digest(overrides: Partial<HandoverDigest> = {}): HandoverDigest {
     crossUnit: overrides.crossUnit ?? { units: [] },
     missingPreconditions: overrides.missingPreconditions ?? {
       noLiveAgents: true,
-      singleUnitOnly: false,
     },
   };
 }
@@ -222,11 +221,13 @@ describe("ProducerConsole", () => {
     expect(onSelect).toHaveBeenCalledWith("/p/beta", "beta");
   });
 
-  it("shows the singleUnitOnly posture notice when missingPreconditions flags it", () => {
-    // Per the simulated-onboarded posture DR, the WebUI is honest
-    // about the multi-repo / dormant-unit wire gap (tmai-core#340)
-    // by surfacing this notice in the ⬢ Cross-unit status section
-    // whenever only one unit is derivable from live agents.
+  it("does not render the retired singleUnitOnly posture notice", () => {
+    // The dormant-unit gap is now closed by the `api.units()`
+    // reconciliation in `useHandover` (tmai-core #460), so the
+    // "Showing one unit only" apology that used to live in the
+    // ⬢ Cross-unit status section is gone. This test pins that:
+    // even in the single-unit case, the section renders without
+    // the retired posture block.
     useHandoverMock.mockReturnValue(
       digest({
         crossUnit: {
@@ -240,31 +241,13 @@ describe("ProducerConsole", () => {
             },
           ],
         },
-        missingPreconditions: { noLiveAgents: false, singleUnitOnly: true },
+        missingPreconditions: { noLiveAgents: false },
       }),
     );
 
     render(
       <ProducerConsole {...makeProps({ currentProjectPath: "/p/alpha", unitName: "alpha" })} />,
     );
-
-    expect(screen.getByText(/Showing one unit only/i)).toBeTruthy();
-  });
-
-  it("omits the singleUnitOnly notice when more than one unit is derived", () => {
-    useHandoverMock.mockReturnValue(
-      digest({
-        crossUnit: {
-          units: [
-            { path: "/p/a", name: "a", state: "in-progress", agentCount: 1, attentionCount: 0 },
-            { path: "/p/b", name: "b", state: "quiet", agentCount: 0, attentionCount: 0 },
-          ],
-        },
-        missingPreconditions: { noLiveAgents: false, singleUnitOnly: false },
-      }),
-    );
-
-    render(<ProducerConsole {...makeProps()} />);
 
     expect(screen.queryByText(/Showing one unit only/i)).toBeNull();
   });

--- a/clients/react/src/components/producer-console/sections/CrossUnitStatusSection.tsx
+++ b/clients/react/src/components/producer-console/sections/CrossUnitStatusSection.tsx
@@ -1,23 +1,17 @@
 // ⬢ Cross-unit status — second hand-over section.
 //
-// One line per unit (= project derived from active agents). State pill
-// is read off `useHandover`'s `UnitStatus.state`:
+// One line per unit, reconciled from two sources by `useHandover`:
+// configured membership comes from `GET /api/units` (tmai-core #460,
+// wire half of #439); the state pill is derived client-side from the
+// live agent list. A unit configured but currently dormant (no live
+// agent) renders here with state `quiet`.
+//
+// State pill semantics:
 //
 // - 🔴 needs-you   — at least one agent has non-null `attention`
 // - 🟡 in-progress — agents present, none on the attention axis
-// - ⚪ quiet       — no agents (but the unit is known)
-//
-// Phase A note: the unit list is *derived* from live agents, not read
-// from a `[[unit]]`-config endpoint, so units configured but currently
-// dormant are not visible here. Phase C will reconcile against a
-// `GET /api/units` endpoint and surface those too.
-//
-// TODO(tmai-core#340): when multi-repo / dormant-unit wire lands,
-// replace the live-agent derivation with a proper unit list. The
-// `singleUnitOnly` posture notice below is part of the
-// simulated-onboarded posture DR (`doc/decisions/2026-05-14-webui-
-// simulated-onboarded-posture.md`) and should be removed in the
-// same change.
+// - ⚪ quiet       — no agents (dormant configured unit, or a unit
+//                   whose every live agent has exited)
 
 import type { CrossUnitStatus, MissingPreconditions, UnitState } from "@/hooks/useHandover";
 
@@ -26,8 +20,10 @@ interface CrossUnitStatusSectionProps {
   activePath: string | null;
   onSelectUnit: (path: string, name: string) => void;
   /** Weak posture signals — see `MissingPreconditions` doc.
-   *  When omitted, no notice is rendered (back-compat for existing
-   *  tests / older callers). */
+   *  Currently unused by this section (the `singleUnitOnly` notice
+   *  retired with the units-wire reconciliation); kept on the prop
+   *  surface so callers can continue forwarding `missingPreconditions`
+   *  uniformly across all four sections without conditional plumbing. */
   preconditions?: MissingPreconditions;
 }
 
@@ -35,22 +31,28 @@ export function CrossUnitStatusSection({
   data,
   activePath,
   onSelectUnit,
-  preconditions,
 }: CrossUnitStatusSectionProps) {
+  // Configured vs live split: the count line stays honest about which
+  // half of the reconciled list is reading from where. A dormant
+  // configured unit lands in `data.units` with `agentCount === 0` so
+  // the difference is exactly the dormant-unit count.
+  const total = data.units.length;
+  const live = data.units.filter((u) => u.agentCount > 0).length;
+
   return (
     <section>
       <header className="mb-2 flex items-baseline gap-2">
         <span className="text-base text-primary">⬢</span>
         <h3 className="text-sm font-semibold text-foreground">Cross-unit status</h3>
         <span className="text-xs text-muted-foreground">
-          {data.units.length} unit{data.units.length === 1 ? "" : "s"} derived from live agents
+          {total} configured / {live} live
         </span>
       </header>
 
       {data.units.length === 0 ? (
         <p className="pl-6 text-xs text-muted-foreground">
-          No active units. Spawn an agent on any project to populate this list — dormant configured
-          units aren't surfaced here yet.
+          No configured units yet. Add a <code>[[unit]]</code> in config.toml or spawn an agent on
+          any project to populate this list.
         </p>
       ) : (
         <ul className="space-y-0.5 pl-6 text-xs text-foreground">
@@ -83,15 +85,6 @@ export function CrossUnitStatusSection({
             );
           })}
         </ul>
-      )}
-
-      {preconditions?.singleUnitOnly && (
-        // TODO(tmai-core#340): remove this notice once multi-repo /
-        // dormant-unit reconciliation lands.
-        <p className="mt-2 pl-6 text-[11px] text-subtle-foreground">
-          Showing one unit only — a tmai project can span multiple repos and have dormant configured
-          units, but that view isn't wired yet.
-        </p>
       )}
     </section>
   );

--- a/clients/react/src/components/producer-console/sections/__tests__/CrossUnitStatusSection.test.tsx
+++ b/clients/react/src/components/producer-console/sections/__tests__/CrossUnitStatusSection.test.tsx
@@ -1,0 +1,108 @@
+// @vitest-environment jsdom
+//
+// CrossUnitStatusSection — the ⬢ Cross-unit status section that
+// reconciles configured-unit membership against live agents.
+//
+// Once `tmai-core #460` (units wire) landed, the section retired its
+// `singleUnitOnly` posture-apology block — dormant units are now
+// surfaced as real rows by `useHandover`. This file pins:
+//   - the retired `singleUnitOnly` notice never renders, even when the
+//     caller still forwards a `preconditions` object;
+//   - dormant rows render with the quiet pill;
+//   - the count line reads "configured / live".
+//
+// We use `fireEvent.click` (NOT `.click()`) so a future click test
+// stays inside React's act() boundary — known gotcha across the suite.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { CrossUnitStatus } from "@/hooks/useHandover";
+import { CrossUnitStatusSection } from "../CrossUnitStatusSection";
+
+function dormantQuietRow(): CrossUnitStatus["units"][number] {
+  return {
+    path: "/home/u/proj-dormant",
+    name: "proj-dormant",
+    state: "quiet",
+    agentCount: 0,
+    attentionCount: 0,
+  };
+}
+
+function liveInProgressRow(): CrossUnitStatus["units"][number] {
+  return {
+    path: "/home/u/proj-a",
+    name: "proj-a",
+    state: "in-progress",
+    agentCount: 1,
+    attentionCount: 0,
+  };
+}
+
+describe("CrossUnitStatusSection", () => {
+  it("renders dormant configured units with the quiet pill", () => {
+    render(
+      <CrossUnitStatusSection
+        data={{ units: [dormantQuietRow()] }}
+        activePath={null}
+        onSelectUnit={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("proj-dormant")).toBeTruthy();
+    // ⚪ pill (the quiet variant) carries title="no agents".
+    expect(screen.getByTitle("no agents")).toBeTruthy();
+  });
+
+  it("reads 'configured / live' on the count line — dormant rows count in 'configured' but not 'live'", () => {
+    render(
+      <CrossUnitStatusSection
+        data={{ units: [liveInProgressRow(), dormantQuietRow()] }}
+        activePath={null}
+        onSelectUnit={vi.fn()}
+      />,
+    );
+    // Two configured, one with live agents.
+    expect(screen.getByText(/2 configured \/ 1 live/i)).toBeTruthy();
+  });
+
+  it("does NOT render the retired singleUnitOnly notice even with preconditions still forwarded", () => {
+    // Callers (`ProducerConsole`, `AttentionStrip`) still forward
+    // `preconditions={missingPreconditions}` uniformly across all four
+    // sections — the section signature accepts it but must IGNORE the
+    // (now retired) `singleUnitOnly` field. We pass a deliberately
+    // over-shaped object to verify the old branch is gone for good:
+    // even if a stale caller still set `singleUnitOnly: true`, no
+    // "Showing one unit only" copy escapes into the DOM.
+    render(
+      <CrossUnitStatusSection
+        data={{ units: [liveInProgressRow()] }}
+        activePath="/home/u/proj-a"
+        onSelectUnit={vi.fn()}
+        preconditions={
+          // Cast to placate the type while we verify *runtime* absence
+          // of the retired branch (a stale call site couldn't be caught
+          // by the type alone — that's what this test pins).
+          { noLiveAgents: false, singleUnitOnly: true } as unknown as Parameters<
+            typeof CrossUnitStatusSection
+          >[0]["preconditions"]
+        }
+      />,
+    );
+    expect(screen.queryByText(/Showing one unit only/i)).toBeNull();
+  });
+
+  it("routes a row click through onSelectUnit with the row's path + name", () => {
+    const onSelect = vi.fn();
+    render(
+      <CrossUnitStatusSection
+        data={{ units: [dormantQuietRow()] }}
+        activePath={null}
+        onSelectUnit={onSelect}
+      />,
+    );
+    // `fireEvent.click` keeps the click inside React's act() — the
+    // bare `element.click()` path has bitten this suite before.
+    fireEvent.click(screen.getByRole("button", { name: /proj-dormant/ }));
+    expect(onSelect).toHaveBeenCalledWith("/home/u/proj-dormant", "proj-dormant");
+  });
+});

--- a/clients/react/src/hooks/__tests__/useHandover.test.ts
+++ b/clients/react/src/hooks/__tests__/useHandover.test.ts
@@ -2,17 +2,19 @@
 //
 // Aggregation tests for the Producer console's hand-over digest.
 //
-// We mock `useAgents` and `useWorktrees` directly so the test exercises
-// `useHandover`'s composition logic (project grouping, attention
-// filtering, state-pill derivation) without spinning up SSEProvider.
+// We mock `useAgents`, `useWorktrees`, and `useUnits` directly so the
+// test exercises `useHandover`'s composition logic (project grouping,
+// attention filtering, state-pill derivation, cross-unit reconciliation)
+// without spinning up SSEProvider or hitting `api.units`.
 
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentSnapshot, WorktreeSnapshot } from "@/lib/api";
+import type { AgentSnapshot, UnitsResponse, WorktreeSnapshot } from "@/lib/api";
 import { useHandover } from "../useHandover";
 
 const useAgentsMock = vi.fn();
 const useWorktreesMock = vi.fn();
+const useUnitsMock = vi.fn();
 
 vi.mock("@/hooks/useAgents", () => ({
   useAgents: () => useAgentsMock(),
@@ -20,6 +22,10 @@ vi.mock("@/hooks/useAgents", () => ({
 
 vi.mock("@/hooks/useWorktrees", () => ({
   useWorktrees: () => useWorktreesMock(),
+}));
+
+vi.mock("@/hooks/useUnits", () => ({
+  useUnits: () => useUnitsMock(),
 }));
 
 function agent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot {
@@ -53,6 +59,7 @@ function agent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot 
 beforeEach(() => {
   useAgentsMock.mockReset();
   useWorktreesMock.mockReset();
+  useUnitsMock.mockReset();
   useAgentsMock.mockReturnValue({
     agents: [],
     attentionCount: 0,
@@ -63,6 +70,13 @@ beforeEach(() => {
     worktrees: [] as WorktreeSnapshot[],
     loading: false,
     refresh: vi.fn(),
+  });
+  // Default: no configured-unit membership loaded (wire pre-resolve).
+  // Tests that exercise reconciliation override this per-case.
+  useUnitsMock.mockReturnValue({
+    data: null,
+    loading: true,
+    error: null,
   });
 });
 
@@ -228,6 +242,76 @@ describe("useHandover — crossUnit derivation", () => {
   });
 });
 
+describe("useHandover — crossUnit reconciliation against api.units()", () => {
+  // tmai-core #460 closes the dormant-unit gap: configured `[[unit]]`
+  // tables that have no live agent must still appear in the cross-unit
+  // status section so the operator can SELECT them (and spawn a
+  // Producer at their primary repo). The state pill stays
+  // client-derived; reconciliation only adds rows, never alters them.
+
+  it("appends a configured unit with no live agents as state: quiet", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [agent({ id: "a1", cwd: "/home/u/proj-a", git_common_dir: "/home/u/proj-a/.git" })],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+    const unitsData: UnitsResponse = {
+      units: [
+        // Live unit — already covered by `proj-a` live row.
+        { name: "proj-a", repos: [{ path: "/home/u/proj-a", primary: true }] },
+        // Dormant unit — must be reconciled in.
+        { name: "proj-dormant", repos: [{ path: "/home/u/proj-dormant", primary: true }] },
+      ],
+    };
+    useUnitsMock.mockReturnValue({ data: unitsData, loading: false, error: null });
+
+    const { result } = renderHook(() => useHandover(null));
+    const names = result.current.crossUnit.units.map((u) => u.name);
+    expect(names).toEqual(expect.arrayContaining(["proj-a", "proj-dormant"]));
+    const dormant = result.current.crossUnit.units.find((u) => u.name === "proj-dormant");
+    expect(dormant?.state).toBe("quiet");
+    expect(dormant?.agentCount).toBe(0);
+    expect(dormant?.attentionCount).toBe(0);
+    // Dormant row points at the unit's primary repo path so unit
+    // selection sets `currentProject` to the spawn-cwd target.
+    expect(dormant?.path).toBe("/home/u/proj-dormant");
+  });
+
+  it("does not duplicate a configured unit that already has live agents", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [agent({ id: "a1", cwd: "/home/u/proj-a", git_common_dir: "/home/u/proj-a/.git" })],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+    const unitsData: UnitsResponse = {
+      units: [{ name: "proj-a", repos: [{ path: "/home/u/proj-a", primary: true }] }],
+    };
+    useUnitsMock.mockReturnValue({ data: unitsData, loading: false, error: null });
+
+    const { result } = renderHook(() => useHandover(null));
+    expect(result.current.crossUnit.units).toHaveLength(1);
+    expect(result.current.crossUnit.units[0]?.name).toBe("proj-a");
+    // Live row's state survives reconciliation (in-progress, not quiet).
+    expect(result.current.crossUnit.units[0]?.state).toBe("in-progress");
+  });
+
+  it("falls back to live-only rows while api.units() is still resolving", () => {
+    useAgentsMock.mockReturnValue({
+      agents: [agent({ id: "a1", cwd: "/home/u/proj-a", git_common_dir: "/home/u/proj-a/.git" })],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+    useUnitsMock.mockReturnValue({ data: null, loading: true, error: null });
+
+    const { result } = renderHook(() => useHandover(null));
+    expect(result.current.crossUnit.units).toHaveLength(1);
+    expect(result.current.crossUnit.units[0]?.name).toBe("proj-a");
+  });
+});
+
 describe("useHandover — missingPreconditions (simulated-onboarded posture)", () => {
   it("flags noLiveAgents when the agent list is empty", () => {
     const { result } = renderHook(() => useHandover(null));
@@ -246,41 +330,14 @@ describe("useHandover — missingPreconditions (simulated-onboarded posture)", (
     expect(result.current.missingPreconditions.noLiveAgents).toBe(false);
   });
 
-  it("flags singleUnitOnly when only one project group is derived", () => {
-    useAgentsMock.mockReturnValue({
-      agents: [agent({ id: "a1", cwd: "/home/u/proj-a", git_common_dir: "/home/u/proj-a/.git" })],
-      attentionCount: 0,
-      loading: false,
-      refresh: vi.fn(),
-    });
-
-    const { result } = renderHook(() => useHandover(null));
-    expect(result.current.missingPreconditions.singleUnitOnly).toBe(true);
-  });
-
-  it("clears singleUnitOnly when two or more projects are present", () => {
-    useAgentsMock.mockReturnValue({
-      agents: [
-        agent({ id: "a1", cwd: "/home/u/proj-a", git_common_dir: "/home/u/proj-a/.git" }),
-        agent({ id: "a2", cwd: "/home/u/proj-b", git_common_dir: "/home/u/proj-b/.git" }),
-      ],
-      attentionCount: 0,
-      loading: false,
-      refresh: vi.fn(),
-    });
-
-    const { result } = renderHook(() => useHandover(null));
-    expect(result.current.missingPreconditions.singleUnitOnly).toBe(false);
-  });
-
   // The Producer launch wraps `tmai producer <unit>` under `bash -c` to
   // satisfy tmai-core's `/api/spawn` allow-list (DR polish v4). The
   // resulting agent has `agent_type: Custom("bash")` but its canonical
   // `id` is already `claude:UUID` — `useHandover` must classify it as
   // an AI coding agent via the id-scheme fallback, otherwise the
   // Producer's own unit drops out of `projectGroups` and the posture
-  // notices ("no live agents" / "showing one unit only") all misfire
-  // even though the Producer is plainly running.
+  // notices ("no live agents") misfire even though the Producer is
+  // plainly running.
   it("classifies a bash-wrapped Producer as an AI agent via canonical id scheme", () => {
     useAgentsMock.mockReturnValue({
       agents: [
@@ -299,7 +356,6 @@ describe("useHandover — missingPreconditions (simulated-onboarded posture)", (
 
     const { result } = renderHook(() => useHandover(null));
     expect(result.current.missingPreconditions.noLiveAgents).toBe(false);
-    expect(result.current.missingPreconditions.singleUnitOnly).toBe(true);
     expect(result.current.crossUnit.units).toHaveLength(1);
   });
 
@@ -322,5 +378,15 @@ describe("useHandover — missingPreconditions (simulated-onboarded posture)", (
     const { result } = renderHook(() => useHandover(null));
     expect(result.current.missingPreconditions.noLiveAgents).toBe(true);
     expect(result.current.crossUnit.units).toEqual([]);
+  });
+
+  // Field-absence guard: `singleUnitOnly` retired with the units-wire
+  // reconciliation (tmai-core #460). Any reader that quietly resurrects
+  // it would surface as a TS error first — this assertion documents the
+  // contract at runtime so a `Partial<MissingPreconditions>` casting
+  // accident can't sneak the field back in.
+  it("does not carry the retired singleUnitOnly field on missingPreconditions", () => {
+    const { result } = renderHook(() => useHandover(null));
+    expect("singleUnitOnly" in result.current.missingPreconditions).toBe(false);
   });
 });

--- a/clients/react/src/hooks/useHandover.ts
+++ b/clients/react/src/hooks/useHandover.ts
@@ -6,42 +6,37 @@
 // composed from four sections — ▶ Where-you-left-off, ⬢ Cross-unit
 // status, ⬡ Settled decisions, ◐ Working-with-this-human.
 //
-// Phase A scope (this file): wire what we already have on the client.
-//
 // - `whereYouLeftOff` — derived from `useAgents` + `useWorktrees`
 //   scoped to `currentProjectPath`. Reuses `groupByProject` so the
 //   sidebar's worktree shape matches the console's worktree shape
 //   exactly (single source of truth for project grouping).
-// - `crossUnit` — every project derived from active agents, with a
-//   state pill (needs-you / in-progress / quiet). The "unit" here is
-//   the *derived* project — not yet read from a `[[unit]]`-config
-//   wire endpoint. Phase C will reconcile against
-//   `GET /api/units` and surface units that have no live agents.
+// - `crossUnit` — reconciles two sources so the section reflects the
+//   FULL configured-unit space, not only what's running:
+//     • configured-unit MEMBERSHIP comes from `api.units()` (tmai-core
+//       #460 wire half of #439, public types mirror tmai#741); membership
+//       only — no server-side state pill, no server-side live-agent join;
+//     • the per-unit STATE PILL (needs-you / in-progress / quiet) is
+//       still derived client-side from the live agent list.
+//   A unit configured but currently dormant (no live agent) shows up
+//   here with state `quiet`. Reconciliation closes the gap the Phase-A
+//   "live-agent derivation only" implementation left behind.
 //
-// Placeholders for Phase C wire:
+// Both compose-driven sections (`⬡ Settled decisions` and `◐ Working
+// with this human`) are wired directly to their own endpoints — the
+// sections own their own polling via `useDecisions(unitName)` /
+// `useWorkingWithHuman(unitName)` rather than receiving data from this
+// hook. The hook keeps only the client-derived signals.
 //
-// - `settledDecisions` — decision records live in this repo's
-//   `doc/decisions/`, but there is no wire endpoint yet to expose
-//   their frontmatter (status / tier / temperature) to the WebUI.
-//   The section renders an explicit "not yet wired" notice so the
-//   operator knows the placeholder is intentional, not a bug.
-// - `workingWithHuman` — same shape, same reason. Composed by the
-//   Producer's `compose()` baseline builder; needs a read endpoint.
-//
-// Both placeholders carry the exact wire-gap reason in the `reason`
-// field — the section components render that text directly so the
-// surface is self-documenting.
-//
-// Posture annotations (DR `doc/decisions/2026-05-14-webui-simulated-
-// onboarded-posture.md`): until tmai-core lands #340 (multi-repo) /
-// #341 (cold-start), this hook degrades gracefully and surfaces a
-// weak `missingPreconditions` signal so sections can render honest
-// notices instead of fabricating data. Anything tagged
-// `TODO(tmai-core#340)` / `TODO(tmai-core#341)` in this file is
-// scheduled for retirement once those ship.
+// Posture annotation (DR `doc/decisions/2026-05-14-webui-simulated-
+// onboarded-posture.md`): the `noLiveAgents` flag survives — that
+// compensation is independent of the units wire and stays useful for
+// the "agents-fetch pre-load" honest-degradation branch. The
+// `singleUnitOnly` companion is gone now that dormant configured units
+// are surfaced via reconciliation.
 
 import { useMemo } from "react";
 import { useAgents } from "@/hooks/useAgents";
+import { useUnits } from "@/hooks/useUnits";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import {
   type AgentAttention,
@@ -101,26 +96,17 @@ export interface CrossUnitStatus {
   units: UnitStatus[];
 }
 
-// Both compose-driven sections (`⬡ Settled decisions` and `◐ Working
-// with this human`) are now wired to their respective wire endpoints
-// — the sections own their own polling via `useDecisions(unitName)` /
-// `useWorkingWithHuman(unitName)` rather than receiving placeholder
-// data from this hook. The hook keeps only the client-derived signals:
-// `whereYouLeftOff` (project scoping + attention agents) and
-// `crossUnit` (per-unit hotness).
-
 /**
- * Weak client-side signals that the unit might be incompletely onboarded
- * or that we're only seeing a sliver of its real surface. Per the
- * simulated-onboarded posture DR, the WebUI is not allowed to fabricate
- * data when the underlying wire is absent — it has to be honest about
- * which inferences are based on partial signals.
- *
- * These flags are *weak* by design: they come from the data we already
- * have on the client (agent list, project grouping), not from a
- * dedicated `compose().meta` payload (which is what tmai-core#341 will
- * provide). Section components treat them as "may want to surface a
+ * Weak client-side signals that the live agent observation may be a
+ * sliver of the unit's real surface. Per the simulated-onboarded posture
+ * DR, the WebUI must not fabricate data when the underlying wire is
+ * absent — section components treat this as "may want to surface a
  * notice", not as definitive state.
+ *
+ * The `singleUnitOnly` flag this used to carry is retired: dormant
+ * configured units are now surfaced via the `api.units()` reconciliation
+ * in `crossUnit` (tmai-core #460), so there is no longer a multi-unit
+ * gap for the cross-unit section to apologise for.
  */
 export interface MissingPreconditions {
   /** No live agents have been observed for this client session.
@@ -129,12 +115,6 @@ export interface MissingPreconditions {
    *  endpoint reports actual missing preconditions (no
    *  `doc/decisions/`, no `[[unit]]` config, etc.). */
   noLiveAgents: boolean;
-  /** Only one unit derived from live agents. Because the wire side
-   *  doesn't yet expose dormant `[[unit]]` configs (#340) or a way
-   *  for a unit to span multiple repos (#340), the single-unit
-   *  view here is necessarily partial.
-   *  TODO(tmai-core#340): replace with `GET /api/units` reconciliation. */
-  singleUnitOnly: boolean;
 }
 
 export interface HandoverDigest {
@@ -166,6 +146,7 @@ function deriveUnitState(group: ProjectGroup): UnitState {
 export function useHandover(currentProjectPath: string | null): HandoverDigest {
   const { agents } = useAgents();
   const { worktrees } = useWorktrees();
+  const { data: unitsData } = useUnits();
 
   const aiAgents = useMemo(() => agents.filter(isAiAgentLoose), [agents]);
 
@@ -204,25 +185,69 @@ export function useHandover(currentProjectPath: string | null): HandoverDigest {
     };
   }, [currentProjectPath, projectGroups, aiAgents]);
 
-  const crossUnit = useMemo<CrossUnitStatus>(
-    () => ({
-      units: projectGroups.map((g) => ({
-        path: g.path,
-        name: g.name,
-        state: deriveUnitState(g),
-        agentCount: g.totalAgents,
-        attentionCount: g.attentionAgents,
-      })),
-    }),
-    [projectGroups],
-  );
+  const crossUnit = useMemo<CrossUnitStatus>(() => {
+    // Live-agent-derived rows first — these carry real `state` /
+    // `agentCount` / `attentionCount` from the live snapshot.
+    const liveRows: UnitStatus[] = projectGroups.map((g) => ({
+      path: g.path,
+      name: g.name,
+      state: deriveUnitState(g),
+      agentCount: g.totalAgents,
+      attentionCount: g.attentionAgents,
+    }));
 
-  // Weak posture-signal derivation. See `MissingPreconditions` doc for
-  // why these are tagged TODO(tmai-core#NNN) — they get retired once
-  // the wire side surfaces the real precondition data.
+    // Reconcile against the configured-unit membership wire (tmai-core
+    // #460): any configured unit without a corresponding live-agent row
+    // is appended with state `quiet`. The membership row's `path` is the
+    // unit's PRIMARY repo (per `UnitRepoWire.primary`) so selecting a
+    // dormant row sets `currentProject` to the same path a fresh
+    // Producer launch would land at — keeps unit selection / spawn cwd
+    // / `findProducerForUnit` resolution all on the same path key.
+    if (!unitsData) {
+      // Wire not yet loaded — fall back to live-only. Reconciliation
+      // catches up on the next render once `useUnits` resolves.
+      return { units: liveRows };
+    }
+
+    // Match configured units against live rows by unit NAME — the
+    // grouping key in `groupByProject` is the agent's `unit` field
+    // (which is exactly the configured unit name) when present, and the
+    // primary repo's basename (which by convention equals the unit
+    // name) when not. Either way the `name` field on `liveRows`
+    // collides with the configured-unit name in the same-shape unit case.
+    const liveNames = new Set(liveRows.map((r) => r.name));
+
+    const dormantRows: UnitStatus[] = [];
+    for (const unit of unitsData.units) {
+      if (liveNames.has(unit.name)) continue;
+      const primary = unit.repos.find((r) => r.primary);
+      // No primary row on the wire → cannot pin a selection target.
+      // Drop the dormant entry rather than fabricate a path; the
+      // membership view always carries a primary in practice and a
+      // missing primary signals a wire-side bug we shouldn't paper over.
+      if (!primary) continue;
+      dormantRows.push({
+        path: primary.path,
+        name: unit.name,
+        state: "quiet",
+        agentCount: 0,
+        attentionCount: 0,
+      });
+    }
+
+    // Stable order: live rows in their existing order (preserves
+    // `groupByProject`'s name-sort), then dormant rows sorted by name
+    // so the section's reading order stays predictable across renders.
+    dormantRows.sort((a, b) => a.name.localeCompare(b.name));
+    return { units: [...liveRows, ...dormantRows] };
+  }, [projectGroups, unitsData]);
+
+  // Weak posture-signal derivation. `noLiveAgents` survives the units-
+  // wire landing — it's still useful for the agents-fetch pre-load
+  // honest-degradation branch (and for distinguishing "you haven't
+  // spawned anything yet" from "your unit is configured but quiet").
   const missingPreconditions: MissingPreconditions = {
     noLiveAgents: aiAgents.length === 0,
-    singleUnitOnly: projectGroups.length === 1,
   };
 
   return { whereYouLeftOff, crossUnit, missingPreconditions };

--- a/clients/react/src/hooks/useUnits.ts
+++ b/clients/react/src/hooks/useUnits.ts
@@ -1,0 +1,70 @@
+// Polling hook for the configured-unit membership view (tmai-core
+// #460, public types mirror tmai#741) — the wire half of #439.
+//
+// `GET /api/units` returns the engine's configured `[[unit]]`
+// membership (one entry per unit, each carrying its `repos[]` with the
+// `primary` flag). It is the only **dormant-unit-aware** surface: the
+// live-agent derivation in `groupByProject` only sees units that have
+// at least one live agent, so reconciling against this list is what
+// lets `useHandover` surface configured-but-quiet units in the cross-
+// unit status section with state `quiet`.
+//
+// Membership is human-paced (operator edits config.toml) so a 60-second
+// poll (same cadence as the sibling unit-scoped wires) is ample; we keep
+// the previous response visible while a re-fetch is in flight so the
+// reconciled list does not flicker. `loading` reflects only the
+// initial fetch, mirroring `useCalibration` / `useUnitPrs` / `useApproaches`.
+
+import { useEffect, useState } from "react";
+import { api, type UnitsResponse } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface UseUnitsResult {
+  data: UnitsResponse | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useUnits(): UseUnitsResult {
+  const [data, setData] = useState<UnitsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    // Unlike the sibling unit-scoped hooks (`useCalibration`,
+    // `useUnitPrs`, `useApproaches`), this endpoint has no unit-scope
+    // discriminator that could swap mid-flight — there is one global
+    // membership list. So the generation guard those hooks use to drop
+    // stale responses against a newer unit isn't required here.
+    let cancelled = false;
+
+    const fetchOnce = async () => {
+      try {
+        const res = await api.units();
+        if (cancelled) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  return { data, loading, error };
+}

--- a/clients/react/src/lib/__tests__/find-producer-for-unit.test.ts
+++ b/clients/react/src/lib/__tests__/find-producer-for-unit.test.ts
@@ -1,0 +1,214 @@
+// @vitest-environment jsdom
+//
+// Unit tests for `findProducerForUnit` — the shared Producer resolver
+// that every "talk to the Producer" surface (digest button, ctx
+// readout, conversation-header gate, failure-dialog Force-kill target)
+// reads from.
+//
+// Two contract axes the resolver MUST honour:
+//
+//  1. **Cross-repo awareness** (tmai-core #439 / #460, public mirror
+//     tmai#741). When a unit spans multiple repos, the resolver pins
+//     the Producer to the unit's PRIMARY repo specifically — a
+//     `claude:`+`!is_worktree` agent that happens to sit at a NON-primary
+//     repo of the same unit is NOT mis-classified as the unit's
+//     Producer. The Producer launch always runs at the primary repo, so
+//     anything elsewhere is at most a sibling Claude session, not the
+//     Producer.
+//
+//  2. **Back-compat single-path overload**. Callers not yet threaded
+//     through the units wire (and cwd-synthesized units that the units
+//     endpoint doesn't enumerate) pass a single `string` repo path,
+//     which the resolver treats as the primary directly.
+
+import { describe, expect, it } from "vitest";
+import type { AgentSnapshot, UnitRepoWire } from "@/lib/api";
+import { findProducerForUnit } from "../producer";
+
+function stubAgent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot {
+  return {
+    id: partial.id,
+    target: partial.target ?? partial.id,
+    agent_type: partial.agent_type ?? "ClaudeCode",
+    title: partial.title ?? partial.id,
+    cwd: partial.cwd ?? "/repo",
+    display_cwd: partial.display_cwd ?? "repo",
+    display_name: partial.display_name ?? partial.id,
+    detection_source: partial.detection_source ?? "IpcSocket",
+    git_branch: partial.git_branch ?? "main",
+    git_dirty: partial.git_dirty ?? false,
+    is_worktree: partial.is_worktree ?? false,
+    git_common_dir: partial.git_common_dir ?? "/repo/.git",
+    worktree_name: partial.worktree_name ?? null,
+    worktree_base_branch: partial.worktree_base_branch ?? null,
+    effort_level: partial.effort_level ?? null,
+    active_subagents: partial.active_subagents ?? 0,
+    compaction_count: partial.compaction_count ?? 0,
+    pty_session_id: partial.pty_session_id ?? null,
+    send_capability: partial.send_capability ?? "Ipc",
+    is_virtual: partial.is_virtual ?? false,
+    team_info: partial.team_info ?? null,
+    attention: partial.attention ?? null,
+    is_orchestrator: partial.is_orchestrator,
+  };
+}
+
+describe("findProducerForUnit — back-compat single-path overload", () => {
+  it("returns null when the unit path is null", () => {
+    expect(findProducerForUnit([], null)).toBeNull();
+  });
+
+  it("resolves a single `claude:`+`!is_worktree` agent at the unit path", () => {
+    const producer = stubAgent({
+      id: "claude:prod-1",
+      cwd: "/repo",
+      git_common_dir: "/repo/.git",
+      is_worktree: false,
+    });
+    expect(findProducerForUnit([producer], "/repo")).toBe(producer);
+  });
+
+  it("normalizes a trailing `/.git` on the unit path before matching", () => {
+    const producer = stubAgent({
+      id: "claude:prod-1",
+      cwd: "/repo",
+      git_common_dir: "/repo/.git",
+      is_worktree: false,
+    });
+    expect(findProducerForUnit([producer], "/repo/.git")).toBe(producer);
+  });
+
+  it("rejects an agent without the canonical `claude:` id scheme", () => {
+    const notProducer = stubAgent({
+      id: "codex:c-1",
+      cwd: "/repo",
+      git_common_dir: "/repo/.git",
+      is_worktree: false,
+    });
+    expect(findProducerForUnit([notProducer], "/repo")).toBeNull();
+  });
+
+  it("rejects an agent with `is_worktree: true` (worktree clones host workers, not Producers)", () => {
+    const worker = stubAgent({
+      id: "claude:work-1",
+      cwd: "/repo/.claude/worktrees/feat-x",
+      git_common_dir: "/repo/.git",
+      is_worktree: true,
+    });
+    expect(findProducerForUnit([worker], "/repo")).toBeNull();
+  });
+
+  it("returns null when more than one candidate is present (single-Producer invariant)", () => {
+    const a = stubAgent({
+      id: "claude:prod-a",
+      cwd: "/repo",
+      git_common_dir: "/repo/.git",
+      is_worktree: false,
+    });
+    const b = stubAgent({
+      id: "claude:prod-b",
+      cwd: "/repo",
+      git_common_dir: "/repo/.git",
+      is_worktree: false,
+    });
+    expect(findProducerForUnit([a, b], "/repo")).toBeNull();
+  });
+});
+
+describe("findProducerForUnit — cross-repo (UnitRepoWire[]) overload", () => {
+  // The unit's repo membership as the units wire serves it: primary
+  // first, secondary after. The resolver pins the Producer to the
+  // primary-flagged row internally.
+  const multiRepoUnit: Array<UnitRepoWire> = [
+    { path: "/repos/primary", primary: true },
+    { path: "/repos/secondary", primary: false },
+  ];
+
+  it("resolves an agent at the unit's PRIMARY repo as the Producer", () => {
+    const producer = stubAgent({
+      id: "claude:prod-1",
+      cwd: "/repos/primary",
+      git_common_dir: "/repos/primary/.git",
+      is_worktree: false,
+    });
+    expect(findProducerForUnit([producer], multiRepoUnit)).toBe(producer);
+  });
+
+  it("does NOT mis-classify a `claude:`+`!is_worktree` agent at a NON-primary repo", () => {
+    // The agent matches all the same shape filters as a Producer
+    // (`claude:` + `!is_worktree`) but sits at the unit's secondary
+    // repo — the Producer launch only ever runs at the primary, so
+    // this agent must NOT be returned as the unit's Producer even
+    // though it would have looked like one under the old single-path
+    // filter.
+    const nonPrimaryClaude = stubAgent({
+      id: "claude:sibling-1",
+      cwd: "/repos/secondary",
+      git_common_dir: "/repos/secondary/.git",
+      is_worktree: false,
+    });
+    expect(findProducerForUnit([nonPrimaryClaude], multiRepoUnit)).toBeNull();
+  });
+
+  it("returns the primary-repo Producer even when a non-primary sibling Claude session also exists", () => {
+    const producer = stubAgent({
+      id: "claude:prod-1",
+      cwd: "/repos/primary",
+      git_common_dir: "/repos/primary/.git",
+      is_worktree: false,
+    });
+    const sibling = stubAgent({
+      id: "claude:sibling-1",
+      cwd: "/repos/secondary",
+      git_common_dir: "/repos/secondary/.git",
+      is_worktree: false,
+    });
+    expect(findProducerForUnit([producer, sibling], multiRepoUnit)).toBe(producer);
+  });
+
+  it("returns null when the unit has no primary-flagged row (refuses to guess)", () => {
+    // Malformed wire payload — the resolver MUST refuse rather than
+    // pick a Producer location heuristically. The simulated-onboarded
+    // posture DR forbids fabricating data when the wire is incoherent.
+    const allSecondary: Array<UnitRepoWire> = [
+      { path: "/repos/a", primary: false },
+      { path: "/repos/b", primary: false },
+    ];
+    const claudeAtA = stubAgent({
+      id: "claude:prod-1",
+      cwd: "/repos/a",
+      git_common_dir: "/repos/a/.git",
+      is_worktree: false,
+    });
+    expect(findProducerForUnit([claudeAtA], allSecondary)).toBeNull();
+  });
+
+  it("treats an empty repo list the same as a missing primary (null)", () => {
+    const claudeAtPrimary = stubAgent({
+      id: "claude:prod-1",
+      cwd: "/repos/primary",
+      git_common_dir: "/repos/primary/.git",
+      is_worktree: false,
+    });
+    expect(findProducerForUnit([claudeAtPrimary], [])).toBeNull();
+  });
+
+  it("preserves the single-Producer invariant when two `claude:` agents are both at the primary repo", () => {
+    // The cross-repo signature widens repo eligibility but does NOT
+    // weaken the "exactly one or null" invariant. Two same-shape
+    // agents at the primary repo → ambiguous → null.
+    const a = stubAgent({
+      id: "claude:prod-a",
+      cwd: "/repos/primary",
+      git_common_dir: "/repos/primary/.git",
+      is_worktree: false,
+    });
+    const b = stubAgent({
+      id: "claude:prod-b",
+      cwd: "/repos/primary",
+      git_common_dir: "/repos/primary/.git",
+      is_worktree: false,
+    });
+    expect(findProducerForUnit([a, b], multiRepoUnit)).toBeNull();
+  });
+});

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -27,6 +27,9 @@ import type { TeamSnapshot } from "@/types/generated/TeamSnapshot";
 import type { TerminalSubscription } from "@/types/generated/TerminalSubscription";
 import type { TriageVerdict } from "@/types/generated/TriageVerdict";
 import type { UnitPrsResponse } from "@/types/generated/UnitPrsResponse";
+import type { UnitRepoWire } from "@/types/generated/UnitRepoWire";
+import type { UnitResponse } from "@/types/generated/UnitResponse";
+import type { UnitsResponse } from "@/types/generated/UnitsResponse";
 import type { Vendor } from "@/types/generated/Vendor";
 import type { WorkerDispatchMap } from "@/types/generated/WorkerDispatchMap";
 import type { WorkflowSnapshot } from "@/types/generated/WorkflowSnapshot";
@@ -55,6 +58,9 @@ export type {
   TerminalSubscription,
   TriageVerdict,
   UnitPrsResponse,
+  UnitRepoWire,
+  UnitResponse,
+  UnitsResponse,
   Vendor,
   WorkerDispatchMap,
 };
@@ -1523,6 +1529,14 @@ export const api = {
   // list, NOT a per-repo switcher. Single-repo unit collapses to
   // `repos.length === 1`.
   unitPrs: (unit: string) => apiFetch<UnitPrsResponse>(`/units/${encodeURIComponent(unit)}/prs`),
+
+  // Configured-unit membership (tmai-core #460, public mirror tmai#741).
+  // Membership-only — no live agent state is joined server-side; the
+  // WebUI reconciles configured units against the live agent list
+  // client-side to surface dormant units in the cross-unit list with a
+  // client-derived state pill.
+  units: () => apiFetch<UnitsResponse>("/units"),
+  unit: (name: string) => apiFetch<UnitResponse>(`/units/${encodeURIComponent(name)}`),
 
   // Working-with-human view — memory dir + MEMORY.md projection of
   // `compose()`'s ◐ section per the same DR. Surfaces the same content

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -265,6 +265,11 @@ export const api = {
   // fanned out over the unit's repos; no Tauri-specific path needed)
   unitPrs: (unit: string) => httpApi.unitPrs(unit),
 
+  // Configured-unit membership view (HTTP only — membership-only,
+  // no live agent state joined server-side; no Tauri-specific path needed)
+  units: () => httpApi.units(),
+  unit: (name: string) => httpApi.unit(name),
+
   // Working-with-human view (HTTP only — on-demand JSON projection of
   // compose()'s ◐ section; no Tauri-specific path needed)
   workingWithHuman: (unit: string) => httpApi.workingWithHuman(unit),

--- a/clients/react/src/lib/producer.ts
+++ b/clients/react/src/lib/producer.ts
@@ -7,7 +7,7 @@
 // copy-pasted verbatim across `ProducerConsoleActions` and
 // `ProducerCtxHeader`; it lives here once so every consumer agrees.
 
-import { type AgentSnapshot, normalizeGitDir } from "@/lib/api";
+import { type AgentSnapshot, normalizeGitDir, type UnitRepoWire } from "@/lib/api";
 
 // Canonical AgentId scheme that marks a Producer-eligible Claude
 // session. Per DR `2026-05-14-react-producer-console-rebuild.md`
@@ -24,16 +24,45 @@ export const PRODUCER_ID_SCHEME = "claude:";
  *   1. `id` starts with `claude:` (canonical scheme)
  *   2. `!is_worktree` — Producer runs at the repo root, not in a
  *      worktree clone (worktree Producers would be Worker agents)
- *   3. cwd / `git_common_dir` resolves to the unit's repo path
+ *   3. cwd / `git_common_dir` resolves to the unit's **primary** repo
+ *      path — per `UnitRepoWire.primary`, the one repo a unit's
+ *      Producer is launched at, even when the unit spans multiple repos
+ *
+ *  Cross-repo signature (tmai-core #439, wire #460, public types #741):
+ *  callers on the units wire pass the unit's full `UnitRepoWire[]`
+ *  membership — the function picks the `primary: true` row internally,
+ *  so a Producer-shape agent that happens to sit at a NON-primary repo
+ *  of the same unit (e.g., an opportunistic Claude session at a
+ *  secondary repo) is NOT mis-classified as the unit's Producer.
+ *
+ *  Back-compat: a single `string` path is treated as the primary repo
+ *  directly — for callers (`ProducerCtxHeader`, `ProducerConsoleActions`,
+ *  `ProducerRoster`, App-level fallbacks) not yet threaded through the
+ *  units wire.
  *
  *  If zero or more than one candidate exists, returns `null` — the
  *  handoff ritual operates on a *single* Producer; we never guess. */
 export function findProducerForUnit(
   agents: AgentSnapshot[],
-  unitRepoPath: string | null,
+  unitRepos: string | Array<UnitRepoWire> | null,
 ): AgentSnapshot | null {
-  if (unitRepoPath === null) return null;
-  const targetPath = normalizeGitDir(unitRepoPath);
+  if (unitRepos === null) return null;
+  // Resolve the unit's primary repo path. The single-string overload is
+  // the back-compat path: a unit known only by its repo dir (no units-
+  // wire reconciliation yet) is treated as a one-repo unit whose sole
+  // member is the primary.
+  let primaryPath: string;
+  if (typeof unitRepos === "string") {
+    primaryPath = unitRepos;
+  } else {
+    const primary = unitRepos.find((r) => r.primary);
+    // No `primary: true` row → we can't pin a Producer location. Refuse
+    // to guess (would re-introduce the single-Producer-invariant gap
+    // exactly the way the simulated-onboarded-posture DR forbids).
+    if (!primary) return null;
+    primaryPath = primary.path;
+  }
+  const targetPath = normalizeGitDir(primaryPath);
   const candidates = agents.filter((a) => {
     if (!a.id.startsWith(PRODUCER_ID_SCHEME)) return false;
     if (a.is_worktree === true) return false;


### PR DESCRIPTION
Wires the public-tmai React consumer half of `trust-delta/tmai-core#439` opt-2 Scope B. The tmai-core wire half landed in [`tmai-core#460`](https://github.com/trust-delta/tmai-core/pull/460) (merged); the generated types are on this repo's main via [`tmai#741`](https://github.com/trust-delta/tmai/pull/741) (merged): `UnitsResponse`, `UnitResponse`, `UnitRepoWire` in `clients/react/src/types/generated/`, backed by `GET /api/units` + `GET /api/units/{unit}` (membership only — the client joins live state).

## Three consumer changes (all under `clients/react/src/`)

### 1. `lib/api-http.ts` + `lib/api-tauri.ts` — new helpers

Two new entries next to the existing `unitPrs` / `calibration` / `decisions` / `approaches` / `workingWithHuman` helpers:

- `api.units()` → `Promise<UnitsResponse>` from `GET /api/units`
- `api.unit(name)` → `Promise<UnitResponse>` from `GET /api/units/{unit}` (path segment encoded via `encodeURIComponent` like the siblings)

Both are membership-only; no live state is joined server-side.

### 2. `lib/producer.ts` — cross-repo `findProducerForUnit`

The signature now accepts either a single `string` repo path (back-compat for callers not yet on the units wire — `ProducerCtxHeader`, `ProducerConsoleActions`, `ProducerRoster`, and the App-level fallback when the units wire hasn't resolved yet) or the unit's full `UnitRepoWire[]` membership. When given the array form, the resolver pins the Producer to the unit's PRIMARY repo specifically, so a `claude:`+`!is_worktree` agent at a NON-primary repo of the same unit is NOT mis-classified as the Producer. The single-Producer invariant, the `is_worktree === false` filter, and the `claude:` id-scheme filter are unchanged. `App.tsx` threads `useUnits` through to its call site; the in-component call sites stay on the single-path back-compat overload for now per the brief.

### 3. `hooks/useHandover.ts` + `CrossUnitStatusSection.tsx` — units-wire reconciliation

A new `useUnits` polling hook (60s, mirrors the cadence of `useCalibration` / `useUnitPrs` / `useApproaches`) feeds `useHandover`, which reconciles the live-agent-derived cross-unit list against `api.units()`. A configured-but-dormant unit (no live agent) appears in the cross-unit list with state `quiet`. The state pill stays client-derived from live agents — no server-side pill. The retired `singleUnitOnly` posture compensation, its `TODO(tmai-core#340)` markers, and the Phase A note are dropped — that gap is closed now. The `noLiveAgents` posture path stays intact. The count line in the section now reads "configured / live" to honestly reflect the reconciled membership.

## Contract boundaries

- **Membership-only stays membership-only** — no server-side computed state pill, no server-side join. The state pill is derived client-side from live agents in `useHandover`.
- **Single-Producer-per-unit invariant unchanged** — `findProducerForUnit` still returns `null` when zero or more than one candidate is present.
- `api-spec/`, `types/generated/`, tmai-core source, and any record under `doc/decisions/` / `doc/approaches/` are untouched.
- The dashboard-return path (`StatusBar` 🏠 button) and the `noLiveAgents` posture path are untouched.

## Tests

- `lib/__tests__/find-producer-for-unit.test.ts` (NEW) — covers back-compat single-path and the cross-repo `UnitRepoWire[]` semantics: primary-repo agent IS resolved even when the unit has multiple repos; non-primary agent is NOT mis-classified; refuses to guess on malformed wire (no `primary: true` row, empty list); single-Producer invariant held.
- `hooks/__tests__/useHandover.test.ts` — new reconciliation suite: dormant configured unit reconciled with state `quiet`; live row state survives reconciliation; live-only fallback while `api.units()` is still resolving; field-absence guard for the retired `singleUnitOnly` flag.
- `components/producer-console/sections/__tests__/CrossUnitStatusSection.test.tsx` (NEW) — pins that the retired `singleUnitOnly` notice never renders, dormant rows render with the quiet pill, the count line reads "configured / live", and a row click routes through `onSelectUnit` (via `fireEvent.click` per the suite-wide `act()` boundary discipline).

## Gate (`clients/react`)

```
pnpm tsc -b        # ✓
pnpm lint          # ✓ (biome check)
pnpm build         # ✓
pnpm test          # ✓ 516 passed | 2 skipped
```

## Cross-refs

- wire half: [`trust-delta/tmai-core#460`](https://github.com/trust-delta/tmai-core/pull/460)
- types mirror: [`trust-delta/tmai#741`](https://github.com/trust-delta/tmai/pull/741)
- tracker: [`trust-delta/tmai-core#439`](https://github.com/trust-delta/tmai-core/issues/439)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 複数リポジトリにまたがるユニット構成に対応し、Producerエージェント解決の信頼性が向上
  * ユニット一覧表示で「設定済み / ライブ」の区分表示に切り替わり、アクティブでない構成済みユニットも表示可能に

* **Bug Fixes**
  * ハンドオフダイアログおよびProducerヘッダーの表示対象がクロスリポジトリ対応に改善

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/743?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->