### PR TITLE
feat(r-panel): R₂ focus mode — viewer reuses R₁'s frame, never squeezes the center

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -127,15 +127,16 @@ export function App() {
   // through the shared useSplitPane engine (ratio-based), so we convert
   // at the seams. See the rPanel*Width helpers above.
   const [rPanelWidth, setRPanelWidth] = useUIPref("attentionStripWidth");
-  // The artifact open in the independent R₂ viewer column. R₂ hosts
-  // exactly ONE focused artifact at a time — a PR (#749), a record
-  // (decision/approach), or an issue — so focusing one kind clears the
-  // others (the invariant lives in `useFocusedArtifact`). All null = no
-  // viewer (it never
-  // auto-opens — the operator clicks a row in the R₁ inventory to select;
-  // viewer-approach negative space). Lives at App level because R₂
-  // renders as a sibling column of <main> / RPanel, not inside the
-  // inventory panel (R₁ stays a pure inventory).
+  // The artifact in focus in R₂. R₂ hosts exactly ONE focused artifact at
+  // a time — a PR (#749), a record (decision/approach), or an issue — so
+  // focusing one kind clears the others (the invariant lives in
+  // `useFocusedArtifact`). All null = no viewer (it never auto-opens — the
+  // operator clicks a row in the R₁ inventory to select; viewer-approach
+  // negative space). Lives at App level because focus mode (spine
+  // `2026-05-29-c-and-r-as-the-development-substrate`) RIDES the R panel's
+  // single column: a focus swaps R₁'s inventory body for the R₂ viewer at
+  // the same drag-set width (`viewer` prop below), rather than adding a
+  // fourth column that would steal width from the centre conversation.
   const {
     selectedPr,
     selectedRecord,
@@ -591,6 +592,26 @@ export function App() {
     </>
   );
 
+  // Focus-mode viewer node (spine `2026-05-29-c-and-r-as-the-development-
+  // substrate`). At most one of the three is non-null (`useFocusedArtifact`
+  // keeps them mutually exclusive), so this resolves to a single viewer or
+  // null. It is handed to RPanel as `viewer`, where it REPLACES the R₁
+  // inventory body in the same column — opening/closing it never changes
+  // the centre column's width (only dragging the divider does). Its close
+  // (‹ Inventory) clears the focus and reveals the inventory again.
+  const rViewer = selectedPr ? (
+    <RPrViewer selected={selectedPr} onClose={clearPr} />
+  ) : selectedRecord ? (
+    <RRecordViewer
+      selected={selectedRecord}
+      unitName={unitName}
+      onSelectRecord={selectRecord}
+      onClose={clearRecord}
+    />
+  ) : selectedIssue ? (
+    <RIssueViewer selected={selectedIssue} onClose={clearIssue} />
+  ) : null;
+
   return (
     <div ref={rPanelSplit.containerRef} className="flex h-screen text-foreground">
       {/* Mobile: overlay backdrop when drawer is open */}
@@ -804,11 +825,19 @@ export function App() {
         )}
       </main>
 
-      {/* Persistent right R panel — third flex column, sibling of <main>
-          and OUTSIDE the selection switch above, so it stays co-visible
-          with whatever the centre shows (Producer conversation or
-          hand-over digest). Hidden on narrow / mobile so it never
-          crowds a small viewport; folds to a thin rail otherwise. */}
+      {/* Persistent right R panel — third (and LAST) flex column, sibling
+          of <main> and OUTSIDE the selection switch above, so it stays
+          co-visible with whatever the centre shows (Producer conversation
+          or hand-over digest). Hidden on narrow / mobile so it never
+          crowds a small viewport; folds to a thin rail otherwise.
+
+          Focus mode: when an artifact is focused, `viewer` is the R₂
+          viewer node and RPanel renders it in place of the R₁ inventory
+          body — SAME column, SAME drag-set width. There is deliberately no
+          additional R₂ sibling column here: opening a viewer must not
+          steal width from the centre conversation (the C-width invariant).
+          The single split divider on this column is the only thing that
+          changes C's width. */}
       {!isNarrowScreen && !isMobileScreen && (
         <RPanel
           currentProjectPath={currentProject}
@@ -842,42 +871,8 @@ export function App() {
               ? selectedIssueKey(selectedIssue.repoPath, selectedIssue.issue.number)
               : null
           }
+          viewer={rViewer}
         />
-      )}
-
-      {/* R₂ — independent in-tmai PR content viewer column (#749). The
-          spine's γ-lean 4-column shape (L / C / R₁ inventory / R₂ viewer):
-          this is the rightmost column, present ONLY when the operator has
-          selected a PR in the R₁ inventory (never auto-opens). Gated on the
-          same narrow/mobile guard as RPanel so it never crowds a small
-          viewport. */}
-      {!isNarrowScreen && !isMobileScreen && selectedPr && (
-        <RPrViewer selected={selectedPr} onClose={clearPr} />
-      )}
-
-      {/* R₂ — independent in-tmai record content viewer column (decisions +
-          approaches). Shares the R₂ column with the PR viewer above:
-          `useFocusedArtifact` keeps the two mutually exclusive, so at most
-          one renders. Present ONLY when the operator has selected a record
-          in the R₁ inventory (never auto-opens). Same narrow/mobile guard
-          as RPanel. */}
-      {!isNarrowScreen && !isMobileScreen && selectedRecord && (
-        <RRecordViewer
-          selected={selectedRecord}
-          unitName={unitName}
-          onSelectRecord={selectRecord}
-          onClose={clearRecord}
-        />
-      )}
-
-      {/* R₂ — independent in-tmai issue content viewer column (per-repo,
-          full body + comments, read-only). Shares the R₂ column with the
-          PR + record viewers above: `useFocusedArtifact` keeps all three
-          mutually exclusive, so at most one renders. Present ONLY when the
-          operator has selected an issue in the R₁ inventory (never
-          auto-opens). Same narrow/mobile guard as RPanel. */}
-      {!isNarrowScreen && !isMobileScreen && selectedIssue && (
-        <RIssueViewer selected={selectedIssue} onClose={clearIssue} />
       )}
 
       {/* Help overlay */}

--- a/clients/react/src/__tests__/App.r-panel.test.tsx
+++ b/clients/react/src/__tests__/App.r-panel.test.tsx
@@ -17,9 +17,14 @@
 //   3. on a narrow viewport the R panel is gone — its guard reads
 //      isNarrowScreen off the sole surviving useSplitPane;
 //   4. a cross-unit click re-scopes currentProject instead of opening
-//      a removed full-screen view.
+//      a removed full-screen view;
+//   5. FOCUS MODE: opening a viewer renders it INSIDE the single R panel
+//      column (handed in as RPanel's `viewer` prop), never as an additive
+//      sibling column — protecting the centre's width — and the ‹ Inventory
+//      back affordance clears the focus to reveal the inventory again.
 
-import { fireEvent, screen } from "@testing-library/react";
+import { fireEvent, screen, within } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentSnapshot } from "@/lib/api";
 import { renderWithProviders } from "@/test/render";
@@ -66,8 +71,51 @@ vi.mock("@/hooks/useProducerFeed", () => ({
 }));
 
 // ── component stubs (everything heavy / networked) ──
+// The R panel stub surfaces TWO focus-mode seams: (a) a `focus-pr` button
+// wired to `onSelectPr` so a test can set the focus from the (stubbed)
+// inventory, and (b) it renders the `viewer` prop in-place — so we can
+// assert the viewer lands INSIDE this single column rather than as an
+// additive sibling.
 vi.mock("@/components/producer-console/r-panel/RPanel", () => ({
-  RPanel: () => <div data-testid="r-panel-stub">r-panel</div>,
+  RPanel: ({ viewer, onSelectPr }: { viewer?: ReactNode; onSelectPr?: (sel: unknown) => void }) => (
+    <div data-testid="r-panel-stub">
+      <button
+        type="button"
+        onClick={() =>
+          onSelectPr?.({
+            repoPath: "/p/alpha",
+            repoLabel: "alpha",
+            pr: { number: 5n },
+            billingDead: false,
+          })
+        }
+      >
+        focus-pr
+      </button>
+      {viewer}
+    </div>
+  ),
+}));
+// The three R₂ viewers are stubbed to lightweight markers (the App test
+// only cares about WHERE they render, not their content). Each module also
+// exports the `selected*Key` helper App imports alongside the component.
+vi.mock("@/components/producer-console/r-panel/r-viewer/RPrViewer", () => ({
+  RPrViewer: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="r-pr-viewer-stub">
+      <button type="button" onClick={onClose}>
+        back-to-inventory
+      </button>
+    </div>
+  ),
+  selectedPrKey: () => "pr-key",
+}));
+vi.mock("@/components/producer-console/r-panel/r-viewer/RRecordViewer", () => ({
+  RRecordViewer: () => <div data-testid="r-record-viewer-stub">record</div>,
+  selectedRecordKey: () => "rec-key",
+}));
+vi.mock("@/components/producer-console/r-panel/r-viewer/RIssueViewer", () => ({
+  RIssueViewer: () => <div data-testid="r-issue-viewer-stub">issue</div>,
+  selectedIssueKey: () => "iss-key",
 }));
 // The console stub surfaces `currentProjectPath` and a button that fires
 // `onSelectProjectByPath`, so the cross-unit re-scope reroute is
@@ -229,5 +277,38 @@ describe("App — persistent R panel layout", () => {
 
     expect(screen.getByTestId("console-current-project").textContent).toBe("/p/beta");
     expect(screen.getByTestId("producer-console-stub")).toBeTruthy();
+  });
+
+  it("focus mode: a focus renders the viewer INSIDE the single R panel column (no additive sibling)", () => {
+    renderWithProviders(<App />);
+
+    // No focus yet → no viewer anywhere.
+    expect(screen.queryByTestId("r-pr-viewer-stub")).toBeNull();
+
+    // Focus a PR from the (stubbed) inventory.
+    fireEvent.click(screen.getByText("focus-pr"));
+
+    // The viewer renders, and it lives INSIDE the single R panel column —
+    // it was handed in as RPanel's `viewer`, not rendered as a separate
+    // fourth column that would steal width from the centre. (C-width
+    // invariant, asserted structurally per the brief.)
+    const panel = screen.getByTestId("r-panel-stub");
+    expect(within(panel).getByTestId("r-pr-viewer-stub")).toBeTruthy();
+    // Exactly one viewer in the whole tree — focus mode toggles, never stacks.
+    expect(screen.getAllByTestId("r-pr-viewer-stub")).toHaveLength(1);
+  });
+
+  it("focus mode: the ‹ Inventory back affordance clears the focus (returns to inventory)", () => {
+    renderWithProviders(<App />);
+
+    fireEvent.click(screen.getByText("focus-pr"));
+    expect(screen.getByTestId("r-pr-viewer-stub")).toBeTruthy();
+
+    // The viewer's close (‹ Inventory) is wired to App's clearPr → focus
+    // clears → the column swaps back to the inventory (viewer unmounts).
+    fireEvent.click(screen.getByText("back-to-inventory"));
+    expect(screen.queryByTestId("r-pr-viewer-stub")).toBeNull();
+    // The R panel column itself is still present (it never left).
+    expect(screen.getByTestId("r-panel-stub")).toBeTruthy();
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/RPanel.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPanel.tsx
@@ -81,6 +81,16 @@ interface RPanelProps {
   /** `selectedIssueKey(...)` of the issue currently open in R₂, so the
    *  focused R₁ Issues row marks itself. */
   selectedIssueKey?: string | null;
+  /** Focus mode (spine `2026-05-29-c-and-r-as-the-development-substrate`,
+   *  its deferred "R₁/R₂ visual ratio" point): the R₂ viewer for the
+   *  currently-focused artifact. When non-null it RIDES THIS SAME COLUMN —
+   *  rendered in place of the R₁ inventory body, at the same drag-set
+   *  width, with the same collapse/drag machinery — so opening a viewer
+   *  NEVER adds a width-stealing fourth column (the load-bearing
+   *  C-width invariant). When null, the inventory shows as today. The
+   *  parent (App) composes the node and keeps PR/record/issue mutually
+   *  exclusive via `useFocusedArtifact`. */
+  viewer?: React.ReactNode;
 }
 
 const SECTION_IDS = [
@@ -108,6 +118,7 @@ export function RPanel({
   selectedRecordKey,
   onSelectIssue,
   selectedIssueKey,
+  viewer,
 }: RPanelProps) {
   const [expanded, setExpanded] = useUIPref("rPanelExpandedSections");
 
@@ -181,73 +192,83 @@ export function RPanel({
         />
       </div>
 
-      <header className="flex shrink-0 items-center justify-between border-b border-hairline px-4 py-3">
-        <h2 className="text-sm font-semibold text-foreground">R · Inventory</h2>
-        <button
-          type="button"
-          onClick={onToggleCollapsed}
-          title="Collapse R panel"
-          aria-label="Collapse R panel"
-          aria-expanded={true}
-          className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
-        >
-          ›
-        </button>
-      </header>
+      {/* Focus mode: when a viewer is handed in, it REPLACES the inventory
+          body in this same column (same width, same drag splitter above),
+          so opening a viewer never adds a fourth column that would steal
+          width from the centre conversation. The viewer fills the column
+          (`flex-1`) and brings its own header + ‹ Inventory back
+          affordance. Otherwise the R₁ inventory renders exactly as before. */}
+      {viewer ?? (
+        <>
+          <header className="flex shrink-0 items-center justify-between border-b border-hairline px-4 py-3">
+            <h2 className="text-sm font-semibold text-foreground">R · Inventory</h2>
+            <button
+              type="button"
+              onClick={onToggleCollapsed}
+              title="Collapse R panel"
+              aria-label="Collapse R panel"
+              aria-expanded={true}
+              className="flex h-7 w-7 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+            >
+              ›
+            </button>
+          </header>
 
-      <DeltaStream
-        unitName={unitName}
-        data={producerFeedData}
-        onTriggerDeltaPull={onTriggerDeltaPull}
-        producerAvailable={producerAvailable}
-      />
+          <DeltaStream
+            unitName={unitName}
+            data={producerFeedData}
+            onTriggerDeltaPull={onTriggerDeltaPull}
+            producerAvailable={producerAvailable}
+          />
 
-      <div className="flex-1 space-y-1 overflow-y-auto px-2 py-2">
-        <RPrsSection
-          unitName={unitName}
-          expanded={isExpanded("prs")}
-          onToggle={() => toggle("prs")}
-          onSelectPr={onSelectPr}
-          selectedKey={selectedPrKey}
-        />
-        <RIssuesSection
-          currentProjectPath={currentProjectPath}
-          expanded={isExpanded("issues")}
-          onToggle={() => toggle("issues")}
-          onSelectIssue={onSelectIssue}
-          selectedKey={selectedIssueKey}
-        />
-        <RDecisionsSection
-          unitName={unitName}
-          expanded={isExpanded("decisions")}
-          onToggle={() => toggle("decisions")}
-          onSelect={onSelectRecord}
-          selectedKey={selectedRecordKey}
-        />
-        <RApproachesSection
-          unitName={unitName}
-          expanded={isExpanded("approaches")}
-          onToggle={() => toggle("approaches")}
-          onSelect={onSelectRecord}
-          selectedKey={selectedRecordKey}
-        />
-        <RCalibrationSection
-          unitName={unitName}
-          expanded={isExpanded("calibration")}
-          onToggle={() => toggle("calibration")}
-        />
-        <RHandoverSection
-          unitName={unitName}
-          expanded={isExpanded("handover")}
-          onToggle={() => toggle("handover")}
-        />
-        <RFilesSection
-          currentProjectPath={currentProjectPath}
-          unitName={unitName}
-          expanded={isExpanded("files")}
-          onToggle={() => toggle("files")}
-        />
-      </div>
+          <div className="flex-1 space-y-1 overflow-y-auto px-2 py-2">
+            <RPrsSection
+              unitName={unitName}
+              expanded={isExpanded("prs")}
+              onToggle={() => toggle("prs")}
+              onSelectPr={onSelectPr}
+              selectedKey={selectedPrKey}
+            />
+            <RIssuesSection
+              currentProjectPath={currentProjectPath}
+              expanded={isExpanded("issues")}
+              onToggle={() => toggle("issues")}
+              onSelectIssue={onSelectIssue}
+              selectedKey={selectedIssueKey}
+            />
+            <RDecisionsSection
+              unitName={unitName}
+              expanded={isExpanded("decisions")}
+              onToggle={() => toggle("decisions")}
+              onSelect={onSelectRecord}
+              selectedKey={selectedRecordKey}
+            />
+            <RApproachesSection
+              unitName={unitName}
+              expanded={isExpanded("approaches")}
+              onToggle={() => toggle("approaches")}
+              onSelect={onSelectRecord}
+              selectedKey={selectedRecordKey}
+            />
+            <RCalibrationSection
+              unitName={unitName}
+              expanded={isExpanded("calibration")}
+              onToggle={() => toggle("calibration")}
+            />
+            <RHandoverSection
+              unitName={unitName}
+              expanded={isExpanded("handover")}
+              onToggle={() => toggle("handover")}
+            />
+            <RFilesSection
+              currentProjectPath={currentProjectPath}
+              unitName={unitName}
+              expanded={isExpanded("files")}
+              onToggle={() => toggle("files")}
+            />
+          </div>
+        </>
+      )}
     </aside>
   );
 }

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RPanel.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RPanel.test.tsx
@@ -6,7 +6,7 @@
 // expand, localStorage persistence, no severity colors in rendered
 // output) plus the relocated Δ stream trigger button.
 
-import { fireEvent, screen } from "@testing-library/react";
+import { fireEvent, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { ProducerFeedStatus } from "@/lib/api";
 import { renderWithProviders } from "@/test/render";
@@ -180,6 +180,25 @@ describe("RPanel — accordion shell", () => {
 
     fireEvent.click(screen.getByRole("button", { name: /Expand R panel/ }));
     expect(onToggle).toHaveBeenCalledTimes(1);
+  });
+
+  it("focus mode: renders the viewer in place of the inventory (toggles, never stacks)", () => {
+    // A focus is set → RPanel renders the R₂ viewer node IN the same column
+    // (same drag-set width) instead of the R₁ inventory body. There is no
+    // additive second column — the load-bearing C-width invariant.
+    renderWithProviders(
+      <RPanel {...makeProps({ viewer: <div data-testid="r2-viewer-stub">viewer</div> })} />,
+    );
+
+    const panel = screen.getByTestId("r-panel");
+    // The viewer rides the SAME R panel column slot…
+    expect(within(panel).getByTestId("r2-viewer-stub")).toBeTruthy();
+    // …and the inventory sections are NOT additionally rendered (swap, not stack).
+    expect(screen.queryByTestId("prs-section")).toBeNull();
+    expect(screen.queryByTestId("decisions-section")).toBeNull();
+    expect(screen.queryByTestId("files-section")).toBeNull();
+    // Drag-resize machinery is preserved on the focused column.
+    expect(within(panel).getByRole("separator", { name: /Resize R panel/ })).toBeTruthy();
   });
 
   it("uses NO severity-color classes in the rendered output (negative-space)", () => {

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/InventoryBackButton.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/InventoryBackButton.tsx
@@ -1,0 +1,27 @@
+// Shared "‹ Inventory" back affordance for the three R₂ viewers.
+//
+// Focus mode (spine `2026-05-29-c-and-r-as-the-development-substrate`): a
+// viewer rides the R panel's single column IN PLACE OF the R₁ inventory,
+// rather than as an additive column. So the viewer's close is not a column
+// dismiss — it REVEALS the inventory again. This button reads as that
+// return ("‹ Inventory"), not an ambiguous ×. It is still wired to the
+// viewer's `onClose`, which clears the focus (App's clearPr / clearRecord
+// / clearIssue) and so swaps the column back to the inventory body.
+//
+// Plain styling only (`text-muted-foreground` / `text-foreground`) — the
+// viewers' negative-space rule (no severity tint on chrome) applies here
+// too.
+
+export function InventoryBackButton({ onClose }: { onClose: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClose}
+      title="Back to inventory"
+      aria-label="Back to inventory"
+      className="-ml-1 mb-1.5 flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+    >
+      <span aria-hidden="true">‹</span> Inventory
+    </button>
+  );
+}

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/RIssueViewer.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/RIssueViewer.tsx
@@ -5,11 +5,13 @@
 // `2026-05-16-dev-loop-completes-in-tmai` (read the project's issues
 // in-tmai, no github.com round-trip).
 //
-// Mirrors `RPrViewer` / `RRecordViewer` posture exactly: an INDEPENDENT
-// right-side column that NEVER auto-opens — it mounts only on an explicit
-// operator row click in the R₁ inventory (the parent gates the mount on a
-// non-null `selectedIssue`). R₁ (`RIssuesSection`) stays a pure
-// inventory; this column renders the clicked issue's full content.
+// Mirrors `RPrViewer` / `RRecordViewer` posture exactly: in focus mode
+// (spine `2026-05-29-c-and-r-as-the-development-substrate`) it RIDES the R
+// panel's single column IN PLACE OF the R₁ inventory — same drag-set
+// width, never an additive column. It NEVER auto-opens — it mounts only on
+// an explicit operator row click in the R₁ inventory (the parent gates the
+// mount on a non-null `selectedIssue`). R₁ (`RIssuesSection`) stays a pure
+// inventory; this viewer renders the clicked issue's full content.
 //
 // SCOPE — read-only, per-repo, NO actions. This is the (ii) judgment-info
 // viewer only. The (iii) lifecycle acts (close / comment / reopen) need
@@ -47,6 +49,7 @@ import Markdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useIssueDetail } from "@/hooks/useIssueDetail";
 import type { IssueComment, IssueDetail, IssueInfo, IssueLabel } from "@/lib/api";
+import { InventoryBackButton } from "./InventoryBackButton";
 import { PROSE_CLASSES } from "./prose";
 
 // What R₁ hands R₂ on an issue row click. The full `IssueInfo` rides
@@ -75,11 +78,12 @@ export function RIssueViewer({ selected, onClose }: RIssueViewerProps) {
   const { repoPath, repoLabel, issue } = selected;
   const { data, loading, error } = useIssueDetail(repoPath, issue.number);
 
+  // Focus mode (spine `2026-05-29-c-and-r-as-the-development-substrate`):
+  // fills the R panel's single column (`flex-1`) at the operator's
+  // drag-set width — imposes no width of its own, so it never squeezes the
+  // centre conversation.
   return (
-    <aside
-      data-testid="r-issue-viewer"
-      className="glass flex w-[clamp(22rem,40vw,48rem)] shrink-0 flex-col border-l border-hairline"
-    >
+    <div data-testid="r-issue-viewer" className="flex min-h-0 flex-1 flex-col">
       <ViewerHeader repoLabel={repoLabel} issue={issue} detail={data} onClose={onClose} />
       <div className="flex-1 space-y-4 overflow-y-auto px-4 py-3 text-xs">
         {loading && <Loading />}
@@ -93,7 +97,7 @@ export function RIssueViewer({ selected, onClose }: RIssueViewerProps) {
           </>
         )}
       </div>
-    </aside>
+    </div>
   );
 }
 
@@ -117,24 +121,14 @@ function ViewerHeader({
 }) {
   return (
     <header className="shrink-0 border-b border-hairline px-4 py-3">
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <p className="text-[11px] uppercase tracking-wide text-subtle-foreground">
-            {repoLabel} · issue
-          </p>
-          <h2 className="text-sm font-semibold text-foreground">
-            <span className="font-mono text-muted-foreground">#{issue.number}</span> {issue.title}
-          </h2>
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          title="Close issue viewer"
-          aria-label="Close issue viewer"
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
-        >
-          ×
-        </button>
+      <InventoryBackButton onClose={onClose} />
+      <div className="min-w-0">
+        <p className="text-[11px] uppercase tracking-wide text-subtle-foreground">
+          {repoLabel} · issue
+        </p>
+        <h2 className="text-sm font-semibold text-foreground">
+          <span className="font-mono text-muted-foreground">#{issue.number}</span> {issue.title}
+        </h2>
       </div>
       <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-subtle-foreground">
         <span className="text-muted-foreground">{issue.state.toLowerCase()}</span>

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/RPrViewer.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/RPrViewer.tsx
@@ -3,9 +3,12 @@
 // substrate` "🔀 PRs (iii)").
 //
 // γ-lean shape (`doc/approaches/2026-05-29-artifact-content-viewer.md`,
-// Phase 1, PR artifact kind): an INDEPENDENT right-side viewer column.
+// Phase 1, PR artifact kind): the R₂ PR viewer. In focus mode (spine
+// `2026-05-29-c-and-r-as-the-development-substrate`) it RIDES the R panel's
+// single column IN PLACE OF the R₁ inventory — same drag-set width, never
+// an additive column that would squeeze the centre conversation.
 // R₁ (`RPrsSection`) stays a pure inventory; clicking a PR row there
-// selects it and this column renders that PR's full content — diff,
+// selects it and this viewer renders that PR's full content — diff,
 // body, comments (incl. CodeRabbit), labels, mergeable / review / check
 // status, CI status + failure-log drill-down — entirely in-tmai, with
 // ZERO github.com round-trip, plus the action layer (merge soft-valve /
@@ -56,6 +59,7 @@ import {
   type PrMergeStatus,
   type PrSummaryWire,
 } from "@/lib/api";
+import { InventoryBackButton } from "./InventoryBackButton";
 import { PROSE_CLASSES } from "./prose";
 
 // What R₁ hands R₂ on a row click. The full `PrSummaryWire` rides along
@@ -86,11 +90,12 @@ export function RPrViewer({ selected, onClose }: RPrViewerProps) {
   const { repoPath, repoLabel, pr, billingDead } = selected;
   const prNumber = Number(pr.number);
 
+  // Focus mode (spine `2026-05-29-c-and-r-as-the-development-substrate`):
+  // the viewer fills the R panel's single column (`flex-1`) at the
+  // operator's drag-set width — it imposes NO width of its own, so opening
+  // it never adds a column that would squeeze the centre conversation.
   return (
-    <aside
-      data-testid="r-pr-viewer"
-      className="glass flex w-[clamp(22rem,40vw,48rem)] shrink-0 flex-col border-l border-hairline"
-    >
+    <div data-testid="r-pr-viewer" className="flex min-h-0 flex-1 flex-col">
       <ViewerHeader repoLabel={repoLabel} pr={pr} onClose={onClose} />
       <div className="flex-1 space-y-4 overflow-y-auto px-4 py-3 text-xs">
         <LabelsSection repoPath={repoPath} prNumber={prNumber} />
@@ -112,7 +117,7 @@ export function RPrViewer({ selected, onClose }: RPrViewerProps) {
         billingDead={billingDead}
         onMerged={onClose}
       />
-    </aside>
+    </div>
   );
 }
 
@@ -377,22 +382,12 @@ function ViewerHeader({
 }) {
   return (
     <header className="shrink-0 border-b border-hairline px-4 py-3">
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <p className="text-[11px] uppercase tracking-wide text-subtle-foreground">{repoLabel}</p>
-          <h2 className="text-sm font-semibold text-foreground">
-            <span className="font-mono text-muted-foreground">#{Number(pr.number)}</span> {pr.title}
-          </h2>
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          title="Close PR viewer"
-          aria-label="Close PR viewer"
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
-        >
-          ×
-        </button>
+      <InventoryBackButton onClose={onClose} />
+      <div className="min-w-0">
+        <p className="text-[11px] uppercase tracking-wide text-subtle-foreground">{repoLabel}</p>
+        <h2 className="text-sm font-semibold text-foreground">
+          <span className="font-mono text-muted-foreground">#{Number(pr.number)}</span> {pr.title}
+        </h2>
       </div>
       <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-subtle-foreground">
         <span className="font-mono">

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/RRecordViewer.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/RRecordViewer.tsx
@@ -5,12 +5,14 @@
 // (γ-lean R₂ viewer) + `2026-05-16-dev-loop-completes-in-tmai` (read the
 // project's records in-tmai, no editor round-trip).
 //
-// Mirrors `RPrViewer`'s posture exactly: an INDEPENDENT right-side column
-// that NEVER auto-opens — it mounts only on an explicit operator row
-// click in the R₁ inventory (the parent gates the mount on a non-null
-// `selectedRecord`). R₁ (`RDecisionsSection` / `RApproachesSection`)
-// stays a pure inventory; this column renders the clicked record's
-// content.
+// Mirrors `RPrViewer`'s posture exactly: in focus mode (spine
+// `2026-05-29-c-and-r-as-the-development-substrate`) it RIDES the R
+// panel's single column IN PLACE OF the R₁ inventory — same drag-set
+// width, never an additive column. It NEVER auto-opens — it mounts only
+// on an explicit operator row click in the R₁ inventory (the parent gates
+// the mount on a non-null `selectedRecord`). R₁ (`RDecisionsSection` /
+// `RApproachesSection`) stays a pure inventory; this viewer renders the
+// clicked record's content.
 //
 // SCOPE — read-only, excerpt-level, NO actions. This is the (ii)
 // judgment-info viewer only: it renders the rich frontmatter + the
@@ -45,6 +47,7 @@ import type {
   DecisionWire,
   ReviewTriggerWire,
 } from "@/lib/api";
+import { InventoryBackButton } from "./InventoryBackButton";
 import { PROSE_CLASSES } from "./prose";
 
 // What R₁ hands R₂ on a record row click. The full wire object rides
@@ -79,11 +82,12 @@ export function RRecordViewer({ selected, unitName, onSelectRecord, onClose }: R
   const { data: approaches } = useApproaches(unitName);
   const index = useMemo(() => buildRecordIndex(decisions, approaches), [decisions, approaches]);
 
+  // Focus mode (spine `2026-05-29-c-and-r-as-the-development-substrate`):
+  // fills the R panel's single column (`flex-1`) at the operator's
+  // drag-set width — imposes no width of its own, so it never squeezes the
+  // centre conversation.
   return (
-    <aside
-      data-testid="r-record-viewer"
-      className="glass flex w-[clamp(22rem,40vw,48rem)] shrink-0 flex-col border-l border-hairline"
-    >
+    <div data-testid="r-record-viewer" className="flex min-h-0 flex-1 flex-col">
       <ViewerHeader selected={selected} onClose={onClose} />
       <div className="flex-1 space-y-4 overflow-y-auto px-4 py-3 text-xs">
         <FrontmatterTable selected={selected} index={index} onSelectRecord={onSelectRecord} />
@@ -99,7 +103,7 @@ export function RRecordViewer({ selected, unitName, onSelectRecord, onClose }: R
           onSelectRecord={onSelectRecord}
         />
       </div>
-    </aside>
+    </div>
   );
 }
 
@@ -163,22 +167,12 @@ function ViewerHeader({ selected, onClose }: { selected: SelectedRecord; onClose
   const kindFact = selected.kind === "decision" ? selected.record.category : selected.record.date;
   return (
     <header className="shrink-0 border-b border-hairline px-4 py-3">
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <p className="text-[11px] uppercase tracking-wide text-subtle-foreground">
-            {repoLabel} · {selected.kind}
-          </p>
-          <h2 className="text-sm font-semibold text-foreground">{record.title}</h2>
-        </div>
-        <button
-          type="button"
-          onClick={onClose}
-          title="Close record viewer"
-          aria-label="Close record viewer"
-          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
-        >
-          ×
-        </button>
+      <InventoryBackButton onClose={onClose} />
+      <div className="min-w-0">
+        <p className="text-[11px] uppercase tracking-wide text-subtle-foreground">
+          {repoLabel} · {selected.kind}
+        </p>
+        <h2 className="text-sm font-semibold text-foreground">{record.title}</h2>
       </div>
       <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-subtle-foreground">
         <span className="font-mono">{record.slug}</span>

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RIssueViewer.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RIssueViewer.test.tsx
@@ -141,10 +141,19 @@ describe("RIssueViewer", () => {
     expect(container.querySelector("a[href*='github.com']")).toBeNull();
   });
 
-  it("fires onClose from the close button", () => {
+  it("returns to the inventory via the ‹ Inventory back affordance (clears the focus)", () => {
     const onClose = vi.fn();
     render(<RIssueViewer selected={selected()} onClose={onClose} />);
-    screen.getByRole("button", { name: /Close issue viewer/ }).click();
+    // Focus mode: closing returns to the inventory; still wired to onClose.
+    screen.getByRole("button", { name: /Back to inventory/ }).click();
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("fills the R region — carries no fixed clamp width (focus mode rides the R column)", () => {
+    const { container } = render(<RIssueViewer selected={selected()} onClose={vi.fn()} />);
+    const root = container.querySelector('[data-testid="r-issue-viewer"]');
+    expect(root).not.toBeNull();
+    expect(root?.className ?? "").not.toMatch(/w-\[/);
+    expect(root?.className ?? "").toMatch(/flex-1/);
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RPrViewer.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RPrViewer.test.tsx
@@ -140,11 +140,23 @@ describe("RPrViewer", () => {
     expect(container.querySelector("a[href*='github.com']")).toBeNull();
   });
 
-  it("fires onClose from the close button", () => {
+  it("returns to the inventory via the ‹ Inventory back affordance (clears the focus)", () => {
     const onClose = vi.fn();
     render(<RPrViewer selected={selected()} onClose={onClose} />);
-    fireEvent.click(screen.getByRole("button", { name: /Close PR viewer/ }));
+    // Focus mode: the close is a RETURN to the inventory, not a column
+    // dismiss. It is still wired to `onClose`, which clears the focus.
+    fireEvent.click(screen.getByRole("button", { name: /Back to inventory/ }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("fills the R region — carries no fixed clamp width (focus mode rides the R column)", () => {
+    const { container } = render(<RPrViewer selected={selected()} onClose={vi.fn()} />);
+    const root = container.querySelector('[data-testid="r-pr-viewer"]');
+    expect(root).not.toBeNull();
+    // No self-imposed width (the retired `w-[clamp(22rem,40vw,48rem)]`); it
+    // fills the R panel column instead.
+    expect(root?.className ?? "").not.toMatch(/w-\[/);
+    expect(root?.className ?? "").toMatch(/flex-1/);
   });
 
   it("drills into a failed check's failure log only on operator click", async () => {

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RRecordViewer.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RRecordViewer.test.tsx
@@ -207,7 +207,7 @@ describe("RRecordViewer — decision", () => {
     expect(screen.queryByText("Drift")).toBeNull();
   });
 
-  it("fires onClose from the close button", () => {
+  it("returns to the inventory via the ‹ Inventory back affordance (clears the focus)", () => {
     const onClose = vi.fn();
     render(
       <RRecordViewer
@@ -217,8 +217,24 @@ describe("RRecordViewer — decision", () => {
         onClose={onClose}
       />,
     );
-    fireEvent.click(screen.getByRole("button", { name: /Close record viewer/ }));
+    // Focus mode: closing returns to the inventory; still wired to onClose.
+    fireEvent.click(screen.getByRole("button", { name: /Back to inventory/ }));
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("fills the R region — carries no fixed clamp width (focus mode rides the R column)", () => {
+    const { container } = render(
+      <RRecordViewer
+        selected={decisionSelection(decision())}
+        unitName="u"
+        onSelectRecord={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    );
+    const root = container.querySelector('[data-testid="r-record-viewer"]');
+    expect(root).not.toBeNull();
+    expect(root?.className ?? "").not.toMatch(/w-\[/);
+    expect(root?.className ?? "").toMatch(/flex-1/);
   });
 
   it("uses NO severity-color classes on facts (negative space)", () => {


### PR DESCRIPTION
## Why

Lived dogfooding friction: with the R panel (R₁ inventory) open, opening an R₂ viewer **also added a column**, squeezing the **center conversation column (C)** too narrow. C is the most-important surface and must not be squeezed by opening a viewer.

Today the R₂ viewer (`RPrViewer` / `RRecordViewer` / `RIssueViewer`) rendered as a **separate sibling column** to the right of `RPanel` (R₁), each hardcoded `w-[clamp(22rem,40vw,48rem)]`. So the layout was `[sidebar][C][R₁][R₂]` and `C = total − L − R₁ − R₂` — opening R₂ stole from C. That is the bug.

Serves the spine `2026-05-29-c-and-r-as-the-development-substrate` (its deferred "R₁/R₂ visual ratio / persistence" structural point) — sharpening "C+R co-primary" into **"C is the protected primary; R₂ does not add width."**

## What — focus mode (one toggling column)

The right region is now **ONE column** whose width is the existing drag-set `attentionStripWidth` (with the existing collapse-to-rail + narrow/mobile guard). It shows **EITHER** the R₁ inventory (`RPanel`) **OR** the R₂ viewer — never both as two additive columns:

- **No focus** → the column shows `RPanel` (R₁ inventory), exactly as before.
- **A focus is set** → the **same** column shows the R₂ viewer instead, at the **same width**, with R₁ hidden behind it.

Concretely:

1. **`App.tsx`** no longer renders R₂ as a separate sibling column. It composes a single `rViewer` node from the mutually-exclusive focus state (`useFocusedArtifact`) and hands it to `RPanel` via a new `viewer` prop. `RPanel` renders the viewer **in place of** its inventory body, in the same column, behind the same collapse / drag / narrow-guard machinery.
2. **Removed the hardcoded `w-[clamp(22rem,40vw,48rem)]`** from all three viewers — they now fill the region (`flex-1`) and impose no width of their own. The region's width stays the drag-set `attentionStripWidth`.
3. **`‹ Inventory` back affordance**: the viewers' close (formerly an ambiguous `×`) is now a shared `InventoryBackButton` that reads as **returning to the inventory** (it reveals R₁ rather than dismissing a column). Still wired to `onClose` → clears the focus (`clearPr` / `clearRecord` / `clearIssue`).
4. **Preserved** all existing right-region behaviour: drag-resize (`attentionStripWidth` + the split-pane handler), collapse-to-rail (`attentionStripCollapsed`), the narrow/mobile hide guard, and the unit-change clear. The viewer simply rides the same column those already govern.

## Load-bearing invariant

**Opening or closing a viewer never changes C's width** — only dragging the divider does. The viewer occupies the RPanel slot (no fourth column), so C's flex/width is identical whether or not a viewer is open.

## Tests

- `RPanel.test`: focus mode renders the viewer in the slot, the inventory sections are **not** additionally rendered (toggles, never stacks), and the drag splitter is preserved.
- Viewer tests: each viewer carries **no fixed clamp width** (fills the region), and the `‹ Inventory` back affordance clears the focus.
- `App.r-panel.test`: a focus renders the viewer **inside the single R panel column** (no additive sibling) — the C-width invariant covered structurally — and the back affordance returns to the inventory.
- Existing RPanel collapse/drag + narrow/mobile-guard tests unchanged and green.

## Scope

`clients/react/` only — no generated types (`types/generated/**`), no tmai-core.

## Gate

`pnpm install` / `pnpm lint` / `pnpm build` / `pnpm test` — all green (587 passed, 2 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * R パネルにフォーカスモードを追加し、PR・レコード・Issue をパネル内の単一列で表示できるようになりました。
  * フォーカス表示からインベントリに戻るための「‹ Inventory」ナビゲーションボタンを追加しました。

* **UI/UX Improvements**
  * R パネル内でのフォーカス表示時、コンテンツが単一列で表示されるようになり、複数列表示から統合されました。

* **Tests**
  * フォーカスモード機能の動作検証テストを拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->