### PR TITLE
feat(r-panel): R₂ Decisions + Approaches viewers (shared base, excerpt-level, read-only)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -13,11 +13,11 @@ import { HandoffRitualOverlay } from "@/components/producer-console/HandoffRitua
 import { ProducerConsole } from "@/components/producer-console/ProducerConsole";
 import { ProducerConversationHeader } from "@/components/producer-console/ProducerConversationHeader";
 import { RPanel } from "@/components/producer-console/r-panel/RPanel";
+import { RPrViewer, selectedPrKey } from "@/components/producer-console/r-panel/r-viewer/RPrViewer";
 import {
-  RPrViewer,
-  type SelectedPr,
-  selectedPrKey,
-} from "@/components/producer-console/r-panel/r-viewer/RPrViewer";
+  RRecordViewer,
+  selectedRecordKey,
+} from "@/components/producer-console/r-panel/r-viewer/RRecordViewer";
 import { ProducerFeedChip } from "@/components/producer-feed/ProducerFeedChip";
 import { SecurityPanel } from "@/components/settings/SecurityPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
@@ -28,6 +28,7 @@ import { useApplyTheme } from "@/hooks/useActiveTheme";
 import { useAgentSelectionFallback } from "@/hooks/useAgentSelectionFallback";
 import { useAgents } from "@/hooks/useAgents";
 import { useCalibration } from "@/hooks/useCalibration";
+import { useFocusedArtifact } from "@/hooks/useFocusedArtifact";
 import { useHandoffRitual } from "@/hooks/useHandoffRitual";
 import { useIdleNotification } from "@/hooks/useIdleNotification";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -122,12 +123,23 @@ export function App() {
   // through the shared useSplitPane engine (ratio-based), so we convert
   // at the seams. See the rPanel*Width helpers above.
   const [rPanelWidth, setRPanelWidth] = useUIPref("attentionStripWidth");
-  // The PR open in the independent R₂ viewer column (#749). `null` =
-  // no viewer (it never auto-opens — the operator clicks a row in the
-  // R₁ inventory to select; viewer-approach negative space). Lives at
-  // App level because R₂ renders as a sibling column of <main> / RPanel,
-  // not inside the inventory panel (R₁ stays a pure inventory).
-  const [selectedPr, setSelectedPr] = useState<SelectedPr | null>(null);
+  // The artifact open in the independent R₂ viewer column. R₂ hosts
+  // exactly ONE focused artifact at a time — a PR (#749), a decision, or
+  // an approach — so focusing one kind clears the other (the invariant
+  // lives in `useFocusedArtifact`). `null`/`null` = no viewer (it never
+  // auto-opens — the operator clicks a row in the R₁ inventory to select;
+  // viewer-approach negative space). Lives at App level because R₂
+  // renders as a sibling column of <main> / RPanel, not inside the
+  // inventory panel (R₁ stays a pure inventory).
+  const {
+    selectedPr,
+    selectedRecord,
+    selectPr,
+    selectRecord,
+    clearPr,
+    clearRecord,
+    clearAll: clearFocusedArtifact,
+  } = useFocusedArtifact();
   const showSettings = mainPanel === "settings";
   const showSecurity = mainPanel === "security";
   const showCalibration = mainPanel === "calibration";
@@ -185,13 +197,14 @@ export function App() {
   const { data: calibrationData } = useCalibration(unitName);
   const { data: producerFeedData } = useProducerFeed(unitName);
 
-  // Close the R₂ PR viewer when the focused unit changes — its open PR
-  // belongs to the previous unit, so it must not linger under a new
-  // unit's inventory (mirrors useUnitPrs clearing its list on unit change).
-  // unitName is the intended trigger even though the body only clears state.
+  // Close the R₂ viewer when the focused unit changes — its open artifact
+  // (PR or record) belongs to the previous unit, so it must not linger
+  // under a new unit's inventory (mirrors useUnitPrs clearing its list on
+  // unit change). unitName is the intended trigger even though the body
+  // only clears state.
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional unit-change trigger
   useEffect(() => {
-    setSelectedPr(null);
+    clearFocusedArtifact();
   }, [unitName]);
   // Configured-unit membership (tmai-core #460 — wire half of #439).
   // Threaded into `findProducerForUnit` below so multi-repo units
@@ -805,9 +818,15 @@ export function App() {
             onDoubleClick: () => setRPanelWidth(ATTENTION_STRIP_WIDTH_DEFAULT),
             onAdjust: rPanelSplit.adjustRatio,
           }}
-          onSelectPr={setSelectedPr}
+          onSelectPr={selectPr}
           selectedPrKey={
             selectedPr ? selectedPrKey(selectedPr.repoPath, selectedPr.pr.number) : null
+          }
+          onSelectRecord={selectRecord}
+          selectedRecordKey={
+            selectedRecord
+              ? selectedRecordKey(selectedRecord.repoPath, selectedRecord.record.slug)
+              : null
           }
         />
       )}
@@ -819,7 +838,22 @@ export function App() {
           same narrow/mobile guard as RPanel so it never crowds a small
           viewport. */}
       {!isNarrowScreen && !isMobileScreen && selectedPr && (
-        <RPrViewer selected={selectedPr} onClose={() => setSelectedPr(null)} />
+        <RPrViewer selected={selectedPr} onClose={clearPr} />
+      )}
+
+      {/* R₂ — independent in-tmai record content viewer column (decisions +
+          approaches). Shares the R₂ column with the PR viewer above:
+          `useFocusedArtifact` keeps the two mutually exclusive, so at most
+          one renders. Present ONLY when the operator has selected a record
+          in the R₁ inventory (never auto-opens). Same narrow/mobile guard
+          as RPanel. */}
+      {!isNarrowScreen && !isMobileScreen && selectedRecord && (
+        <RRecordViewer
+          selected={selectedRecord}
+          unitName={unitName}
+          onSelectRecord={selectRecord}
+          onClose={clearRecord}
+        />
       )}
 
       {/* Help overlay */}

--- a/clients/react/src/components/producer-console/r-panel/RApproachesSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RApproachesSection.tsx
@@ -14,12 +14,20 @@
 
 import { useApproaches } from "@/hooks/useApproaches";
 import type { ApproachStatus, ApproachWire, RepoApproachesWire } from "@/lib/api";
+import { type SelectedRecord, selectedRecordKey } from "./r-viewer/RRecordViewer";
 import { Section } from "./Section";
 
 interface RApproachesSectionProps {
   unitName: string | null;
   expanded: boolean;
   onToggle: () => void;
+  /** Open an approach in the R₂ record viewer column (mirrors
+   *  `RPrsSection.onSelectPr`). Optional so the section still renders
+   *  standalone in isolation. */
+  onSelect?: (sel: SelectedRecord) => void;
+  /** `selectedRecordKey(repoPath, slug)` of the record currently open in
+   *  R₂, so the row marks itself as the one being viewed. */
+  selectedKey?: string | null;
 }
 
 const STATUS_ORDER: readonly ApproachStatus[] = [
@@ -32,7 +40,13 @@ const STATUS_ORDER: readonly ApproachStatus[] = [
   "replaced",
 ];
 
-export function RApproachesSection({ unitName, expanded, onToggle }: RApproachesSectionProps) {
+export function RApproachesSection({
+  unitName,
+  expanded,
+  onToggle,
+  onSelect,
+  selectedKey,
+}: RApproachesSectionProps) {
   const { data, loading, error } = useApproaches(unitName);
   const running =
     data === null
@@ -51,7 +65,14 @@ export function RApproachesSection({ unitName, expanded, onToggle }: RApproaches
       expanded={expanded}
       onToggle={onToggle}
     >
-      <Body unitName={unitName} repos={data?.repos ?? null} loading={loading} error={error} />
+      <Body
+        unitName={unitName}
+        repos={data?.repos ?? null}
+        loading={loading}
+        error={error}
+        onSelect={onSelect}
+        selectedKey={selectedKey ?? null}
+      />
     </Section>
   );
 }
@@ -61,9 +82,11 @@ interface BodyProps {
   repos: RepoApproachesWire[] | null;
   loading: boolean;
   error: Error | null;
+  onSelect?: (sel: SelectedRecord) => void;
+  selectedKey: string | null;
 }
 
-function Body({ unitName, repos, loading, error }: BodyProps) {
+function Body({ unitName, repos, loading, error, onSelect, selectedKey }: BodyProps) {
   if (unitName === null) {
     return <p className="text-subtle-foreground">Pick a project to see approaches.</p>;
   }
@@ -80,13 +103,29 @@ function Body({ unitName, repos, loading, error }: BodyProps) {
   return (
     <div className="space-y-2">
       {repos.map((repo) => (
-        <RepoBlock key={repo.repo_root} repo={repo} multiRepo={multiRepo} />
+        <RepoBlock
+          key={repo.repo_root}
+          repo={repo}
+          multiRepo={multiRepo}
+          onSelect={onSelect}
+          selectedKey={selectedKey}
+        />
       ))}
     </div>
   );
 }
 
-function RepoBlock({ repo, multiRepo }: { repo: RepoApproachesWire; multiRepo: boolean }) {
+function RepoBlock({
+  repo,
+  multiRepo,
+  onSelect,
+  selectedKey,
+}: {
+  repo: RepoApproachesWire;
+  multiRepo: boolean;
+  onSelect?: (sel: SelectedRecord) => void;
+  selectedKey: string | null;
+}) {
   // Group by status then sort by date desc within each group. No
   // filter chips — every status is shown, every item is rendered.
   const byStatus = new Map<ApproachStatus, ApproachWire[]>();
@@ -115,16 +154,54 @@ function RepoBlock({ repo, multiRepo }: { repo: RepoApproachesWire; multiRepo: b
             </p>
             <ul className="space-y-0.5">
               {list.map((a) => (
-                <li key={a.slug} className="leading-snug">
-                  <span className="font-mono text-subtle-foreground">{a.date}</span>{" "}
-                  <span className="text-foreground">{a.title}</span>
-                  <div className="text-[11px] text-subtle-foreground">{a.slug}</div>
-                </li>
+                <ApproachRow
+                  key={a.slug}
+                  approach={a}
+                  repoPath={repo.repo_root}
+                  repoLabel={repo.repo_label}
+                  onSelect={onSelect}
+                  selected={selectedKey === selectedRecordKey(repo.repo_root, a.slug)}
+                />
               ))}
             </ul>
           </div>
         );
       })}
     </div>
+  );
+}
+
+// The whole row is a button that opens the approach in the R₂ record
+// viewer (mirrors `RPrsSection`'s `PrRow`). `aria-current` marks the row
+// whose content is currently open in R₂ — a mechanical "open here" fact,
+// no severity styling.
+function ApproachRow({
+  approach,
+  repoPath,
+  repoLabel,
+  onSelect,
+  selected,
+}: {
+  approach: ApproachWire;
+  repoPath: string;
+  repoLabel: string;
+  onSelect?: (sel: SelectedRecord) => void;
+  selected: boolean;
+}) {
+  return (
+    <li className="leading-snug">
+      <button
+        type="button"
+        onClick={() => onSelect?.({ kind: "approach", repoPath, repoLabel, record: approach })}
+        aria-current={selected ? "true" : undefined}
+        className={`w-full rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
+          selected ? "bg-surface-strong/40" : ""
+        }`}
+      >
+        <span className="font-mono text-subtle-foreground">{approach.date}</span>{" "}
+        <span className="text-foreground">{approach.title}</span>
+        <div className="text-[11px] text-subtle-foreground">{approach.slug}</div>
+      </button>
+    </li>
   );
 }

--- a/clients/react/src/components/producer-console/r-panel/RDecisionsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RDecisionsSection.tsx
@@ -8,15 +8,30 @@
 
 import { useDecisions } from "@/hooks/useDecisions";
 import type { DecisionWire, RepoDecisionsWire } from "@/lib/api";
+import { type SelectedRecord, selectedRecordKey } from "./r-viewer/RRecordViewer";
 import { Section } from "./Section";
 
 interface RDecisionsSectionProps {
   unitName: string | null;
   expanded: boolean;
   onToggle: () => void;
+  /** Open a decision in the R₂ record viewer column. Clicking a row
+   *  selects it for in-tmai viewing (mirrors `RPrsSection.onSelectPr`).
+   *  Optional so the section still renders standalone in isolation. */
+  onSelect?: (sel: SelectedRecord) => void;
+  /** `selectedRecordKey(repoPath, slug)` of the record currently open in
+   *  R₂, so the row marks itself as the one being viewed (a mechanical
+   *  "open here" fact, not appraisal). */
+  selectedKey?: string | null;
 }
 
-export function RDecisionsSection({ unitName, expanded, onToggle }: RDecisionsSectionProps) {
+export function RDecisionsSection({
+  unitName,
+  expanded,
+  onToggle,
+  onSelect,
+  selectedKey,
+}: RDecisionsSectionProps) {
   const { data, loading, error } = useDecisions(unitName);
   const total = data === null ? 0 : data.repos.reduce((n, r) => n + flattenAll(r).length, 0);
 
@@ -29,7 +44,14 @@ export function RDecisionsSection({ unitName, expanded, onToggle }: RDecisionsSe
       expanded={expanded}
       onToggle={onToggle}
     >
-      <Body unitName={unitName} repos={data?.repos ?? null} loading={loading} error={error} />
+      <Body
+        unitName={unitName}
+        repos={data?.repos ?? null}
+        loading={loading}
+        error={error}
+        onSelect={onSelect}
+        selectedKey={selectedKey ?? null}
+      />
     </Section>
   );
 }
@@ -43,9 +65,11 @@ interface BodyProps {
   repos: RepoDecisionsWire[] | null;
   loading: boolean;
   error: Error | null;
+  onSelect?: (sel: SelectedRecord) => void;
+  selectedKey: string | null;
 }
 
-function Body({ unitName, repos, loading, error }: BodyProps) {
+function Body({ unitName, repos, loading, error, onSelect, selectedKey }: BodyProps) {
   if (unitName === null) {
     return <p className="text-subtle-foreground">Pick a project to see decisions.</p>;
   }
@@ -75,18 +99,56 @@ function Body({ unitName, repos, loading, error }: BodyProps) {
             )}
             <ul className="space-y-0.5">
               {sorted.map((d) => (
-                <li key={d.slug} className="leading-snug">
-                  <span className="font-mono text-subtle-foreground">{d.last_verified}</span>{" "}
-                  <span className="text-foreground">{d.title}</span>
-                  <div className="text-[11px] text-subtle-foreground">
-                    {d.slug} · {d.status}
-                  </div>
-                </li>
+                <DecisionRow
+                  key={d.slug}
+                  decision={d}
+                  repoPath={repo.repo_root}
+                  repoLabel={repo.repo_label}
+                  onSelect={onSelect}
+                  selected={selectedKey === selectedRecordKey(repo.repo_root, d.slug)}
+                />
               ))}
             </ul>
           </div>
         );
       })}
     </div>
+  );
+}
+
+// The whole row is a button that opens the decision in the R₂ record
+// viewer (mirrors `RPrsSection`'s `PrRow`). `aria-current` marks the row
+// whose content is currently open in R₂ — a mechanical "open here" fact,
+// no severity styling.
+function DecisionRow({
+  decision,
+  repoPath,
+  repoLabel,
+  onSelect,
+  selected,
+}: {
+  decision: DecisionWire;
+  repoPath: string;
+  repoLabel: string;
+  onSelect?: (sel: SelectedRecord) => void;
+  selected: boolean;
+}) {
+  return (
+    <li className="leading-snug">
+      <button
+        type="button"
+        onClick={() => onSelect?.({ kind: "decision", repoPath, repoLabel, record: decision })}
+        aria-current={selected ? "true" : undefined}
+        className={`w-full rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
+          selected ? "bg-surface-strong/40" : ""
+        }`}
+      >
+        <span className="font-mono text-subtle-foreground">{decision.last_verified}</span>{" "}
+        <span className="text-foreground">{decision.title}</span>
+        <div className="text-[11px] text-subtle-foreground">
+          {decision.slug} · {decision.status}
+        </div>
+      </button>
+    </li>
   );
 }

--- a/clients/react/src/components/producer-console/r-panel/RPanel.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPanel.tsx
@@ -37,6 +37,7 @@ import { RHandoverSection } from "./RHandoverSection";
 import { RIssuesSection } from "./RIssuesSection";
 import { RPrsSection } from "./RPrsSection";
 import type { SelectedPr } from "./r-viewer/RPrViewer";
+import type { SelectedRecord } from "./r-viewer/RRecordViewer";
 
 export interface RPanelResize {
   width: number;
@@ -65,6 +66,13 @@ interface RPanelProps {
   /** `selectedPrKey(...)` of the PR currently open in R₂, so the R₁ row
    *  marks itself as the one being viewed. */
   selectedPrKey?: string | null;
+  /** Open a decision/approach in the R₂ record viewer column. Threaded to
+   *  the R₁ Decisions + Approaches inventories so a row click selects the
+   *  record for in-tmai viewing. */
+  onSelectRecord?: (sel: SelectedRecord) => void;
+  /** `selectedRecordKey(...)` of the record currently open in R₂, so the
+   *  focused R₁ Decisions/Approaches row marks itself. */
+  selectedRecordKey?: string | null;
 }
 
 const SECTION_IDS = [
@@ -88,6 +96,8 @@ export function RPanel({
   resize,
   onSelectPr,
   selectedPrKey,
+  onSelectRecord,
+  selectedRecordKey,
 }: RPanelProps) {
   const [expanded, setExpanded] = useUIPref("rPanelExpandedSections");
 
@@ -199,11 +209,15 @@ export function RPanel({
           unitName={unitName}
           expanded={isExpanded("decisions")}
           onToggle={() => toggle("decisions")}
+          onSelect={onSelectRecord}
+          selectedKey={selectedRecordKey}
         />
         <RApproachesSection
           unitName={unitName}
           expanded={isExpanded("approaches")}
           onToggle={() => toggle("approaches")}
+          onSelect={onSelectRecord}
+          selectedKey={selectedRecordKey}
         />
         <RCalibrationSection
           unitName={unitName}

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RApproachesSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RApproachesSection.test.tsx
@@ -3,7 +3,7 @@
 // RApproachesSection — status group, date desc within, no
 // verification-debt gauge (that's C's layer), no filter chips.
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { ApproachesResponse, ApproachWire } from "@/lib/api";
 
@@ -21,6 +21,7 @@ vi.mock("@/lib/api", async () => {
 });
 
 import { RApproachesSection } from "../RApproachesSection";
+import { type SelectedRecord, selectedRecordKey } from "../r-viewer/RRecordViewer";
 
 function approachStub(overrides: Partial<ApproachWire> = {}): ApproachWire {
   return {
@@ -121,5 +122,43 @@ describe("RApproachesSection", () => {
       expect(screen.getByText(/2 running/)).toBeTruthy();
     });
     expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
+  });
+
+  // ── R₂ selection wiring (mirrors RPrsSection's onSelectPr/aria-current) ──
+
+  it("clicking a row calls onSelect with the approach wire object", async () => {
+    approachesMock.mockResolvedValue(
+      responseStub([approachStub({ slug: "2026-05-01-a", title: "Approach A" })]),
+    );
+    const onSelect = vi.fn();
+    render(
+      <RApproachesSection unitName="u" expanded={true} onToggle={vi.fn()} onSelect={onSelect} />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Approach A/ }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    const arg = onSelect.mock.calls[0][0] as SelectedRecord;
+    expect(arg.kind).toBe("approach");
+    expect(arg.repoPath).toBe("/p/u");
+    expect(arg.repoLabel).toBe("u");
+    expect(arg.record.slug).toBe("2026-05-01-a");
+  });
+
+  it("marks the focused row with aria-current", async () => {
+    approachesMock.mockResolvedValue(
+      responseStub([approachStub({ slug: "2026-05-01-a", title: "Approach A" })]),
+    );
+    render(
+      <RApproachesSection
+        unitName="u"
+        expanded={true}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+        selectedKey={selectedRecordKey("/p/u", "2026-05-01-a")}
+      />,
+    );
+
+    const row = await screen.findByRole("button", { name: /Approach A/ });
+    expect(row.getAttribute("aria-current")).toBe("true");
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RDecisionsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RDecisionsSection.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/lib/api", async () => {
 });
 
 import { RDecisionsSection } from "../RDecisionsSection";
+import { type SelectedRecord, selectedRecordKey } from "../r-viewer/RRecordViewer";
 
 function decisionStub(overrides: Partial<DecisionWire> = {}): DecisionWire {
   return {
@@ -152,5 +153,57 @@ describe("RDecisionsSection", () => {
     render(<RDecisionsSection unitName={null} expanded={true} onToggle={vi.fn()} />);
     expect(screen.getByText(/Pick a project/i)).toBeTruthy();
     expect(decisionsMock).not.toHaveBeenCalled();
+  });
+
+  // ── R₂ selection wiring (mirrors RPrsSection's onSelectPr/aria-current) ──
+
+  it("clicking a row calls onSelect with the decision wire object", async () => {
+    decisionsMock.mockResolvedValue(
+      responseStub({
+        repos: [
+          {
+            ...responseStub().repos[0],
+            in_play: [decisionStub({ slug: "2026-05-01-a", title: "Decision A" })],
+          },
+        ],
+      }),
+    );
+    const onSelect = vi.fn();
+    render(
+      <RDecisionsSection unitName="u" expanded={true} onToggle={vi.fn()} onSelect={onSelect} />,
+    );
+
+    fireEvent.click(await screen.findByRole("button", { name: /Decision A/ }));
+    expect(onSelect).toHaveBeenCalledTimes(1);
+    const arg = onSelect.mock.calls[0][0] as SelectedRecord;
+    expect(arg.kind).toBe("decision");
+    expect(arg.repoPath).toBe("/p/u");
+    expect(arg.repoLabel).toBe("u");
+    expect(arg.record.slug).toBe("2026-05-01-a");
+  });
+
+  it("marks the focused row with aria-current", async () => {
+    decisionsMock.mockResolvedValue(
+      responseStub({
+        repos: [
+          {
+            ...responseStub().repos[0],
+            in_play: [decisionStub({ slug: "2026-05-01-a", title: "Decision A" })],
+          },
+        ],
+      }),
+    );
+    render(
+      <RDecisionsSection
+        unitName="u"
+        expanded={true}
+        onToggle={vi.fn()}
+        onSelect={vi.fn()}
+        selectedKey={selectedRecordKey("/p/u", "2026-05-01-a")}
+      />,
+    );
+
+    const row = await screen.findByRole("button", { name: /Decision A/ });
+    expect(row.getAttribute("aria-current")).toBe("true");
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/RPrViewer.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/RPrViewer.tsx
@@ -56,6 +56,7 @@ import {
   type PrMergeStatus,
   type PrSummaryWire,
 } from "@/lib/api";
+import { PROSE_CLASSES } from "./prose";
 
 // What R₁ hands R₂ on a row click. The full `PrSummaryWire` rides along
 // so the header renders every inventory fact (CI / review / draft /
@@ -75,22 +76,6 @@ export interface SelectedPr {
 export function selectedPrKey(repoPath: string, prNumber: bigint): string {
   return `${repoPath}#${prNumber}`;
 }
-
-// Markdown prose classes — same palette the transcript / digest markdown
-// uses so the body and comments read like the rest of the WebUI.
-const PROSE_CLASSES = `prose prose-invert prose-sm max-w-none
-  prose-headings:text-foreground prose-headings:font-semibold
-  prose-p:text-foreground prose-p:leading-relaxed prose-p:my-1
-  prose-a:text-info prose-a:no-underline hover:prose-a:underline
-  prose-strong:text-foreground
-  prose-code:text-primary prose-code:bg-surface prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:before:content-none prose-code:after:content-none
-  prose-pre:bg-surface-strong/50 prose-pre:border prose-pre:border-hairline prose-pre:rounded-lg prose-pre:my-1
-  prose-li:text-foreground prose-li:my-0
-  prose-ul:my-1 prose-ol:my-1
-  prose-th:text-foreground prose-th:border-hairline-strong
-  prose-td:text-muted-foreground prose-td:border-hairline-strong
-  prose-hr:border-hairline-strong
-  prose-blockquote:border-info/30 prose-blockquote:text-muted-foreground`;
 
 interface RPrViewerProps {
   selected: SelectedPr;

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/RRecordViewer.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/RRecordViewer.tsx
@@ -1,0 +1,500 @@
+// R₂ — the in-tmai record content viewer, shared base across BOTH record
+// kinds (⬡ decision / ▣ approach). Serves the spine
+// `2026-05-29-c-and-r-as-the-development-substrate` (the per-kind walk's
+// "(ii) judgment-info" surface) + `2026-05-29-artifact-content-viewer`
+// (γ-lean R₂ viewer) + `2026-05-16-dev-loop-completes-in-tmai` (read the
+// project's records in-tmai, no editor round-trip).
+//
+// Mirrors `RPrViewer`'s posture exactly: an INDEPENDENT right-side column
+// that NEVER auto-opens — it mounts only on an explicit operator row
+// click in the R₁ inventory (the parent gates the mount on a non-null
+// `selectedRecord`). R₁ (`RDecisionsSection` / `RApproachesSection`)
+// stays a pure inventory; this column renders the clicked record's
+// content.
+//
+// SCOPE — read-only, excerpt-level, NO actions. This is the (ii)
+// judgment-info viewer only: it renders the rich frontmatter + the
+// `excerpt` the wire already carries. The full markdown body + Update
+// history live behind a deferred tmai-core content endpoint and are NOT
+// fetched here. The (iii) lifecycle acts (accept / verdict / amend /
+// archive / bump) need an unbuilt R-lifecycle backend and are explicitly
+// deferred — the viewer mutates nothing.
+//
+// Negative space (the serving `2026-05-26-tmai-states-facts-not-appraisals`
+// posture — tmai states facts, never appraises):
+//   - all record facts (frontmatter, drift, review triggers, signals)
+//     stay PLAIN inline — `text-foreground` / `text-muted-foreground` /
+//     `text-subtle-foreground` only, never warning / destructive /
+//     success accents;
+//   - the drift + review-trigger indicators are PLAIN facts, not alarms
+//     (silence-is-not-neutral: a present drift / a ready trigger is shown
+//     plainly; their absence shows nothing — no "all clear" reassurance,
+//     no "changed since you last looked" / unread / TL;DR / auto-summary);
+//   - the ONE allowed convention is standard markdown rendering inside
+//     the excerpt (via `PROSE_CLASSES`), same as `RPrViewer`'s body.
+
+import { useMemo } from "react";
+import Markdown, { type Components, defaultUrlTransform } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { useApproaches } from "@/hooks/useApproaches";
+import { useDecisions } from "@/hooks/useDecisions";
+import type {
+  ApproachesResponse,
+  ApproachWire,
+  DecisionsResponse,
+  DecisionWire,
+  ReviewTriggerWire,
+} from "@/lib/api";
+import { PROSE_CLASSES } from "./prose";
+
+// What R₁ hands R₂ on a record row click. The full wire object rides
+// along (like `SelectedPr` carries the full `pr`) so the viewer renders
+// every fact without re-fetching; `repoPath` / `repoLabel` mirror the PR
+// selection so the header reads identically. A discriminated union on
+// `kind` keeps the two record shapes honest at the type level.
+export type SelectedRecord =
+  | { kind: "decision"; repoPath: string; repoLabel: string; record: DecisionWire }
+  | { kind: "approach"; repoPath: string; repoLabel: string; record: ApproachWire };
+
+export function selectedRecordKey(repoPath: string, slug: string): string {
+  return `${repoPath}#${slug}`;
+}
+
+interface RRecordViewerProps {
+  selected: SelectedRecord;
+  /** Unit whose decisions + approaches feed cross-ref resolution. The
+   *  viewer re-fetches both sets (cheap 60s polls, same hooks R₁ uses) so
+   *  a clicked slug can be resolved to whichever kind owns it. The
+   *  focused record itself rides in `selected` and needs no fetch. */
+  unitName: string | null;
+  /** Re-focus R₂ on a cross-referenced record (stays in this column). */
+  onSelectRecord: (sel: SelectedRecord) => void;
+  onClose: () => void;
+}
+
+export function RRecordViewer({ selected, unitName, onSelectRecord, onClose }: RRecordViewerProps) {
+  // Both sets back the cross-ref index: a clicked slug is resolved against
+  // decisions AND approaches and focuses whichever kind matches.
+  const { data: decisions } = useDecisions(unitName);
+  const { data: approaches } = useApproaches(unitName);
+  const index = useMemo(() => buildRecordIndex(decisions, approaches), [decisions, approaches]);
+
+  return (
+    <aside
+      data-testid="r-record-viewer"
+      className="glass flex w-[clamp(22rem,40vw,48rem)] shrink-0 flex-col border-l border-hairline"
+    >
+      <ViewerHeader selected={selected} onClose={onClose} />
+      <div className="flex-1 space-y-4 overflow-y-auto px-4 py-3 text-xs">
+        <FrontmatterTable selected={selected} index={index} onSelectRecord={onSelectRecord} />
+        {selected.kind === "decision" ? (
+          <DriftIndicator decision={selected.record} />
+        ) : (
+          <ReviewTriggerIndicator approach={selected.record} />
+        )}
+        {selected.kind === "approach" && <SignalsHoist approach={selected.record} />}
+        <ExcerptSection
+          excerpt={selected.record.excerpt}
+          index={index}
+          onSelectRecord={onSelectRecord}
+        />
+      </div>
+    </aside>
+  );
+}
+
+// ── Cross-ref index — slug → the SelectedRecord that owns it ──
+//
+// Decisions are indexed first so a slug colliding across kinds (rare —
+// the two live in different directories) resolves to the decision. A
+// slug absent from the index is a not-yet-existing ref, rendered plain.
+
+function flattenDecisions(decisions: DecisionsResponse | null): {
+  repoPath: string;
+  repoLabel: string;
+  record: DecisionWire;
+}[] {
+  if (decisions === null) return [];
+  return decisions.repos.flatMap((repo) =>
+    [...repo.foundations, ...repo.in_play, ...repo.warm, ...repo.cold, ...repo.superseded].map(
+      (record) => ({ repoPath: repo.repo_root, repoLabel: repo.repo_label, record }),
+    ),
+  );
+}
+
+function flattenApproaches(approaches: ApproachesResponse | null): {
+  repoPath: string;
+  repoLabel: string;
+  record: ApproachWire;
+}[] {
+  if (approaches === null) return [];
+  return approaches.repos.flatMap((repo) =>
+    repo.approaches.map((record) => ({
+      repoPath: repo.repo_root,
+      repoLabel: repo.repo_label,
+      record,
+    })),
+  );
+}
+
+function buildRecordIndex(
+  decisions: DecisionsResponse | null,
+  approaches: ApproachesResponse | null,
+): Map<string, SelectedRecord> {
+  const index = new Map<string, SelectedRecord>();
+  for (const { repoPath, repoLabel, record } of flattenDecisions(decisions)) {
+    if (!index.has(record.slug)) {
+      index.set(record.slug, { kind: "decision", repoPath, repoLabel, record });
+    }
+  }
+  for (const { repoPath, repoLabel, record } of flattenApproaches(approaches)) {
+    if (!index.has(record.slug)) {
+      index.set(record.slug, { kind: "approach", repoPath, repoLabel, record });
+    }
+  }
+  return index;
+}
+
+// ── Header — mechanical identity facts, all plain (no severity tint) ──
+
+function ViewerHeader({ selected, onClose }: { selected: SelectedRecord; onClose: () => void }) {
+  const { repoLabel, record } = selected;
+  // Decision: kind-fact = category. Approach: kind-fact = creation date.
+  const kindFact = selected.kind === "decision" ? selected.record.category : selected.record.date;
+  return (
+    <header className="shrink-0 border-b border-hairline px-4 py-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-[11px] uppercase tracking-wide text-subtle-foreground">
+            {repoLabel} · {selected.kind}
+          </p>
+          <h2 className="text-sm font-semibold text-foreground">{record.title}</h2>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          title="Close record viewer"
+          aria-label="Close record viewer"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+        >
+          ×
+        </button>
+      </div>
+      <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-subtle-foreground">
+        <span className="font-mono">{record.slug}</span>
+        <span className="text-muted-foreground">{record.status}</span>
+        <span className="text-muted-foreground">{kindFact}</span>
+      </div>
+    </header>
+  );
+}
+
+// ── Section frame (mirrors RPrViewer's plain section heading) ──
+
+function SectionFrame({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-subtle-foreground">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+// ── Frontmatter table — plain `dl` of mechanical facts, no tint ──
+//
+// Slug-valued rows (serves / superseded_by / strengthened_by /
+// replaced_by) render their entries as cross-refs; `governs[]` entries
+// are PATHS, not slugs, so they are always plain, never clickable.
+
+type FrontmatterRow =
+  | { label: string; kind: "scalar"; value: string }
+  | { label: string; kind: "paths"; values: string[] }
+  | { label: string; kind: "slugs"; values: string[] };
+
+function decisionRows(d: DecisionWire): FrontmatterRow[] {
+  return [
+    { label: "category", kind: "scalar", value: d.category },
+    { label: "contract_surface", kind: "scalar", value: d.contract_surface ? "true" : "false" },
+    { label: "governs", kind: "paths", values: d.governs },
+    { label: "superseded_by", kind: "slugs", values: d.superseded_by },
+    { label: "strengthened_by", kind: "slugs", values: d.strengthened_by },
+  ];
+}
+
+function approachRows(a: ApproachWire): FrontmatterRow[] {
+  return [
+    { label: "serves", kind: "slugs", values: a.serves },
+    { label: "governs", kind: "paths", values: a.governs },
+    { label: "confidence", kind: "scalar", value: a.confidence ?? "—" },
+    { label: "replaced_by", kind: "slugs", values: a.replaced_by },
+  ];
+}
+
+function FrontmatterTable({
+  selected,
+  index,
+  onSelectRecord,
+}: {
+  selected: SelectedRecord;
+  index: Map<string, SelectedRecord>;
+  onSelectRecord: (sel: SelectedRecord) => void;
+}) {
+  const rows =
+    selected.kind === "decision" ? decisionRows(selected.record) : approachRows(selected.record);
+  return (
+    <SectionFrame title="Frontmatter">
+      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1">
+        {rows.map((row) => (
+          <div key={row.label} className="contents">
+            <dt className="text-subtle-foreground">{row.label}</dt>
+            <dd className="text-foreground">
+              <FrontmatterValue row={row} index={index} onSelectRecord={onSelectRecord} />
+            </dd>
+          </div>
+        ))}
+      </dl>
+    </SectionFrame>
+  );
+}
+
+function FrontmatterValue({
+  row,
+  index,
+  onSelectRecord,
+}: {
+  row: FrontmatterRow;
+  index: Map<string, SelectedRecord>;
+  onSelectRecord: (sel: SelectedRecord) => void;
+}) {
+  if (row.kind === "scalar") {
+    return <span className="font-mono">{row.value}</span>;
+  }
+  if (row.values.length === 0) {
+    return <span className="text-subtle-foreground">—</span>;
+  }
+  if (row.kind === "paths") {
+    return (
+      <ul className="space-y-0.5">
+        {row.values.map((path) => (
+          <li key={path} className="font-mono text-foreground">
+            {path}
+          </li>
+        ))}
+      </ul>
+    );
+  }
+  return (
+    <ul className="flex flex-wrap gap-x-3 gap-y-0.5">
+      {row.values.map((slug) => (
+        <li key={slug}>
+          <CrossRef slug={slug} index={index} onSelectRecord={onSelectRecord} />
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+// ── Cross-ref — a slug that resolves to a loaded record is clickable ──
+//
+// Plain styling (no severity / info tint): a dotted underline marks it as
+// interactive without appraising it. An unresolved slug (a record that
+// doesn't exist yet) is NOT an error — it renders as plain, non-clickable
+// text.
+
+function CrossRef({
+  slug,
+  index,
+  onSelectRecord,
+}: {
+  slug: string;
+  index: Map<string, SelectedRecord>;
+  onSelectRecord: (sel: SelectedRecord) => void;
+}) {
+  const target = index.get(slug);
+  if (target === undefined) {
+    return <span className="font-mono text-muted-foreground">{slug}</span>;
+  }
+  return (
+    <button
+      type="button"
+      onClick={() => onSelectRecord(target)}
+      className="rounded font-mono text-foreground underline decoration-dotted underline-offset-2 transition-colors hover:bg-surface-strong/40"
+    >
+      {slug}
+    </button>
+  );
+}
+
+// ── Drift indicator (decision) — PLAIN fact, never an alarm ──
+
+function DriftIndicator({ decision }: { decision: DecisionWire }) {
+  const stale = decision.stale_since;
+  // Absent when no drift: a clean decision shows nothing here (no "all
+  // clear" reassurance). Present drift is a plain fact, not a warning.
+  if (stale === null) return null;
+  return (
+    <SectionFrame title="Drift">
+      <p className="text-muted-foreground">
+        <span className="font-mono text-foreground">{stale.path}</span> changed {stale.change_date}{" "}
+        after last-verified {decision.last_verified}
+        {stale.change_subject !== "" && (
+          <span className="text-subtle-foreground"> — {stale.change_subject}</span>
+        )}
+      </p>
+    </SectionFrame>
+  );
+}
+
+// ── Review-trigger indicator (approach) — PLAIN facts, never alarms ──
+//
+// Every trigger is listed plainly. A date-kind trigger whose date is on
+// or before today is annotated "(review-trigger ready: <date>)" — the one
+// thing tmai CAN auto-detect from a date. The non-date triggers
+// (pr-closed / pr-merged / issue-closed / *-status / manual) are listed
+// without a fired/not-fired claim, because tmai cannot auto-detect their
+// firing.
+
+// `YYYY-MM-DD` for today (UTC day boundary is immaterial for this plain
+// fact). ISO date strings compare correctly lexicographically.
+function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function formatTrigger(t: ReviewTriggerWire): string {
+  switch (t.kind) {
+    case "date":
+      return `review-after ${t.value}`;
+    case "pr-closed":
+      return `pr-closed ${t.ref}`;
+    case "pr-merged":
+      return `pr-merged ${t.ref}`;
+    case "issue-closed":
+      return `issue-closed ${t.ref}`;
+    case "decision-status":
+      return `decision-status ${t.ref} → ${t["target-status"]}`;
+    case "approach-status":
+      return `approach-status ${t.ref} → ${t["target-status"]}`;
+    case "manual":
+      return `manual: ${t.description}`;
+  }
+}
+
+function ReviewTriggerIndicator({ approach }: { approach: ApproachWire }) {
+  const today = todayIso();
+  return (
+    <SectionFrame title="Review triggers">
+      <ul className="space-y-0.5">
+        {approach.review_triggers.map((t) => {
+          // The formatted line is the natural stable key — it encodes the
+          // trigger's kind + ref/value, and triggers are parse-validated
+          // (no exact duplicates within a record).
+          const text = formatTrigger(t);
+          const ready = t.kind === "date" && t.value <= today;
+          return (
+            <li key={text} className="text-foreground">
+              <span className="font-mono text-muted-foreground">{text}</span>
+              {ready && t.kind === "date" && (
+                <span className="text-foreground"> (review-trigger ready: {t.value})</span>
+              )}
+            </li>
+          );
+        })}
+      </ul>
+    </SectionFrame>
+  );
+}
+
+// ── Approach signal hoist — success / failure signal, prominent + plain ──
+//
+// These are the verdict material (does the approach's bet pay off?), so
+// the viewer hoists them out of the body into labelled blocks. Plain —
+// they state the bet, they don't appraise it.
+
+function SignalsHoist({ approach }: { approach: ApproachWire }) {
+  return (
+    <div className="space-y-2">
+      <SectionFrame title="Success signal">
+        <p className="text-foreground">{approach.success_signal}</p>
+      </SectionFrame>
+      <SectionFrame title="Failure signal">
+        <p className="text-foreground">{approach.failure_signal}</p>
+      </SectionFrame>
+    </div>
+  );
+}
+
+// ── Excerpt — markdown via the shared PROSE_CLASSES, with `[[slug]]`
+//    cross-refs ──
+//
+// The wire carries an `excerpt` (decision: the `## Decision` section for
+// in-play, else a one-paragraph summary; approach: the first paragraph),
+// NOT the full body. `[[slug]]` wiki-links in the excerpt are rewritten
+// to markdown links with a `record:` scheme; the `a` override turns
+// resolved ones into in-prose cross-ref buttons and leaves unresolved
+// slugs as plain text.
+
+const WIKILINK = /\[\[([^[\]]+)\]\]/g;
+
+function ExcerptSection({
+  excerpt,
+  index,
+  onSelectRecord,
+}: {
+  excerpt: string;
+  index: Map<string, SelectedRecord>;
+  onSelectRecord: (sel: SelectedRecord) => void;
+}) {
+  const trimmed = excerpt.trim();
+  const withLinks = useMemo(
+    () => trimmed.replace(WIKILINK, (_m, slug: string) => `[${slug}](record:${slug})`),
+    [trimmed],
+  );
+  const components = useMemo<Components>(
+    () => ({
+      a({ href, children }) {
+        if (href?.startsWith("record:")) {
+          const slug = href.slice("record:".length);
+          const target = index.get(slug);
+          if (target === undefined) {
+            // A not-yet-existing ref is not an error — plain text.
+            return <span className="text-muted-foreground">{children}</span>;
+          }
+          return (
+            <button
+              type="button"
+              onClick={() => onSelectRecord(target)}
+              className="font-mono text-foreground underline decoration-dotted underline-offset-2 hover:decoration-solid"
+            >
+              {children}
+            </button>
+          );
+        }
+        // Real links keep the standard prose link rendering.
+        return <a href={href}>{children}</a>;
+      },
+    }),
+    [index, onSelectRecord],
+  );
+
+  return (
+    <SectionFrame title="Excerpt">
+      {trimmed === "" ? (
+        <p className="text-subtle-foreground">No excerpt.</p>
+      ) : (
+        <div className={PROSE_CLASSES}>
+          <Markdown
+            remarkPlugins={[remarkGfm]}
+            // Preserve the synthetic `record:` scheme; sanitize everything
+            // else exactly as react-markdown would by default.
+            urlTransform={(url) => (url.startsWith("record:") ? url : defaultUrlTransform(url))}
+            components={components}
+          >
+            {withLinks}
+          </Markdown>
+        </div>
+      )}
+    </SectionFrame>
+  );
+}

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RRecordViewer.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RRecordViewer.test.tsx
@@ -1,0 +1,431 @@
+// @vitest-environment jsdom
+//
+// RRecordViewer — the R₂ shared record content viewer (decisions +
+// approaches). The cross-ref index fetchers (useDecisions / useApproaches)
+// are mocked so this test proves: the frontmatter table renders the
+// kind's fields; the drift indicator shows when `stale_since` is present
+// and is absent when null; the approach review-trigger-ready indicator
+// fires for a past date and not a future one; success/failure-signal are
+// hoisted for approaches; the excerpt renders as markdown; cross-refs
+// re-focus R₂ and an unresolved slug stays plain text; governs paths are
+// never cross-refs; and status facts carry NO severity tint.
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ApproachesResponse, ApproachWire, DecisionsResponse, DecisionWire } from "@/lib/api";
+
+const useDecisionsMock = vi.fn();
+const useApproachesMock = vi.fn();
+
+vi.mock("@/hooks/useDecisions", () => ({
+  useDecisions: (...a: unknown[]) => useDecisionsMock(...a),
+}));
+vi.mock("@/hooks/useApproaches", () => ({
+  useApproaches: (...a: unknown[]) => useApproachesMock(...a),
+}));
+
+import { RRecordViewer, type SelectedRecord } from "../RRecordViewer";
+
+// ── wire builders ──
+
+function decision(overrides: Partial<DecisionWire> = {}): DecisionWire {
+  return {
+    slug: "2026-05-01-the-decision",
+    title: "The Decision",
+    status: "accepted",
+    category: "principle",
+    governs: ["src/lib/api.ts"],
+    last_verified: "2026-05-01",
+    contract_surface: true,
+    stale_since: null,
+    superseded_by: [],
+    strengthened_by: [],
+    excerpt: "",
+    ...overrides,
+  };
+}
+
+function approach(overrides: Partial<ApproachWire> = {}): ApproachWire {
+  return {
+    slug: "2026-05-10-the-approach",
+    title: "The Approach",
+    date: "2026-05-10",
+    status: "running",
+    governs: ["doc/decisions/"],
+    serves: ["2026-05-01-the-decision"],
+    success_signal: "the metric climbs",
+    failure_signal: "the metric stalls",
+    review_triggers: [{ kind: "date", value: "2099-01-01" }],
+    review_history: [],
+    confidence: "high",
+    replaced_by: [],
+    excerpt: "",
+    ...overrides,
+  };
+}
+
+function decisionsResponse(decisions: DecisionWire[] = []): DecisionsResponse {
+  return {
+    unit: "u",
+    composed_at: "2026-05-29T00:00:00Z",
+    repos: [
+      {
+        repo_label: "u",
+        repo_root: "/p/u",
+        primary: true,
+        repo_head: null,
+        counts: {
+          total: 0,
+          in_play: 0,
+          warm: 0,
+          cold: 0,
+          foundations: 0,
+          superseded: 0,
+          stale_suspect: 0,
+        },
+        currency_sweep: [],
+        foundational_due: [],
+        foundations: [],
+        in_play: decisions,
+        warm: [],
+        cold: [],
+        superseded: [],
+      },
+    ],
+  };
+}
+
+function approachesResponse(approaches: ApproachWire[] = []): ApproachesResponse {
+  return {
+    unit: "u",
+    composed_at: "2026-05-29T00:00:00Z",
+    repos: [
+      {
+        repo_label: "u",
+        repo_root: "/p/u",
+        primary: true,
+        repo_head: null,
+        approaches,
+      },
+    ],
+  };
+}
+
+function decisionSelection(d: DecisionWire): SelectedRecord {
+  return { kind: "decision", repoPath: "/p/u", repoLabel: "u", record: d };
+}
+function approachSelection(a: ApproachWire): SelectedRecord {
+  return { kind: "approach", repoPath: "/p/u", repoLabel: "u", record: a };
+}
+
+beforeEach(() => {
+  useDecisionsMock.mockReset();
+  useApproachesMock.mockReset();
+  // Default: empty cross-ref index. Individual tests override.
+  useDecisionsMock.mockReturnValue({ data: decisionsResponse([]), loading: false, error: null });
+  useApproachesMock.mockReturnValue({ data: approachesResponse([]), loading: false, error: null });
+});
+
+describe("RRecordViewer — decision", () => {
+  it("renders the header identity facts (repo · kind, title, slug, status, category)", () => {
+    const { container } = render(
+      <RRecordViewer
+        selected={decisionSelection(decision())}
+        unitName="u"
+        onSelectRecord={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    // Scope to the header — the category ("principle") also appears in the
+    // frontmatter table below, so a global query would match twice.
+    const header = container.querySelector("header");
+    expect(header).not.toBeNull();
+    if (header === null) return;
+    expect(within(header).getByText("The Decision")).toBeTruthy();
+    expect(within(header).getByText("2026-05-01-the-decision")).toBeTruthy();
+    expect(within(header).getByText("accepted")).toBeTruthy();
+    // Header carries the kind-fact (category) and the repo · kind label.
+    expect(within(header).getByText("principle")).toBeTruthy();
+    expect(within(header).getByText("u · decision")).toBeTruthy();
+  });
+
+  it("renders the decision frontmatter fields (category, contract_surface, governs, supersede chains)", () => {
+    render(
+      <RRecordViewer
+        selected={decisionSelection(
+          decision({
+            governs: ["src/a.ts", "src/b.ts"],
+            superseded_by: ["2026-06-01-newer"],
+            strengthened_by: ["2026-05-20-also"],
+          }),
+        )}
+        unitName="u"
+        onSelectRecord={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("contract_surface")).toBeTruthy();
+    expect(screen.getByText("governs")).toBeTruthy();
+    expect(screen.getByText("src/a.ts")).toBeTruthy();
+    expect(screen.getByText("src/b.ts")).toBeTruthy();
+    expect(screen.getByText("superseded_by")).toBeTruthy();
+    expect(screen.getByText("strengthened_by")).toBeTruthy();
+  });
+
+  it("shows the drift indicator when stale_since is present", () => {
+    render(
+      <RRecordViewer
+        selected={decisionSelection(
+          decision({
+            last_verified: "2026-05-01",
+            stale_since: {
+              path: "src/lib/api.ts",
+              change_date: "2026-05-20",
+              change_sha: "abc1234",
+              change_subject: "rename the field",
+            },
+          }),
+        )}
+        unitName="u"
+        onSelectRecord={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Drift")).toBeTruthy();
+    expect(screen.getByText(/changed 2026-05-20 after last-verified 2026-05-01/)).toBeTruthy();
+  });
+
+  it("omits the drift indicator when stale_since is null", () => {
+    render(
+      <RRecordViewer
+        selected={decisionSelection(decision({ stale_since: null }))}
+        unitName="u"
+        onSelectRecord={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.queryByText("Drift")).toBeNull();
+  });
+
+  it("fires onClose from the close button", () => {
+    const onClose = vi.fn();
+    render(
+      <RRecordViewer
+        selected={decisionSelection(decision())}
+        unitName="u"
+        onSelectRecord={vi.fn()}
+        onClose={onClose}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Close record viewer/ }));
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("uses NO severity-color classes on facts (negative space)", () => {
+    const { container } = render(
+      <RRecordViewer
+        selected={decisionSelection(
+          decision({
+            stale_since: {
+              path: "src/lib/api.ts",
+              change_date: "2026-05-20",
+              change_sha: "abc",
+              change_subject: "x",
+            },
+          }),
+        )}
+        unitName="u"
+        onSelectRecord={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    const html = container.innerHTML;
+    expect(html).not.toMatch(/text-warning/);
+    expect(html).not.toMatch(/text-destructive/);
+    expect(html).not.toMatch(/text-success/);
+  });
+});
+
+describe("RRecordViewer — approach", () => {
+  it("renders the approach frontmatter fields (serves, governs, confidence, replaced_by)", () => {
+    render(
+      <RRecordViewer
+        selected={approachSelection(approach({ confidence: "low", replaced_by: ["2026-06-01-x"] }))}
+        unitName="u"
+        onSelectRecord={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("serves")).toBeTruthy();
+    expect(screen.getByText("confidence")).toBeTruthy();
+    expect(screen.getByText("low")).toBeTruthy();
+    expect(screen.getByText("replaced_by")).toBeTruthy();
+  });
+
+  it("hoists success and failure signals for approaches", () => {
+    render(
+      <RRecordViewer
+        selected={approachSelection(approach())}
+        unitName="u"
+        onSelectRecord={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("Success signal")).toBeTruthy();
+    expect(screen.getByText("the metric climbs")).toBeTruthy();
+    expect(screen.getByText("Failure signal")).toBeTruthy();
+    expect(screen.getByText("the metric stalls")).toBeTruthy();
+  });
+
+  it("marks a past date trigger ready and leaves a future one unmarked", () => {
+    render(
+      <RRecordViewer
+        selected={approachSelection(
+          approach({
+            review_triggers: [
+              { kind: "date", value: "2020-01-01" },
+              { kind: "date", value: "2099-01-01" },
+            ],
+          }),
+        )}
+        unitName="u"
+        onSelectRecord={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/review-trigger ready: 2020-01-01/)).toBeTruthy();
+    expect(screen.queryByText(/review-trigger ready: 2099-01-01/)).toBeNull();
+  });
+
+  it("lists a manual trigger plainly (no fired/not-fired claim)", () => {
+    render(
+      <RRecordViewer
+        selected={approachSelection(
+          approach({
+            review_triggers: [{ kind: "manual", description: "re-check after the migration" }],
+          }),
+        )}
+        unitName="u"
+        onSelectRecord={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText(/manual: re-check after the migration/)).toBeTruthy();
+    expect(screen.queryByText(/review-trigger ready/)).toBeNull();
+  });
+});
+
+describe("RRecordViewer — excerpt + cross-refs", () => {
+  it("renders the excerpt as markdown", () => {
+    render(
+      <RRecordViewer
+        selected={decisionSelection(
+          decision({ excerpt: "## Decision\n\nWe **commit** to the thing." }),
+        )}
+        unitName="u"
+        onSelectRecord={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    // The `## Decision` heading renders (h2) and the bold text is present.
+    expect(screen.getByRole("heading", { name: "Decision" })).toBeTruthy();
+    expect(screen.getByText("commit")).toBeTruthy();
+  });
+
+  it("makes a frontmatter slug that resolves clickable, re-focusing R₂ on it", () => {
+    // The serves[] target exists in the decisions set → resolvable.
+    const target = decision({ slug: "2026-05-01-the-decision", title: "The Decision" });
+    useDecisionsMock.mockReturnValue({
+      data: decisionsResponse([target]),
+      loading: false,
+      error: null,
+    });
+    const onSelectRecord = vi.fn();
+    render(
+      <RRecordViewer
+        selected={approachSelection(approach({ serves: ["2026-05-01-the-decision"] }))}
+        unitName="u"
+        onSelectRecord={onSelectRecord}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "2026-05-01-the-decision" }));
+    expect(onSelectRecord).toHaveBeenCalledTimes(1);
+    const arg = onSelectRecord.mock.calls[0][0] as SelectedRecord;
+    expect(arg.kind).toBe("decision");
+    expect(arg.record.slug).toBe("2026-05-01-the-decision");
+  });
+
+  it("leaves an unresolved frontmatter slug as plain, non-clickable text", () => {
+    // Nothing in either set resolves the slug.
+    const onSelectRecord = vi.fn();
+    render(
+      <RRecordViewer
+        selected={approachSelection(approach({ serves: ["2026-01-01-ghost"] }))}
+        unitName="u"
+        onSelectRecord={onSelectRecord}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("2026-01-01-ghost")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "2026-01-01-ghost" })).toBeNull();
+  });
+
+  it("renders governs entries as plain paths, never cross-refs", () => {
+    // Even when a governs path string coincidentally matches a known slug,
+    // governs entries are PATHS and must stay plain (never clickable).
+    const target = decision({ slug: "doc/decisions/", title: "Edge" });
+    useDecisionsMock.mockReturnValue({
+      data: decisionsResponse([target]),
+      loading: false,
+      error: null,
+    });
+    render(
+      <RRecordViewer
+        selected={approachSelection(approach({ governs: ["doc/decisions/"] }))}
+        unitName="u"
+        onSelectRecord={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "doc/decisions/" })).toBeNull();
+  });
+
+  it("makes a [[slug]] wiki-link in the excerpt clickable and re-focuses on click", () => {
+    const target = approach({ slug: "2026-05-10-the-approach", title: "The Approach" });
+    useApproachesMock.mockReturnValue({
+      data: approachesResponse([target]),
+      loading: false,
+      error: null,
+    });
+    const onSelectRecord = vi.fn();
+    render(
+      <RRecordViewer
+        selected={decisionSelection(
+          decision({ excerpt: "See [[2026-05-10-the-approach]] for the experiment." }),
+        )}
+        unitName="u"
+        onSelectRecord={onSelectRecord}
+        onClose={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "2026-05-10-the-approach" }));
+    expect(onSelectRecord).toHaveBeenCalledTimes(1);
+    const arg = onSelectRecord.mock.calls[0][0] as SelectedRecord;
+    expect(arg.kind).toBe("approach");
+    expect(arg.record.slug).toBe("2026-05-10-the-approach");
+  });
+
+  it("leaves an unresolved [[slug]] in the excerpt as plain text", () => {
+    render(
+      <RRecordViewer
+        selected={decisionSelection(decision({ excerpt: "See [[2026-01-01-ghost]] (missing)." }))}
+        unitName="u"
+        onSelectRecord={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    expect(screen.getByText("2026-01-01-ghost")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: "2026-01-01-ghost" })).toBeNull();
+  });
+});

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/prose.ts
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/prose.ts
@@ -1,0 +1,21 @@
+// Shared markdown prose classes for the R₂ viewers (PR content + record
+// excerpt). Same palette the transcript / digest markdown uses so bodies
+// and excerpts read like the rest of the WebUI. Extracted from
+// `RPrViewer` so the record viewer (`RRecordViewer`) reuses the EXACT
+// styling without restyling — per `2026-05-29-artifact-content-viewer`,
+// standard markdown rendering is the ONE allowed convention inside the
+// viewer's prose, and it must look identical across both R₂ kinds.
+
+export const PROSE_CLASSES = `prose prose-invert prose-sm max-w-none
+  prose-headings:text-foreground prose-headings:font-semibold
+  prose-p:text-foreground prose-p:leading-relaxed prose-p:my-1
+  prose-a:text-info prose-a:no-underline hover:prose-a:underline
+  prose-strong:text-foreground
+  prose-code:text-primary prose-code:bg-surface prose-code:rounded prose-code:px-1 prose-code:py-0.5 prose-code:text-xs prose-code:before:content-none prose-code:after:content-none
+  prose-pre:bg-surface-strong/50 prose-pre:border prose-pre:border-hairline prose-pre:rounded-lg prose-pre:my-1
+  prose-li:text-foreground prose-li:my-0
+  prose-ul:my-1 prose-ol:my-1
+  prose-th:text-foreground prose-th:border-hairline-strong
+  prose-td:text-muted-foreground prose-td:border-hairline-strong
+  prose-hr:border-hairline-strong
+  prose-blockquote:border-info/30 prose-blockquote:text-muted-foreground`;

--- a/clients/react/src/hooks/__tests__/useFocusedArtifact.test.ts
+++ b/clients/react/src/hooks/__tests__/useFocusedArtifact.test.ts
@@ -1,0 +1,110 @@
+// @vitest-environment jsdom
+//
+// useFocusedArtifact — the R₂ "exactly one focused artifact" invariant.
+// Focusing a PR clears any focused record and vice versa, so the PR
+// viewer and the record viewer are never both mounted.
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { SelectedPr } from "@/components/producer-console/r-panel/r-viewer/RPrViewer";
+import type { SelectedRecord } from "@/components/producer-console/r-panel/r-viewer/RRecordViewer";
+import { useFocusedArtifact } from "@/hooks/useFocusedArtifact";
+
+function prSelection(): SelectedPr {
+  return {
+    repoPath: "/p/u",
+    repoLabel: "u",
+    billingDead: false,
+    pr: {
+      number: 100n,
+      title: "Add the thing",
+      state: "OPEN",
+      head_branch: "feat/x",
+      head_sha: "abc1234",
+      base_branch: "main",
+      url: "https://github.com/o/r/pull/100",
+      review_decision: "APPROVED",
+      check_status: "SUCCESS",
+      is_draft: false,
+      additions: 10n,
+      deletions: 1n,
+      comments: 2n,
+      reviews: 0n,
+      author: "me",
+      merge_commit_sha: null,
+    },
+  };
+}
+
+function recordSelection(): SelectedRecord {
+  return {
+    kind: "decision",
+    repoPath: "/p/u",
+    repoLabel: "u",
+    record: {
+      slug: "2026-05-01-the-decision",
+      title: "The Decision",
+      status: "accepted",
+      category: "principle",
+      governs: [],
+      last_verified: "2026-05-01",
+      contract_surface: true,
+      stale_since: null,
+      superseded_by: [],
+      strengthened_by: [],
+      excerpt: "",
+    },
+  };
+}
+
+describe("useFocusedArtifact", () => {
+  it("starts with nothing focused", () => {
+    const { result } = renderHook(() => useFocusedArtifact());
+    expect(result.current.selectedPr).toBeNull();
+    expect(result.current.selectedRecord).toBeNull();
+  });
+
+  it("selecting a record clears a selected PR (exactly one focus)", () => {
+    const { result } = renderHook(() => useFocusedArtifact());
+
+    act(() => result.current.selectPr(prSelection()));
+    expect(result.current.selectedPr).not.toBeNull();
+    expect(result.current.selectedRecord).toBeNull();
+
+    act(() => result.current.selectRecord(recordSelection()));
+    expect(result.current.selectedRecord).not.toBeNull();
+    expect(result.current.selectedPr).toBeNull();
+  });
+
+  it("selecting a PR clears a selected record (the reverse direction)", () => {
+    const { result } = renderHook(() => useFocusedArtifact());
+
+    act(() => result.current.selectRecord(recordSelection()));
+    expect(result.current.selectedRecord).not.toBeNull();
+
+    act(() => result.current.selectPr(prSelection()));
+    expect(result.current.selectedPr).not.toBeNull();
+    expect(result.current.selectedRecord).toBeNull();
+  });
+
+  it("clearPr / clearRecord clear only their own kind", () => {
+    const { result } = renderHook(() => useFocusedArtifact());
+
+    act(() => result.current.selectPr(prSelection()));
+    act(() => result.current.clearPr());
+    expect(result.current.selectedPr).toBeNull();
+
+    act(() => result.current.selectRecord(recordSelection()));
+    act(() => result.current.clearRecord());
+    expect(result.current.selectedRecord).toBeNull();
+  });
+
+  it("clearAll clears both (used on a unit change)", () => {
+    const { result } = renderHook(() => useFocusedArtifact());
+
+    act(() => result.current.selectRecord(recordSelection()));
+    act(() => result.current.clearAll());
+    expect(result.current.selectedPr).toBeNull();
+    expect(result.current.selectedRecord).toBeNull();
+  });
+});

--- a/clients/react/src/hooks/useFocusedArtifact.ts
+++ b/clients/react/src/hooks/useFocusedArtifact.ts
@@ -1,0 +1,56 @@
+// R₂ focus state — exactly ONE focused artifact at a time.
+//
+// The R₂ column (`doc/approaches/2026-05-29-artifact-content-viewer.md`)
+// hosts a single focused artifact: a PR, a decision, or an approach.
+// Focusing one kind clears the other, so the PR viewer (`RPrViewer`) and
+// the record viewer (`RRecordViewer`) are never both mounted. The
+// invariant lives here — in one small testable hook — rather than spread
+// across App's render, so "exactly-one-focus" is provable in isolation.
+
+import { useCallback, useState } from "react";
+import type { SelectedPr } from "@/components/producer-console/r-panel/r-viewer/RPrViewer";
+import type { SelectedRecord } from "@/components/producer-console/r-panel/r-viewer/RRecordViewer";
+
+export interface FocusedArtifact {
+  selectedPr: SelectedPr | null;
+  selectedRecord: SelectedRecord | null;
+  /** Focus a PR in R₂; clears any focused record. */
+  selectPr: (sel: SelectedPr) => void;
+  /** Focus a decision/approach in R₂; clears any focused PR. */
+  selectRecord: (sel: SelectedRecord) => void;
+  clearPr: () => void;
+  clearRecord: () => void;
+  /** Clear both — used on a unit change, where the previous unit's
+   *  artifact must not linger under a new unit's inventory. */
+  clearAll: () => void;
+}
+
+export function useFocusedArtifact(): FocusedArtifact {
+  const [selectedPr, setSelectedPr] = useState<SelectedPr | null>(null);
+  const [selectedRecord, setSelectedRecord] = useState<SelectedRecord | null>(null);
+
+  const selectPr = useCallback((sel: SelectedPr) => {
+    setSelectedRecord(null);
+    setSelectedPr(sel);
+  }, []);
+  const selectRecord = useCallback((sel: SelectedRecord) => {
+    setSelectedPr(null);
+    setSelectedRecord(sel);
+  }, []);
+  const clearPr = useCallback(() => setSelectedPr(null), []);
+  const clearRecord = useCallback(() => setSelectedRecord(null), []);
+  const clearAll = useCallback(() => {
+    setSelectedPr(null);
+    setSelectedRecord(null);
+  }, []);
+
+  return {
+    selectedPr,
+    selectedRecord,
+    selectPr,
+    selectRecord,
+    clearPr,
+    clearRecord,
+    clearAll,
+  };
+}


### PR DESCRIPTION
## What

R₂ content viewers for the two record kinds (⬡ **Decisions**, ▣ **Approaches**), sharing **one base component**, wired from R₁ row clicks. Mirrors the PR-kind viewer (`RPrViewer`, #751) posture exactly — an independent right-side viewer column that never auto-opens.

Serves the spine `2026-05-29-c-and-r-as-the-development-substrate` (the per-kind "(ii) judgment-info" surface), `2026-05-29-artifact-content-viewer` (γ-lean R₂ viewer), and `2026-05-16-dev-loop-completes-in-tmai` (read the project's records in-tmai).

## Shape

- **Shared base** (`r-viewer/RRecordViewer.tsx`) used by **both** record kinds via a discriminated-union `SelectedRecord`. It renders:
  - header identity facts (repo · kind, title, slug, status, category/date);
  - a plain frontmatter `dl` (decision: category / contract_surface / governs / superseded_by / strengthened_by; approach: serves / governs / confidence / replaced_by);
  - the kind's **drift / review-trigger** indicator — PLAIN inline, no severity colour (decision `stale_since` → "<path> changed <date> after last-verified <date>"; approach date-trigger ≤ today → "(review-trigger ready: <date>)"; manual/other triggers listed plainly);
  - the approach **success/failure-signal hoist** (the verdict material), labelled + plain;
  - the wire **`excerpt`** as markdown, reusing `RPrViewer`'s `PROSE_CLASSES` (extracted to a shared `prose.ts`) + `react-markdown` + `remark-gfm`;
  - **cross-ref navigation**: slugs in serves/superseded_by/strengthened_by/replaced_by **and** any `[[slug]]` inside the excerpt resolve against BOTH loaded decisions + approaches sets and re-focus R₂ on whichever kind matches. `governs[]` entries are PATHS → always plain; an unresolved slug is not an error → plain, non-clickable text.
- **One-R₂-focus invariant** (`hooks/useFocusedArtifact.ts`): R₂ hosts exactly **one** focused artifact — focusing a PR clears any focused record and vice versa, so the PR viewer and record viewer are never both mounted. The existing PR path in `App.tsx` is behaviourally unchanged.
- **R₁ selection wiring**: `RDecisionsSection` / `RApproachesSection` rows become buttons (`onSelect` + `aria-current`), threaded up through `RPanel` to `App.tsx` — mirroring `RPrsSection`'s `onSelectPr` / `selectedKey`.

## Scope (what's deferred)

- **Excerpt-level**: the full markdown body + Update-history are NOT fetched here — they need a deferred tmai-core content endpoint. The viewer renders only the rich metadata + `excerpt` the existing wire already carries (no backend change).
- **Read-only**: this is the (ii) judgment-info viewer only. The (iii) lifecycle actions (accept / verdict / amend / archive / bump) and a `[→Producer brief]` button are explicitly **deferred** — they need an unbuilt R-lifecycle-act backend. The viewer mutates nothing.

## Negative space

No severity/priority/relevance tinting on facts; no "changed since you last looked" / unread / TL;DR / auto-summary. The drift + review-trigger indicators are plain facts, not alarms (per `2026-05-26-tmai-states-facts-not-appraisals`). The one allowed convention is standard markdown rendering inside the excerpt.

## Tests

- `RRecordViewer.test.tsx` — frontmatter fields per kind; drift shows when `stale_since` present / absent when null; review-trigger-ready fires for a past date and not a future one; success/failure-signal hoist; excerpt markdown renders; cross-ref click re-focuses (frontmatter slug + in-excerpt `[[slug]]`); unresolved slug stays plain; governs rendered as plain paths.
- `useFocusedArtifact.test.ts` — mutual exclusion both directions + clear semantics.
- Updated `RDecisionsSection` / `RApproachesSection` tests — click → `onSelect` with the wire object; `aria-current` on the focused row.

Gate (run from `clients/react/`): `pnpm lint` ✅ · `pnpm build` (tsc -b && vite build) ✅ · `pnpm test` (563 passed, 2 skipped) ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)