### PR TITLE
feat(r-panel): R₂ Issue viewer (per-repo, full body + comments, read-only)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -13,6 +13,10 @@ import { HandoffRitualOverlay } from "@/components/producer-console/HandoffRitua
 import { ProducerConsole } from "@/components/producer-console/ProducerConsole";
 import { ProducerConversationHeader } from "@/components/producer-console/ProducerConversationHeader";
 import { RPanel } from "@/components/producer-console/r-panel/RPanel";
+import {
+  RIssueViewer,
+  selectedIssueKey,
+} from "@/components/producer-console/r-panel/r-viewer/RIssueViewer";
 import { RPrViewer, selectedPrKey } from "@/components/producer-console/r-panel/r-viewer/RPrViewer";
 import {
   RRecordViewer,
@@ -124,9 +128,10 @@ export function App() {
   // at the seams. See the rPanel*Width helpers above.
   const [rPanelWidth, setRPanelWidth] = useUIPref("attentionStripWidth");
   // The artifact open in the independent R₂ viewer column. R₂ hosts
-  // exactly ONE focused artifact at a time — a PR (#749), a decision, or
-  // an approach — so focusing one kind clears the other (the invariant
-  // lives in `useFocusedArtifact`). `null`/`null` = no viewer (it never
+  // exactly ONE focused artifact at a time — a PR (#749), a record
+  // (decision/approach), or an issue — so focusing one kind clears the
+  // others (the invariant lives in `useFocusedArtifact`). All null = no
+  // viewer (it never
   // auto-opens — the operator clicks a row in the R₁ inventory to select;
   // viewer-approach negative space). Lives at App level because R₂
   // renders as a sibling column of <main> / RPanel, not inside the
@@ -134,10 +139,13 @@ export function App() {
   const {
     selectedPr,
     selectedRecord,
+    selectedIssue,
     selectPr,
     selectRecord,
+    selectIssue,
     clearPr,
     clearRecord,
+    clearIssue,
     clearAll: clearFocusedArtifact,
   } = useFocusedArtifact();
   const showSettings = mainPanel === "settings";
@@ -198,10 +206,10 @@ export function App() {
   const { data: producerFeedData } = useProducerFeed(unitName);
 
   // Close the R₂ viewer when the focused unit changes — its open artifact
-  // (PR or record) belongs to the previous unit, so it must not linger
-  // under a new unit's inventory (mirrors useUnitPrs clearing its list on
-  // unit change). unitName is the intended trigger even though the body
-  // only clears state.
+  // (PR, record, or issue) belongs to the previous unit, so it must not
+  // linger under a new unit's inventory (mirrors useUnitPrs clearing its
+  // list on unit change). unitName is the intended trigger even though the
+  // body only clears state.
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional unit-change trigger
   useEffect(() => {
     clearFocusedArtifact();
@@ -828,6 +836,12 @@ export function App() {
               ? selectedRecordKey(selectedRecord.repoPath, selectedRecord.record.slug)
               : null
           }
+          onSelectIssue={selectIssue}
+          selectedIssueKey={
+            selectedIssue
+              ? selectedIssueKey(selectedIssue.repoPath, selectedIssue.issue.number)
+              : null
+          }
         />
       )}
 
@@ -854,6 +868,16 @@ export function App() {
           onSelectRecord={selectRecord}
           onClose={clearRecord}
         />
+      )}
+
+      {/* R₂ — independent in-tmai issue content viewer column (per-repo,
+          full body + comments, read-only). Shares the R₂ column with the
+          PR + record viewers above: `useFocusedArtifact` keeps all three
+          mutually exclusive, so at most one renders. Present ONLY when the
+          operator has selected an issue in the R₁ inventory (never
+          auto-opens). Same narrow/mobile guard as RPanel. */}
+      {!isNarrowScreen && !isMobileScreen && selectedIssue && (
+        <RIssueViewer selected={selectedIssue} onClose={clearIssue} />
       )}
 
       {/* Help overlay */}

--- a/clients/react/src/components/producer-console/r-panel/RIssuesSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RIssuesSection.tsx
@@ -33,8 +33,16 @@ interface RIssuesSectionProps {
 // identically to the PR / record viewers. Issues carry no repo_label on
 // the wire (they are per-repo, not unit-scoped), so it is derived from the
 // project path basename — the same derivation App uses for `unitName`.
+//
+// Must NEVER return "" (a blank header reads as broken). `filter(Boolean)`
+// drops empty segments so a trailing slash still yields the basename; when
+// there is no non-empty segment at all (path is "", whitespace, or only
+// slashes) we fall back to the trimmed path, or a non-empty placeholder.
 function repoLabelOf(path: string): string {
-  return path.split("/").filter(Boolean).pop() ?? path;
+  const trimmed = path.trim();
+  const parts = trimmed.split("/").filter(Boolean);
+  if (parts.length > 0) return parts[parts.length - 1];
+  return trimmed || "<unknown>";
 }
 
 export function RIssuesSection({

--- a/clients/react/src/components/producer-console/r-panel/RIssuesSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RIssuesSection.tsx
@@ -1,21 +1,49 @@
-// 📋 Issues — R panel's raw issue inventory.
+// 📋 Issues — R panel's raw issue inventory (R₁).
 //
 // Fetches via `useIssues(repoPath)` because no unit-scoped issues
 // endpoint exists yet (PRs have one — issues don't). R keeps issues
 // scoped to the currently-focused repo path; multi-repo aggregation
 // belongs upstream (see the approach's defer list).
+//
+// A row click opens the issue in the R₂ viewer column (`RIssueViewer`),
+// mirroring `RPrsSection`'s `onSelectPr` / `selectedKey` / `aria-current`
+// exactly — the github.com link-out that used to live on the issue number
+// is gone; the issue's full content is reviewed in-tmai with no
+// round-trip. R₁ stays a pure inventory; the row is just a select.
 
 import { useIssues } from "@/hooks/useIssues";
 import type { IssueInfo } from "@/lib/api";
+import { type SelectedIssue, selectedIssueKey } from "./r-viewer/RIssueViewer";
 import { Section } from "./Section";
 
 interface RIssuesSectionProps {
   currentProjectPath: string | null;
   expanded: boolean;
   onToggle: () => void;
+  /** Open an issue in the R₂ viewer column. Optional so the section still
+   *  renders standalone (e.g. in isolation tests). */
+  onSelectIssue?: (sel: SelectedIssue) => void;
+  /** `selectedIssueKey(repoPath, number)` of the issue currently open in
+   *  R₂, so the row marks itself as the one being viewed (a mechanical
+   *  "open here" fact, not appraisal). */
+  selectedKey?: string | null;
 }
 
-export function RIssuesSection({ currentProjectPath, expanded, onToggle }: RIssuesSectionProps) {
+// The repo label rides into the R₂ selection so the viewer header reads
+// identically to the PR / record viewers. Issues carry no repo_label on
+// the wire (they are per-repo, not unit-scoped), so it is derived from the
+// project path basename — the same derivation App uses for `unitName`.
+function repoLabelOf(path: string): string {
+  return path.split("/").filter(Boolean).pop() ?? path;
+}
+
+export function RIssuesSection({
+  currentProjectPath,
+  expanded,
+  onToggle,
+  onSelectIssue,
+  selectedKey,
+}: RIssuesSectionProps) {
   const { data, loading, error } = useIssues(currentProjectPath);
   // `open` is the load-bearing list — header count AND body rows both
   // read off it. Closed items aren't surfaced in R's issue inventory;
@@ -33,7 +61,14 @@ export function RIssuesSection({ currentProjectPath, expanded, onToggle }: RIssu
       expanded={expanded}
       onToggle={onToggle}
     >
-      <Body currentProjectPath={currentProjectPath} items={open} loading={loading} error={error} />
+      <Body
+        currentProjectPath={currentProjectPath}
+        items={open}
+        loading={loading}
+        error={error}
+        onSelectIssue={onSelectIssue}
+        selectedKey={selectedKey ?? null}
+      />
     </Section>
   );
 }
@@ -43,9 +78,18 @@ interface BodyProps {
   items: IssueInfo[] | null;
   loading: boolean;
   error: Error | null;
+  onSelectIssue?: (sel: SelectedIssue) => void;
+  selectedKey: string | null;
 }
 
-function Body({ currentProjectPath, items, loading, error }: BodyProps) {
+function Body({
+  currentProjectPath,
+  items,
+  loading,
+  error,
+  onSelectIssue,
+  selectedKey,
+}: BodyProps) {
   if (currentProjectPath === null) {
     return <p className="text-subtle-foreground">Pick a project to see issues.</p>;
   }
@@ -58,31 +102,59 @@ function Body({ currentProjectPath, items, loading, error }: BodyProps) {
   if (items === null || items.length === 0) {
     return <p className="text-subtle-foreground">No issues.</p>;
   }
+  const repoLabel = repoLabelOf(currentProjectPath);
   return (
     <ul className="space-y-1">
       {items.map((i) => (
-        <IssueRow key={i.number} issue={i} />
+        <IssueRow
+          key={i.number}
+          issue={i}
+          repoPath={currentProjectPath}
+          repoLabel={repoLabel}
+          onSelectIssue={onSelectIssue}
+          selected={selectedKey === selectedIssueKey(currentProjectPath, i.number)}
+        />
       ))}
     </ul>
   );
 }
 
-function IssueRow({ issue }: { issue: IssueInfo }) {
+function IssueRow({
+  issue,
+  repoPath,
+  repoLabel,
+  onSelectIssue,
+  selected,
+}: {
+  issue: IssueInfo;
+  repoPath: string;
+  repoLabel: string;
+  onSelectIssue?: (sel: SelectedIssue) => void;
+  selected: boolean;
+}) {
+  // The whole row is a button that opens the issue in the R₂ viewer —
+  // there is NO github.com link-out anymore; the issue's full content is
+  // reviewed in-tmai. `aria-current` marks the row whose content is
+  // currently open in R₂ (a mechanical "open here" fact, not appraisal).
   return (
     <li className="leading-snug">
-      <a
-        href={issue.url}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="font-mono text-foreground hover:underline"
+      <button
+        type="button"
+        onClick={() => onSelectIssue?.({ repoPath, repoLabel, issue })}
+        aria-current={selected ? "true" : undefined}
+        className={`w-full rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
+          selected ? "bg-surface-strong/40" : ""
+        }`}
       >
-        #{issue.number}
-      </a>{" "}
-      <span className="text-foreground">{issue.title}</span>
-      <div className="text-[11px] text-subtle-foreground">
-        {issue.state.toLowerCase()}
-        {issue.labels.length > 0 && ` · ${issue.labels.map((l) => l.name).join(", ")}`}
-      </div>
+        <span>
+          <span className="font-mono text-foreground">#{issue.number}</span>{" "}
+          <span className="text-foreground">{issue.title}</span>
+        </span>
+        <div className="text-[11px] text-subtle-foreground">
+          {issue.state.toLowerCase()}
+          {issue.labels.length > 0 && ` · ${issue.labels.map((l) => l.name).join(", ")}`}
+        </div>
+      </button>
     </li>
   );
 }

--- a/clients/react/src/components/producer-console/r-panel/RPanel.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPanel.tsx
@@ -36,6 +36,7 @@ import { RFilesSection } from "./RFilesSection";
 import { RHandoverSection } from "./RHandoverSection";
 import { RIssuesSection } from "./RIssuesSection";
 import { RPrsSection } from "./RPrsSection";
+import type { SelectedIssue } from "./r-viewer/RIssueViewer";
 import type { SelectedPr } from "./r-viewer/RPrViewer";
 import type { SelectedRecord } from "./r-viewer/RRecordViewer";
 
@@ -73,6 +74,13 @@ interface RPanelProps {
   /** `selectedRecordKey(...)` of the record currently open in R₂, so the
    *  focused R₁ Decisions/Approaches row marks itself. */
   selectedRecordKey?: string | null;
+  /** Open an issue in the R₂ issue viewer column. Threaded to the R₁
+   *  Issues inventory so a row click selects the issue for in-tmai
+   *  viewing. */
+  onSelectIssue?: (sel: SelectedIssue) => void;
+  /** `selectedIssueKey(...)` of the issue currently open in R₂, so the
+   *  focused R₁ Issues row marks itself. */
+  selectedIssueKey?: string | null;
 }
 
 const SECTION_IDS = [
@@ -98,6 +106,8 @@ export function RPanel({
   selectedPrKey,
   onSelectRecord,
   selectedRecordKey,
+  onSelectIssue,
+  selectedIssueKey,
 }: RPanelProps) {
   const [expanded, setExpanded] = useUIPref("rPanelExpandedSections");
 
@@ -204,6 +214,8 @@ export function RPanel({
           currentProjectPath={currentProjectPath}
           expanded={isExpanded("issues")}
           onToggle={() => toggle("issues")}
+          onSelectIssue={onSelectIssue}
+          selectedKey={selectedIssueKey}
         />
         <RDecisionsSection
           unitName={unitName}

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RIssuesSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RIssuesSection.test.tsx
@@ -112,6 +112,26 @@ describe("RIssuesSection", () => {
     expect(sel.issue.number).toBe(1);
   });
 
+  it("derives a non-empty repoLabel even when the project path has a trailing slash", async () => {
+    const onSelectIssue = vi.fn();
+    listIssuesMock.mockResolvedValue([issue()]);
+    render(
+      <RIssuesSection
+        currentProjectPath="/p/u/"
+        expanded={true}
+        onToggle={vi.fn()}
+        onSelectIssue={onSelectIssue}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Issue 1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText("Issue 1"));
+    // Trailing slash must not blank the label — empty segments are dropped
+    // so the basename still resolves.
+    expect(onSelectIssue.mock.calls[0][0].repoLabel).toBe("u");
+  });
+
   it("marks the focused row with aria-current (and no others)", async () => {
     listIssuesMock.mockResolvedValue([issue(), issue({ number: 2, title: "Issue 2" })]);
     render(

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RIssuesSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RIssuesSection.test.tsx
@@ -3,7 +3,7 @@
 // RIssuesSection — `N open` count from a new fetch (useIssues
 // fans out to api.listIssues for the focused repo).
 
-import { render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { IssueInfo } from "@/lib/api";
 
@@ -74,5 +74,60 @@ describe("RIssuesSection", () => {
       expect(screen.getByText("Issue 1")).toBeTruthy();
     });
     expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
+  });
+
+  it("has NO github.com link-out — the row is an in-tmai select", async () => {
+    listIssuesMock.mockResolvedValue([issue()]);
+    const { container } = render(
+      <RIssuesSection currentProjectPath="/p/u" expanded={true} onToggle={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Issue 1")).toBeTruthy();
+    });
+    // The issue number used to be an <a href> to github.com; it is now a
+    // button that opens the R₂ viewer in-tmai. No anchor should remain.
+    expect(container.querySelector("a[href*='github.com']")).toBeNull();
+  });
+
+  it("clicking an issue row selects it for the R₂ viewer with the full payload", async () => {
+    const onSelectIssue = vi.fn();
+    listIssuesMock.mockResolvedValue([issue()]);
+    render(
+      <RIssuesSection
+        currentProjectPath="/p/u"
+        expanded={true}
+        onToggle={vi.fn()}
+        onSelectIssue={onSelectIssue}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Issue 1")).toBeTruthy();
+    });
+    fireEvent.click(screen.getByText("Issue 1"));
+    expect(onSelectIssue).toHaveBeenCalledTimes(1);
+    const sel = onSelectIssue.mock.calls[0][0];
+    expect(sel.repoPath).toBe("/p/u");
+    // repoLabel is derived from the project path basename.
+    expect(sel.repoLabel).toBe("u");
+    expect(sel.issue.number).toBe(1);
+  });
+
+  it("marks the focused row with aria-current (and no others)", async () => {
+    listIssuesMock.mockResolvedValue([issue(), issue({ number: 2, title: "Issue 2" })]);
+    render(
+      <RIssuesSection
+        currentProjectPath="/p/u"
+        expanded={true}
+        onToggle={vi.fn()}
+        selectedKey="/p/u#2"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("Issue 2")).toBeTruthy();
+    });
+    const row2 = screen.getByText("Issue 2").closest("button");
+    expect(row2?.getAttribute("aria-current")).toBe("true");
+    const row1 = screen.getByText("Issue 1").closest("button");
+    expect(row1?.getAttribute("aria-current")).toBeNull();
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/RIssueViewer.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/RIssueViewer.tsx
@@ -1,0 +1,277 @@
+// R₂ — the in-tmai issue content viewer (per-repo, full body + comments,
+// read-only). Serves the spine `2026-05-29-c-and-r-as-the-development-
+// substrate` (the per-kind walk's "📋 Issues (ii) judgment-info" surface)
+// + `2026-05-29-artifact-content-viewer` (γ-lean R₂ viewer) +
+// `2026-05-16-dev-loop-completes-in-tmai` (read the project's issues
+// in-tmai, no github.com round-trip).
+//
+// Mirrors `RPrViewer` / `RRecordViewer` posture exactly: an INDEPENDENT
+// right-side column that NEVER auto-opens — it mounts only on an explicit
+// operator row click in the R₁ inventory (the parent gates the mount on a
+// non-null `selectedIssue`). R₁ (`RIssuesSection`) stays a pure
+// inventory; this column renders the clicked issue's full content.
+//
+// SCOPE — read-only, per-repo, NO actions. This is the (ii) judgment-info
+// viewer only. The (iii) lifecycle acts (close / comment / reopen) need
+// an issue write endpoint that does NOT exist server-side and are
+// explicitly deferred — the viewer mutates nothing, and there is no
+// `[→Producer brief]` button. Issues stay PER-REPO (the existing
+// `useIssues(repoPath)` single-project fetch); cross-repo unit-scoping is
+// a deferred tmai-core follow-up.
+//
+// Unlike `RPrViewer` (which fans out N section fetches against several
+// `gh`-backed endpoints), there is ONE issue-detail endpoint that returns
+// the FULL issue — body, labels, assignees, timestamps, comments — so the
+// viewer makes a single `useIssueDetail` fetch and renders every section
+// off that one coherent object. Header identity (repoLabel / number /
+// title / state) rides along in `selected` and renders immediately; the
+// detail-only facts (timestamps, comment count) + the body/labels/
+// assignees/comments fill in once the fetch resolves.
+//
+// Negative space (the serving `2026-05-26-tmai-states-facts-not-appraisals`
+// posture — tmai states facts, never appraises):
+//   - all status facts (state, labels, assignees, counts, timestamps)
+//     stay PLAIN inline — `text-foreground` / `text-muted-foreground` /
+//     `text-subtle-foreground` only, never warning / destructive /
+//     success accents. An issue's "closed"/"open" state is a fact, not
+//     an appraisal; a label's github colour is dropped for the same
+//     reason (the chip is a plain fact);
+//   - NO "changed since you last looked" / unread / TL;DR / auto-summary,
+//     NO state-transition / cross-reference fabrication — only what the
+//     wire carries is rendered;
+//   - the ONE allowed convention is standard markdown rendering in the
+//     body + comments (via the shared `PROSE_CLASSES`), same as the other
+//     two R₂ viewers.
+
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { useIssueDetail } from "@/hooks/useIssueDetail";
+import type { IssueComment, IssueDetail, IssueInfo, IssueLabel } from "@/lib/api";
+import { PROSE_CLASSES } from "./prose";
+
+// What R₁ hands R₂ on an issue row click. The full `IssueInfo` rides
+// along (like `SelectedPr` carries the full `pr`) so the header renders
+// identity facts without waiting on the detail fetch; `repoPath` + the
+// issue number drive the detail fetch, and `repoLabel` reads identically
+// to the PR / record selections. Issues are PER-REPO, so there is no
+// unit / repo-level flag to thread (the asymmetry with `SelectedPr`'s
+// `billingDead` is intentional — see scope note above).
+export interface SelectedIssue {
+  repoPath: string;
+  repoLabel: string;
+  issue: IssueInfo;
+}
+
+export function selectedIssueKey(repoPath: string, issueNumber: number): string {
+  return `${repoPath}#${issueNumber}`;
+}
+
+interface RIssueViewerProps {
+  selected: SelectedIssue;
+  onClose: () => void;
+}
+
+export function RIssueViewer({ selected, onClose }: RIssueViewerProps) {
+  const { repoPath, repoLabel, issue } = selected;
+  const { data, loading, error } = useIssueDetail(repoPath, issue.number);
+
+  return (
+    <aside
+      data-testid="r-issue-viewer"
+      className="glass flex w-[clamp(22rem,40vw,48rem)] shrink-0 flex-col border-l border-hairline"
+    >
+      <ViewerHeader repoLabel={repoLabel} issue={issue} detail={data} onClose={onClose} />
+      <div className="flex-1 space-y-4 overflow-y-auto px-4 py-3 text-xs">
+        {loading && <Loading />}
+        {error && <FetchError what="issue" message={error.message} />}
+        {data !== null && (
+          <>
+            <LabelsSection labels={data.labels} />
+            <AssigneesSection assignees={data.assignees} />
+            <BodySection body={data.body} />
+            <CommentsSection comments={data.comments} />
+          </>
+        )}
+      </div>
+    </aside>
+  );
+}
+
+// ── Header — mechanical inventory facts, all plain (no severity tint) ──
+//
+// Identity (repoLabel / number / title / state) renders immediately from
+// the ride-along `issue`; the detail-only facts (created / updated /
+// comment count) appear once `detail` resolves. All plain — an issue's
+// open/closed state and its timestamps are facts, not appraisals.
+
+function ViewerHeader({
+  repoLabel,
+  issue,
+  detail,
+  onClose,
+}: {
+  repoLabel: string;
+  issue: IssueInfo;
+  detail: IssueDetail | null;
+  onClose: () => void;
+}) {
+  return (
+    <header className="shrink-0 border-b border-hairline px-4 py-3">
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <p className="text-[11px] uppercase tracking-wide text-subtle-foreground">
+            {repoLabel} · issue
+          </p>
+          <h2 className="text-sm font-semibold text-foreground">
+            <span className="font-mono text-muted-foreground">#{issue.number}</span> {issue.title}
+          </h2>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          title="Close issue viewer"
+          aria-label="Close issue viewer"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+        >
+          ×
+        </button>
+      </div>
+      <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-subtle-foreground">
+        <span className="text-muted-foreground">{issue.state.toLowerCase()}</span>
+        {detail !== null && (
+          <>
+            <span className="text-muted-foreground">created {detail.created_at}</span>
+            <span className="text-muted-foreground">updated {detail.updated_at}</span>
+            <span className="text-muted-foreground">{detail.comments.length} comments</span>
+          </>
+        )}
+      </div>
+    </header>
+  );
+}
+
+// ── Section frame + async states (plain, never a fabricated empty) ──
+//
+// Ported 1:1 from `RPrViewer` so the three R₂ viewers read identically.
+
+function SectionFrame({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-subtle-foreground">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function Loading() {
+  return <p className="text-subtle-foreground">Loading…</p>;
+}
+
+function FetchError({ what, message }: { what: string; message: string }) {
+  return (
+    <p className="text-muted-foreground">
+      Failed to load {what}: {message}
+    </p>
+  );
+}
+
+// ── Labels — plain chips (github label colour dropped: a plain fact) ──
+
+function LabelsSection({ labels }: { labels: IssueLabel[] }) {
+  return (
+    <SectionFrame title="Labels">
+      {labels.length === 0 ? (
+        <p className="text-subtle-foreground">No labels.</p>
+      ) : (
+        <ul className="flex flex-wrap gap-1">
+          {labels.map((label) => (
+            <li
+              key={label.name}
+              className="rounded border border-hairline-strong/40 bg-surface px-1.5 py-0.5 text-[11px] text-foreground"
+            >
+              {label.name}
+            </li>
+          ))}
+        </ul>
+      )}
+    </SectionFrame>
+  );
+}
+
+// ── Assignees — plain list; "Unassigned." when empty ──
+
+function AssigneesSection({ assignees }: { assignees: string[] }) {
+  return (
+    <SectionFrame title="Assignees">
+      {assignees.length === 0 ? (
+        <p className="text-subtle-foreground">Unassigned.</p>
+      ) : (
+        <ul className="flex flex-wrap gap-x-3 gap-y-0.5">
+          {assignees.map((a) => (
+            <li key={a} className="text-foreground">
+              @{a}
+            </li>
+          ))}
+        </ul>
+      )}
+    </SectionFrame>
+  );
+}
+
+// ── Issue body (markdown via the shared PROSE_CLASSES) ──
+
+function BodySection({ body }: { body: string }) {
+  const empty = body.trim() === "";
+  return (
+    <SectionFrame title="Description">
+      {empty ? (
+        <p className="text-subtle-foreground">No description.</p>
+      ) : (
+        <div className={PROSE_CLASSES}>
+          <Markdown remarkPlugins={[remarkGfm]}>{body}</Markdown>
+        </div>
+      )}
+    </SectionFrame>
+  );
+}
+
+// ── Comments — chronological (wire order), plain PR-level only ──
+//
+// Issues have NO inline diff_hunk / path (those are PR review-comment
+// concepts); `IssueComment` is a plain author / created_at / body triple.
+// The wire delivers comments in chronological order; the viewer preserves
+// it (no re-sort, no fabricated transition events).
+
+function CommentsSection({ comments }: { comments: IssueComment[] }) {
+  return (
+    <SectionFrame title={`Comments (${comments.length})`}>
+      {comments.length === 0 ? (
+        <p className="text-subtle-foreground">No comments.</p>
+      ) : (
+        <ul className="space-y-2">
+          {comments.map((c) => (
+            // A comment's `url` is unique per GitHub comment — a stable key
+            // with no array index needed.
+            <CommentItem key={c.url} comment={c} />
+          ))}
+        </ul>
+      )}
+    </SectionFrame>
+  );
+}
+
+function CommentItem({ comment }: { comment: IssueComment }) {
+  return (
+    <li className="rounded border border-hairline-strong/40 bg-surface-strong/20 px-2 py-1.5">
+      <div className="flex flex-wrap items-baseline gap-x-2 text-[11px]">
+        <span className="font-semibold text-foreground">@{comment.author}</span>
+        <span className="text-subtle-foreground">{comment.created_at}</span>
+      </div>
+      <div className={`mt-1 ${PROSE_CLASSES}`}>
+        <Markdown remarkPlugins={[remarkGfm]}>{comment.body}</Markdown>
+      </div>
+    </li>
+  );
+}

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RIssueViewer.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RIssueViewer.test.tsx
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+//
+// RIssueViewer — the R₂ in-tmai issue content viewer (per-repo, full body
+// + comments, read-only). The single detail fetcher is mocked so this
+// test proves: header identity renders immediately from the selection;
+// the body markdown / labels / assignees / timestamps / comment count
+// render from the detail fetch; comments render in chronological (wire)
+// order; labels + assignees show their empty states; mechanical status
+// facts stay PLAIN (no severity tint — viewer-approach negative space);
+// and the viewer is selection-driven (it fetches exactly the selected
+// issue, never auto-opening an arbitrary one).
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { IssueDetail, IssueInfo } from "@/lib/api";
+
+const getIssueDetail = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getIssueDetail: (...a: unknown[]) => getIssueDetail(...a),
+  },
+}));
+
+import { RIssueViewer, type SelectedIssue } from "../RIssueViewer";
+
+function issue(overrides: Partial<IssueInfo> = {}): IssueInfo {
+  return {
+    number: 7,
+    title: "Fix the bug",
+    state: "open",
+    url: "https://github.com/o/r/issues/7",
+    labels: [],
+    assignees: [],
+    ...overrides,
+  };
+}
+
+function selected(overrides: Partial<IssueInfo> = {}): SelectedIssue {
+  return { repoPath: "/p/u", repoLabel: "u", issue: issue(overrides) };
+}
+
+function detail(overrides: Partial<IssueDetail> = {}): IssueDetail {
+  return {
+    number: 7,
+    title: "Fix the bug",
+    state: "open",
+    url: "https://github.com/o/r/issues/7",
+    body: "## Body heading\n\nbody text",
+    labels: [{ name: "bug", color: "ff0000" }],
+    // Assignee distinct from comment authors so the `@name` lookups are
+    // unambiguous below.
+    assignees: ["dave"],
+    created_at: "2026-05-20T10:00:00Z",
+    updated_at: "2026-05-21T12:00:00Z",
+    comments: [
+      {
+        author: "alice",
+        body: "first comment",
+        created_at: "2026-05-20T11:00:00Z",
+        url: "https://github.com/o/r/issues/7#c1",
+      },
+      {
+        author: "bob",
+        body: "second comment",
+        created_at: "2026-05-20T12:00:00Z",
+        url: "https://github.com/o/r/issues/7#c2",
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  getIssueDetail.mockReset();
+  getIssueDetail.mockResolvedValue(detail());
+});
+
+describe("RIssueViewer", () => {
+  it("renders header identity immediately from the selection", () => {
+    render(<RIssueViewer selected={selected()} onClose={vi.fn()} />);
+    expect(screen.getByText("Fix the bug")).toBeTruthy();
+    expect(screen.getByText("#7")).toBeTruthy();
+  });
+
+  it("is selection-driven: fetches detail for exactly the selected issue", () => {
+    // The viewer renders only because it was handed a selection, and it
+    // fetches that selection's number — it never auto-opens an arbitrary
+    // issue (the parent gates the mount; here we prove the fetch is keyed
+    // to the selection).
+    render(<RIssueViewer selected={selected()} onClose={vi.fn()} />);
+    expect(screen.getByTestId("r-issue-viewer")).toBeTruthy();
+    expect(getIssueDetail).toHaveBeenCalledWith("/p/u", 7);
+  });
+
+  it("renders body markdown, labels, assignees, timestamps and comment count from the detail fetch", async () => {
+    render(<RIssueViewer selected={selected()} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Body heading")).toBeTruthy());
+    expect(screen.getByText("bug")).toBeTruthy();
+    // Assignee (distinct from the comment authors).
+    expect(screen.getByText("@dave")).toBeTruthy();
+    // Detail-only header facts.
+    expect(screen.getByText(/created 2026-05-20/)).toBeTruthy();
+    expect(screen.getByText(/updated 2026-05-21/)).toBeTruthy();
+    expect(screen.getByText(/2 comments/)).toBeTruthy();
+  });
+
+  it("renders comments in chronological (wire) order", async () => {
+    const { container } = render(<RIssueViewer selected={selected()} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("first comment")).toBeTruthy());
+    expect(screen.getByText("@alice")).toBeTruthy();
+    expect(screen.getByText("@bob")).toBeTruthy();
+    const text = container.textContent ?? "";
+    // Wire order preserved: comment 1 appears before comment 2 in the DOM.
+    expect(text.indexOf("first comment")).toBeLessThan(text.indexOf("second comment"));
+  });
+
+  it("shows empty states for an issue with no body / labels / assignees / comments", async () => {
+    getIssueDetail.mockResolvedValue(detail({ body: "", labels: [], assignees: [], comments: [] }));
+    render(<RIssueViewer selected={selected()} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("No description.")).toBeTruthy());
+    expect(screen.getByText("No labels.")).toBeTruthy();
+    expect(screen.getByText("Unassigned.")).toBeTruthy();
+    expect(screen.getByText("No comments.")).toBeTruthy();
+  });
+
+  it("uses NO severity-color classes on any status fact (negative-space)", async () => {
+    // The issue viewer has no action layer — the WHOLE viewer (state,
+    // labels, assignees, timestamps, counts) must stay plain.
+    const { container } = render(<RIssueViewer selected={selected()} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Body heading")).toBeTruthy());
+    const html = container.innerHTML;
+    expect(html).not.toMatch(/text-warning/);
+    expect(html).not.toMatch(/text-destructive/);
+    expect(html).not.toMatch(/text-success/);
+  });
+
+  it("has NO github.com link-out anywhere in the viewer (in-tmai)", async () => {
+    const { container } = render(<RIssueViewer selected={selected()} onClose={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Body heading")).toBeTruthy());
+    expect(container.querySelector("a[href*='github.com']")).toBeNull();
+  });
+
+  it("fires onClose from the close button", () => {
+    const onClose = vi.fn();
+    render(<RIssueViewer selected={selected()} onClose={onClose} />);
+    screen.getByRole("button", { name: /Close issue viewer/ }).click();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/react/src/hooks/__tests__/useFocusedArtifact.test.ts
+++ b/clients/react/src/hooks/__tests__/useFocusedArtifact.test.ts
@@ -1,11 +1,13 @@
 // @vitest-environment jsdom
 //
 // useFocusedArtifact — the R₂ "exactly one focused artifact" invariant.
-// Focusing a PR clears any focused record and vice versa, so the PR
-// viewer and the record viewer are never both mounted.
+// Focusing any one of a PR / record / issue clears the other two, so the
+// PR viewer, the record viewer, and the issue viewer are never both/all
+// mounted.
 
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import type { SelectedIssue } from "@/components/producer-console/r-panel/r-viewer/RIssueViewer";
 import type { SelectedPr } from "@/components/producer-console/r-panel/r-viewer/RPrViewer";
 import type { SelectedRecord } from "@/components/producer-console/r-panel/r-viewer/RRecordViewer";
 import { useFocusedArtifact } from "@/hooks/useFocusedArtifact";
@@ -57,11 +59,27 @@ function recordSelection(): SelectedRecord {
   };
 }
 
+function issueSelection(): SelectedIssue {
+  return {
+    repoPath: "/p/u",
+    repoLabel: "u",
+    issue: {
+      number: 7,
+      title: "Fix the bug",
+      state: "open",
+      url: "https://github.com/o/r/issues/7",
+      labels: [],
+      assignees: [],
+    },
+  };
+}
+
 describe("useFocusedArtifact", () => {
   it("starts with nothing focused", () => {
     const { result } = renderHook(() => useFocusedArtifact());
     expect(result.current.selectedPr).toBeNull();
     expect(result.current.selectedRecord).toBeNull();
+    expect(result.current.selectedIssue).toBeNull();
   });
 
   it("selecting a record clears a selected PR (exactly one focus)", () => {
@@ -87,7 +105,37 @@ describe("useFocusedArtifact", () => {
     expect(result.current.selectedRecord).toBeNull();
   });
 
-  it("clearPr / clearRecord clear only their own kind", () => {
+  it("selecting an issue clears BOTH a selected PR and record (exactly one focus across three)", () => {
+    const { result } = renderHook(() => useFocusedArtifact());
+
+    act(() => result.current.selectPr(prSelection()));
+    act(() => result.current.selectIssue(issueSelection()));
+    expect(result.current.selectedIssue).not.toBeNull();
+    expect(result.current.selectedPr).toBeNull();
+    expect(result.current.selectedRecord).toBeNull();
+
+    // Re-arm from a record and confirm the same clear.
+    act(() => result.current.selectRecord(recordSelection()));
+    act(() => result.current.selectIssue(issueSelection()));
+    expect(result.current.selectedIssue).not.toBeNull();
+    expect(result.current.selectedRecord).toBeNull();
+  });
+
+  it("selecting a PR or a record clears a selected issue (the reverse direction)", () => {
+    const { result } = renderHook(() => useFocusedArtifact());
+
+    act(() => result.current.selectIssue(issueSelection()));
+    act(() => result.current.selectPr(prSelection()));
+    expect(result.current.selectedPr).not.toBeNull();
+    expect(result.current.selectedIssue).toBeNull();
+
+    act(() => result.current.selectIssue(issueSelection()));
+    act(() => result.current.selectRecord(recordSelection()));
+    expect(result.current.selectedRecord).not.toBeNull();
+    expect(result.current.selectedIssue).toBeNull();
+  });
+
+  it("clearPr / clearRecord / clearIssue clear only their own kind", () => {
     const { result } = renderHook(() => useFocusedArtifact());
 
     act(() => result.current.selectPr(prSelection()));
@@ -97,14 +145,19 @@ describe("useFocusedArtifact", () => {
     act(() => result.current.selectRecord(recordSelection()));
     act(() => result.current.clearRecord());
     expect(result.current.selectedRecord).toBeNull();
+
+    act(() => result.current.selectIssue(issueSelection()));
+    act(() => result.current.clearIssue());
+    expect(result.current.selectedIssue).toBeNull();
   });
 
-  it("clearAll clears both (used on a unit change)", () => {
+  it("clearAll clears all three (used on a unit change)", () => {
     const { result } = renderHook(() => useFocusedArtifact());
 
-    act(() => result.current.selectRecord(recordSelection()));
+    act(() => result.current.selectIssue(issueSelection()));
     act(() => result.current.clearAll());
     expect(result.current.selectedPr).toBeNull();
     expect(result.current.selectedRecord).toBeNull();
+    expect(result.current.selectedIssue).toBeNull();
   });
 });

--- a/clients/react/src/hooks/__tests__/useIssueDetail.test.ts
+++ b/clients/react/src/hooks/__tests__/useIssueDetail.test.ts
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+//
+// useIssueDetail — the one-shot issue-detail fetch hook behind the R₂
+// issue viewer. We mock `api.getIssueDetail` and assert the shared `{
+// data, loading, error }` contract: a `null` arg parks (no fetch), a real
+// issue fetches once and exposes the response, errors surface without
+// fabricating data, and switching issues re-fetches + clears the previous
+// payload (generation guard) — mirroring the usePrDetail tests.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { IssueDetail } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    getIssueDetail: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+import { useIssueDetail } from "../useIssueDetail";
+
+function detail(n: number): IssueDetail {
+  return {
+    number: n,
+    title: `Issue ${n}`,
+    state: "open",
+    url: `https://github.com/o/r/issues/${n}`,
+    body: `body ${n}`,
+    labels: [],
+    assignees: [],
+    created_at: "2026-05-20T10:00:00Z",
+    updated_at: "2026-05-21T12:00:00Z",
+    comments: [],
+  };
+}
+
+describe("useIssueDetail", () => {
+  beforeEach(() => {
+    vi.mocked(api.getIssueDetail).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parks when the issue is null — no fetch, not loading", () => {
+    const { result } = renderHook(() => useIssueDetail(null, null));
+    expect(api.getIssueDetail).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetches the detail once on a real issue and exposes the response", async () => {
+    vi.mocked(api.getIssueDetail).mockResolvedValue(detail(42));
+    const { result } = renderHook(() => useIssueDetail("/p/u", 42));
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(api.getIssueDetail).toHaveBeenCalledWith("/p/u", 42);
+    expect(result.current.data?.number).toBe(42);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a fetch error without fabricating data", async () => {
+    vi.mocked(api.getIssueDetail).mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useIssueDetail("/p/u", 7));
+    await waitFor(() => expect(result.current.error?.message).toBe("boom"));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("re-fetches when the issue number changes and clears the previous payload", async () => {
+    vi.mocked(api.getIssueDetail).mockImplementation((_repo: string, n: number) =>
+      Promise.resolve(detail(n)),
+    );
+    const { result, rerender } = renderHook(({ n }) => useIssueDetail("/p/u", n), {
+      initialProps: { n: 1 },
+    });
+    await waitFor(() => expect(result.current.data?.number).toBe(1));
+
+    rerender({ n: 2 });
+    // Cleared synchronously on issue change so the old detail is never shown.
+    expect(result.current.data).toBeNull();
+    await waitFor(() => expect(result.current.data?.number).toBe(2));
+  });
+});

--- a/clients/react/src/hooks/useFocusedArtifact.ts
+++ b/clients/react/src/hooks/useFocusedArtifact.ts
@@ -1,26 +1,32 @@
 // R₂ focus state — exactly ONE focused artifact at a time.
 //
 // The R₂ column (`doc/approaches/2026-05-29-artifact-content-viewer.md`)
-// hosts a single focused artifact: a PR, a decision, or an approach.
-// Focusing one kind clears the other, so the PR viewer (`RPrViewer`) and
-// the record viewer (`RRecordViewer`) are never both mounted. The
-// invariant lives here — in one small testable hook — rather than spread
-// across App's render, so "exactly-one-focus" is provable in isolation.
+// hosts a single focused artifact: a PR, a record (decision/approach), or
+// an issue. Focusing one kind clears the other two, so the PR viewer
+// (`RPrViewer`), the record viewer (`RRecordViewer`), and the issue
+// viewer (`RIssueViewer`) are never both/all mounted. The invariant lives
+// here — in one small testable hook — rather than spread across App's
+// render, so "exactly-one-focus" is provable in isolation.
 
 import { useCallback, useState } from "react";
+import type { SelectedIssue } from "@/components/producer-console/r-panel/r-viewer/RIssueViewer";
 import type { SelectedPr } from "@/components/producer-console/r-panel/r-viewer/RPrViewer";
 import type { SelectedRecord } from "@/components/producer-console/r-panel/r-viewer/RRecordViewer";
 
 export interface FocusedArtifact {
   selectedPr: SelectedPr | null;
   selectedRecord: SelectedRecord | null;
-  /** Focus a PR in R₂; clears any focused record. */
+  selectedIssue: SelectedIssue | null;
+  /** Focus a PR in R₂; clears any focused record + issue. */
   selectPr: (sel: SelectedPr) => void;
-  /** Focus a decision/approach in R₂; clears any focused PR. */
+  /** Focus a decision/approach in R₂; clears any focused PR + issue. */
   selectRecord: (sel: SelectedRecord) => void;
+  /** Focus an issue in R₂; clears any focused PR + record. */
+  selectIssue: (sel: SelectedIssue) => void;
   clearPr: () => void;
   clearRecord: () => void;
-  /** Clear both — used on a unit change, where the previous unit's
+  clearIssue: () => void;
+  /** Clear all three — used on a unit change, where the previous unit's
    *  artifact must not linger under a new unit's inventory. */
   clearAll: () => void;
 }
@@ -28,29 +34,42 @@ export interface FocusedArtifact {
 export function useFocusedArtifact(): FocusedArtifact {
   const [selectedPr, setSelectedPr] = useState<SelectedPr | null>(null);
   const [selectedRecord, setSelectedRecord] = useState<SelectedRecord | null>(null);
+  const [selectedIssue, setSelectedIssue] = useState<SelectedIssue | null>(null);
 
   const selectPr = useCallback((sel: SelectedPr) => {
     setSelectedRecord(null);
+    setSelectedIssue(null);
     setSelectedPr(sel);
   }, []);
   const selectRecord = useCallback((sel: SelectedRecord) => {
     setSelectedPr(null);
+    setSelectedIssue(null);
     setSelectedRecord(sel);
+  }, []);
+  const selectIssue = useCallback((sel: SelectedIssue) => {
+    setSelectedPr(null);
+    setSelectedRecord(null);
+    setSelectedIssue(sel);
   }, []);
   const clearPr = useCallback(() => setSelectedPr(null), []);
   const clearRecord = useCallback(() => setSelectedRecord(null), []);
+  const clearIssue = useCallback(() => setSelectedIssue(null), []);
   const clearAll = useCallback(() => {
     setSelectedPr(null);
     setSelectedRecord(null);
+    setSelectedIssue(null);
   }, []);
 
   return {
     selectedPr,
     selectedRecord,
+    selectedIssue,
     selectPr,
     selectRecord,
+    selectIssue,
     clearPr,
     clearRecord,
+    clearIssue,
     clearAll,
   };
 }

--- a/clients/react/src/hooks/useIssueDetail.ts
+++ b/clients/react/src/hooks/useIssueDetail.ts
@@ -1,0 +1,65 @@
+// Issue-detail fetch hook for the R₂ in-tmai issue viewer.
+//
+// Mirrors `usePrDetail`'s one-shot resource contract (`{ data, loading,
+// error }` + a generation guard so a stale in-flight response from a
+// previously selected issue never stamps over the current one + a `null`
+// arg that parks the hook), but with a single resource: there is ONE
+// issue-detail endpoint that returns the FULL issue (body / labels /
+// assignees / timestamps / comments), so the viewer needs only this one
+// fetch rather than the PR viewer's per-section fan-out.
+//
+// WHY one-shot, not the 60s poll `useIssues` runs: the viewer only mounts
+// after an explicit operator click on an issue row (no auto-open on focus
+// — viewer-approach negative space), and an issue's body / comments are
+// stable across a single review pass. Re-selecting the issue (or
+// switching units, which clears the selection) re-fetches.
+
+import { useEffect, useRef, useState } from "react";
+import { api, type IssueDetail } from "@/lib/api";
+
+export interface UseIssueDetailResult {
+  data: IssueDetail | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useIssueDetail(
+  repoPath: string | null,
+  issueNumber: number | null,
+): UseIssueDetailResult {
+  const [data, setData] = useState<IssueDetail | null>(null);
+  const [loading, setLoading] = useState(repoPath !== null && issueNumber !== null);
+  const [error, setError] = useState<Error | null>(null);
+  // Gates against stale responses across (repo, issue) changes — a slow
+  // fetch from a previously selected issue returning after a newer
+  // selection must not stamp over the current data.
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    if (repoPath === null || issueNumber === null) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    setData(null);
+    setError(null);
+    setLoading(true);
+    void (async () => {
+      try {
+        const res = await api.getIssueDetail(repoPath, issueNumber);
+        if (myGen !== generationRef.current) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (myGen !== generationRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (myGen === generationRef.current) setLoading(false);
+      }
+    })();
+  }, [repoPath, issueNumber]);
+
+  return { data, loading, error };
+}


### PR DESCRIPTION
## What

Adds the **third R₂ artifact viewer** — the in-tmai **issue content viewer** — completing the per-kind walk after PRs (#749) and Decisions+Approaches (#752). Clicking an issue row in the R₁ inventory (`📋 Issues`) opens its full content in the independent R₂ column: body, labels, assignees, timestamps, and all comments — entirely in-tmai, no github.com round-trip.

It **reuses the shared viewer scaffolding** (`SectionFrame` / `Loading` / `FetchError`) and the shared `PROSE_CLASSES` markdown styling, mirroring `RPrViewer` / `RRecordViewer` posture exactly: an independent right-side column that **never auto-opens** (parent-gated on a non-null `selectedIssue`; R₁ stays a pure inventory).

## How

- **`useFocusedArtifact` gains a 3rd focus kind** — `selectedIssue` + `selectIssue` / `clearIssue`. The **exactly-one-R₂-focus invariant now spans pr / record / issue**: selecting any one clears the other two, and `clearAll` (unit-change) clears all three.
- **`RIssueViewer.tsx`** (new) — renders the FULL issue from a single `useIssueDetail(repoPath, issueNumber)` fetch (one detail endpoint returns body / labels / assignees / timestamps / comments, so no per-section fan-out). Header identity rides along in `SelectedIssue` and renders immediately; detail-only facts fill in on fetch. Empty states throughout (`No description.` / `No labels.` / `Unassigned.` / `No comments.`). Comments render in chronological wire order; issues have no inline `diff_hunk` / `path`, so they're plain author/created_at/body items.
- **`useIssueDetail.ts`** (new) — one-shot `{ data, loading, error }` hook with a generation guard, mirroring `usePrDetail`.
- **`RIssuesSection.tsx`** — issue rows become in-tmai **select buttons** (`onSelectIssue` + `aria-current`, github.com link-out removed), mirroring `RPrsSection`. R₁ rendering otherwise unchanged. `repoLabel` derived from the project-path basename.
- **`RPanel` / `App`** thread `onSelectIssue` + `selectedIssueKey`; `App` renders `RIssueViewer` as the 3rd mutually-exclusive R₂ case; the unit-change `clearAll` effect already covers it.

## Scope (as briefed)

- **Read-only**: (iii) actions (close / comment / reopen) are **deferred** — no issue write endpoint exists server-side, so there is no action layer and no `[→Producer brief]` button.
- **Per-repo only**: issues stay on the existing `useIssues(repoPath)` single-project fetch. Cross-repo **unit-scoping is a deferred tmai-core follow-up** (`useUnitIssues`); the asymmetry with PRs (which have a unit-scoped wire) is intentional.
- Status facts (state / labels / counts / timestamps) stay **PLAIN** — no warning/destructive/success accents — per `2026-05-26-tmai-states-facts-not-appraisals`. The one allowed convention is standard markdown rendering in body/comments via `PROSE_CLASSES`.

Serves `2026-05-29-c-and-r-as-the-development-substrate` (📋 Issues per-kind walk), `2026-05-29-artifact-content-viewer` (γ-lean R₂ viewer), `2026-05-16-dev-loop-completes-in-tmai`.

## Tests

- `RIssueViewer.test.tsx` — body markdown renders; comments chronological; labels + assignees render incl. empty states; status facts plain (no severity classes); no github.com link-out; selection-driven fetch; close button.
- `useIssueDetail.test.ts` — park-on-null / fetch-once / error / re-fetch-clears-previous (mirrors `usePrDetail`).
- `RIssuesSection.test.tsx` — click → `onSelectIssue` with full payload; `aria-current` on the focused row; no link-out.
- `useFocusedArtifact.test.ts` — `selectIssue` clears pr + record (and selecting pr/record clears issue); exactly-one-focus across all three.

## Gate (all green from `clients/react/`)

`pnpm install` · `pnpm lint` · `pnpm build` (tsc -b && vite build) · `pnpm test` (580 passed, 2 pre-existing skip).

`clients/react/` only — no `api-spec/`, `clients/ratatui/`, tmai-core, or generated-type edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Issue の詳細表示機能を追加しました。Issue を選択すると、ラベル、アサイニー、本文、コメントが右側のビューアパネルに表示されます。
  * Issue 一覧から Issue を選択できるようになりました。選択状態がビューアに同期されます。

* **テスト**
  * Issue ビューアと Issue 詳細取得ロジックのテストを追加しました。
  * Issue 選択インタラクションと状態管理のテストカバレッジを拡大しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->