### PR TITLE
R-panel: in-tmai PR content viewer (R₂ viewer column, γ-lean) — no github.com round-trip (#749)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -13,6 +13,11 @@ import { HandoffRitualOverlay } from "@/components/producer-console/HandoffRitua
 import { ProducerConsole } from "@/components/producer-console/ProducerConsole";
 import { ProducerConversationHeader } from "@/components/producer-console/ProducerConversationHeader";
 import { RPanel } from "@/components/producer-console/r-panel/RPanel";
+import {
+  RPrViewer,
+  type SelectedPr,
+  selectedPrKey,
+} from "@/components/producer-console/r-panel/r-viewer/RPrViewer";
 import { ProducerFeedChip } from "@/components/producer-feed/ProducerFeedChip";
 import { SecurityPanel } from "@/components/settings/SecurityPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
@@ -117,6 +122,12 @@ export function App() {
   // through the shared useSplitPane engine (ratio-based), so we convert
   // at the seams. See the rPanel*Width helpers above.
   const [rPanelWidth, setRPanelWidth] = useUIPref("attentionStripWidth");
+  // The PR open in the independent R₂ viewer column (#749). `null` =
+  // no viewer (it never auto-opens — the operator clicks a row in the
+  // R₁ inventory to select; viewer-approach negative space). Lives at
+  // App level because R₂ renders as a sibling column of <main> / RPanel,
+  // not inside the inventory panel (R₁ stays a pure inventory).
+  const [selectedPr, setSelectedPr] = useState<SelectedPr | null>(null);
   const showSettings = mainPanel === "settings";
   const showSecurity = mainPanel === "security";
   const showCalibration = mainPanel === "calibration";
@@ -173,6 +184,15 @@ export function App() {
   }, [currentProject]);
   const { data: calibrationData } = useCalibration(unitName);
   const { data: producerFeedData } = useProducerFeed(unitName);
+
+  // Close the R₂ PR viewer when the focused unit changes — its open PR
+  // belongs to the previous unit, so it must not linger under a new
+  // unit's inventory (mirrors useUnitPrs clearing its list on unit change).
+  // unitName is the intended trigger even though the body only clears state.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: intentional unit-change trigger
+  useEffect(() => {
+    setSelectedPr(null);
+  }, [unitName]);
   // Configured-unit membership (tmai-core #460 — wire half of #439).
   // Threaded into `findProducerForUnit` below so multi-repo units
   // resolve their Producer against the primary repo specifically,
@@ -785,7 +805,21 @@ export function App() {
             onDoubleClick: () => setRPanelWidth(ATTENTION_STRIP_WIDTH_DEFAULT),
             onAdjust: rPanelSplit.adjustRatio,
           }}
+          onSelectPr={setSelectedPr}
+          selectedPrKey={
+            selectedPr ? selectedPrKey(selectedPr.repoPath, selectedPr.pr.number) : null
+          }
         />
+      )}
+
+      {/* R₂ — independent in-tmai PR content viewer column (#749). The
+          spine's γ-lean 4-column shape (L / C / R₁ inventory / R₂ viewer):
+          this is the rightmost column, present ONLY when the operator has
+          selected a PR in the R₁ inventory (never auto-opens). Gated on the
+          same narrow/mobile guard as RPanel so it never crowds a small
+          viewport. */}
+      {!isNarrowScreen && !isMobileScreen && selectedPr && (
+        <RPrViewer selected={selectedPr} onClose={() => setSelectedPr(null)} />
       )}
 
       {/* Help overlay */}

--- a/clients/react/src/components/producer-console/r-panel/RPanel.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPanel.tsx
@@ -36,6 +36,7 @@ import { RFilesSection } from "./RFilesSection";
 import { RHandoverSection } from "./RHandoverSection";
 import { RIssuesSection } from "./RIssuesSection";
 import { RPrsSection } from "./RPrsSection";
+import type { SelectedPr } from "./r-viewer/RPrViewer";
 
 export interface RPanelResize {
   width: number;
@@ -57,6 +58,13 @@ interface RPanelProps {
   collapsed: boolean;
   onToggleCollapsed: () => void;
   resize: RPanelResize;
+  /** Open a PR in the independent R₂ viewer column (#749). Threaded to
+   *  the R₁ PR inventory so a row click selects the PR for in-tmai
+   *  viewing instead of linking out to github.com. */
+  onSelectPr?: (sel: SelectedPr) => void;
+  /** `selectedPrKey(...)` of the PR currently open in R₂, so the R₁ row
+   *  marks itself as the one being viewed. */
+  selectedPrKey?: string | null;
 }
 
 const SECTION_IDS = [
@@ -78,6 +86,8 @@ export function RPanel({
   collapsed,
   onToggleCollapsed,
   resize,
+  onSelectPr,
+  selectedPrKey,
 }: RPanelProps) {
   const [expanded, setExpanded] = useUIPref("rPanelExpandedSections");
 
@@ -177,6 +187,8 @@ export function RPanel({
           unitName={unitName}
           expanded={isExpanded("prs")}
           onToggle={() => toggle("prs")}
+          onSelectPr={onSelectPr}
+          selectedKey={selectedPrKey}
         />
         <RIssuesSection
           currentProjectPath={currentProjectPath}

--- a/clients/react/src/components/producer-console/r-panel/RPrsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPrsSection.tsx
@@ -10,15 +10,31 @@
 
 import { useUnitPrs } from "@/hooks/useUnitPrs";
 import type { PrSummaryWire, RepoPrsWire } from "@/lib/api";
+import { type SelectedPr, selectedPrKey } from "./r-viewer/RPrViewer";
 import { Section } from "./Section";
 
 interface RPrsSectionProps {
   unitName: string | null;
   expanded: boolean;
   onToggle: () => void;
+  /** Open a PR in the R₂ viewer column (#749). The github.com link-out
+   *  used to live on the PR number; clicking a row now selects the PR
+   *  for in-tmai viewing — no round-trip. Optional so the section still
+   *  renders standalone (e.g. in isolation tests). */
+  onSelectPr?: (sel: SelectedPr) => void;
+  /** `selectedPrKey(repoPath, number)` of the PR currently open in R₂,
+   *  so the row marks itself as the one being viewed (a mechanical
+   *  "open here" fact, not appraisal). */
+  selectedKey?: string | null;
 }
 
-export function RPrsSection({ unitName, expanded, onToggle }: RPrsSectionProps) {
+export function RPrsSection({
+  unitName,
+  expanded,
+  onToggle,
+  onSelectPr,
+  selectedKey,
+}: RPrsSectionProps) {
   const { data, loading, error } = useUnitPrs(unitName);
   const total = data === null ? 0 : data.repos.reduce((n, r) => n + r.prs.length, 0);
 
@@ -31,7 +47,14 @@ export function RPrsSection({ unitName, expanded, onToggle }: RPrsSectionProps) 
       expanded={expanded}
       onToggle={onToggle}
     >
-      <Body unitName={unitName} repos={data?.repos ?? null} loading={loading} error={error} />
+      <Body
+        unitName={unitName}
+        repos={data?.repos ?? null}
+        loading={loading}
+        error={error}
+        onSelectPr={onSelectPr}
+        selectedKey={selectedKey ?? null}
+      />
     </Section>
   );
 }
@@ -41,9 +64,11 @@ interface BodyProps {
   repos: RepoPrsWire[] | null;
   loading: boolean;
   error: Error | null;
+  onSelectPr?: (sel: SelectedPr) => void;
+  selectedKey: string | null;
 }
 
-function Body({ unitName, repos, loading, error }: BodyProps) {
+function Body({ unitName, repos, loading, error, onSelectPr, selectedKey }: BodyProps) {
   if (unitName === null) {
     return <p className="text-subtle-foreground">Pick a project to see open PRs.</p>;
   }
@@ -60,13 +85,29 @@ function Body({ unitName, repos, loading, error }: BodyProps) {
   return (
     <div className="space-y-2">
       {repos.map((repo) => (
-        <RepoBlock key={repo.repo_path} repo={repo} multiRepo={multiRepo} />
+        <RepoBlock
+          key={repo.repo_path}
+          repo={repo}
+          multiRepo={multiRepo}
+          onSelectPr={onSelectPr}
+          selectedKey={selectedKey}
+        />
       ))}
     </div>
   );
 }
 
-function RepoBlock({ repo, multiRepo }: { repo: RepoPrsWire; multiRepo: boolean }) {
+function RepoBlock({
+  repo,
+  multiRepo,
+  onSelectPr,
+  selectedKey,
+}: {
+  repo: RepoPrsWire;
+  multiRepo: boolean;
+  onSelectPr?: (sel: SelectedPr) => void;
+  selectedKey: string | null;
+}) {
   if (repo.prs.length === 0) return null;
   return (
     <div>
@@ -77,34 +118,62 @@ function RepoBlock({ repo, multiRepo }: { repo: RepoPrsWire; multiRepo: boolean 
       )}
       <ul className="space-y-1">
         {repo.prs.map((pr) => (
-          <PrRow key={`${repo.repo_path}#${pr.number}`} pr={pr} />
+          <PrRow
+            key={`${repo.repo_path}#${pr.number}`}
+            pr={pr}
+            repoPath={repo.repo_path}
+            repoLabel={repo.repo_label}
+            onSelectPr={onSelectPr}
+            selected={selectedKey === selectedPrKey(repo.repo_path, pr.number)}
+          />
         ))}
       </ul>
     </div>
   );
 }
 
-function PrRow({ pr }: { pr: PrSummaryWire }) {
+function PrRow({
+  pr,
+  repoPath,
+  repoLabel,
+  onSelectPr,
+  selected,
+}: {
+  pr: PrSummaryWire;
+  repoPath: string;
+  repoLabel: string;
+  onSelectPr?: (sel: SelectedPr) => void;
+  selected: boolean;
+}) {
   // Plain-text status — no severity-color CI / review badges. The
-  // operator can read "CI SUCCESS" / "CI FAILURE" identically; R
-  // is inventory, not triage.
+  // operator can read "CI SUCCESS" / "CI FAILURE" identically; R is
+  // inventory, not triage.
+  //
+  // The whole row is a button that opens the PR in the R₂ viewer
+  // (#749) — there is NO github.com link-out anymore; the PR's full
+  // content is reviewed in-tmai. `aria-current` marks the row whose
+  // content is currently open in R₂ (a mechanical "open here" fact).
   return (
     <li className="leading-snug">
-      <a
-        href={pr.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="font-mono text-foreground hover:underline"
+      <button
+        type="button"
+        onClick={() => onSelectPr?.({ repoPath, repoLabel, pr })}
+        aria-current={selected ? "true" : undefined}
+        className={`w-full rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
+          selected ? "bg-surface-strong/40" : ""
+        }`}
       >
-        #{Number(pr.number)}
-      </a>{" "}
-      <span className="text-foreground">{pr.title}</span>
-      <div className="text-[11px] text-subtle-foreground">
-        {pr.head_branch} → {pr.base_branch}
-        {pr.check_status !== null && ` · CI ${pr.check_status}`}
-        {pr.review_decision !== null && ` · ${pr.review_decision}`}
-        {pr.is_draft && " · draft"}
-      </div>
+        <span>
+          <span className="font-mono text-foreground">#{Number(pr.number)}</span>{" "}
+          <span className="text-foreground">{pr.title}</span>
+        </span>
+        <div className="text-[11px] text-subtle-foreground">
+          {pr.head_branch} → {pr.base_branch}
+          {pr.check_status !== null && ` · CI ${pr.check_status}`}
+          {pr.review_decision !== null && ` · ${pr.review_decision}`}
+          {pr.is_draft && " · draft"}
+        </div>
+      </button>
     </li>
   );
 }

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RPrsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RPrsSection.test.tsx
@@ -5,7 +5,7 @@
 // text-warning/destructive/success classes for state; R intentionally
 // does not.
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { PrSummaryWire, UnitPrsResponse } from "@/lib/api";
 
@@ -85,5 +85,30 @@ describe("RPrsSection", () => {
       expect(screen.getByText(/0 open/)).toBeTruthy();
     });
     expect(screen.getByText(/No open PRs/i)).toBeTruthy();
+  });
+
+  it("has NO github.com link-out — the row is an in-tmai select (#749)", async () => {
+    unitPrsMock.mockResolvedValue(response([pr()]));
+    const { container } = render(<RPrsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText("PR title")).toBeTruthy();
+    });
+    // The PR number used to be an <a href> to github.com; it is now a
+    // button that opens the R₂ viewer in-tmai. No anchor should remain.
+    expect(container.querySelector("a[href*='github.com']")).toBeNull();
+  });
+
+  it("clicking a PR row selects it for the R₂ viewer", async () => {
+    const onSelectPr = vi.fn();
+    unitPrsMock.mockResolvedValue(response([pr()]));
+    render(<RPrsSection unitName="u" expanded={true} onToggle={vi.fn()} onSelectPr={onSelectPr} />);
+    await waitFor(() => {
+      expect(screen.getByText("PR title")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText("PR title"));
+    expect(onSelectPr).toHaveBeenCalledTimes(1);
+    const sel = onSelectPr.mock.calls[0][0];
+    expect(sel.repoPath).toBe("/p/u");
+    expect(sel.pr.number).toBe(100n);
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/RPrViewer.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/RPrViewer.tsx
@@ -1,0 +1,404 @@
+// R₂ — the in-tmai PR content viewer (#749).
+//
+// γ-lean shape (`doc/approaches/2026-05-29-artifact-content-viewer.md`,
+// Phase 1, PR artifact kind): an INDEPENDENT right-side viewer column.
+// R₁ (`RPrsSection`) stays a pure inventory; clicking a PR row there
+// selects it and this column renders that PR's full content — diff,
+// body, comments (incl. CodeRabbit), labels, mergeable / review / check
+// status, CI status + failure-log drill-down — entirely in-tmai, with
+// ZERO github.com round-trip. It serves
+// `2026-05-16-dev-loop-completes-in-tmai`.
+//
+// Negative space (the serving `2026-05-26-tmai-states-facts-not-appraisals`
+// posture — tmai states facts, never appraises):
+//   - the viewer NEVER auto-opens; it only mounts on an explicit operator
+//     row click (the parent gates the mount on `selectedPr !== null`);
+//   - NO "changed since you last looked" / unread / unseen / read-done
+//     markers, NO TL;DR / auto-summary, NO relevance / priority / severity
+//     tinting on status facts;
+//   - mechanical facts (CI status, merge state, comment count, timestamps)
+//     stay PLAIN inline and always visible (silence-is-not-neutral) — they
+//     use only `text-foreground` / `text-muted-foreground` /
+//     `text-subtle-foreground`, never the C-column warning / destructive /
+//     success accents.
+//
+// The ONE allowed convention is the standard unified-diff `+`/`-`
+// red/green colouring inside the reused `DiffViewer` — that IS the diff
+// fact's conventional representation, not an appraisal layered on top, so
+// `DiffViewer` is used as-is.
+
+import { useState } from "react";
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { DiffViewer } from "@/components/worktree/DiffViewer";
+import {
+  usePrBody,
+  usePrChecks,
+  usePrComments,
+  usePrDiff,
+  usePrLabels,
+  usePrMergeStatus,
+} from "@/hooks/usePrDetail";
+import {
+  api,
+  type CiCheck,
+  type PrComment,
+  type PrMergeStatus,
+  type PrSummaryWire,
+} from "@/lib/api";
+
+// What R₁ hands R₂ on a row click. The full `PrSummaryWire` rides along
+// so the header renders every inventory fact (CI / review / draft /
+// counts) without re-fetching; `repoPath` + the PR number drive the
+// detail fetches.
+export interface SelectedPr {
+  repoPath: string;
+  repoLabel: string;
+  pr: PrSummaryWire;
+}
+
+export function selectedPrKey(repoPath: string, prNumber: bigint): string {
+  return `${repoPath}#${prNumber}`;
+}
+
+// Markdown prose classes — same palette the transcript / digest markdown
+// uses so the body and comments read like the rest of the WebUI.
+const PROSE_CLASSES = `prose prose-invert prose-sm max-w-none
+  prose-headings:text-foreground prose-headings:font-semibold
+  prose-p:text-foreground prose-p:leading-relaxed prose-p:my-1
+  prose-a:text-info prose-a:no-underline hover:prose-a:underline
+  prose-strong:text-foreground
+  prose-code:text-primary prose-code:bg-surface prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:before:content-none prose-code:after:content-none
+  prose-pre:bg-surface-strong/50 prose-pre:border prose-pre:border-hairline prose-pre:rounded-lg prose-pre:my-1
+  prose-li:text-foreground prose-li:my-0
+  prose-ul:my-1 prose-ol:my-1
+  prose-th:text-foreground prose-th:border-hairline-strong
+  prose-td:text-muted-foreground prose-td:border-hairline-strong
+  prose-hr:border-hairline-strong
+  prose-blockquote:border-info/30 prose-blockquote:text-muted-foreground`;
+
+interface RPrViewerProps {
+  selected: SelectedPr;
+  onClose: () => void;
+}
+
+export function RPrViewer({ selected, onClose }: RPrViewerProps) {
+  const { repoPath, repoLabel, pr } = selected;
+  const prNumber = Number(pr.number);
+
+  return (
+    <aside
+      data-testid="r-pr-viewer"
+      className="glass flex w-[clamp(22rem,40vw,48rem)] shrink-0 flex-col border-l border-hairline"
+    >
+      <ViewerHeader repoLabel={repoLabel} pr={pr} onClose={onClose} />
+      <div className="flex-1 space-y-4 overflow-y-auto px-4 py-3 text-xs">
+        <LabelsSection repoPath={repoPath} prNumber={prNumber} />
+        <MergeStatusSection repoPath={repoPath} prNumber={prNumber} />
+        <CiSection repoPath={repoPath} branch={pr.head_branch} />
+        <BodySection repoPath={repoPath} prNumber={prNumber} />
+        <CommentsSection repoPath={repoPath} prNumber={prNumber} />
+        <DiffSection repoPath={repoPath} prNumber={prNumber} />
+      </div>
+    </aside>
+  );
+}
+
+// ── Header — mechanical inventory facts, all plain (no severity tint) ──
+
+function ViewerHeader({
+  repoLabel,
+  pr,
+  onClose,
+}: {
+  repoLabel: string;
+  pr: PrSummaryWire;
+  onClose: () => void;
+}) {
+  return (
+    <header className="shrink-0 border-b border-hairline px-4 py-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-[11px] uppercase tracking-wide text-subtle-foreground">{repoLabel}</p>
+          <h2 className="text-sm font-semibold text-foreground">
+            <span className="font-mono text-muted-foreground">#{Number(pr.number)}</span> {pr.title}
+          </h2>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          title="Close PR viewer"
+          aria-label="Close PR viewer"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+        >
+          ×
+        </button>
+      </div>
+      <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-subtle-foreground">
+        <span className="font-mono">
+          {pr.head_branch} → {pr.base_branch}
+        </span>
+        <span className="text-muted-foreground">
+          +{Number(pr.additions)} −{Number(pr.deletions)}
+        </span>
+        {pr.check_status !== null && (
+          <span className="text-muted-foreground">CI {pr.check_status}</span>
+        )}
+        {pr.review_decision !== null && (
+          <span className="text-muted-foreground">{pr.review_decision}</span>
+        )}
+        {pr.is_draft && <span className="text-muted-foreground">draft</span>}
+        <span className="text-muted-foreground">{Number(pr.comments)} comments</span>
+        <span>@{pr.author}</span>
+      </div>
+    </header>
+  );
+}
+
+// ── Section frame + async states (plain, never a fabricated empty) ──
+
+function SectionFrame({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-subtle-foreground">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function Loading() {
+  return <p className="text-subtle-foreground">Loading…</p>;
+}
+
+function FetchError({ what, message }: { what: string; message: string }) {
+  return (
+    <p className="text-muted-foreground">
+      Failed to load {what}: {message}
+    </p>
+  );
+}
+
+// ── Labels ──
+
+function LabelsSection({ repoPath, prNumber }: { repoPath: string; prNumber: number }) {
+  const { data, loading, error } = usePrLabels(repoPath, prNumber);
+  return (
+    <SectionFrame title="Labels">
+      {loading && <Loading />}
+      {error && <FetchError what="labels" message={error.message} />}
+      {!loading && !error && (data === null || data.length === 0) && (
+        <p className="text-subtle-foreground">No labels.</p>
+      )}
+      {data !== null && data.length > 0 && (
+        <ul className="flex flex-wrap gap-1">
+          {data.map((label) => (
+            <li
+              key={label}
+              className="rounded border border-hairline-strong/40 bg-surface px-1.5 py-0.5 text-[11px] text-foreground"
+            >
+              {label}
+            </li>
+          ))}
+        </ul>
+      )}
+    </SectionFrame>
+  );
+}
+
+// ── Mergeable / review / check status ──
+
+function MergeStatusSection({ repoPath, prNumber }: { repoPath: string; prNumber: number }) {
+  const { data, loading, error } = usePrMergeStatus(repoPath, prNumber);
+  return (
+    <SectionFrame title="Merge status">
+      {loading && <Loading />}
+      {error && <FetchError what="merge status" message={error.message} />}
+      {data !== null && <MergeStatusFacts status={data} />}
+    </SectionFrame>
+  );
+}
+
+function MergeStatusFacts({ status }: { status: PrMergeStatus }) {
+  // All plain rows — these are mechanical facts, never severity-tinted.
+  const rows: { label: string; value: string }[] = [
+    { label: "mergeable", value: status.mergeable },
+    { label: "state", value: status.merge_state_status },
+    { label: "review", value: status.review_decision ?? "none" },
+    { label: "checks", value: status.check_status ?? "none" },
+  ];
+  return (
+    <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-0.5">
+      {rows.map((r) => (
+        <div key={r.label} className="contents">
+          <dt className="text-subtle-foreground">{r.label}</dt>
+          <dd className="font-mono text-foreground">{r.value}</dd>
+        </div>
+      ))}
+    </dl>
+  );
+}
+
+// ── CI status + failure-log drill-down ──
+
+function CiSection({ repoPath, branch }: { repoPath: string; branch: string }) {
+  const { data, loading, error } = usePrChecks(repoPath, branch);
+  return (
+    <SectionFrame title="CI">
+      {loading && <Loading />}
+      {error && <FetchError what="CI status" message={error.message} />}
+      {!loading && !error && data !== null && data.checks.length === 0 && (
+        <p className="text-subtle-foreground">No checks.</p>
+      )}
+      {data !== null && data.checks.length > 0 && (
+        <div className="space-y-1">
+          <p className="text-subtle-foreground">
+            rollup <span className="font-mono text-foreground">{data.rollup}</span>
+          </p>
+          <ul className="space-y-1">
+            {data.checks.map((check) => (
+              <CiCheckRow key={check.name} repoPath={repoPath} check={check} />
+            ))}
+          </ul>
+        </div>
+      )}
+    </SectionFrame>
+  );
+}
+
+function CiCheckRow({ repoPath, check }: { repoPath: string; check: CiCheck }) {
+  const [log, setLog] = useState<string | null>(null);
+  const [logLoading, setLogLoading] = useState(false);
+  const [logError, setLogError] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+
+  // Failure log is a drill-down: fetched on the first operator click and
+  // cached for the row's lifetime. Only failed checks carrying a `run_id`
+  // can be drilled into (the log is keyed by Actions run).
+  const canDrill = check.conclusion === "failure" && check.run_id !== null;
+
+  const toggleLog = () => {
+    const opening = !open;
+    setOpen(opening);
+    if (!opening || log !== null || logLoading || check.run_id === null) return;
+    setLogLoading(true);
+    setLogError(null);
+    api
+      .getCiFailureLog(repoPath, check.run_id)
+      .then((res) => setLog(res.log_text))
+      .catch((e: unknown) => setLogError(e instanceof Error ? e.message : String(e)))
+      .finally(() => setLogLoading(false));
+  };
+
+  return (
+    <li>
+      <div className="flex flex-wrap items-baseline gap-x-2">
+        <span className="font-mono text-foreground">{check.name}</span>
+        <span className="text-subtle-foreground">{check.status}</span>
+        {check.conclusion !== null && (
+          <span className="text-muted-foreground">{check.conclusion}</span>
+        )}
+        {canDrill && (
+          <button
+            type="button"
+            onClick={toggleLog}
+            className="rounded bg-surface px-1.5 py-0.5 text-[10px] text-foreground transition-colors hover:bg-surface-strong"
+          >
+            {open ? "Hide failure log" : "View failure log"}
+          </button>
+        )}
+      </div>
+      {open && (
+        <div className="mt-1">
+          {logLoading && <Loading />}
+          {logError && <FetchError what="failure log" message={logError} />}
+          {log !== null && (
+            <pre className="max-h-80 overflow-auto rounded border border-hairline bg-surface-strong/40 px-2 py-1 text-[10.5px] leading-relaxed text-muted-foreground">
+              {log}
+            </pre>
+          )}
+        </div>
+      )}
+    </li>
+  );
+}
+
+// ── PR body (markdown) ──
+
+function BodySection({ repoPath, prNumber }: { repoPath: string; prNumber: number }) {
+  const { data, loading, error } = usePrBody(repoPath, prNumber);
+  const empty = data !== null && data.trim() === "";
+  return (
+    <SectionFrame title="Description">
+      {loading && <Loading />}
+      {error && <FetchError what="description" message={error.message} />}
+      {empty && <p className="text-subtle-foreground">No description.</p>}
+      {data !== null && !empty && (
+        <div className={PROSE_CLASSES}>
+          <Markdown remarkPlugins={[remarkGfm]}>{data}</Markdown>
+        </div>
+      )}
+    </SectionFrame>
+  );
+}
+
+// ── Comments (PR-level + inline, incl. CodeRabbit) ──
+
+function CommentsSection({ repoPath, prNumber }: { repoPath: string; prNumber: number }) {
+  const { data, loading, error } = usePrComments(repoPath, prNumber);
+  return (
+    <SectionFrame title={data !== null ? `Comments (${data.length})` : "Comments"}>
+      {loading && <Loading />}
+      {error && <FetchError what="comments" message={error.message} />}
+      {!loading && !error && data !== null && data.length === 0 && (
+        <p className="text-subtle-foreground">No comments.</p>
+      )}
+      {data !== null && data.length > 0 && (
+        <ul className="space-y-2">
+          {data.map((c) => (
+            // A comment's `url` is unique per GitHub comment — a stable key
+            // with no array index needed.
+            <CommentItem key={c.url} comment={c} />
+          ))}
+        </ul>
+      )}
+    </SectionFrame>
+  );
+}
+
+function CommentItem({ comment }: { comment: PrComment }) {
+  const inline = comment.path !== null;
+  return (
+    <li className="rounded border border-hairline-strong/40 bg-surface-strong/20 px-2 py-1.5">
+      <div className="flex flex-wrap items-baseline gap-x-2 text-[11px]">
+        <span className="font-semibold text-foreground">@{comment.author}</span>
+        <span className="text-subtle-foreground">{comment.created_at}</span>
+        {inline && <span className="font-mono text-subtle-foreground">{comment.path}</span>}
+      </div>
+      {inline && comment.diff_hunk !== null && comment.diff_hunk !== "" && (
+        <pre className="mt-1 overflow-x-auto rounded border border-hairline bg-surface-strong/40 px-2 py-1 font-mono text-[10.5px] leading-relaxed text-muted-foreground">
+          {comment.diff_hunk}
+        </pre>
+      )}
+      <div className={`mt-1 ${PROSE_CLASSES}`}>
+        <Markdown remarkPlugins={[remarkGfm]}>{comment.body}</Markdown>
+      </div>
+    </li>
+  );
+}
+
+// ── Diff (reuses DiffViewer; +/- red/green is the diff convention) ──
+
+function DiffSection({ repoPath, prNumber }: { repoPath: string; prNumber: number }) {
+  const { data, loading, error } = usePrDiff(repoPath, prNumber);
+  const empty = data !== null && data.trim() === "";
+  return (
+    <SectionFrame title="Diff">
+      {loading && <Loading />}
+      {error && <FetchError what="diff" message={error.message} />}
+      {empty && <p className="text-subtle-foreground">Empty diff (head matches base).</p>}
+      {data !== null && !empty && <DiffViewer diff={data} />}
+    </SectionFrame>
+  );
+}

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RPrViewer.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RPrViewer.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+//
+// RPrViewer — the R₂ in-tmai PR content viewer (#749). The detail
+// fetchers are mocked so this test proves: every section renders its
+// fetched fact (body / labels / comments / merge-status / CI / diff),
+// mechanical status facts stay PLAIN (no severity tint — viewer-approach
+// negative space), there is NO github.com link-out, the close button
+// fires, and the CI failure-log drill-down is operator-initiated.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PrSummaryWire } from "@/lib/api";
+
+const prBody = vi.fn();
+const prLabels = vi.fn();
+const getPrComments = vi.fn();
+const getPrMergeStatus = vi.fn();
+const prDiff = vi.fn();
+const listChecks = vi.fn();
+const getCiFailureLog = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    prBody: (...a: unknown[]) => prBody(...a),
+    prLabels: (...a: unknown[]) => prLabels(...a),
+    getPrComments: (...a: unknown[]) => getPrComments(...a),
+    getPrMergeStatus: (...a: unknown[]) => getPrMergeStatus(...a),
+    prDiff: (...a: unknown[]) => prDiff(...a),
+    listChecks: (...a: unknown[]) => listChecks(...a),
+    getCiFailureLog: (...a: unknown[]) => getCiFailureLog(...a),
+  },
+}));
+
+import { RPrViewer, type SelectedPr } from "../RPrViewer";
+
+function pr(overrides: Partial<PrSummaryWire> = {}): PrSummaryWire {
+  return {
+    number: 100n,
+    title: "Add the thing",
+    state: "OPEN",
+    head_branch: "feat/x",
+    head_sha: "abc1234",
+    base_branch: "main",
+    url: "https://github.com/o/r/pull/100",
+    review_decision: "APPROVED",
+    check_status: "SUCCESS",
+    is_draft: false,
+    additions: 10n,
+    deletions: 1n,
+    comments: 2n,
+    reviews: 0n,
+    author: "me",
+    merge_commit_sha: null,
+    ...overrides,
+  };
+}
+
+function selected(overrides: Partial<PrSummaryWire> = {}): SelectedPr {
+  return { repoPath: "/p/u", repoLabel: "u", pr: pr(overrides) };
+}
+
+beforeEach(() => {
+  for (const m of [prBody, prLabels, getPrComments, getPrMergeStatus, prDiff, listChecks]) {
+    m.mockReset();
+  }
+  getCiFailureLog.mockReset();
+  // Default happy-path resolutions; individual tests override as needed.
+  prBody.mockResolvedValue("## Body heading\n\nbody text");
+  prLabels.mockResolvedValue(["enhancement", "webui"]);
+  getPrComments.mockResolvedValue([
+    {
+      author: "coderabbitai",
+      body: "nit: rename this",
+      created_at: "2026-05-30T10:00:00Z",
+      url: "https://github.com/o/r/pull/100#c1",
+      comment_type: "review",
+      path: "src/lib/api.ts",
+      diff_hunk: "@@ -1,3 +1,3 @@\n-old\n+new",
+    },
+  ]);
+  getPrMergeStatus.mockResolvedValue({
+    mergeable: "MERGEABLE",
+    merge_state_status: "CLEAN",
+    review_decision: "APPROVED",
+    check_status: "SUCCESS",
+  });
+  prDiff.mockResolvedValue({ repo: "/p/u", pr_number: 100n, patch: "" });
+  listChecks.mockResolvedValue({ branch: "feat/x", checks: [], rollup: "SUCCESS" });
+});
+
+describe("RPrViewer", () => {
+  it("renders header inventory facts for the selected PR", () => {
+    render(<RPrViewer selected={selected()} onClose={vi.fn()} />);
+    expect(screen.getByText("Add the thing")).toBeTruthy();
+    expect(screen.getByText("#100")).toBeTruthy();
+    expect(screen.getByText("feat/x → main")).toBeTruthy();
+    expect(screen.getByText("@me")).toBeTruthy();
+  });
+
+  it("renders body, labels, comments, merge-status and CI from the fetchers", async () => {
+    render(<RPrViewer selected={selected()} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Body heading")).toBeTruthy());
+    expect(screen.getByText("enhancement")).toBeTruthy();
+    expect(screen.getByText("webui")).toBeTruthy();
+    expect(screen.getByText("@coderabbitai")).toBeTruthy();
+    expect(screen.getByText("nit: rename this")).toBeTruthy();
+    // Merge-status facts are plain.
+    expect(screen.getByText("MERGEABLE")).toBeTruthy();
+    expect(prBody).toHaveBeenCalledWith("/p/u", 100);
+    expect(listChecks).toHaveBeenCalledWith("/p/u", "feat/x");
+  });
+
+  it("uses NO severity-color classes on status facts (negative-space)", async () => {
+    // Empty diff → DiffViewer not mounted, so the only colours present
+    // would be appraisal tints — there must be none.
+    const { container } = render(<RPrViewer selected={selected()} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("MERGEABLE")).toBeTruthy());
+    const html = container.innerHTML;
+    expect(html).not.toMatch(/text-warning/);
+    expect(html).not.toMatch(/text-destructive/);
+    expect(html).not.toMatch(/text-success/);
+  });
+
+  it("has NO github.com link-out anywhere in the viewer (#749)", async () => {
+    const { container } = render(<RPrViewer selected={selected()} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Body heading")).toBeTruthy());
+    expect(container.querySelector("a[href*='github.com']")).toBeNull();
+  });
+
+  it("fires onClose from the close button", () => {
+    const onClose = vi.fn();
+    render(<RPrViewer selected={selected()} onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /Close PR viewer/ }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("drills into a failed check's failure log only on operator click", async () => {
+    listChecks.mockResolvedValue({
+      branch: "feat/x",
+      rollup: "FAILURE",
+      checks: [
+        {
+          name: "build",
+          status: "completed",
+          conclusion: "failure",
+          url: "https://github.com/o/r/runs/9",
+          started_at: null,
+          completed_at: null,
+          run_id: 9,
+        },
+      ],
+    });
+    getCiFailureLog.mockResolvedValue({ run_id: 9, log_text: "error: boom on line 3" });
+    render(<RPrViewer selected={selected()} onClose={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText("build")).toBeTruthy());
+    // Not fetched until clicked.
+    expect(getCiFailureLog).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: /View failure log/ }));
+    await waitFor(() => expect(screen.getByText(/boom on line 3/)).toBeTruthy());
+    expect(getCiFailureLog).toHaveBeenCalledWith("/p/u", 9);
+  });
+
+  it("shows an empty-diff notice when head matches base", async () => {
+    render(<RPrViewer selected={selected()} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText(/Empty diff/)).toBeTruthy());
+  });
+});

--- a/clients/react/src/hooks/__tests__/usePrDetail.test.ts
+++ b/clients/react/src/hooks/__tests__/usePrDetail.test.ts
@@ -1,0 +1,90 @@
+// @vitest-environment jsdom
+//
+// usePrDetail — the one-shot PR-detail fetch hooks behind the R₂ viewer
+// (#749). We mock the `api` helpers and assert the shared `{ data,
+// loading, error }` contract: a `null` arg parks (no fetch), a real PR
+// fetches once and exposes the response, errors surface without
+// fabricating data, and switching PRs re-fetches + clears the previous
+// payload (generation guard).
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    prBody: vi.fn(),
+    prLabels: vi.fn(),
+    getPrComments: vi.fn(),
+    getPrMergeStatus: vi.fn(),
+    prDiff: vi.fn(),
+    listChecks: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+import { usePrBody, usePrChecks, usePrDiff, usePrLabels } from "../usePrDetail";
+
+describe("usePrDetail", () => {
+  beforeEach(() => {
+    vi.mocked(api.prBody).mockReset();
+    vi.mocked(api.prLabels).mockReset();
+    vi.mocked(api.prDiff).mockReset();
+    vi.mocked(api.listChecks).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parks when the PR is null — no fetch, not loading", () => {
+    const { result } = renderHook(() => usePrBody(null, null));
+    expect(api.prBody).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetches the body once on a real PR and exposes the string", async () => {
+    vi.mocked(api.prBody).mockResolvedValue("## hello");
+    const { result } = renderHook(() => usePrBody("/p/u", 42));
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(api.prBody).toHaveBeenCalledWith("/p/u", 42);
+    expect(result.current.data).toBe("## hello");
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a fetch error without fabricating data", async () => {
+    vi.mocked(api.prLabels).mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => usePrLabels("/p/u", 7));
+    await waitFor(() => expect(result.current.error?.message).toBe("boom"));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("re-fetches when the PR number changes and clears the previous payload", async () => {
+    vi.mocked(api.prDiff).mockImplementation((_repo: string, n: number) =>
+      Promise.resolve({ repo: "/p/u", pr_number: BigInt(n), patch: `patch-${n}` }),
+    );
+    const { result, rerender } = renderHook(({ n }) => usePrDiff("/p/u", n), {
+      initialProps: { n: 1 },
+    });
+    await waitFor(() => expect(result.current.data).toBe("patch-1"));
+
+    rerender({ n: 2 });
+    // Cleared synchronously on PR change so the old patch is never shown.
+    expect(result.current.data).toBeNull();
+    await waitFor(() => expect(result.current.data).toBe("patch-2"));
+  });
+
+  it("keys CI checks on (repo, branch)", async () => {
+    vi.mocked(api.listChecks).mockResolvedValue({
+      branch: "feat/x",
+      checks: [],
+      rollup: "SUCCESS",
+    });
+    const { result } = renderHook(() => usePrChecks("/p/u", "feat/x"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(api.listChecks).toHaveBeenCalledWith("/p/u", "feat/x");
+    expect(result.current.data?.rollup).toBe("SUCCESS");
+  });
+});

--- a/clients/react/src/hooks/usePrDetail.ts
+++ b/clients/react/src/hooks/usePrDetail.ts
@@ -1,0 +1,132 @@
+// PR-detail fetch hooks for the R₂ in-tmai PR viewer (#749).
+//
+// One generic one-shot resource hook (`usePrResource`) plus thin named
+// wrappers (body / labels / comments / merge-status / diff / checks),
+// mirroring the `useUnitPrs` contract shape: `{ data, loading, error }`,
+// a generation guard so a stale in-flight response from a previously
+// selected PR never stamps over the current one, and a `null` dep that
+// parks the hook (no fetch).
+//
+// WHY one-shot, not the 60s poll `useUnitPrs` runs: the viewer only
+// mounts after an explicit operator click on a PR row (no auto-open on
+// focus — viewer approach negative space), and a PR's body / diff /
+// comments are stable across a single review pass. Re-selecting the PR
+// (or switching units, which clears the selection) re-fetches. Keeping
+// it poll-free also avoids piling N background intervals (one per
+// detail section) onto the existing `useUnitPrs` poll.
+
+import { useEffect, useRef, useState } from "react";
+import { api, type CiSummary, type PrComment, type PrMergeStatus } from "@/lib/api";
+
+export interface UsePrResourceResult<T> {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+// `depKey` is the stable identity of the request (e.g. `${repo}#${n}`);
+// the effect re-runs only when it changes. `fetcher` is read through a
+// ref so a fresh closure each render does not retrigger the effect — the
+// same anti-churn discipline as `useUnitPrs`, expressed for a one-shot.
+function usePrResource<T>(
+  depKey: string | null,
+  fetcher: () => Promise<T>,
+): UsePrResourceResult<T> {
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(depKey !== null);
+  const [error, setError] = useState<Error | null>(null);
+  const generationRef = useRef(0);
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+
+  useEffect(() => {
+    if (depKey === null) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    setData(null);
+    setError(null);
+    setLoading(true);
+    void (async () => {
+      try {
+        const res = await fetcherRef.current();
+        if (myGen !== generationRef.current) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (myGen !== generationRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (myGen === generationRef.current) setLoading(false);
+      }
+    })();
+  }, [depKey]);
+
+  return { data, loading, error };
+}
+
+function prKey(repoPath: string | null, prNumber: number | null): string | null {
+  return repoPath !== null && prNumber !== null ? `${repoPath}#${prNumber}` : null;
+}
+
+export function usePrBody(
+  repoPath: string | null,
+  prNumber: number | null,
+): UsePrResourceResult<string> {
+  return usePrResource(prKey(repoPath, prNumber), () =>
+    // The dep key is non-null exactly when both args are non-null, so the
+    // fetcher only ever runs with concrete values.
+    api.prBody(repoPath as string, prNumber as number),
+  );
+}
+
+export function usePrLabels(
+  repoPath: string | null,
+  prNumber: number | null,
+): UsePrResourceResult<string[]> {
+  return usePrResource(prKey(repoPath, prNumber), () =>
+    api.prLabels(repoPath as string, prNumber as number),
+  );
+}
+
+export function usePrComments(
+  repoPath: string | null,
+  prNumber: number | null,
+): UsePrResourceResult<PrComment[]> {
+  return usePrResource(prKey(repoPath, prNumber), () =>
+    api.getPrComments(repoPath as string, prNumber as number),
+  );
+}
+
+export function usePrMergeStatus(
+  repoPath: string | null,
+  prNumber: number | null,
+): UsePrResourceResult<PrMergeStatus> {
+  return usePrResource(prKey(repoPath, prNumber), () =>
+    api.getPrMergeStatus(repoPath as string, prNumber as number),
+  );
+}
+
+export function usePrDiff(
+  repoPath: string | null,
+  prNumber: number | null,
+): UsePrResourceResult<string> {
+  return usePrResource(prKey(repoPath, prNumber), async () => {
+    const res = await api.prDiff(repoPath as string, prNumber as number);
+    return res.patch;
+  });
+}
+
+// CI checks key on (repo, branch) — a PR's head branch is the natural
+// identity for `gh`'s check rollup; `getCiFailureLog` drill-down is
+// operator-initiated inside the section, so it is not a hook.
+export function usePrChecks(
+  repoPath: string | null,
+  branch: string | null,
+): UsePrResourceResult<CiSummary> {
+  const key = repoPath !== null && branch !== null ? `${repoPath}@${branch}` : null;
+  return usePrResource(key, () => api.listChecks(repoPath as string, branch as string));
+}

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -1230,6 +1230,18 @@ export const api = {
     apiFetch<PrComment[]>(
       `/github/pr/comments?repo=${encodeURIComponent(repoPath)}&pr_number=${prNumber}`,
     ),
+  // R₂ in-tmai PR viewer (#749). The PR body / labels endpoints already
+  // exist server-side; these are the missing thin React wrappers. Body is
+  // a JSON string (the PR description markdown), labels a JSON string[] of
+  // label names — both shapes match the rest of the `gh`-backed handlers
+  // that pre-date the codegen spec, so they ride the same `apiFetch` JSON
+  // path as `getPrComments` above rather than a generated binding.
+  prBody: (repoPath: string, prNumber: number) =>
+    apiFetch<string>(`/github/pr/body?repo=${encodeURIComponent(repoPath)}&pr_number=${prNumber}`),
+  prLabels: (repoPath: string, prNumber: number) =>
+    apiFetch<string[]>(
+      `/github/pr/labels?repo=${encodeURIComponent(repoPath)}&pr_number=${prNumber}`,
+    ),
   getPrFiles: (repoPath: string, prNumber: number) =>
     apiFetch<PrChangedFile[]>(
       `/github/pr/files?repo=${encodeURIComponent(repoPath)}&pr_number=${prNumber}`,

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -143,6 +143,9 @@ export const api = {
   getIssueDetail: (repoPath: string, issueNumber: number) =>
     httpApi.getIssueDetail(repoPath, issueNumber),
   getPrComments: (repoPath: string, prNumber: number) => httpApi.getPrComments(repoPath, prNumber),
+  // R₂ in-tmai PR viewer (#749) — HTTP only, gh-CLI passthrough.
+  prBody: (repoPath: string, prNumber: number) => httpApi.prBody(repoPath, prNumber),
+  prLabels: (repoPath: string, prNumber: number) => httpApi.prLabels(repoPath, prNumber),
   getPrFiles: (repoPath: string, prNumber: number) => httpApi.getPrFiles(repoPath, prNumber),
   getPrMergeStatus: (repoPath: string, prNumber: number) =>
     httpApi.getPrMergeStatus(repoPath, prNumber),


### PR DESCRIPTION
Resolves #749.

## What

A PR's full content is now viewable **inside tmai** — no github.com round-trip. Clicking a PR row in the R₁ inventory (`RPrsSection`) opens that PR in a new **independent R₂ viewer column** (the spine's γ-lean 4-column `L / C / R₁ inventory / R₂ viewer` shape). R₁ stays a pure inventory; content lives in the separate R₂ column.

R₂ renders, all in-tmai:
- **diff** — reuses `DiffViewer` (standard unified +/- coloring kept as-is)
- **body / description** — `react-markdown` + `remark-gfm`
- **comments** — PR-level + inline, incl. CodeRabbit (author / timestamp / body / path+hunk)
- **labels**
- **mergeable status / review decision / check status** (header inline + merge-status section)
- **CI status + failure-log drill-down** (operator-initiated)

The github.com link-out on the PR number is gone — the row is now an in-tmai select.

## Scope

`clients/react/` only. tmai-core untouched — every PR-detail endpoint already existed; this is a pure consumer. Generated types and the lockfile are unchanged.

### New
- `prBody` / `prLabels` helpers in `api-http.ts` (+ `api-tauri.ts` delegation); other helpers reused
- `usePrDetail` one-shot fetch hooks (body / labels / comments / merge-status / diff / checks), `useUnitPrs`-shaped `{ data, loading, error }` contract
- `r-panel/r-viewer/RPrViewer` column + PR-detail sections
- App-level `selectedPr` state + R₂ column render; selection cleared on unit change

## Design constraints honored (negative space)
- ❌ no auto-open on focus — the viewer mounts only on an explicit operator row click
- ❌ no unread / unseen / changed-since markers, no read/done marks, no TL;DR, no relevance/priority sort, no severity tinting on status facts
- ✅ standard unified-diff +/- red/green coloring kept (the diff fact's convention)
- **silence-is-not-neutral**: CI status / merge state / comment count / timestamps stay plain inline and always visible
- **R₁ pure inventory**: content lives in the separate R₂ column
- **vendor-neutral**: markdown via the existing renderer, PR data via the existing GH-backed endpoints

Out of scope (untouched): operator affordances (bookmark/pin/color), other artifact-kind viewers, the merge button.

## Gate (all green locally)
`pnpm install --frozen-lockfile` · `tsc --noEmit` · `biome check src/` (0 errors/warnings) · `vitest run` (549 passed, +new tests) · `pnpm build` · `pnpm audit --prod --audit-level high` (no vulns).

Implements Phase 1 (PR artifact kind) of the artifact-content-viewer approach; serves `2026-05-16-dev-loop-completes-in-tmai`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * PR一覧からPRを選択すると、詳細情報が右側パネルに表示されるようになりました。ラベル、マージステータス、CIチェック、説明、コメント、差分を確認できます。

* **Tests**
  * PR詳細表示機能のテストを追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/trust-delta/tmai/pull/750?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->