### PR TITLE
feat(react): consume approach lifecycle wire — verdict-inbox = running, dashboard = all statuses

### DIFF
--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -32,6 +32,7 @@ import type {
 import { ProducerConsoleActions } from "./ProducerConsoleActions";
 import { ProducerCtxHeader } from "./ProducerCtxHeader";
 import { ActiveApproachesSection } from "./sections/ActiveApproachesSection";
+import { AllApproachesSection } from "./sections/AllApproachesSection";
 import { CrossUnitStatusSection } from "./sections/CrossUnitStatusSection";
 import { SettledDecisionsSection } from "./sections/SettledDecisionsSection";
 import { UnitPrsSection } from "./sections/UnitPrsSection";
@@ -146,6 +147,7 @@ export function ProducerConsole({
         />
         <SettledDecisionsSection unitName={unitName} />
         <ActiveApproachesSection unitName={unitName} />
+        <AllApproachesSection unitName={unitName} />
         <UnitPrsSection unitName={unitName} />
         <WorkingWithThisHumanSection unitName={unitName} />
       </div>

--- a/clients/react/src/components/producer-console/sections/ActiveApproachesSection.tsx
+++ b/clients/react/src/components/producer-console/sections/ActiveApproachesSection.tsx
@@ -1,4 +1,4 @@
-// ▣ Active approaches — the Producer console's Verdict-inbox, wired to
+// ▣ Running approaches — the Producer console's Verdict-inbox, wired to
 // `GET /api/units/{unit}/approaches` (tmai-core PR #369).
 //
 // Essence (deliberately NOT the decisions surface — see
@@ -8,12 +8,20 @@
 // triages by "does this need your verdict now?", not by temperature
 // buckets. Low-priority bands are collapsed; only ⚡ is open.
 //
-// Client-degraded by design (A1). The wire is `status: active` only and
-// carries no resolved trigger/verdict state, so the client can faithfully
-// evaluate only `kind: date` triggers (vs today) + `confidence`. Triggers
-// the engine must resolve (pr-*/issue-closed/decision-status/approach-
-// status/manual) and the human-vs-Producer verdict split are surfaced
-// honestly, never fabricated — per the simulated-onboarded posture
+// The wire (tmai-core#463 / tmai#744) carries ALL statuses; this section
+// narrows to `status: "running"` only — the dischargeable verification
+// debt (formerly `active`'s role, before the lifecycle split into Ready +
+// Running per tmai-core#462 Amendment 2026-05-28). Other statuses
+// (Planned / Partial / Ready / Validated / Rejected / Replaced) surface
+// in `AllApproachesSection` below as the operator dashboard's
+// task-selection axis.
+//
+// Client-degraded by design (A1). The wire carries no resolved
+// trigger/verdict state, so the client can faithfully evaluate only
+// `kind: date` triggers (vs today) + `confidence`. Triggers the engine
+// must resolve (pr-*/issue-closed/decision-status/approach-status/manual)
+// and the human-vs-Producer verdict split are surfaced honestly, never
+// fabricated — per the simulated-onboarded posture
 // (`doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md`):
 // graceful degradation, transparency over completeness, retirable
 // compensation. Full fidelity is tracked in tmai-core#381.
@@ -33,7 +41,7 @@ export function ActiveApproachesSection({ unitName }: ActiveApproachesSectionPro
     <section>
       <header className="mb-2 flex items-baseline gap-2">
         <span className="text-base text-primary">▣</span>
-        <h3 className="text-sm font-semibold text-foreground">Active approaches</h3>
+        <h3 className="text-sm font-semibold text-foreground">Running approaches</h3>
         {loading && data === null && (
           <span className="text-[10px] text-muted-foreground">loading…</span>
         )}
@@ -57,7 +65,7 @@ function Body({ unitName, data, loading, error }: BodyProps) {
         <p>
           Pick a project (a unit chip in{" "}
           <span className="text-muted-foreground">⬢ Cross-unit status</span> above, or the sidebar)
-          to see its active approaches awaiting a verdict.
+          to see its running approaches awaiting a verdict.
         </p>
       </div>
     );
@@ -85,9 +93,9 @@ function Body({ unitName, data, loading, error }: BodyProps) {
     return (
       <div className="pl-6 text-xs text-muted-foreground">
         <p>
-          No active approaches for <code className="text-foreground">{unitName}</code>. The unit
+          No running approaches for <code className="text-foreground">{unitName}</code>. The unit
           either has no <code className="text-foreground">doc/approaches/</code> directory yet, or
-          no record is <code className="text-foreground">status: active</code>.
+          no record is <code className="text-foreground">status: running</code>.
         </p>
       </div>
     );
@@ -184,7 +192,8 @@ function classify(a: ApproachWire): Classified {
 }
 
 function RepoGroup({ repo, singleRepo }: { repo: RepoApproachesWire; singleRepo: boolean }) {
-  const classified = repo.active.map(classify);
+  const running = repo.approaches.filter((a) => a.status === "running");
+  const classified = running.map(classify);
   const verdict = classified.filter((c) => c.band === "verdict");
   const watch = classified.filter((c) => c.band === "watch");
   const quiet = classified.filter((c) => c.band === "quiet");
@@ -203,7 +212,7 @@ function RepoGroup({ repo, singleRepo }: { repo: RepoApproachesWire; singleRepo:
       )}
 
       <p className="text-[11px] text-subtle-foreground">
-        {`${repo.active.length} active · `}
+        {`${running.length} running · `}
         <span className="text-muted-foreground">{`⚡ ${verdict.length}  🟡 ${watch.length}  ⚪ ${quiet.length}`}</span>
       </p>
 
@@ -222,8 +231,8 @@ function RepoGroup({ repo, singleRepo }: { repo: RepoApproachesWire; singleRepo:
             evaluate (shown under Watch until tmai-core#381).
           </>
         )}{" "}
-        Settled (validated / rejected / replaced) approaches are audit-trail and not on the wire yet
-        (tmai-core#381).
+        Other statuses (planned / partial / ready / validated / rejected / replaced) live in the
+        dashboard surface below.
       </p>
     </div>
   );
@@ -233,7 +242,7 @@ function VerdictBand({ items }: { items: Classified[] }) {
   if (items.length === 0) {
     return (
       <p className="rounded border border-hairline-strong/40 bg-surface-strong/30 px-2 py-1 text-[11px] text-muted-foreground">
-        ⚡ No verdict due — no active approach has a fired date trigger.
+        ⚡ No verdict due — no running approach has a fired date trigger.
       </p>
     );
   }

--- a/clients/react/src/components/producer-console/sections/AllApproachesSection.tsx
+++ b/clients/react/src/components/producer-console/sections/AllApproachesSection.tsx
@@ -1,0 +1,283 @@
+// ▤ All approaches — operator dashboard's task-selection surface, sibling
+// to `▣ Running approaches` (the verdict-inbox).
+//
+// Per tmai-core#462 Amendment 2026-05-28's dashboard 全件可視化
+// direction, the wire (tmai-core#463 → tmai#744) carries every approach
+// record in `RepoApproachesWire.approaches` regardless of status:
+// `Planned` / `Partial` / `Ready` / `Running` / `Validated` / `Rejected`
+// / `Replaced`. tmai does NOT filter or sort authoritatively — the
+// operator filters/sorts client-side here.
+//
+// Axes (kept distinct so the surfaces stay honest):
+//   • Verdict-inbox  (▣ Running approaches above) — verification axis,
+//     `status: running` only. The verification-debt gauge counts those.
+//   • Task-selection (this section)              — "what should we work
+//     on next" across all 7 statuses.
+//
+// Reuses the same `useApproaches(unitName)` payload as the section above
+// — both feed off the one fetch.
+//
+// Default ordering = the wire's order (most-recent-first by slug per
+// `RepoApproachesWire`). The status filter is client-side; default
+// all-on; toggling chips hides statuses the operator does not care
+// about. The verification gauge counts `status: running` ONLY per
+// tmai-core#462 body ("running を直接 count、ready/planned/partial は
+// 混ぜない") — do not blend other statuses into the verification number.
+
+import { useMemo, useState } from "react";
+import { useApproaches } from "@/hooks/useApproaches";
+import type { ApproachStatus, ApproachWire, RepoApproachesWire } from "@/lib/api";
+
+interface AllApproachesSectionProps {
+  unitName: string | null;
+}
+
+const STATUS_ORDER: readonly ApproachStatus[] = [
+  "running",
+  "ready",
+  "planned",
+  "partial",
+  "validated",
+  "rejected",
+  "replaced",
+];
+
+export function AllApproachesSection({ unitName }: AllApproachesSectionProps) {
+  const { data, loading, error } = useApproaches(unitName);
+
+  return (
+    <section>
+      <header className="mb-2 flex items-baseline gap-2">
+        <span className="text-base text-primary">▤</span>
+        <h3 className="text-sm font-semibold text-foreground">All approaches</h3>
+        {loading && data === null && (
+          <span className="text-[10px] text-muted-foreground">loading…</span>
+        )}
+      </header>
+      <Body unitName={unitName} data={data} loading={loading} error={error} />
+    </section>
+  );
+}
+
+interface BodyProps {
+  unitName: string | null;
+  data: ReturnType<typeof useApproaches>["data"];
+  loading: boolean;
+  error: Error | null;
+}
+
+function Body({ unitName, data, loading, error }: BodyProps) {
+  if (unitName === null) {
+    return (
+      <div className="pl-6 text-xs text-muted-foreground">
+        <p>
+          Pick a project (a unit chip in{" "}
+          <span className="text-muted-foreground">⬢ Cross-unit status</span> above, or the sidebar)
+          to see its full approach roster across every status.
+        </p>
+      </div>
+    );
+  }
+
+  if (error !== null) {
+    // The sibling section already surfaces the error verbatim; keep the
+    // dashboard surface quiet on the same fetch failure rather than
+    // double-alarming the operator.
+    return null;
+  }
+
+  if (data === null && loading) {
+    return <div className="pl-6 text-xs text-muted-foreground">Loading…</div>;
+  }
+
+  if (data === null || data.repos.length === 0) {
+    return (
+      <div className="pl-6 text-xs text-muted-foreground">
+        <p>
+          No approaches for <code className="text-foreground">{unitName}</code> yet.
+        </p>
+      </div>
+    );
+  }
+
+  return <DashboardBody repos={data.repos} />;
+}
+
+function DashboardBody({ repos }: { repos: RepoApproachesWire[] }) {
+  // Default = all statuses visible. Operator toggles statuses they do
+  // not care about off — client-side, no refetch.
+  const [hidden, setHidden] = useState<ReadonlySet<ApproachStatus>>(() => new Set());
+
+  const toggle = (s: ApproachStatus) => {
+    setHidden((prev) => {
+      const next = new Set(prev);
+      if (next.has(s)) next.delete(s);
+      else next.add(s);
+      return next;
+    });
+  };
+
+  // Verification-debt gauge across the unit = running count only. Do
+  // NOT mix planned/partial/ready into this number (tmai-core#462).
+  const runningCount = useMemo(
+    () =>
+      repos.reduce(
+        (total, repo) => total + repo.approaches.filter((a) => a.status === "running").length,
+        0,
+      ),
+    [repos],
+  );
+
+  // Per-status totals across the unit, for the filter chips' counts
+  // and the operator's at-a-glance shape sense.
+  const totalsByStatus = useMemo(() => {
+    const m = new Map<ApproachStatus, number>();
+    for (const s of STATUS_ORDER) m.set(s, 0);
+    for (const repo of repos) {
+      for (const a of repo.approaches) {
+        m.set(a.status, (m.get(a.status) ?? 0) + 1);
+      }
+    }
+    return m;
+  }, [repos]);
+
+  return (
+    <div className="space-y-3 pl-6 text-xs">
+      <Gauge runningCount={runningCount} />
+      <StatusFilter totalsByStatus={totalsByStatus} hidden={hidden} onToggle={toggle} />
+      <div className="space-y-3">
+        {repos.map((repo) => (
+          <RepoBlock
+            key={repo.repo_root}
+            repo={repo}
+            hidden={hidden}
+            singleRepo={repos.length === 1}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function Gauge({ runningCount }: { runningCount: number }) {
+  return (
+    <p
+      // The verification-debt gauge counts `status: running` ONLY per
+      // tmai-core#462 body ("running を直接 count、ready/planned/partial
+      // は混ぜない"). Other statuses are visible below but excluded here.
+      data-testid="verification-gauge"
+      className="rounded border border-hairline-strong/40 bg-surface-strong/30 px-2 py-1 text-[11px] text-muted-foreground"
+    >
+      Verification debt: <span className="text-foreground">{runningCount}</span> running
+    </p>
+  );
+}
+
+interface StatusFilterProps {
+  totalsByStatus: ReadonlyMap<ApproachStatus, number>;
+  hidden: ReadonlySet<ApproachStatus>;
+  onToggle: (s: ApproachStatus) => void;
+}
+
+function StatusFilter({ totalsByStatus, hidden, onToggle }: StatusFilterProps) {
+  return (
+    <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
+      <span className="text-subtle-foreground">filter:</span>
+      {STATUS_ORDER.map((s) => {
+        const total = totalsByStatus.get(s) ?? 0;
+        const active = !hidden.has(s);
+        const pill = pillClasses(s, active);
+        return (
+          <button
+            key={s}
+            type="button"
+            onClick={() => onToggle(s)}
+            aria-pressed={active}
+            className={`${pill} rounded-full border px-2 py-0.5 transition-colors`}
+          >
+            {s} {total}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+interface RepoBlockProps {
+  repo: RepoApproachesWire;
+  hidden: ReadonlySet<ApproachStatus>;
+  singleRepo: boolean;
+}
+
+function RepoBlock({ repo, hidden, singleRepo }: RepoBlockProps) {
+  const visible = repo.approaches.filter((a) => !hidden.has(a.status));
+
+  return (
+    <div className="space-y-1.5">
+      {!singleRepo && (
+        <h4 className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+          <code className="font-mono text-foreground">{repo.repo_label}</code>
+          {repo.primary && <span className="ml-1 text-primary">(primary)</span>}
+          {repo.repo_head && (
+            <span className="ml-2 text-subtle-foreground">@ {repo.repo_head}</span>
+          )}
+        </h4>
+      )}
+      {visible.length === 0 ? (
+        <p className="text-[11px] text-subtle-foreground">All statuses filtered out.</p>
+      ) : (
+        <ul className="space-y-1">
+          {visible.map((a) => (
+            <ApproachRow key={a.slug} approach={a} />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+function ApproachRow({ approach }: { approach: ApproachWire }) {
+  return (
+    <li className="flex items-baseline gap-2 text-[11px] leading-snug">
+      <StatusPill status={approach.status} />
+      <code className="text-foreground">{approach.slug}</code>
+      <span className="text-muted-foreground">— {approach.title}</span>
+      {approach.confidence !== null && (
+        <span className="text-subtle-foreground">· conf {approach.confidence}</span>
+      )}
+    </li>
+  );
+}
+
+function StatusPill({ status }: { status: ApproachStatus }) {
+  return (
+    <span className={`${pillClasses(status, true)} rounded-full border px-1.5 py-0.5 text-[10px]`}>
+      {status}
+    </span>
+  );
+}
+
+// Semantic-token mapping — never raw Tailwind palette per
+// `no-raw-palette.test.ts`. Active = filled tint, inactive = muted/
+// hairline so the operator can see which statuses are toggled off
+// without losing the row's status identity.
+function pillClasses(status: ApproachStatus, active: boolean): string {
+  if (!active) {
+    return "border-hairline bg-transparent text-subtle-foreground hover:text-muted-foreground";
+  }
+  switch (status) {
+    case "running":
+      return "border-warning/40 bg-warning/[0.08] text-warning";
+    case "ready":
+      return "border-primary/40 bg-primary/[0.08] text-primary";
+    case "validated":
+      return "border-success/40 bg-success/[0.08] text-success";
+    case "rejected":
+      return "border-destructive/40 bg-destructive/[0.08] text-destructive";
+    case "replaced":
+      return "border-hairline-strong/50 bg-surface-strong/40 text-muted-foreground";
+    case "planned":
+    case "partial":
+      return "border-hairline-strong/50 bg-surface-strong/30 text-foreground";
+  }
+}

--- a/clients/react/src/components/producer-console/sections/__tests__/ActiveApproachesSection.test.tsx
+++ b/clients/react/src/components/producer-console/sections/__tests__/ActiveApproachesSection.test.tsx
@@ -3,7 +3,13 @@
 // ActiveApproachesSection — the Verdict-inbox, wired to
 // `useApproaches(unitName)` against `GET /api/units/{unit}/approaches`
 // (tmai-core #369). We mock `api.approaches` so each test feeds a
-// deterministic active-only payload and asserts on the band routing.
+// deterministic payload and asserts on the band routing.
+//
+// Post tmai-core#463 / tmai#744 / tmai-core#462 Amendment 2026-05-28:
+// the wire is `RepoApproachesWire.approaches: ApproachWire[]` carrying
+// every status; this section filters client-side to `status: "running"`
+// for the verdict-inbox surface. Fixtures use the new shape with mixed
+// statuses; non-running records must not appear in the bands.
 //
 // Per the simulated-onboarded posture DR the section must: pick-a-project
 // notice on null unit; honest error (no fabricated render); honest empty
@@ -34,12 +40,13 @@ function approachStub(overrides: Partial<ApproachWire> = {}): ApproachWire {
     slug: "2026-05-16-some-approach",
     title: "Some approach",
     date: "2026-05-16",
-    status: "active",
+    status: "running",
     governs: [],
     serves: ["2026-05-15-protect-scarce-human-judgment"],
     success_signal: "the thing works",
     failure_signal: "the thing does not work",
     review_triggers: [{ kind: "date", value: "2099-01-01" }],
+    review_history: [],
     confidence: "high",
     replaced_by: [],
     excerpt: "…",
@@ -53,7 +60,7 @@ function repoStub(overrides: Partial<RepoApproachesWire> = {}): RepoApproachesWi
     repo_root: "/home/u/works/tmai-core",
     primary: true,
     repo_head: "abc1234",
-    active: [],
+    approaches: [],
     ...overrides,
   };
 }
@@ -83,7 +90,7 @@ describe("ActiveApproachesSection", () => {
       responseStub({
         repos: [
           repoStub({
-            active: [
+            approaches: [
               approachStub({
                 slug: "2026-05-16-authority-derived-from-act",
                 title: "Authority derived from the act",
@@ -114,7 +121,7 @@ describe("ActiveApproachesSection", () => {
       responseStub({
         repos: [
           repoStub({
-            active: [
+            approaches: [
               approachStub({
                 slug: "2026-05-16-low-conf-thing",
                 confidence: "low",
@@ -143,7 +150,7 @@ describe("ActiveApproachesSection", () => {
       responseStub({
         repos: [
           repoStub({
-            active: [
+            approaches: [
               approachStub({
                 slug: "2026-05-16-manual-only",
                 confidence: "high",
@@ -178,19 +185,19 @@ describe("ActiveApproachesSection", () => {
     expect(screen.queryByText(/Your verdict/)).toBeNull();
   });
 
-  it("renders an empty-state notice when the unit has no active approaches", async () => {
+  it("renders an empty-state notice when the unit has no approaches", async () => {
     approachesMock.mockResolvedValue(responseStub({ repos: [] }));
 
     render(<ActiveApproachesSection unitName="newunit" />);
 
     await waitFor(() => {
-      expect(screen.getByText(/No active approaches for/i)).toBeTruthy();
+      expect(screen.getByText(/No running approaches for/i)).toBeTruthy();
     });
   });
 
   it("shows the single-repo caveat (tmai-core#340)", async () => {
     approachesMock.mockResolvedValue(
-      responseStub({ repos: [repoStub({ active: [approachStub()] })] }),
+      responseStub({ repos: [repoStub({ approaches: [approachStub()] })] }),
     );
 
     render(<ActiveApproachesSection unitName="tmai" />);
@@ -199,5 +206,67 @@ describe("ActiveApproachesSection", () => {
       expect(screen.getByText(/primary repo only/i)).toBeTruthy();
     });
     expect(screen.getByText(/tmai-core#340/)).toBeTruthy();
+  });
+
+  it("filters out non-running statuses — verdict-inbox sees only `running`", async () => {
+    // Mixed-status fixture covering every non-running variant. None of
+    // these should land in any band; the verdict-inbox is running-only.
+    approachesMock.mockResolvedValue(
+      responseStub({
+        repos: [
+          repoStub({
+            approaches: [
+              approachStub({
+                slug: "2026-05-27-planned-x",
+                status: "planned",
+                review_triggers: [{ kind: "date", value: "2020-01-01" }],
+              }),
+              approachStub({
+                slug: "2026-05-27-partial-x",
+                status: "partial",
+                review_triggers: [{ kind: "date", value: "2020-01-01" }],
+              }),
+              approachStub({
+                slug: "2026-05-27-ready-x",
+                status: "ready",
+                review_triggers: [{ kind: "date", value: "2020-01-01" }],
+              }),
+              approachStub({
+                slug: "2026-05-27-validated-x",
+                status: "validated",
+                review_triggers: [{ kind: "date", value: "2020-01-01" }],
+              }),
+              approachStub({
+                slug: "2026-05-27-rejected-x",
+                status: "rejected",
+                review_triggers: [{ kind: "date", value: "2020-01-01" }],
+              }),
+              approachStub({
+                slug: "2026-05-27-replaced-x",
+                status: "replaced",
+                replaced_by: ["2026-05-27-newer-x"],
+                review_triggers: [{ kind: "date", value: "2020-01-01" }],
+              }),
+            ],
+          }),
+        ],
+      }),
+    );
+
+    render(<ActiveApproachesSection unitName="tmai" />);
+
+    // Initial fetch settles → "loading…" is gone.
+    await waitFor(() => {
+      expect(screen.queryByText("loading…")).toBeNull();
+    });
+    // Verdict-inbox sees zero running approaches — the empty-band notice
+    // appears, and the running count is 0.
+    expect(screen.getByText(/⚡ No verdict due/)).toBeTruthy();
+    expect(screen.getByText(/0 running/)).toBeTruthy();
+    // None of the non-running slugs leak through.
+    expect(screen.queryByText(/2026-05-27-planned-x/)).toBeNull();
+    expect(screen.queryByText(/2026-05-27-validated-x/)).toBeNull();
+    expect(screen.queryByText(/2026-05-27-rejected-x/)).toBeNull();
+    expect(screen.queryByText(/2026-05-27-replaced-x/)).toBeNull();
   });
 });

--- a/clients/react/src/components/producer-console/sections/__tests__/AllApproachesSection.test.tsx
+++ b/clients/react/src/components/producer-console/sections/__tests__/AllApproachesSection.test.tsx
@@ -1,0 +1,204 @@
+// @vitest-environment jsdom
+//
+// AllApproachesSection — the operator dashboard's task-selection
+// surface (sibling to the verdict-inbox).
+//
+// Asserts on the #462 Amendment 2026-05-28 contract:
+//   • Renders every status on the wire (Planned / Partial / Ready /
+//     Running / Validated / Rejected / Replaced); the client filters,
+//     tmai does not.
+//   • Status filter chips toggle visibility client-side, no refetch.
+//   • Verification-debt gauge counts `status: running` ONLY — never
+//     blends in ready / planned / partial / validated / rejected /
+//     replaced (per tmai-core#462 body).
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  ApproachesResponse,
+  ApproachStatus,
+  ApproachWire,
+  RepoApproachesWire,
+} from "@/lib/api";
+
+const approachesMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      approaches: (...args: unknown[]) => approachesMock(...args),
+    },
+  };
+});
+
+import { AllApproachesSection } from "../AllApproachesSection";
+
+function approachStub(overrides: Partial<ApproachWire> = {}): ApproachWire {
+  return {
+    slug: "2026-05-27-an-approach",
+    title: "An approach",
+    date: "2026-05-27",
+    status: "running",
+    governs: [],
+    serves: [],
+    success_signal: "ok",
+    failure_signal: "not ok",
+    review_triggers: [{ kind: "date", value: "2099-01-01" }],
+    review_history: [],
+    confidence: null,
+    replaced_by: [],
+    excerpt: "…",
+    ...overrides,
+  };
+}
+
+const ALL_STATUSES: readonly ApproachStatus[] = [
+  "planned",
+  "partial",
+  "ready",
+  "running",
+  "validated",
+  "rejected",
+  "replaced",
+];
+
+function fullRosterRepo(): RepoApproachesWire {
+  return {
+    repo_label: "tmai-core",
+    repo_root: "/home/u/works/tmai-core",
+    primary: true,
+    repo_head: "abc1234",
+    approaches: ALL_STATUSES.map((s) =>
+      approachStub({
+        slug: `2026-05-27-${s}-row`,
+        title: `${s} approach`,
+        status: s,
+      }),
+    ),
+  };
+}
+
+function responseStub(overrides: Partial<ApproachesResponse> = {}): ApproachesResponse {
+  return {
+    unit: "tmai",
+    composed_at: "2026-05-27T01:00:00Z",
+    repos: [fullRosterRepo()],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  approachesMock.mockReset();
+});
+
+describe("AllApproachesSection", () => {
+  it("shows a pick-a-project notice when unitName is null and does not fetch", () => {
+    render(<AllApproachesSection unitName={null} />);
+    expect(screen.getByText(/Pick a project/i)).toBeTruthy();
+    expect(approachesMock).not.toHaveBeenCalled();
+  });
+
+  it("renders one row per approach across all 7 statuses", async () => {
+    approachesMock.mockResolvedValue(responseStub());
+    render(<AllApproachesSection unitName="tmai" />);
+
+    for (const s of ALL_STATUSES) {
+      await waitFor(() => {
+        expect(screen.getByText(new RegExp(`2026-05-27-${s}-row`))).toBeTruthy();
+      });
+    }
+  });
+
+  it("toggles a status off via its filter chip and back on (client-side, no refetch)", async () => {
+    approachesMock.mockResolvedValue(responseStub());
+    render(<AllApproachesSection unitName="tmai" />);
+
+    // Wait for first paint then snapshot the fetch count.
+    await waitFor(() => {
+      expect(screen.getByText(/2026-05-27-rejected-row/)).toBeTruthy();
+    });
+    const callsBefore = approachesMock.mock.calls.length;
+
+    // Toggle "rejected" off — the row should disappear, no new fetch.
+    const rejectedChip = screen.getByRole("button", { name: /^rejected\b/ });
+    expect(rejectedChip.getAttribute("aria-pressed")).toBe("true");
+    fireEvent.click(rejectedChip);
+    await waitFor(() => {
+      expect(screen.queryByText(/2026-05-27-rejected-row/)).toBeNull();
+    });
+    expect(rejectedChip.getAttribute("aria-pressed")).toBe("false");
+    expect(approachesMock.mock.calls.length).toBe(callsBefore);
+
+    // Other statuses remain visible.
+    expect(screen.getByText(/2026-05-27-running-row/)).toBeTruthy();
+    expect(screen.getByText(/2026-05-27-validated-row/)).toBeTruthy();
+
+    // Toggle back on — the row returns.
+    fireEvent.click(rejectedChip);
+    await waitFor(() => {
+      expect(screen.getByText(/2026-05-27-rejected-row/)).toBeTruthy();
+    });
+    expect(rejectedChip.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("verification-debt gauge counts running approaches ONLY (per tmai-core#462)", async () => {
+    // 2 running among many other statuses — gauge must read "2", never
+    // anything that would bleed in ready / planned / partial.
+    approachesMock.mockResolvedValue(
+      responseStub({
+        repos: [
+          {
+            repo_label: "tmai-core",
+            repo_root: "/home/u/works/tmai-core",
+            primary: true,
+            repo_head: "abc1234",
+            approaches: [
+              approachStub({ slug: "2026-05-27-running-1", status: "running" }),
+              approachStub({ slug: "2026-05-27-running-2", status: "running" }),
+              approachStub({ slug: "2026-05-27-ready-1", status: "ready" }),
+              approachStub({ slug: "2026-05-27-ready-2", status: "ready" }),
+              approachStub({ slug: "2026-05-27-planned-1", status: "planned" }),
+              approachStub({ slug: "2026-05-27-partial-1", status: "partial" }),
+              approachStub({ slug: "2026-05-27-validated-1", status: "validated" }),
+              approachStub({ slug: "2026-05-27-rejected-1", status: "rejected" }),
+              approachStub({ slug: "2026-05-27-replaced-1", status: "replaced" }),
+            ],
+          },
+        ],
+      }),
+    );
+
+    render(<AllApproachesSection unitName="tmai" />);
+
+    const gauge = await screen.findByTestId("verification-gauge");
+    expect(gauge.textContent).toMatch(/Verification debt:\s*2\s*running/);
+    // The gauge does NOT pluralise to the full count when other statuses
+    // are present — the number is running-only.
+    expect(gauge.textContent).not.toMatch(/9\s*running/);
+  });
+
+  it("renders an empty-state notice when the unit has no approaches", async () => {
+    approachesMock.mockResolvedValue(responseStub({ repos: [] }));
+    render(<AllApproachesSection unitName="newunit" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No approaches for/i)).toBeTruthy();
+    });
+  });
+
+  it("stays quiet on fetch errors (sibling Verdict-inbox surfaces the error verbatim)", async () => {
+    approachesMock.mockRejectedValue(new Error("boom"));
+    render(<AllApproachesSection unitName="tmai" />);
+
+    // No "failed" alarm here — we let the sibling Verdict-inbox surface
+    // the same fetch failure to avoid double-alarming the operator.
+    await waitFor(() => {
+      expect(screen.queryByText(/loading…/i)).toBeNull();
+    });
+    expect(screen.queryByText(/Failed to load/i)).toBeNull();
+    expect(screen.queryByText(/All approaches/)).toBeTruthy(); // header still present
+  });
+});

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -2,6 +2,9 @@
 // Replaces Tauri IPC — all communication goes through the existing web API.
 
 import type { AgentCtxUsage } from "@/types/generated/AgentCtxUsage";
+import type { ApproachesResponse } from "@/types/generated/ApproachesResponse";
+import type { ApproachStatus } from "@/types/generated/ApproachStatus";
+import type { ApproachWire } from "@/types/generated/ApproachWire";
 import type { BootstrapRequiredEvent } from "@/types/generated/BootstrapRequiredEvent";
 import type { CalibrationCellWire } from "@/types/generated/CalibrationCellWire";
 import type { CalibrationEntry } from "@/types/generated/CalibrationEntry";
@@ -19,7 +22,10 @@ import type { ProducerPullTrigger } from "@/types/generated/ProducerPullTrigger"
 import type { PrSummaryWire } from "@/types/generated/PrSummaryWire";
 import type { QueueAgentEntry } from "@/types/generated/QueueAgentEntry";
 import type { QueueSnapshot } from "@/types/generated/QueueSnapshot";
+import type { RepoApproachesWire } from "@/types/generated/RepoApproachesWire";
 import type { RepoPrsWire } from "@/types/generated/RepoPrsWire";
+import type { ReviewExtensionWire } from "@/types/generated/ReviewExtensionWire";
+import type { ReviewTriggerWire } from "@/types/generated/ReviewTriggerWire";
 import type { RuntimeSnapshot } from "@/types/generated/RuntimeSnapshot";
 import type { SpawnRole } from "@/types/generated/SpawnRole";
 import type { SpawnRuntime } from "@/types/generated/SpawnRuntime";
@@ -36,6 +42,9 @@ import type { WorkflowSnapshot } from "@/types/generated/WorkflowSnapshot";
 
 export type {
   AgentCtxUsage,
+  ApproachesResponse,
+  ApproachStatus,
+  ApproachWire,
   BootstrapRequiredEvent,
   CalibrationCellWire,
   CalibrationEntry,
@@ -52,7 +61,10 @@ export type {
   PrSummaryWire,
   QueueAgentEntry,
   QueueSnapshot,
+  RepoApproachesWire,
   RepoPrsWire,
+  ReviewExtensionWire,
+  ReviewTriggerWire,
   SpawnRole,
   SpawnRuntime,
   TerminalSubscription,
@@ -1041,67 +1053,16 @@ export interface WorkingWithHumanResponse {
   memory_index: string | null;
 }
 
-// ── Active approaches view (tmai-core PR #369) ──
+// ── Approaches view ──
 //
-// Mirror of `tmai-core::api::approaches_view`. `RepoApproachesWire.active`
-// carries `status: active` records only — validated / rejected / replaced
-// are filtered at compose time (audit-trail, not yet on the wire; the
-// console's Verdict-inbox surfaces that gap honestly per
-// `doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md`).
-// Hand-written until `gen-spec-pr` syncs the generated type; A2 fidelity
-// (core-computed trigger firing + verdict authority + settled projection)
-// is tracked in tmai-core#381.
-
-export type ApproachStatusWire = "active" | "validated" | "rejected" | "replaced";
-
-/** One review trigger, tagged on `kind` (mirrors the Rust enum 1:1; the
- *  `Date` value is an ISO-8601 string on the wire). Only `date` is
- *  client-evaluable; the rest need core/gh resolution (tmai-core#381). */
-export type ReviewTriggerWire =
-  | { kind: "date"; value: string }
-  | { kind: "pr-closed"; ref: string }
-  | { kind: "pr-merged"; ref: string }
-  | { kind: "issue-closed"; ref: string }
-  | { kind: "decision-status"; ref: string; "target-status": string }
-  | { kind: "approach-status"; ref: string; "target-status": string }
-  | { kind: "manual"; description: string };
-
-export interface ApproachWire {
-  slug: string;
-  title: string;
-  /** ISO-8601 date from the slug prefix (creation date — approaches have
-   *  no `last_verified`; re-evaluation is signal-driven). */
-  date: string;
-  status: ApproachStatusWire;
-  governs: string[];
-  /** `serves:` — the decision slug(s) this approach's means serve. */
-  serves: string[];
-  success_signal: string;
-  failure_signal: string;
-  review_triggers: ReviewTriggerWire[];
-  /** Producer confidence; `null` when none on record. */
-  confidence: "high" | "low" | null;
-  /** Successor approach slugs — meaningful only when `status: replaced`. */
-  replaced_by: string[];
-  /** First-paragraph summary of the body. */
-  excerpt: string;
-}
-
-export interface RepoApproachesWire {
-  repo_label: string;
-  repo_root: string;
-  primary: boolean;
-  repo_head: string | null;
-  /** `status: active` records only (see module note). */
-  active: ApproachWire[];
-}
-
-export interface ApproachesResponse {
-  unit: string;
-  /** RFC3339 compose timestamp. */
-  composed_at: string;
-  repos: RepoApproachesWire[];
-}
+// Hand-mirror retired in favor of the generated source-of-truth (see the
+// `import type` block at the top of this file). Post tmai-core#463 / tmai#744
+// the wire is `RepoApproachesWire.approaches: ApproachWire[]` carrying ALL
+// statuses — `Planned` / `Partial` / `Ready` / `Running` / `Validated` /
+// `Rejected` / `Replaced` — sorted most-recent-first by slug. The dashboard
+// filters / sorts client-side per tmai-core#462 Amendment 2026-05-28
+// (全件可視化). The verdict-inbox surface in `ActiveApproachesSection`
+// narrows to `status: "running"` only — the dischargeable verification debt.
 
 // ── API wrappers ──
 
@@ -1515,10 +1476,12 @@ export const api = {
   decisions: (unit: string) =>
     apiFetch<DecisionsResponse>(`/units/${encodeURIComponent(unit)}/decisions`),
 
-  // Active approaches view — `▣ Active approaches` slice of `compose()`
-  // (tmai-core PR #369). `status: active` records only; per-repo groups
-  // (multi-repo follows tmai-core#340, same as decisions). The console
-  // turns this into the Verdict-inbox.
+  // Approaches view — every approach record (all statuses) per repo,
+  // sorted most-recent-first by slug. The console's Verdict-inbox
+  // filters to `status: running` client-side; the dashboard surface
+  // (`AllApproachesSection`) renders all 7 statuses with operator-side
+  // filters per tmai-core#462 Amendment 2026-05-28. Multi-repo follows
+  // tmai-core#340, same as decisions.
   approaches: (unit: string) =>
     apiFetch<ApproachesResponse>(`/units/${encodeURIComponent(unit)}/approaches`),
 


### PR DESCRIPTION
## Summary

Closes the React consumer half of the approach-lifecycle Amendment landed in tmai-core#463 / synced to this repo by #744.

The hand-written wire mirror in `lib/api-http.ts` (`ApproachStatusWire = "active"|…`, `RepoApproachesWire { active: ApproachWire[] }`, …) was shadowing the generated source-of-truth — that's why `tsc` was green on `main` despite the `repo.active.map(…)` references in `ActiveApproachesSection`. At runtime the wire now returns `approaches`, so the consumer would have crashed on `Cannot read properties of undefined (reading 'map')`. This PR removes the shadow and consumes the new shape end-to-end.

- **Retire the hand-mirror** in `clients/react/src/lib/api-http.ts`: delete the hand-written `ApproachStatusWire` / `ReviewTriggerWire` / `ApproachWire` / `RepoApproachesWire` / `ApproachesResponse`; import + re-export them from `@/types/generated/` instead, mirroring the units-wire convention higher in the same file.
- **`ActiveApproachesSection` (▣ verdict-inbox)** filters `repo.approaches` by `status === "running"` (Producer 経路 held — Ready / Planned / Partial intentionally NOT widened in). Count line, empty-state copy, and module / header comments updated to drop "active" wording.
- **Add `AllApproachesSection` (▤ task-selection dashboard)** — sibling to the verdict-inbox, rendered after it in `ProducerConsole.tsx`. Renders every approach across all 7 statuses (`planned` / `partial` / `ready` / `running` / `validated` / `rejected` / `replaced`) with a client-side status-filter chip-row, default all-on. Verification-debt gauge counts `running` ONLY per tmai-core#462 body ("running を直接 count、ready/planned/partial は混ぜない"). Sort default mirrors the wire's most-recent-first-by-slug order; reuses the existing `useApproaches(unitName)` hook (no new fetch). Semantic tokens only (`no-raw-palette.test.ts` lock).
- **Tests** — `ActiveApproachesSection.test.tsx` fixtures rewritten onto the new wire shape, plus a new case asserting non-running statuses never leak into any band. New `AllApproachesSection.test.tsx` covers all-7-statuses render, filter-chip toggle (and no refetch on toggle), the running-only gauge contract, pick-a-project / empty-state / quiet-on-error paths.

Refs:
- tmai-core#463 — approach lifecycle Amendment (Phase 3)
- #744 — gen-spec mirror to this repo
- tmai-core#462 — Amendment 2026-05-28 (dashboard 全件可視化)

## Test plan
- [x] `pnpm exec tsc -b --force` (incremental cache hid the breakage on main — forced fresh check)
- [x] `pnpm lint` (biome)
- [x] `pnpm build`
- [x] `pnpm test` — 523 passed, 2 skipped
- [ ] Manual UI smoke under a real unit's approaches once a build with mixed statuses lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)