### PR TITLE
feat(r-panel): R₂ Calibration viewer (read-only, focus-mode)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -14,6 +14,10 @@ import { ProducerConsole } from "@/components/producer-console/ProducerConsole";
 import { ProducerConversationHeader } from "@/components/producer-console/ProducerConversationHeader";
 import { RPanel } from "@/components/producer-console/r-panel/RPanel";
 import {
+  RCalibrationViewer,
+  selectedCalibrationKey,
+} from "@/components/producer-console/r-panel/r-viewer/RCalibrationViewer";
+import {
   RIssueViewer,
   selectedIssueKey,
 } from "@/components/producer-console/r-panel/r-viewer/RIssueViewer";
@@ -128,11 +132,12 @@ export function App() {
   // at the seams. See the rPanel*Width helpers above.
   const [rPanelWidth, setRPanelWidth] = useUIPref("attentionStripWidth");
   // The artifact in focus in R₂. R₂ hosts exactly ONE focused artifact at
-  // a time — a PR (#749), a record (decision/approach), or an issue — so
-  // focusing one kind clears the others (the invariant lives in
-  // `useFocusedArtifact`). All null = no viewer (it never auto-opens — the
-  // operator clicks a row in the R₁ inventory to select; viewer-approach
-  // negative space). Lives at App level because focus mode (spine
+  // a time — a PR (#749), a record (decision/approach), an issue, or the
+  // unit's calibration — so focusing one kind clears the others (the
+  // invariant lives in `useFocusedArtifact`). All null = no viewer (it
+  // never auto-opens — the operator clicks a row in the R₁ inventory to
+  // select; viewer-approach negative space). Lives at App level because
+  // focus mode (spine
   // `2026-05-29-c-and-r-as-the-development-substrate`) RIDES the R panel's
   // single column: a focus swaps R₁'s inventory body for the R₂ viewer at
   // the same drag-set width (`viewer` prop below), rather than adding a
@@ -141,12 +146,15 @@ export function App() {
     selectedPr,
     selectedRecord,
     selectedIssue,
+    selectedCalibration,
     selectPr,
     selectRecord,
     selectIssue,
+    selectCalibration,
     clearPr,
     clearRecord,
     clearIssue,
+    clearCalibration,
     clearAll: clearFocusedArtifact,
   } = useFocusedArtifact();
   const showSettings = mainPanel === "settings";
@@ -593,7 +601,7 @@ export function App() {
   );
 
   // Focus-mode viewer node (spine `2026-05-29-c-and-r-as-the-development-
-  // substrate`). At most one of the three is non-null (`useFocusedArtifact`
+  // substrate`). At most one of the four is non-null (`useFocusedArtifact`
   // keeps them mutually exclusive), so this resolves to a single viewer or
   // null. It is handed to RPanel as `viewer`, where it REPLACES the R₁
   // inventory body in the same column — opening/closing it never changes
@@ -610,6 +618,8 @@ export function App() {
     />
   ) : selectedIssue ? (
     <RIssueViewer selected={selectedIssue} onClose={clearIssue} />
+  ) : selectedCalibration ? (
+    <RCalibrationViewer selected={selectedCalibration} onClose={clearCalibration} />
   ) : null;
 
   return (
@@ -870,6 +880,10 @@ export function App() {
             selectedIssue
               ? selectedIssueKey(selectedIssue.repoPath, selectedIssue.issue.number)
               : null
+          }
+          onSelectCalibration={selectCalibration}
+          selectedCalibrationKey={
+            selectedCalibration ? selectedCalibrationKey(selectedCalibration.unit) : null
           }
           viewer={rViewer}
         />

--- a/clients/react/src/components/producer-console/r-panel/RCalibrationSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RCalibrationSection.tsx
@@ -1,22 +1,44 @@
-// 📊 Calibration — R panel's raw calibration inventory.
+// 📊 Calibration — R panel's raw calibration inventory (R₁).
 //
 // Reuses `useCalibration(unit)` (App.tsx already polls it for the
 // top-bar chip + tripwire banner — but the hook is poll-and-cache
 // at the hook layer, so reading it again here is fine; the polling
 // is per-unit per-hook-instance). Entries date desc, plain text,
 // no severity coloring.
+//
+// Unlike the PR / issue / decision sections (a unit has MANY of each, so
+// each row is a select), a unit has exactly ONE calibration — so the open
+// affordance is a single "View calibration detail ›" button on the body
+// (not a per-row select). It focuses the R₂ `RCalibrationViewer` via
+// `onSelectCalibration({ unit })`, mirroring the other sections'
+// `onSelect*` / `selectedKey` / `aria-current` posture. R₁ stays a pure
+// inventory; the button is just a focus.
 
 import { useCalibration } from "@/hooks/useCalibration";
 import type { CalibrationEntry, CalibrationResponse } from "@/lib/api";
+import { type SelectedCalibration, selectedCalibrationKey } from "./r-viewer/RCalibrationViewer";
 import { Section } from "./Section";
 
 interface RCalibrationSectionProps {
   unitName: string | null;
   expanded: boolean;
   onToggle: () => void;
+  /** Open the unit's calibration in the R₂ viewer column. Optional so the
+   *  section still renders standalone (e.g. in isolation tests). */
+  onSelectCalibration?: (sel: SelectedCalibration) => void;
+  /** `selectedCalibrationKey(unit)` of the calibration currently open in
+   *  R₂, so the detail affordance marks itself as the one being viewed (a
+   *  mechanical "open here" fact, not appraisal). */
+  selectedKey?: string | null;
 }
 
-export function RCalibrationSection({ unitName, expanded, onToggle }: RCalibrationSectionProps) {
+export function RCalibrationSection({
+  unitName,
+  expanded,
+  onToggle,
+  onSelectCalibration,
+  selectedKey,
+}: RCalibrationSectionProps) {
   const { data, loading, error } = useCalibration(unitName);
   const total = data?.total_in_window ?? 0;
 
@@ -29,7 +51,14 @@ export function RCalibrationSection({ unitName, expanded, onToggle }: RCalibrati
       expanded={expanded}
       onToggle={onToggle}
     >
-      <Body unitName={unitName} data={data} loading={loading} error={error} />
+      <Body
+        unitName={unitName}
+        data={data}
+        loading={loading}
+        error={error}
+        onSelectCalibration={onSelectCalibration}
+        selectedKey={selectedKey ?? null}
+      />
     </Section>
   );
 }
@@ -39,9 +68,11 @@ interface BodyProps {
   data: CalibrationResponse | null;
   loading: boolean;
   error: Error | null;
+  onSelectCalibration?: (sel: SelectedCalibration) => void;
+  selectedKey: string | null;
 }
 
-function Body({ unitName, data, loading, error }: BodyProps) {
+function Body({ unitName, data, loading, error, onSelectCalibration, selectedKey }: BodyProps) {
   if (unitName === null) {
     return <p className="text-subtle-foreground">Pick a project to see calibration.</p>;
   }
@@ -56,27 +87,68 @@ function Body({ unitName, data, loading, error }: BodyProps) {
   }
   const entries = [...data.tier1_violations, ...data.recent_false_negatives];
   entries.sort((a, b) => b.recorded_at.localeCompare(a.recorded_at));
+  const detail = (
+    <DetailAffordance
+      unit={unitName}
+      onSelectCalibration={onSelectCalibration}
+      selected={selectedKey === selectedCalibrationKey(unitName)}
+    />
+  );
   if (entries.length === 0) {
     return (
-      <p className="text-subtle-foreground">
-        {data.total_in_window} entries in last {data.days} days; no tripwires or false-negatives.
-      </p>
+      <div className="space-y-1">
+        <p className="text-subtle-foreground">
+          {data.total_in_window} entries in last {data.days} days; no tripwires or false-negatives.
+        </p>
+        {detail}
+      </div>
     );
   }
   return (
-    <ul className="space-y-1">
-      {entries.map((e, idx) => (
-        // `CalibrationEntry` has no id field; `(recorded_at, note_source)`
-        // can collide when one synthesis-pass routes multiple verdicts
-        // off the same note. Compose with idx to disambiguate. Safe
-        // here because `entries` is rebuilt on every render from a
-        // stable sort, and the rows are leaf, stateless presentational
-        // <li>s — there is no per-row state that the index reshuffle
-        // could orphan.
-        // biome-ignore lint/suspicious/noArrayIndexKey: index is the disambiguator on top of a composite natural key, not the sole key — see comment above.
-        <EntryRow key={`${e.recorded_at}-${e.note_source}-${idx}`} entry={e} />
-      ))}
-    </ul>
+    <div className="space-y-1">
+      <ul className="space-y-1">
+        {entries.map((e, idx) => (
+          // `CalibrationEntry` has no id field; `(recorded_at, note_source)`
+          // can collide when one synthesis-pass routes multiple verdicts
+          // off the same note. Compose with idx to disambiguate. Safe
+          // here because `entries` is rebuilt on every render from a
+          // stable sort, and the rows are leaf, stateless presentational
+          // <li>s — there is no per-row state that the index reshuffle
+          // could orphan.
+          // biome-ignore lint/suspicious/noArrayIndexKey: index is the disambiguator on top of a composite natural key, not the sole key — see comment above.
+          <EntryRow key={`${e.recorded_at}-${e.note_source}-${idx}`} entry={e} />
+        ))}
+      </ul>
+      {detail}
+    </div>
+  );
+}
+
+// The single "open the R₂ calibration detail" affordance. A unit has ONE
+// calibration, so this is a section-level button, not a per-row select.
+// `aria-current` marks it when the unit's calibration is the one open in
+// R₂ (a mechanical "open here" fact, not appraisal). Plain styling only.
+function DetailAffordance({
+  unit,
+  onSelectCalibration,
+  selected,
+}: {
+  unit: string;
+  onSelectCalibration?: (sel: SelectedCalibration) => void;
+  selected: boolean;
+}) {
+  if (!onSelectCalibration) return null;
+  return (
+    <button
+      type="button"
+      onClick={() => onSelectCalibration({ unit })}
+      aria-current={selected ? "true" : undefined}
+      className={`w-full rounded px-1 py-0.5 text-left text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong/40 hover:text-foreground ${
+        selected ? "bg-surface-strong/40 text-foreground" : ""
+      }`}
+    >
+      View calibration detail ›
+    </button>
   );
 }
 

--- a/clients/react/src/components/producer-console/r-panel/RPanel.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPanel.tsx
@@ -36,6 +36,7 @@ import { RFilesSection } from "./RFilesSection";
 import { RHandoverSection } from "./RHandoverSection";
 import { RIssuesSection } from "./RIssuesSection";
 import { RPrsSection } from "./RPrsSection";
+import type { SelectedCalibration } from "./r-viewer/RCalibrationViewer";
 import type { SelectedIssue } from "./r-viewer/RIssueViewer";
 import type { SelectedPr } from "./r-viewer/RPrViewer";
 import type { SelectedRecord } from "./r-viewer/RRecordViewer";
@@ -81,6 +82,13 @@ interface RPanelProps {
   /** `selectedIssueKey(...)` of the issue currently open in R₂, so the
    *  focused R₁ Issues row marks itself. */
   selectedIssueKey?: string | null;
+  /** Open the unit's calibration in the R₂ calibration viewer column.
+   *  Threaded to the R₁ Calibration section so its detail affordance
+   *  focuses the calibration for in-tmai viewing. */
+  onSelectCalibration?: (sel: SelectedCalibration) => void;
+  /** `selectedCalibrationKey(unit)` of the calibration currently open in
+   *  R₂, so the focused R₁ Calibration affordance marks itself. */
+  selectedCalibrationKey?: string | null;
   /** Focus mode (spine `2026-05-29-c-and-r-as-the-development-substrate`,
    *  its deferred "R₁/R₂ visual ratio" point): the R₂ viewer for the
    *  currently-focused artifact. When non-null it RIDES THIS SAME COLUMN —
@@ -118,6 +126,8 @@ export function RPanel({
   selectedRecordKey,
   onSelectIssue,
   selectedIssueKey,
+  onSelectCalibration,
+  selectedCalibrationKey,
   viewer,
 }: RPanelProps) {
   const [expanded, setExpanded] = useUIPref("rPanelExpandedSections");
@@ -254,6 +264,8 @@ export function RPanel({
               unitName={unitName}
               expanded={isExpanded("calibration")}
               onToggle={() => toggle("calibration")}
+              onSelectCalibration={onSelectCalibration}
+              selectedKey={selectedCalibrationKey}
             />
             <RHandoverSection
               unitName={unitName}

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RCalibrationSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RCalibrationSection.test.tsx
@@ -68,4 +68,44 @@ describe("RCalibrationSection", () => {
     });
     expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
   });
+
+  it("the detail affordance calls onSelectCalibration with { unit }", async () => {
+    calibrationMock.mockResolvedValue(response());
+    const onSelectCalibration = vi.fn();
+    render(
+      <RCalibrationSection
+        unitName="u"
+        expanded={true}
+        onToggle={vi.fn()}
+        onSelectCalibration={onSelectCalibration}
+      />,
+    );
+    const button = await screen.findByText(/View calibration detail/);
+    button.click();
+    expect(onSelectCalibration).toHaveBeenCalledWith({ unit: "u" });
+  });
+
+  it("marks the detail affordance aria-current when its unit is the one open in R₂", async () => {
+    calibrationMock.mockResolvedValue(response());
+    render(
+      <RCalibrationSection
+        unitName="u"
+        expanded={true}
+        onToggle={vi.fn()}
+        onSelectCalibration={vi.fn()}
+        selectedKey="u"
+      />,
+    );
+    const button = await screen.findByText(/View calibration detail/);
+    expect(button.getAttribute("aria-current")).toBe("true");
+  });
+
+  it("omits the detail affordance when no onSelectCalibration is wired", async () => {
+    calibrationMock.mockResolvedValue(response());
+    render(<RCalibrationSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/no tripwires or false-negatives/i)).toBeTruthy();
+    });
+    expect(screen.queryByText(/View calibration detail/)).toBeNull();
+  });
 });

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/RCalibrationViewer.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/RCalibrationViewer.tsx
@@ -288,5 +288,11 @@ function outcomeLabel(outcome: Outcome | null): string {
       return `hotfix ${outcome.commit_sha} (${outcome.date})`;
     case "ci_fail_fix":
       return `ci-fail-fix PR #${outcome.failing_pr} → #${outcome.fix_pr}`;
+    default: {
+      // Exhaustiveness guard: if a future `Outcome` variant is added,
+      // TS fails here (assertNever) rather than silently dropping it.
+      const _exhaustive: never = outcome;
+      return _exhaustive;
+    }
   }
 }

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/RCalibrationViewer.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/RCalibrationViewer.tsx
@@ -1,0 +1,292 @@
+// R₂ — the in-tmai Calibration overview viewer (per-unit, read-only).
+// Serves the spine `2026-05-29-c-and-r-as-the-development-substrate` (the
+// per-kind walk's "📊 Calibration" surface) + `2026-05-29-artifact-content-
+// viewer` (γ-lean R₂ viewer).
+//
+// Mirrors `RPrViewer` / `RRecordViewer` / `RIssueViewer` posture exactly:
+// in focus mode it RIDES the R panel's single column IN PLACE OF the R₁
+// inventory — same drag-set width, never an additive column. It NEVER
+// auto-opens — it mounts only on an explicit operator click in the R₁
+// inventory (the parent gates the mount on a non-null `selectedCalibration`).
+// R₁ (`RCalibrationSection`) stays a pure inventory; this viewer renders
+// the unit's full calibration overview.
+//
+// Calibration is a META-ARTIFACT: it is how the OPERATOR judges the
+// Producer's triage hit-rate. Unlike PR / decision / issue (a unit has
+// MANY of each), a unit has exactly ONE calibration — so there is no row
+// to select, just a "view the detail" affordance, and `SelectedCalibration`
+// carries only the unit name. The viewer re-fetches via `useCalibration`
+// (cheap — App already polls the same per-unit cache for the top-bar chip
+// + tripwire banner) and renders the read-only overview off that one
+// response.
+//
+// SCOPE — read-only, NO actions. The (iii) acts (tier-1 acknowledge, a
+// `[→Producer brief]` button) need endpoints that do NOT exist server-side
+// and are explicitly deferred — the viewer mutates nothing.
+//
+// Negative space (the serving `2026-05-26-tmai-states-facts-not-appraisals`
+// posture — ESPECIALLY load-bearing here: a judge-of-the-Producer surface
+// must not pre-judge for the operator):
+//   - ALL facts stay PLAIN — `text-foreground` / `text-muted-foreground` /
+//     `text-subtle-foreground` only, never warning / destructive / success
+//     accents. This INCLUDES tier-1 violations (a plain `(tier-1)` suffix,
+//     never a red alarm) and hit/miss outcomes (a rate is stated, not
+//     appraised);
+//   - the window aggregation is a PLAIN table of mechanical rates / counts.
+//     A chart was deliberately skipped (the table is the must, the chart is
+//     skippable) — it would risk severity coloring / "good-bad" framing on
+//     the operator's own judging surface, and it adds nothing the table
+//     does not already state;
+//   - NO "changed since you last looked" / unread / TL;DR / auto-summary —
+//     only what the wire carries is rendered.
+
+import { useCalibration } from "@/hooks/useCalibration";
+import type {
+  CalibrationCellWire,
+  CalibrationEntry,
+  CalibrationResponse,
+  Outcome,
+} from "@/lib/api";
+import { InventoryBackButton } from "./InventoryBackButton";
+
+// What R₁ hands R₂ on a "view calibration detail" click. A unit has ONE
+// calibration, so the selection carries only the unit name — there is no
+// per-row identity (the asymmetry with `SelectedPr` / `SelectedIssue`,
+// which carry a full ride-along item, is intentional: there is nothing to
+// ride along, the whole overview re-fetches off the unit).
+export interface SelectedCalibration {
+  unit: string;
+}
+
+// Symmetry helper with `selectedPrKey` / `selectedRecordKey` /
+// `selectedIssueKey`: the unit name IS the focus key (one calibration per
+// unit), so the R₁ affordance marks itself when this equals its unit.
+export function selectedCalibrationKey(unit: string): string {
+  return unit;
+}
+
+interface RCalibrationViewerProps {
+  selected: SelectedCalibration;
+  onClose: () => void;
+}
+
+export function RCalibrationViewer({ selected, onClose }: RCalibrationViewerProps) {
+  const { data, loading, error } = useCalibration(selected.unit);
+
+  // Focus mode: fills the R panel's single column (`flex-1`) at the
+  // operator's drag-set width — imposes no width of its own, so it never
+  // squeezes the centre conversation.
+  return (
+    <div data-testid="r-calibration-viewer" className="flex min-h-0 flex-1 flex-col">
+      <ViewerHeader unit={selected.unit} data={data} onClose={onClose} />
+      <div className="flex-1 space-y-4 overflow-y-auto px-4 py-3 text-xs">
+        {loading && <Loading />}
+        {error && <FetchError what="calibration" message={error.message} />}
+        {data !== null && (
+          <>
+            <CellsSection cells={data.cells} />
+            <EntriesSection title="Tier-1 violations" entries={data.tier1_violations} tierOne />
+            <EntriesSection title="Recent false-negatives" entries={data.recent_false_negatives} />
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ── Header — mechanical window facts, all plain (no severity tint) ──
+//
+// Identity (unit · calibration) renders immediately; the window facts
+// (days / totals / tier-1 routed) and the bootstrap caveat appear once the
+// fetch resolves. The caveat states a plain fact about sample size — "lean
+// toward asking the human" — not a verdict on the Producer.
+
+function ViewerHeader({
+  unit,
+  data,
+  onClose,
+}: {
+  unit: string;
+  data: CalibrationResponse | null;
+  onClose: () => void;
+}) {
+  return (
+    <header className="shrink-0 border-b border-hairline px-4 py-3">
+      <InventoryBackButton onClose={onClose} />
+      <div className="min-w-0">
+        <p className="text-[11px] uppercase tracking-wide text-subtle-foreground">
+          {unit} · calibration
+        </p>
+      </div>
+      {data !== null && (
+        <>
+          <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-subtle-foreground">
+            <span className="text-muted-foreground">last {data.days} days</span>
+            <span className="text-muted-foreground">{data.total_in_window} in window</span>
+            <span className="text-muted-foreground">{data.total_in_store} in store</span>
+            <span className="text-muted-foreground">{data.tier1_routed} tier-1 routed</span>
+          </div>
+          {data.total_in_window < data.bootstrap_threshold && (
+            <p className="mt-1 text-[11px] text-subtle-foreground">
+              Below the bootstrap threshold ({data.total_in_window} &lt; {data.bootstrap_threshold})
+              — lean toward asking the human.
+            </p>
+          )}
+        </>
+      )}
+    </header>
+  );
+}
+
+// ── Section frame + async states (plain, never a fabricated empty) ──
+//
+// Ported 1:1 from the sibling R₂ viewers so the four read identically.
+
+function SectionFrame({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <section>
+      <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-subtle-foreground">
+        {title}
+      </h3>
+      {children}
+    </section>
+  );
+}
+
+function Loading() {
+  return <p className="text-subtle-foreground">Loading…</p>;
+}
+
+function FetchError({ what, message }: { what: string; message: string }) {
+  return (
+    <p className="text-muted-foreground">
+      Failed to load {what}: {message}
+    </p>
+  );
+}
+
+// ── Window aggregation — plain table of mechanical rates / counts ──
+//
+// The `cells` list is the workbench's `(verdict, confidence)` aggregation
+// flattened for JSON. Rendered as a plain numeric table: hit-rate is a
+// stated quotient (`hits / n`), NOT a colored gauge — it states the rate,
+// it does not appraise it.
+
+function formatRate(hits: number, n: number): string {
+  if (n === 0) return "—";
+  return `${Math.round((hits / n) * 100)}%`;
+}
+
+function CellsSection({ cells }: { cells: CalibrationCellWire[] }) {
+  return (
+    <SectionFrame title="Window aggregation">
+      {cells.length === 0 ? (
+        <p className="text-subtle-foreground">No aggregation cells.</p>
+      ) : (
+        <table className="w-full border-collapse text-[11px]">
+          <thead>
+            <tr className="text-left text-subtle-foreground">
+              <th className="py-1 pr-3 font-medium">verdict</th>
+              <th className="py-1 pr-3 font-medium">confidence</th>
+              <th className="py-1 pr-3 text-right font-medium">n</th>
+              <th className="py-1 pr-3 text-right font-medium">hits</th>
+              <th className="py-1 pr-3 text-right font-medium">misses</th>
+              <th className="py-1 text-right font-medium">hit-rate</th>
+            </tr>
+          </thead>
+          <tbody>
+            {cells.map((c) => (
+              // `(verdict, confidence)` is the natural unique key — the wire
+              // is a flattened map, so the pair never repeats.
+              <tr
+                key={`${c.verdict}-${c.confidence}`}
+                className="border-t border-hairline-strong/30 text-foreground"
+              >
+                <td className="py-1 pr-3">{c.verdict}</td>
+                <td className="py-1 pr-3">{c.confidence}</td>
+                <td className="py-1 pr-3 text-right font-mono">{c.n}</td>
+                <td className="py-1 pr-3 text-right font-mono">{c.hits}</td>
+                <td className="py-1 pr-3 text-right font-mono">{c.misses}</td>
+                <td className="py-1 text-right font-mono">{formatRate(c.hits, c.n)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </SectionFrame>
+  );
+}
+
+// ── Calibration entries (tier-1 violations + false-negatives) ──
+//
+// Each entry renders full detail. Tier-1 violations carry a PLAIN
+// `(tier-1)` suffix — a routing fact, never a red alarm. The outcome (if
+// the world has produced one) is stated plainly; a fresh entry says so.
+
+function EntriesSection({
+  title,
+  entries,
+  tierOne,
+}: {
+  title: string;
+  entries: CalibrationEntry[];
+  tierOne?: boolean;
+}) {
+  return (
+    <SectionFrame title={`${title} (${entries.length})`}>
+      {entries.length === 0 ? (
+        <p className="text-subtle-foreground">None.</p>
+      ) : (
+        <ul className="space-y-2">
+          {entries.map((e, idx) => (
+            <EntryItem
+              // `CalibrationEntry` has no id field; `(recorded_at, note_source)`
+              // can collide when one synthesis pass routes multiple verdicts
+              // off the same note. Compose with idx to disambiguate — safe on
+              // these leaf, stateless presentational <li>s (mirrors
+              // `RCalibrationSection`'s key).
+              // biome-ignore lint/suspicious/noArrayIndexKey: index disambiguates a composite natural key, not the sole key.
+              key={`${e.recorded_at}-${e.note_source}-${idx}`}
+              entry={e}
+              tierOne={tierOne}
+            />
+          ))}
+        </ul>
+      )}
+    </SectionFrame>
+  );
+}
+
+function EntryItem({ entry, tierOne }: { entry: CalibrationEntry; tierOne?: boolean }) {
+  return (
+    <li className="rounded border border-hairline-strong/40 bg-surface-strong/20 px-2 py-1.5">
+      <div className="flex flex-wrap items-baseline gap-x-2 text-[11px]">
+        <span className="font-mono text-subtle-foreground">{entry.recorded_at}</span>
+        <span className="text-foreground">{entry.note_source}</span>
+        {tierOne && <span className="text-subtle-foreground">(tier-1)</span>}
+      </div>
+      <div className="mt-1 text-[11px] text-subtle-foreground">
+        verdict {entry.verdict} · confidence {entry.confidence} · tier {entry.tier_routed}
+      </div>
+      <p className="mt-1 text-muted-foreground">{entry.rationale}</p>
+      <div className="mt-1 flex flex-wrap items-baseline gap-x-2 text-[11px] text-subtle-foreground">
+        <span>outcome {outcomeLabel(entry.outcome ?? null)}</span>
+        <span className="font-mono">pass {entry.synthesis_pass_id}</span>
+      </div>
+    </li>
+  );
+}
+
+// The objective outcome is a discriminated union (or absent). Rendered as a
+// plain factual string — no hit/miss coloring, no "good/bad" framing.
+function outcomeLabel(outcome: Outcome | null): string {
+  if (outcome === null) return "none observed yet";
+  switch (outcome.kind) {
+    case "revert_commit":
+      return `revert ${outcome.commit_sha} (${outcome.date})`;
+    case "hotfix_commit":
+      return `hotfix ${outcome.commit_sha} (${outcome.date})`;
+    case "ci_fail_fix":
+      return `ci-fail-fix PR #${outcome.failing_pr} → #${outcome.fix_pr}`;
+  }
+}

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RCalibrationViewer.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RCalibrationViewer.test.tsx
@@ -1,0 +1,225 @@
+// @vitest-environment jsdom
+//
+// RCalibrationViewer — the R₂ in-tmai Calibration overview viewer
+// (per-unit, read-only). The polling `useCalibration` hook is mocked with
+// SYNTHETIC fixtures so this test never touches real/live calibration data
+// (calibration is the operator's judge-of-the-Producer surface — built and
+// tested entirely from hand-made `CalibrationResponse` objects).
+//
+// It proves: header window facts render (unit / days / totals / tier-1
+// routed); the bootstrap caveat shows only when under threshold; the
+// `cells` aggregation renders as a plain table (counts + hit-rate);
+// tier-1 violations + recent false-negatives render with full per-entry
+// detail (note_source / verdict / confidence / tier_routed / rationale /
+// recorded_at / outcome); NO severity classes appear anywhere (the
+// load-bearing plain-everything rule — no red alarm even on tier-1); the
+// viewer fills the R region (no `w-[` clamp, has `flex-1`); and the
+// ‹ Inventory back affordance calls `onClose`.
+
+import { render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+// Type-only import from the mocked hook module — erased at runtime, so it
+// does not collide with the `vi.mock` factory below.
+import type { UseCalibrationResult } from "@/hooks/useCalibration";
+import type { CalibrationEntry, CalibrationResponse } from "@/lib/api";
+
+const useCalibrationMock = vi.fn();
+
+vi.mock("@/hooks/useCalibration", () => ({
+  useCalibration: (...a: unknown[]) => useCalibrationMock(...a),
+}));
+
+import { RCalibrationViewer, type SelectedCalibration } from "../RCalibrationViewer";
+
+// ── synthetic fixtures (NO real calibration data) ──
+
+function entry(overrides: Partial<CalibrationEntry> = {}): CalibrationEntry {
+  return {
+    synthesis_pass_id: "pass-0001",
+    note_source: "20260513-1500-baz.md",
+    verdict: "absorb",
+    confidence: "low",
+    tier_routed: 2,
+    rationale: "looked like a one-off nit, not a contract change",
+    recorded_at: "2026-05-13T15:00:00Z",
+    outcome: null,
+    ...overrides,
+  };
+}
+
+function response(overrides: Partial<CalibrationResponse> = {}): CalibrationResponse {
+  return {
+    unit: "tmai",
+    days: 90,
+    total_in_store: 42,
+    total_in_window: 30,
+    bootstrap_threshold: 10,
+    cells: [
+      { verdict: "absorb", confidence: "low", n: 8, hits: 6, misses: 2 },
+      { verdict: "escalate", confidence: "high", n: 4, hits: 4, misses: 0 },
+    ],
+    tier1_routed: 2,
+    tier1_violations: [
+      entry({
+        synthesis_pass_id: "pass-tier1",
+        note_source: "20260512-0900-tripwire.md",
+        verdict: "escalate",
+        confidence: "high",
+        tier_routed: 1,
+        rationale: "named a contract surface — human gate",
+        recorded_at: "2026-05-12T09:00:00Z",
+        outcome: { kind: "revert_commit", commit_sha: "deadbeef", date: "2026-05-14" },
+      }),
+    ],
+    recent_false_negatives: [
+      entry({
+        synthesis_pass_id: "pass-fn",
+        note_source: "20260511-1200-missed.md",
+        verdict: "absorb",
+        confidence: "low",
+        tier_routed: 2,
+        rationale: "absorbed but the world later disagreed",
+        recorded_at: "2026-05-11T12:00:00Z",
+        outcome: { kind: "ci_fail_fix", failing_pr: 700, fix_pr: 701 },
+      }),
+    ],
+    ...overrides,
+  };
+}
+
+function result(overrides: Partial<UseCalibrationResult> = {}): UseCalibrationResult {
+  return { data: response(), loading: false, error: null, ...overrides };
+}
+
+const selected: SelectedCalibration = { unit: "tmai" };
+
+beforeEach(() => {
+  useCalibrationMock.mockReset();
+  useCalibrationMock.mockReturnValue(result());
+});
+
+describe("RCalibrationViewer", () => {
+  it("fetches calibration for exactly the selected unit (selection-driven)", () => {
+    render(<RCalibrationViewer selected={selected} onClose={vi.fn()} />);
+    expect(useCalibrationMock).toHaveBeenCalledWith("tmai");
+  });
+
+  it("renders header window facts (unit / days / totals / tier-1 routed)", () => {
+    render(<RCalibrationViewer selected={selected} onClose={vi.fn()} />);
+    expect(screen.getByText(/tmai · calibration/)).toBeTruthy();
+    expect(screen.getByText(/last 90 days/)).toBeTruthy();
+    expect(screen.getByText(/30 in window/)).toBeTruthy();
+    expect(screen.getByText(/42 in store/)).toBeTruthy();
+    expect(screen.getByText(/2 tier-1 routed/)).toBeTruthy();
+  });
+
+  it("shows the bootstrap caveat only when total_in_window < bootstrap_threshold", () => {
+    useCalibrationMock.mockReturnValue(
+      result({ data: response({ total_in_window: 4, bootstrap_threshold: 10 }) }),
+    );
+    const { rerender } = render(<RCalibrationViewer selected={selected} onClose={vi.fn()} />);
+    expect(screen.getByText(/lean toward asking the human/)).toBeTruthy();
+
+    // At/over threshold the caveat is absent.
+    useCalibrationMock.mockReturnValue(
+      result({ data: response({ total_in_window: 30, bootstrap_threshold: 10 }) }),
+    );
+    rerender(<RCalibrationViewer selected={selected} onClose={vi.fn()} />);
+    expect(screen.queryByText(/lean toward asking the human/)).toBeNull();
+  });
+
+  it("renders the cells aggregation as a plain table (counts + hit-rate)", () => {
+    const { container } = render(<RCalibrationViewer selected={selected} onClose={vi.fn()} />);
+    const table = container.querySelector("table");
+    expect(table).not.toBeNull();
+    const text = table?.textContent ?? "";
+    // Column headers + numeric cells.
+    expect(text).toMatch(/verdict/);
+    expect(text).toMatch(/hit-rate/);
+    // 6/8 → 75%, 4/4 → 100% (mechanical rates, no appraisal).
+    expect(text).toMatch(/75%/);
+    expect(text).toMatch(/100%/);
+  });
+
+  it("renders tier-1 violations with full per-entry detail and a plain (tier-1) suffix", () => {
+    render(<RCalibrationViewer selected={selected} onClose={vi.fn()} />);
+    expect(screen.getByText("20260512-0900-tripwire.md")).toBeTruthy();
+    expect(screen.getByText(/named a contract surface/)).toBeTruthy();
+    expect(screen.getByText("(tier-1)")).toBeTruthy();
+    // verdict / confidence / tier_routed line.
+    expect(screen.getByText(/verdict escalate · confidence high · tier 1/)).toBeTruthy();
+    // outcome + synthesis_pass_id facts.
+    expect(screen.getByText(/revert deadbeef \(2026-05-14\)/)).toBeTruthy();
+    expect(screen.getByText(/pass pass-tier1/)).toBeTruthy();
+  });
+
+  it("renders recent false-negatives with full per-entry detail", () => {
+    render(<RCalibrationViewer selected={selected} onClose={vi.fn()} />);
+    expect(screen.getByText("20260511-1200-missed.md")).toBeTruthy();
+    expect(screen.getByText(/absorbed but the world later disagreed/)).toBeTruthy();
+    expect(screen.getByText(/ci-fail-fix PR #700 → #701/)).toBeTruthy();
+  });
+
+  it("renders 'none observed yet' for an entry with a null outcome", () => {
+    useCalibrationMock.mockReturnValue(
+      result({
+        data: response({
+          tier1_violations: [],
+          recent_false_negatives: [entry({ outcome: null })],
+        }),
+      }),
+    );
+    render(<RCalibrationViewer selected={selected} onClose={vi.fn()} />);
+    expect(screen.getByText(/outcome none observed yet/)).toBeTruthy();
+  });
+
+  it("shows plain empty states (no aggregation cells / no entries)", () => {
+    useCalibrationMock.mockReturnValue(
+      result({
+        data: response({ cells: [], tier1_violations: [], recent_false_negatives: [] }),
+      }),
+    );
+    render(<RCalibrationViewer selected={selected} onClose={vi.fn()} />);
+    expect(screen.getByText("No aggregation cells.")).toBeTruthy();
+    // Both entry sections show their plain "None." empty state.
+    const tier1 = screen.getByText(/Tier-1 violations \(0\)/).closest("section");
+    expect(tier1).not.toBeNull();
+    expect(within(tier1 as HTMLElement).getByText("None.")).toBeTruthy();
+  });
+
+  it("uses NO severity-color classes anywhere (plain-everything — no red even on tier-1)", () => {
+    const { container } = render(<RCalibrationViewer selected={selected} onClose={vi.fn()} />);
+    const html = container.innerHTML;
+    expect(html).not.toMatch(/text-(warning|destructive|success)/);
+  });
+
+  it("fills the R region — no fixed clamp width, carries flex-1 (focus mode rides the R column)", () => {
+    const { container } = render(<RCalibrationViewer selected={selected} onClose={vi.fn()} />);
+    const root = container.querySelector('[data-testid="r-calibration-viewer"]');
+    expect(root).not.toBeNull();
+    expect(root?.className ?? "").not.toMatch(/w-\[/);
+    expect(root?.className ?? "").toMatch(/flex-1/);
+  });
+
+  it("returns to the inventory via the ‹ Inventory back affordance (clears the focus)", () => {
+    const onClose = vi.fn();
+    render(<RCalibrationViewer selected={selected} onClose={onClose} />);
+    screen.getByRole("button", { name: /Back to inventory/ }).click();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the loading and error states plainly", () => {
+    useCalibrationMock.mockReturnValue(result({ data: null, loading: true }));
+    const { rerender, container } = render(
+      <RCalibrationViewer selected={selected} onClose={vi.fn()} />,
+    );
+    expect(screen.getByText("Loading…")).toBeTruthy();
+
+    useCalibrationMock.mockReturnValue(
+      result({ data: null, loading: false, error: new Error("boom") }),
+    );
+    rerender(<RCalibrationViewer selected={selected} onClose={vi.fn()} />);
+    expect(screen.getByText(/Failed to load calibration: boom/)).toBeTruthy();
+    expect(container.innerHTML).not.toMatch(/text-(warning|destructive|success)/);
+  });
+});

--- a/clients/react/src/hooks/__tests__/useFocusedArtifact.test.ts
+++ b/clients/react/src/hooks/__tests__/useFocusedArtifact.test.ts
@@ -1,12 +1,13 @@
 // @vitest-environment jsdom
 //
 // useFocusedArtifact — the R₂ "exactly one focused artifact" invariant.
-// Focusing any one of a PR / record / issue clears the other two, so the
-// PR viewer, the record viewer, and the issue viewer are never both/all
-// mounted.
+// Focusing any one of a PR / record / issue / calibration clears the other
+// three, so the PR viewer, the record viewer, the issue viewer, and the
+// calibration viewer are never both/all mounted.
 
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import type { SelectedCalibration } from "@/components/producer-console/r-panel/r-viewer/RCalibrationViewer";
 import type { SelectedIssue } from "@/components/producer-console/r-panel/r-viewer/RIssueViewer";
 import type { SelectedPr } from "@/components/producer-console/r-panel/r-viewer/RPrViewer";
 import type { SelectedRecord } from "@/components/producer-console/r-panel/r-viewer/RRecordViewer";
@@ -74,12 +75,17 @@ function issueSelection(): SelectedIssue {
   };
 }
 
+function calibrationSelection(): SelectedCalibration {
+  return { unit: "u" };
+}
+
 describe("useFocusedArtifact", () => {
   it("starts with nothing focused", () => {
     const { result } = renderHook(() => useFocusedArtifact());
     expect(result.current.selectedPr).toBeNull();
     expect(result.current.selectedRecord).toBeNull();
     expect(result.current.selectedIssue).toBeNull();
+    expect(result.current.selectedCalibration).toBeNull();
   });
 
   it("selecting a record clears a selected PR (exactly one focus)", () => {
@@ -135,7 +141,39 @@ describe("useFocusedArtifact", () => {
     expect(result.current.selectedIssue).toBeNull();
   });
 
-  it("clearPr / clearRecord / clearIssue clear only their own kind", () => {
+  it("selecting calibration clears a PR, record, AND issue (exactly one focus across four)", () => {
+    const { result } = renderHook(() => useFocusedArtifact());
+
+    act(() => result.current.selectPr(prSelection()));
+    act(() => result.current.selectRecord(recordSelection()));
+    act(() => result.current.selectIssue(issueSelection()));
+    act(() => result.current.selectCalibration(calibrationSelection()));
+    expect(result.current.selectedCalibration).not.toBeNull();
+    expect(result.current.selectedPr).toBeNull();
+    expect(result.current.selectedRecord).toBeNull();
+    expect(result.current.selectedIssue).toBeNull();
+  });
+
+  it("selecting a PR / record / issue each clears a selected calibration (the reverse direction)", () => {
+    const { result } = renderHook(() => useFocusedArtifact());
+
+    act(() => result.current.selectCalibration(calibrationSelection()));
+    act(() => result.current.selectPr(prSelection()));
+    expect(result.current.selectedPr).not.toBeNull();
+    expect(result.current.selectedCalibration).toBeNull();
+
+    act(() => result.current.selectCalibration(calibrationSelection()));
+    act(() => result.current.selectRecord(recordSelection()));
+    expect(result.current.selectedRecord).not.toBeNull();
+    expect(result.current.selectedCalibration).toBeNull();
+
+    act(() => result.current.selectCalibration(calibrationSelection()));
+    act(() => result.current.selectIssue(issueSelection()));
+    expect(result.current.selectedIssue).not.toBeNull();
+    expect(result.current.selectedCalibration).toBeNull();
+  });
+
+  it("clearPr / clearRecord / clearIssue / clearCalibration clear only their own kind", () => {
     const { result } = renderHook(() => useFocusedArtifact());
 
     act(() => result.current.selectPr(prSelection()));
@@ -149,15 +187,20 @@ describe("useFocusedArtifact", () => {
     act(() => result.current.selectIssue(issueSelection()));
     act(() => result.current.clearIssue());
     expect(result.current.selectedIssue).toBeNull();
+
+    act(() => result.current.selectCalibration(calibrationSelection()));
+    act(() => result.current.clearCalibration());
+    expect(result.current.selectedCalibration).toBeNull();
   });
 
-  it("clearAll clears all three (used on a unit change)", () => {
+  it("clearAll clears all four (used on a unit change)", () => {
     const { result } = renderHook(() => useFocusedArtifact());
 
-    act(() => result.current.selectIssue(issueSelection()));
+    act(() => result.current.selectCalibration(calibrationSelection()));
     act(() => result.current.clearAll());
     expect(result.current.selectedPr).toBeNull();
     expect(result.current.selectedRecord).toBeNull();
     expect(result.current.selectedIssue).toBeNull();
+    expect(result.current.selectedCalibration).toBeNull();
   });
 });

--- a/clients/react/src/hooks/useFocusedArtifact.ts
+++ b/clients/react/src/hooks/useFocusedArtifact.ts
@@ -1,14 +1,16 @@
 // R₂ focus state — exactly ONE focused artifact at a time.
 //
 // The R₂ column (`doc/approaches/2026-05-29-artifact-content-viewer.md`)
-// hosts a single focused artifact: a PR, a record (decision/approach), or
-// an issue. Focusing one kind clears the other two, so the PR viewer
-// (`RPrViewer`), the record viewer (`RRecordViewer`), and the issue
-// viewer (`RIssueViewer`) are never both/all mounted. The invariant lives
-// here — in one small testable hook — rather than spread across App's
-// render, so "exactly-one-focus" is provable in isolation.
+// hosts a single focused artifact: a PR, a record (decision/approach), an
+// issue, or the unit's calibration. Focusing one kind clears the other
+// three, so the PR viewer (`RPrViewer`), the record viewer
+// (`RRecordViewer`), the issue viewer (`RIssueViewer`), and the
+// calibration viewer (`RCalibrationViewer`) are never both/all mounted. The
+// invariant lives here — in one small testable hook — rather than spread
+// across App's render, so "exactly-one-focus" is provable in isolation.
 
 import { useCallback, useState } from "react";
+import type { SelectedCalibration } from "@/components/producer-console/r-panel/r-viewer/RCalibrationViewer";
 import type { SelectedIssue } from "@/components/producer-console/r-panel/r-viewer/RIssueViewer";
 import type { SelectedPr } from "@/components/producer-console/r-panel/r-viewer/RPrViewer";
 import type { SelectedRecord } from "@/components/producer-console/r-panel/r-viewer/RRecordViewer";
@@ -17,16 +19,20 @@ export interface FocusedArtifact {
   selectedPr: SelectedPr | null;
   selectedRecord: SelectedRecord | null;
   selectedIssue: SelectedIssue | null;
-  /** Focus a PR in R₂; clears any focused record + issue. */
+  selectedCalibration: SelectedCalibration | null;
+  /** Focus a PR in R₂; clears any focused record + issue + calibration. */
   selectPr: (sel: SelectedPr) => void;
-  /** Focus a decision/approach in R₂; clears any focused PR + issue. */
+  /** Focus a decision/approach in R₂; clears any focused PR + issue + calibration. */
   selectRecord: (sel: SelectedRecord) => void;
-  /** Focus an issue in R₂; clears any focused PR + record. */
+  /** Focus an issue in R₂; clears any focused PR + record + calibration. */
   selectIssue: (sel: SelectedIssue) => void;
+  /** Focus the unit's calibration in R₂; clears any focused PR + record + issue. */
+  selectCalibration: (sel: SelectedCalibration) => void;
   clearPr: () => void;
   clearRecord: () => void;
   clearIssue: () => void;
-  /** Clear all three — used on a unit change, where the previous unit's
+  clearCalibration: () => void;
+  /** Clear all four — used on a unit change, where the previous unit's
    *  artifact must not linger under a new unit's inventory. */
   clearAll: () => void;
 }
@@ -35,41 +41,56 @@ export function useFocusedArtifact(): FocusedArtifact {
   const [selectedPr, setSelectedPr] = useState<SelectedPr | null>(null);
   const [selectedRecord, setSelectedRecord] = useState<SelectedRecord | null>(null);
   const [selectedIssue, setSelectedIssue] = useState<SelectedIssue | null>(null);
+  const [selectedCalibration, setSelectedCalibration] = useState<SelectedCalibration | null>(null);
 
   const selectPr = useCallback((sel: SelectedPr) => {
     setSelectedRecord(null);
     setSelectedIssue(null);
+    setSelectedCalibration(null);
     setSelectedPr(sel);
   }, []);
   const selectRecord = useCallback((sel: SelectedRecord) => {
     setSelectedPr(null);
     setSelectedIssue(null);
+    setSelectedCalibration(null);
     setSelectedRecord(sel);
   }, []);
   const selectIssue = useCallback((sel: SelectedIssue) => {
     setSelectedPr(null);
     setSelectedRecord(null);
+    setSelectedCalibration(null);
     setSelectedIssue(sel);
+  }, []);
+  const selectCalibration = useCallback((sel: SelectedCalibration) => {
+    setSelectedPr(null);
+    setSelectedRecord(null);
+    setSelectedIssue(null);
+    setSelectedCalibration(sel);
   }, []);
   const clearPr = useCallback(() => setSelectedPr(null), []);
   const clearRecord = useCallback(() => setSelectedRecord(null), []);
   const clearIssue = useCallback(() => setSelectedIssue(null), []);
+  const clearCalibration = useCallback(() => setSelectedCalibration(null), []);
   const clearAll = useCallback(() => {
     setSelectedPr(null);
     setSelectedRecord(null);
     setSelectedIssue(null);
+    setSelectedCalibration(null);
   }, []);
 
   return {
     selectedPr,
     selectedRecord,
     selectedIssue,
+    selectedCalibration,
     selectPr,
     selectRecord,
     selectIssue,
+    selectCalibration,
     clearPr,
     clearRecord,
     clearIssue,
+    clearCalibration,
     clearAll,
   };
 }


### PR DESCRIPTION
## What

Adds the **4th R₂ focus kind**: the per-unit **Calibration overview viewer** (`RCalibrationViewer`), mirroring the three landed R₂ viewers (`RPrViewer` / `RRecordViewer` / `RIssueViewer`) + focus-mode pattern exactly.

The **exactly-one-R₂-focus** invariant now spans **pr / record / issue / calibration**. `useFocusedArtifact` gains `selectedCalibration` + `selectCalibration` / `clearCalibration`; selecting any of the other three also clears calibration, and `clearAll` clears all four. App composes the calibration case into its single `rViewer` node.

Serves spine `2026-05-29-c-and-r-as-the-development-substrate` (the "📊 Calibration" per-kind walk) + `2026-05-29-artifact-content-viewer` (γ-lean R₂ viewer).

## Meta-artifact — built from fixtures

Calibration is a **META-ARTIFACT**: it is how the **operator judges the Producer's** triage hit-rate. The viewer is purely presentational over whatever `useCalibration(unit)` returns at runtime, and is built + tested **entirely from synthetic `CalibrationResponse` / `CalibrationEntry` fixtures** — nothing reads real/live calibration data at build time.

## Read-only — actions deferred

The (iii) lifecycle acts need endpoints that do not exist server-side and are explicitly deferred: **no `[tier-1 acknowledge]`** and **no `[→Producer brief]`** button. The viewer mutates nothing.

## Plain-everything negative space (load-bearing here)

`2026-05-26-tmai-states-facts-not-appraisals` is especially load-bearing for a judge-of-the-Producer surface — tmai must not pre-judge for the operator:
- **all** facts plain — `text-foreground` / `text-muted-foreground` / `text-subtle-foreground` only, **NO** warning / destructive / success accents anywhere, **including tier-1 violations** (a plain `(tier-1)` suffix, never a red alarm) and hit/miss outcomes;
- the window aggregation is a **plain numeric table** of mechanical rates / counts (hit-rate is a stated quotient, not a colored gauge). The optional inline chart was **deliberately skipped** — it would risk severity coloring / "good-bad" framing on the operator's own judging surface and adds nothing the table doesn't already state;
- viewer mounts **only on explicit operator action** (a single "View calibration detail ›" affordance on the R₁ section — a unit has exactly ONE calibration, so it's section-level, not a per-row select); no auto-open, no unread / "changed since" / TL;DR / auto-summary.

No `any`, no `types/generated/**` hand-edits — `clients/react/` only.

## Tests

- `RCalibrationViewer.test.tsx` (synthetic fixtures, mocked `useCalibration`): header facts (unit/days/totals/bootstrap caveat under threshold); cells aggregation table (counts + hit-rate); tier-1 violations + false-negatives with full per-entry detail; NO severity classes anywhere; fills the region (no `w-[` clamp, has `flex-1`); ‹ Inventory back affordance calls `onClose`.
- `useFocusedArtifact.test.ts`: the exactly-one-focus invariant across all four kinds (both directions + per-kind clears + `clearAll`).
- `RCalibrationSection.test.tsx`: the detail affordance calls `onSelectCalibration` with `{ unit }`, marks `aria-current` when focused, and is omitted when no handler is wired.

## Gate

From `clients/react/`: `pnpm install` / `pnpm lint` / `pnpm build` / `pnpm test` — all green (604 passed, 2 pre-existing skips; 27 in the new/updated files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ユニットのキャリブレーション詳細をビューアーで確認できるようになりました
  * R パネルでキャリブレーション選択の操作に対応しました
  * フォーカス対象として PR・レコード・イシューに加えてキャリブレーションが選択可能になりました（同時に 1 つだけ選択可）

<!-- end of auto-generated comment: release notes by coderabbit.ai -->