### PR TITLE
feat(r-panel): R₂ Hand-over viewer + wire R₁ to the #473 handoffs endpoint (read-only, focus-mode)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -18,6 +18,10 @@ import {
   selectedCalibrationKey,
 } from "@/components/producer-console/r-panel/r-viewer/RCalibrationViewer";
 import {
+  RHandoverViewer,
+  selectedHandoffKey,
+} from "@/components/producer-console/r-panel/r-viewer/RHandoverViewer";
+import {
   RIssueViewer,
   selectedIssueKey,
 } from "@/components/producer-console/r-panel/r-viewer/RIssueViewer";
@@ -132,9 +136,10 @@ export function App() {
   // at the seams. See the rPanel*Width helpers above.
   const [rPanelWidth, setRPanelWidth] = useUIPref("attentionStripWidth");
   // The artifact in focus in R₂. R₂ hosts exactly ONE focused artifact at
-  // a time — a PR (#749), a record (decision/approach), an issue, or the
-  // unit's calibration — so focusing one kind clears the others (the
-  // invariant lives in `useFocusedArtifact`). All null = no viewer (it
+  // a time — a PR (#749), a record (decision/approach), an issue, the
+  // unit's calibration, or a hand-over baton — so focusing one kind clears
+  // the others (the invariant lives in `useFocusedArtifact`). All null = no
+  // viewer (it
   // never auto-opens — the operator clicks a row in the R₁ inventory to
   // select; viewer-approach negative space). Lives at App level because
   // focus mode (spine
@@ -147,14 +152,17 @@ export function App() {
     selectedRecord,
     selectedIssue,
     selectedCalibration,
+    selectedHandoff,
     selectPr,
     selectRecord,
     selectIssue,
     selectCalibration,
+    selectHandoff,
     clearPr,
     clearRecord,
     clearIssue,
     clearCalibration,
+    clearHandoff,
     clearAll: clearFocusedArtifact,
   } = useFocusedArtifact();
   const showSettings = mainPanel === "settings";
@@ -215,8 +223,9 @@ export function App() {
   const { data: producerFeedData } = useProducerFeed(unitName);
 
   // Close the R₂ viewer when the focused unit changes — its open artifact
-  // (PR, record, or issue) belongs to the previous unit, so it must not
-  // linger under a new unit's inventory (mirrors useUnitPrs clearing its
+  // (PR, record, issue, calibration, or hand-over baton) belongs to the
+  // previous unit, so it must not linger under a new unit's inventory
+  // (mirrors useUnitPrs clearing its
   // list on unit change). unitName is the intended trigger even though the
   // body only clears state.
   // biome-ignore lint/correctness/useExhaustiveDependencies: intentional unit-change trigger
@@ -601,7 +610,7 @@ export function App() {
   );
 
   // Focus-mode viewer node (spine `2026-05-29-c-and-r-as-the-development-
-  // substrate`). At most one of the four is non-null (`useFocusedArtifact`
+  // substrate`). At most one of the five is non-null (`useFocusedArtifact`
   // keeps them mutually exclusive), so this resolves to a single viewer or
   // null. It is handed to RPanel as `viewer`, where it REPLACES the R₁
   // inventory body in the same column — opening/closing it never changes
@@ -620,6 +629,8 @@ export function App() {
     <RIssueViewer selected={selectedIssue} onClose={clearIssue} />
   ) : selectedCalibration ? (
     <RCalibrationViewer selected={selectedCalibration} onClose={clearCalibration} />
+  ) : selectedHandoff ? (
+    <RHandoverViewer selected={selectedHandoff} onClose={clearHandoff} />
   ) : null;
 
   return (
@@ -884,6 +895,10 @@ export function App() {
           onSelectCalibration={selectCalibration}
           selectedCalibrationKey={
             selectedCalibration ? selectedCalibrationKey(selectedCalibration.unit) : null
+          }
+          onSelectHandoff={selectHandoff}
+          selectedHandoffKey={
+            selectedHandoff ? selectedHandoffKey(selectedHandoff.unit, selectedHandoff.name) : null
           }
           viewer={rViewer}
         />

--- a/clients/react/src/components/producer-console/r-panel/RHandoverSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RHandoverSection.tsx
@@ -1,51 +1,143 @@
-// 📜 Hand-over — R panel's hand-over archive surface.
+// 📜 Hand-over — R panel's hand-over baton inventory (R₁).
 //
-// The approach (`doc/approaches/2026-05-29-r-panel-as-project-artifact-
-// inventory.md`) calls for `~/.tmai/handoffs/<unit>/` archive listing
-// plus the most-recent baseline content. No wire exposes that
-// directory yet; honest-degradation posture
-// (`doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md`)
-// says we surface the gap with a TODO marker rather than fabricate
-// or hide the section. The header (with `(0)` count) is the
-// architecturally-present surface; the body explains why no items
-// are available yet and which wire would populate it.
+// Wired to the operator-side handoffs endpoint (tmai-core PR #473) via
+// `useHandoffs(unit)`. Renders the unit's baton list in the wire order —
+// the active baton first, then archived batons newest-first. Each row is a
+// plain select: name, `active`/`archived` marker, `composed_at`, `task`
+// (when present). A row click opens the baton in the R₂ viewer column
+// (`RHandoverViewer`), mirroring `RPrsSection` / `RIssuesSection`'s
+// `onSelect*` / `selectedKey` / `aria-current` posture exactly. R₁ stays a
+// pure inventory; the row is just a select.
+//
+// Honest-degradation (`doc/decisions/2026-05-14-webui-simulated-onboarded-
+// posture.md`): the `unit === null` and empty states say so plainly ("No
+// hand-overs.") rather than fabricate a list. All facts plain — no severity
+// accents (`doc/decisions/2026-05-26-tmai-states-facts-not-appraisals.md`).
 
+import { useHandoffs } from "@/hooks/useHandoffs";
+import type { HandoffEntryWire } from "@/lib/api";
+import { type SelectedHandoff, selectedHandoffKey } from "./r-viewer/RHandoverViewer";
 import { Section } from "./Section";
 
 interface RHandoverSectionProps {
   unitName: string | null;
   expanded: boolean;
   onToggle: () => void;
+  /** Open a baton in the R₂ viewer column. Optional so the section still
+   *  renders standalone (e.g. in isolation tests). */
+  onSelectHandoff?: (sel: SelectedHandoff) => void;
+  /** `selectedHandoffKey(unit, name)` of the baton currently open in R₂, so
+   *  the row marks itself as the one being viewed (a mechanical "open here"
+   *  fact, not appraisal). */
+  selectedKey?: string | null;
 }
 
-export function RHandoverSection({ unitName, expanded, onToggle }: RHandoverSectionProps) {
+export function RHandoverSection({
+  unitName,
+  expanded,
+  onToggle,
+  onSelectHandoff,
+  selectedKey,
+}: RHandoverSectionProps) {
+  const { data, loading, error } = useHandoffs(unitName);
+  const handoffs = data?.handoffs ?? null;
+
   return (
     <Section
       id="handover"
       glyph="📜"
       label="Hand-over"
-      count="0"
+      count={`${handoffs?.length ?? 0}`}
       expanded={expanded}
       onToggle={onToggle}
     >
-      <Body unitName={unitName} />
+      <Body
+        unitName={unitName}
+        items={handoffs}
+        loading={loading}
+        error={error}
+        onSelectHandoff={onSelectHandoff}
+        selectedKey={selectedKey ?? null}
+      />
     </Section>
   );
 }
 
-function Body({ unitName }: { unitName: string | null }) {
+interface BodyProps {
+  unitName: string | null;
+  items: HandoffEntryWire[] | null;
+  loading: boolean;
+  error: Error | null;
+  onSelectHandoff?: (sel: SelectedHandoff) => void;
+  selectedKey: string | null;
+}
+
+function Body({ unitName, items, loading, error, onSelectHandoff, selectedKey }: BodyProps) {
   if (unitName === null) {
     return <p className="text-subtle-foreground">Pick a project to see hand-overs.</p>;
   }
+  if (error !== null) {
+    return <p className="text-muted-foreground">Failed to load hand-overs: {error.message}</p>;
+  }
+  if (items === null && loading) {
+    return <p className="text-subtle-foreground">Loading…</p>;
+  }
+  if (items === null || items.length === 0) {
+    return <p className="text-subtle-foreground">No hand-overs.</p>;
+  }
   return (
-    <div className="space-y-1">
-      <p className="text-subtle-foreground">
-        Hand-over archive at <code className="text-foreground">~/.tmai/handoffs/{unitName}/</code>.
-      </p>
-      <p className="text-subtle-foreground">
-        TODO(tmai-core: handoff archive wire) — archive enumeration + baseline content not yet
-        surfaced over HTTP. Open the directory directly until the wire lands.
-      </p>
-    </div>
+    <ul className="space-y-1">
+      {items.map((h) => (
+        <HandoffRow
+          // The baton name is unique within a unit (the sentinel "active"
+          // plus per-timestamp archive filenames) — a stable key.
+          key={h.name}
+          unit={unitName}
+          entry={h}
+          onSelectHandoff={onSelectHandoff}
+          selected={selectedKey === selectedHandoffKey(unitName, h.name)}
+        />
+      ))}
+    </ul>
+  );
+}
+
+function HandoffRow({
+  unit,
+  entry,
+  onSelectHandoff,
+  selected,
+}: {
+  unit: string;
+  entry: HandoffEntryWire;
+  onSelectHandoff?: (sel: SelectedHandoff) => void;
+  selected: boolean;
+}) {
+  // The whole row is a button that opens the baton in the R₂ viewer.
+  // `aria-current` marks the row whose content is currently open in R₂ (a
+  // mechanical "open here" fact, not appraisal).
+  return (
+    <li className="leading-snug">
+      <button
+        type="button"
+        onClick={() => onSelectHandoff?.({ unit, name: entry.name })}
+        aria-current={selected ? "true" : undefined}
+        className={`w-full rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
+          selected ? "bg-surface-strong/40" : ""
+        }`}
+      >
+        <span className="flex flex-wrap items-baseline gap-x-2">
+          <span className="break-all font-mono text-foreground">{entry.name}</span>
+          <span className="text-[11px] text-subtle-foreground">{entry.status}</span>
+        </span>
+        {(entry.composed_at !== null || entry.task !== null) && (
+          <div className="text-[11px] text-subtle-foreground">
+            {entry.composed_at !== null && <span>composed {entry.composed_at}</span>}
+            {entry.composed_at !== null && entry.task !== null && " · "}
+            {entry.task !== null && <span>{entry.task}</span>}
+          </div>
+        )}
+      </button>
+    </li>
   );
 }

--- a/clients/react/src/components/producer-console/r-panel/RPanel.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPanel.tsx
@@ -37,6 +37,7 @@ import { RHandoverSection } from "./RHandoverSection";
 import { RIssuesSection } from "./RIssuesSection";
 import { RPrsSection } from "./RPrsSection";
 import type { SelectedCalibration } from "./r-viewer/RCalibrationViewer";
+import type { SelectedHandoff } from "./r-viewer/RHandoverViewer";
 import type { SelectedIssue } from "./r-viewer/RIssueViewer";
 import type { SelectedPr } from "./r-viewer/RPrViewer";
 import type { SelectedRecord } from "./r-viewer/RRecordViewer";
@@ -89,6 +90,13 @@ interface RPanelProps {
   /** `selectedCalibrationKey(unit)` of the calibration currently open in
    *  R₂, so the focused R₁ Calibration affordance marks itself. */
   selectedCalibrationKey?: string | null;
+  /** Open a hand-over baton in the R₂ hand-over viewer column. Threaded to
+   *  the R₁ Hand-over inventory so a row click selects the baton for
+   *  in-tmai viewing. */
+  onSelectHandoff?: (sel: SelectedHandoff) => void;
+  /** `selectedHandoffKey(unit, name)` of the baton currently open in R₂, so
+   *  the focused R₁ Hand-over row marks itself. */
+  selectedHandoffKey?: string | null;
   /** Focus mode (spine `2026-05-29-c-and-r-as-the-development-substrate`,
    *  its deferred "R₁/R₂ visual ratio" point): the R₂ viewer for the
    *  currently-focused artifact. When non-null it RIDES THIS SAME COLUMN —
@@ -128,6 +136,8 @@ export function RPanel({
   selectedIssueKey,
   onSelectCalibration,
   selectedCalibrationKey,
+  onSelectHandoff,
+  selectedHandoffKey,
   viewer,
 }: RPanelProps) {
   const [expanded, setExpanded] = useUIPref("rPanelExpandedSections");
@@ -271,6 +281,8 @@ export function RPanel({
               unitName={unitName}
               expanded={isExpanded("handover")}
               onToggle={() => toggle("handover")}
+              onSelectHandoff={onSelectHandoff}
+              selectedKey={selectedHandoffKey}
             />
             <RFilesSection
               currentProjectPath={currentProjectPath}

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RHandoverSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RHandoverSection.test.tsx
@@ -1,28 +1,137 @@
 // @vitest-environment jsdom
 //
-// RHandoverSection — honest-degradation: no archive wire yet, so
-// the section shows `(0)` count + TODO marker rather than fabricate
-// content.
+// RHandoverSection — the R₁ baton inventory, wired to the operator-side
+// handoffs endpoint (tmai-core #473) via `useHandoffs`. We mock
+// `api.unitHandoffs` and assert: header count = real baton count; rows
+// render in the wire order (active first, then archived) with plain facts;
+// a row click selects the baton for R₂ with `{ unit, name }`; `aria-current`
+// marks the focused row; and the null-unit / empty states degrade honestly
+// rather than fabricate a list.
 
-import { render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HandoffsResponse } from "@/lib/api";
+
+const unitHandoffsMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      unitHandoffs: (...args: unknown[]) => unitHandoffsMock(...args),
+    },
+  };
+});
+
 import { RHandoverSection } from "../RHandoverSection";
 
+function response(overrides: Partial<HandoffsResponse> = {}): HandoffsResponse {
+  return {
+    unit: "u",
+    handoffs: [
+      { name: "active", status: "active", composed_at: "2026-05-12T18:30:00Z", task: "ship it" },
+      {
+        name: "2026-05-10T09-00-00.000Z.md",
+        status: "archived",
+        composed_at: "2026-05-10T09:00:00Z",
+        task: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  unitHandoffsMock.mockReset();
+});
+
 describe("RHandoverSection", () => {
-  it("renders header with count `0` (honest about missing archive wire)", () => {
-    render(<RHandoverSection unitName="u" expanded={false} onToggle={vi.fn()} />);
-    expect(screen.getByText(/^0$/)).toBeTruthy();
-  });
-
-  it("body explains the missing wire via TODO marker (simulated-onboarded posture)", () => {
+  it("renders baton rows from the wire (active first, then archived)", async () => {
+    unitHandoffsMock.mockResolvedValue(response());
     render(<RHandoverSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-    expect(screen.getByText(/handoff archive wire/i)).toBeTruthy();
-    // Path hint is shown so the operator can open the dir directly.
-    expect(screen.getByText(/~\/.tmai\/handoffs/)).toBeTruthy();
+    await waitFor(() => {
+      expect(screen.getByText("2026-05-10T09-00-00.000Z.md")).toBeTruthy();
+    });
+    // Wire order is preserved as-is (active first, then archived) — no
+    // client re-sort. The active baton's name + status both read "active".
+    const rows = screen.getAllByRole("listitem");
+    expect(rows[0].textContent).toContain("active");
+    expect(rows[1].textContent).toContain("2026-05-10T09-00-00.000Z.md");
+    // The active baton's frontmatter task is shown plainly.
+    expect(screen.getByText(/ship it/)).toBeTruthy();
   });
 
-  it("pick-a-project notice when unit is null", () => {
+  it("header count reflects the real baton count", async () => {
+    unitHandoffsMock.mockResolvedValue(response());
+    render(<RHandoverSection unitName="u" expanded={false} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/^2$/)).toBeTruthy();
+    });
+  });
+
+  it("clicking a baton row selects it for the R₂ viewer with { unit, name }", async () => {
+    const onSelectHandoff = vi.fn();
+    unitHandoffsMock.mockResolvedValue(response());
+    render(
+      <RHandoverSection
+        unitName="u"
+        expanded={true}
+        onToggle={vi.fn()}
+        onSelectHandoff={onSelectHandoff}
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText(/ship it/)).toBeTruthy();
+    });
+    // Click via the active baton's unique task text — it bubbles to the
+    // row button, avoiding the "active" name/status text collision.
+    fireEvent.click(screen.getByText(/ship it/));
+    expect(onSelectHandoff).toHaveBeenCalledWith({ unit: "u", name: "active" });
+  });
+
+  it("marks the focused row with aria-current (and no others)", async () => {
+    unitHandoffsMock.mockResolvedValue(response());
+    render(
+      <RHandoverSection
+        unitName="u"
+        expanded={true}
+        onToggle={vi.fn()}
+        selectedKey="u/2026-05-10T09-00-00.000Z.md"
+      />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("2026-05-10T09-00-00.000Z.md")).toBeTruthy();
+    });
+    const archivedRow = screen.getByText("2026-05-10T09-00-00.000Z.md").closest("button");
+    expect(archivedRow?.getAttribute("aria-current")).toBe("true");
+    const activeRow = screen.getByText(/ship it/).closest("button");
+    expect(activeRow?.getAttribute("aria-current")).toBeNull();
+  });
+
+  it("shows the honest empty state when the unit has no batons", async () => {
+    unitHandoffsMock.mockResolvedValue(response({ handoffs: [] }));
+    render(<RHandoverSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText("No hand-overs.")).toBeTruthy();
+    });
+  });
+
+  it("pick-a-project notice when unit is null (no fetch)", () => {
     render(<RHandoverSection unitName={null} expanded={true} onToggle={vi.fn()} />);
     expect(screen.getByText(/Pick a project/i)).toBeTruthy();
+    expect(unitHandoffsMock).not.toHaveBeenCalled();
+  });
+
+  it("uses no severity colors", async () => {
+    unitHandoffsMock.mockResolvedValue(response());
+    const { container } = render(
+      <RHandoverSection unitName="u" expanded={true} onToggle={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("2026-05-10T09-00-00.000Z.md")).toBeTruthy();
+    });
+    expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/RHandoverViewer.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/RHandoverViewer.tsx
@@ -1,0 +1,223 @@
+// R₂ — the in-tmai Hand-over baton viewer (per-unit, read-only). Serves
+// the spine `2026-05-29-c-and-r-as-the-development-substrate` (the per-kind
+// walk's "📜 Hand-over" surface) + `2026-05-29-artifact-content-viewer`
+// (γ-lean R₂ viewer). Realizes the operator-side half of tmai-core PR
+// #473's handoffs endpoint.
+//
+// Mirrors `RPrViewer` / `RRecordViewer` / `RIssueViewer` /
+// `RCalibrationViewer` posture exactly: in focus mode it RIDES the R
+// panel's single column IN PLACE OF the R₁ inventory — same drag-set
+// width, never an additive column that would squeeze the centre
+// conversation. It NEVER auto-opens — it mounts only on an explicit
+// operator row click in the R₁ Hand-over inventory (the parent gates the
+// mount on a non-null `selectedHandoff`). R₁ (`RHandoverSection`) stays a
+// pure baton inventory; this viewer renders the clicked baton's full
+// content.
+//
+// The content endpoint returns ONLY `{ unit, name, content }` (the raw
+// baton markdown, frontmatter + body verbatim). So the header's
+// active/archived marker is derived from the baton name — the active
+// baton's sentinel name is exactly `"active"`, every archived baton is a
+// timestamp filename — and `composed_at` / `task` are parsed from the
+// baton's leading YAML frontmatter (the same fields the backend's
+// `HandoffEntryWire` derives server-side; re-parsed here because the
+// selection carries only `{ unit, name }` and the content hook returns no
+// metadata).
+//
+// SCOPE — read-only, NO actions. `[restore-as-active]` and a
+// `[→Producer brief]` button need endpoints that do NOT exist server-side
+// and are explicitly deferred — the viewer mutates nothing. `diff vs
+// previous baton` (the spine's transition-trace enrich) is also deferred;
+// this increment is the baton list (R₁) + baton content + meta (R₂).
+//
+// Negative space (the serving `2026-05-26-tmai-states-facts-not-appraisals`
+// posture — tmai states facts, never appraises):
+//   - ALL facts stay PLAIN — `text-foreground` / `text-muted-foreground` /
+//     `text-subtle-foreground` only, never warning / destructive / success
+//     accents. A baton's active/archived status is a fact (where it lives),
+//     not an appraisal;
+//   - NO "changed since you last looked" / unread / TL;DR / auto-summary —
+//     only what the wire carries is rendered;
+//   - the ONE allowed convention is standard markdown rendering of the
+//     baton body (via the shared `PROSE_CLASSES`), same as the other R₂
+//     viewers.
+
+import Markdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { useHandoffContent } from "@/hooks/useHandoffs";
+import { InventoryBackButton } from "./InventoryBackButton";
+import { PROSE_CLASSES } from "./prose";
+
+// What R₁ hands R₂ on a baton row click. The selection carries only the
+// unit + baton name (the `{name}` the content endpoint keys on); the
+// header's status/meta are derived from the name + the fetched content's
+// frontmatter, so no `HandoffEntryWire` rides along (the asymmetry with
+// `SelectedPr` / `SelectedIssue`, which carry a full ride-along item, is
+// intentional — see the file header).
+export interface SelectedHandoff {
+  unit: string;
+  name: string;
+}
+
+// Symmetry helper with `selectedPrKey` / `selectedIssueKey` /
+// `selectedCalibrationKey`: `(unit, name)` is the focus key (a unit has
+// many batons, each uniquely named), so the R₁ row marks itself when this
+// equals its own key.
+export function selectedHandoffKey(unit: string, name: string): string {
+  return `${unit}/${name}`;
+}
+
+// The active baton's sentinel name is exactly `"active"`; every archived
+// baton is a timestamp filename. So "is this the active baton?" is a pure
+// name check — no extra wire field needed (matches the backend's
+// `HandoffEntryWire.status` semantics: where the baton lives, not its
+// consumption lifecycle).
+function isActive(name: string): boolean {
+  return name === "active";
+}
+
+interface BatonMeta {
+  composedAt: string | null;
+  task: string | null;
+}
+
+// Parse `composed-at` / `task` from a baton's leading YAML frontmatter.
+//
+// WHY here: the content endpoint returns the raw baton markdown only, and
+// the selection carries just `{ unit, name }` — so the header re-derives
+// these two facts the backend's `HandoffEntryWire` already parses. Either
+// is null when the frontmatter is absent or omits that field (an
+// unparseable / frontmatter-less archived baton still renders, bare). This
+// is a deliberately minimal parser (the two scalar keys the header shows),
+// NOT a general YAML reader; the full baton is rendered verbatim below.
+function parseBatonMeta(content: string): BatonMeta {
+  const meta: BatonMeta = { composedAt: null, task: null };
+  // Frontmatter must be the very first thing in the file: a `---` line,
+  // then key/value lines, then a closing `---` line.
+  const lines = content.split("\n");
+  if (lines.length === 0 || lines[0].trim() !== "---") return meta;
+  for (let i = 1; i < lines.length; i++) {
+    if (lines[i].trim() === "---") break; // end of frontmatter block
+    const sep = lines[i].indexOf(":");
+    if (sep === -1) continue;
+    const key = lines[i].slice(0, sep).trim();
+    // Strip surrounding single/double quotes from the scalar value.
+    const value = lines[i]
+      .slice(sep + 1)
+      .trim()
+      .replace(/^["']|["']$/g, "");
+    if (key === "composed-at" && value !== "") meta.composedAt = value;
+    else if (key === "task" && value !== "") meta.task = value;
+  }
+  return meta;
+}
+
+interface RHandoverViewerProps {
+  selected: SelectedHandoff;
+  onClose: () => void;
+}
+
+export function RHandoverViewer({ selected, onClose }: RHandoverViewerProps) {
+  const { data, loading, error } = useHandoffContent(selected.unit, selected.name);
+  const meta = data !== null ? parseBatonMeta(data.content) : { composedAt: null, task: null };
+
+  // Focus mode: fills the R panel's single column (`flex-1`) at the
+  // operator's drag-set width — imposes no width of its own, so it never
+  // squeezes the centre conversation.
+  return (
+    <div data-testid="r-handover-viewer" className="flex min-h-0 flex-1 flex-col">
+      <ViewerHeader
+        unit={selected.unit}
+        name={selected.name}
+        composedAt={meta.composedAt}
+        task={meta.task}
+        onClose={onClose}
+      />
+      <div className="flex-1 space-y-4 overflow-y-auto px-4 py-3 text-xs">
+        {loading && <Loading />}
+        {error && <FetchError what="hand-over" message={error.message} />}
+        {data !== null && <BatonBody content={data.content} />}
+      </div>
+    </div>
+  );
+}
+
+// ── Header — mechanical baton facts, all plain (no severity tint) ──
+//
+// Identity (unit · hand-over · baton name · active/archived) renders
+// immediately from the selection; `composed_at` / `task` appear once the
+// content resolves and the frontmatter is parsed (omitted when absent).
+
+function ViewerHeader({
+  unit,
+  name,
+  composedAt,
+  task,
+  onClose,
+}: {
+  unit: string;
+  name: string;
+  composedAt: string | null;
+  task: string | null;
+  onClose: () => void;
+}) {
+  return (
+    <header className="shrink-0 border-b border-hairline px-4 py-3">
+      <InventoryBackButton onClose={onClose} />
+      <div className="min-w-0">
+        <p className="text-[11px] uppercase tracking-wide text-subtle-foreground">
+          {unit} · hand-over
+        </p>
+        <h2 className="break-all text-sm font-semibold text-foreground">
+          <span className="font-mono">{name}</span>
+        </h2>
+      </div>
+      <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-0.5 text-[11px] text-subtle-foreground">
+        <span className="text-muted-foreground">{isActive(name) ? "active" : "archived"}</span>
+        {composedAt !== null && (
+          <span className="text-muted-foreground">composed {composedAt}</span>
+        )}
+      </div>
+      {task !== null && <p className="mt-1 text-[11px] text-muted-foreground">{task}</p>}
+    </header>
+  );
+}
+
+// ── Async states (plain, never a fabricated empty) ──
+//
+// Ported 1:1 from the sibling R₂ viewers so the five read identically.
+
+function Loading() {
+  return <p className="text-subtle-foreground">Loading…</p>;
+}
+
+function FetchError({ what, message }: { what: string; message: string }) {
+  return (
+    <p className="text-muted-foreground">
+      Failed to load {what}: {message}
+    </p>
+  );
+}
+
+// ── Baton body (markdown via the shared PROSE_CLASSES) ──
+//
+// The baton is frontmatter + markdown body verbatim — rendered as markdown
+// (the one allowed convention). "Empty baton." when blank.
+
+function BatonBody({ content }: { content: string }) {
+  const empty = content.trim() === "";
+  return (
+    <section>
+      <h3 className="mb-1 text-[11px] font-semibold uppercase tracking-wide text-subtle-foreground">
+        Baton
+      </h3>
+      {empty ? (
+        <p className="text-subtle-foreground">Empty baton.</p>
+      ) : (
+        <div className={PROSE_CLASSES}>
+          <Markdown remarkPlugins={[remarkGfm]}>{content}</Markdown>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RHandoverViewer.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/RHandoverViewer.test.tsx
@@ -1,0 +1,137 @@
+// @vitest-environment jsdom
+//
+// RHandoverViewer — the R₂ in-tmai Hand-over baton viewer (per-unit,
+// read-only). The one-shot `useHandoffContent` hook is mocked with
+// SYNTHETIC fixtures so this test never touches real baton data.
+//
+// It proves: header facts render (name / active|archived marker /
+// composed_at + task parsed from the baton's frontmatter); the baton
+// markdown renders; archived/blank-frontmatter batons render bare; empty /
+// loading / error states; NO severity classes anywhere (plain-everything);
+// the viewer fills the R region (no `w-[` clamp, has `flex-1`); and the
+// ‹ Inventory back affordance calls `onClose`.
+
+import { render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+// Type-only import from the mocked hook module — erased at runtime, so it
+// does not collide with the `vi.mock` factory below.
+import type { UseHandoffContentResult } from "@/hooks/useHandoffs";
+import type { HandoffContentResponse } from "@/lib/api";
+
+const useHandoffContentMock = vi.fn();
+
+vi.mock("@/hooks/useHandoffs", () => ({
+  useHandoffContent: (...a: unknown[]) => useHandoffContentMock(...a),
+}));
+
+import { RHandoverViewer, type SelectedHandoff } from "../RHandoverViewer";
+
+// ── synthetic fixtures (NO real baton data) ──
+
+const ACTIVE_BATON = [
+  "---",
+  "composed-at: 2026-05-12T18:30:00Z",
+  'task: "ship the R₂ hand-over viewer"',
+  "---",
+  "",
+  "# Where you left off",
+  "",
+  "- wired R₁ to the #473 endpoint",
+].join("\n");
+
+function content(overrides: Partial<HandoffContentResponse> = {}): HandoffContentResponse {
+  return { unit: "tmai", name: "active", content: ACTIVE_BATON, ...overrides };
+}
+
+function result(overrides: Partial<UseHandoffContentResult> = {}): UseHandoffContentResult {
+  return { data: content(), loading: false, error: null, ...overrides };
+}
+
+const selected: SelectedHandoff = { unit: "tmai", name: "active" };
+
+beforeEach(() => {
+  useHandoffContentMock.mockReset();
+  useHandoffContentMock.mockReturnValue(result());
+});
+
+describe("RHandoverViewer", () => {
+  it("fetches the baton for exactly the selected unit + name (selection-driven)", () => {
+    render(<RHandoverViewer selected={selected} onClose={vi.fn()} />);
+    expect(useHandoffContentMock).toHaveBeenCalledWith("tmai", "active");
+  });
+
+  it("renders header facts (unit / baton name / active marker / composed_at / task)", () => {
+    const { container } = render(<RHandoverViewer selected={selected} onClose={vi.fn()} />);
+    // Scope to the header: the baton content is rendered verbatim below
+    // (frontmatter included), so the task value also appears in the body —
+    // header-fact assertions must target the header to stay unambiguous.
+    const header = container.querySelector("header");
+    expect(header).not.toBeNull();
+    const h = header as HTMLElement;
+    expect(within(h).getByText(/tmai · hand-over/)).toBeTruthy();
+    // For the active baton the name sentinel and the active/archived marker
+    // are both the literal "active" — the name in the title, the marker
+    // beside it (two matches in the header).
+    expect(within(h).getAllByText("active")).toHaveLength(2);
+    expect(within(h).getByText(/composed 2026-05-12T18:30:00Z/)).toBeTruthy();
+    expect(within(h).getByText("ship the R₂ hand-over viewer")).toBeTruthy();
+  });
+
+  it("derives the archived marker from a non-'active' baton name", () => {
+    const archivedName = "2026-05-10T09-00-00.000Z.md";
+    useHandoffContentMock.mockReturnValue(
+      result({ data: content({ name: archivedName, content: "# bare body" }) }),
+    );
+    render(<RHandoverViewer selected={{ unit: "tmai", name: archivedName }} onClose={vi.fn()} />);
+    expect(screen.getByText("archived")).toBeTruthy();
+    // Frontmatter-less baton: composed/task lines are simply absent.
+    expect(screen.queryByText(/composed /)).toBeNull();
+  });
+
+  it("renders the baton markdown body", () => {
+    render(<RHandoverViewer selected={selected} onClose={vi.fn()} />);
+    expect(screen.getByText("Where you left off")).toBeTruthy();
+    expect(screen.getByText(/wired R₁ to the #473 endpoint/)).toBeTruthy();
+  });
+
+  it("shows the empty-baton state for blank content", () => {
+    useHandoffContentMock.mockReturnValue(result({ data: content({ content: "   " }) }));
+    render(<RHandoverViewer selected={selected} onClose={vi.fn()} />);
+    expect(screen.getByText("Empty baton.")).toBeTruthy();
+  });
+
+  it("renders the loading and error states plainly", () => {
+    useHandoffContentMock.mockReturnValue(result({ data: null, loading: true }));
+    const { rerender, container } = render(
+      <RHandoverViewer selected={selected} onClose={vi.fn()} />,
+    );
+    expect(screen.getByText("Loading…")).toBeTruthy();
+
+    useHandoffContentMock.mockReturnValue(
+      result({ data: null, loading: false, error: new Error("boom") }),
+    );
+    rerender(<RHandoverViewer selected={selected} onClose={vi.fn()} />);
+    expect(screen.getByText(/Failed to load hand-over: boom/)).toBeTruthy();
+    expect(container.innerHTML).not.toMatch(/text-(warning|destructive|success)/);
+  });
+
+  it("uses NO severity-color classes anywhere (plain-everything)", () => {
+    const { container } = render(<RHandoverViewer selected={selected} onClose={vi.fn()} />);
+    expect(container.innerHTML).not.toMatch(/text-(warning|destructive|success)/);
+  });
+
+  it("fills the R region — no fixed clamp width, carries flex-1 (focus mode rides the R column)", () => {
+    const { container } = render(<RHandoverViewer selected={selected} onClose={vi.fn()} />);
+    const root = container.querySelector('[data-testid="r-handover-viewer"]');
+    expect(root).not.toBeNull();
+    expect(root?.className ?? "").not.toMatch(/w-\[/);
+    expect(root?.className ?? "").toMatch(/flex-1/);
+  });
+
+  it("returns to the inventory via the ‹ Inventory back affordance (clears the focus)", () => {
+    const onClose = vi.fn();
+    render(<RHandoverViewer selected={selected} onClose={onClose} />);
+    screen.getByRole("button", { name: /Back to inventory/ }).click();
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/clients/react/src/hooks/__tests__/useFocusedArtifact.test.ts
+++ b/clients/react/src/hooks/__tests__/useFocusedArtifact.test.ts
@@ -1,13 +1,15 @@
 // @vitest-environment jsdom
 //
 // useFocusedArtifact — the R₂ "exactly one focused artifact" invariant.
-// Focusing any one of a PR / record / issue / calibration clears the other
-// three, so the PR viewer, the record viewer, the issue viewer, and the
-// calibration viewer are never both/all mounted.
+// Focusing any one of a PR / record / issue / calibration / hand-over baton
+// clears the other four, so the PR viewer, the record viewer, the issue
+// viewer, the calibration viewer, and the hand-over viewer are never more
+// than one mounted.
 
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import type { SelectedCalibration } from "@/components/producer-console/r-panel/r-viewer/RCalibrationViewer";
+import type { SelectedHandoff } from "@/components/producer-console/r-panel/r-viewer/RHandoverViewer";
 import type { SelectedIssue } from "@/components/producer-console/r-panel/r-viewer/RIssueViewer";
 import type { SelectedPr } from "@/components/producer-console/r-panel/r-viewer/RPrViewer";
 import type { SelectedRecord } from "@/components/producer-console/r-panel/r-viewer/RRecordViewer";
@@ -79,6 +81,10 @@ function calibrationSelection(): SelectedCalibration {
   return { unit: "u" };
 }
 
+function handoffSelection(): SelectedHandoff {
+  return { unit: "u", name: "active" };
+}
+
 describe("useFocusedArtifact", () => {
   it("starts with nothing focused", () => {
     const { result } = renderHook(() => useFocusedArtifact());
@@ -86,6 +92,7 @@ describe("useFocusedArtifact", () => {
     expect(result.current.selectedRecord).toBeNull();
     expect(result.current.selectedIssue).toBeNull();
     expect(result.current.selectedCalibration).toBeNull();
+    expect(result.current.selectedHandoff).toBeNull();
   });
 
   it("selecting a record clears a selected PR (exactly one focus)", () => {
@@ -173,7 +180,46 @@ describe("useFocusedArtifact", () => {
     expect(result.current.selectedCalibration).toBeNull();
   });
 
-  it("clearPr / clearRecord / clearIssue / clearCalibration clear only their own kind", () => {
+  it("selecting a hand-over clears PR, record, issue, AND calibration (exactly one focus across five)", () => {
+    const { result } = renderHook(() => useFocusedArtifact());
+
+    act(() => result.current.selectPr(prSelection()));
+    act(() => result.current.selectRecord(recordSelection()));
+    act(() => result.current.selectIssue(issueSelection()));
+    act(() => result.current.selectCalibration(calibrationSelection()));
+    act(() => result.current.selectHandoff(handoffSelection()));
+    expect(result.current.selectedHandoff).not.toBeNull();
+    expect(result.current.selectedPr).toBeNull();
+    expect(result.current.selectedRecord).toBeNull();
+    expect(result.current.selectedIssue).toBeNull();
+    expect(result.current.selectedCalibration).toBeNull();
+  });
+
+  it("selecting a PR / record / issue / calibration each clears a selected hand-over (the reverse direction)", () => {
+    const { result } = renderHook(() => useFocusedArtifact());
+
+    act(() => result.current.selectHandoff(handoffSelection()));
+    act(() => result.current.selectPr(prSelection()));
+    expect(result.current.selectedPr).not.toBeNull();
+    expect(result.current.selectedHandoff).toBeNull();
+
+    act(() => result.current.selectHandoff(handoffSelection()));
+    act(() => result.current.selectRecord(recordSelection()));
+    expect(result.current.selectedRecord).not.toBeNull();
+    expect(result.current.selectedHandoff).toBeNull();
+
+    act(() => result.current.selectHandoff(handoffSelection()));
+    act(() => result.current.selectIssue(issueSelection()));
+    expect(result.current.selectedIssue).not.toBeNull();
+    expect(result.current.selectedHandoff).toBeNull();
+
+    act(() => result.current.selectHandoff(handoffSelection()));
+    act(() => result.current.selectCalibration(calibrationSelection()));
+    expect(result.current.selectedCalibration).not.toBeNull();
+    expect(result.current.selectedHandoff).toBeNull();
+  });
+
+  it("clearPr / clearRecord / clearIssue / clearCalibration / clearHandoff clear only their own kind", () => {
     const { result } = renderHook(() => useFocusedArtifact());
 
     act(() => result.current.selectPr(prSelection()));
@@ -191,16 +237,21 @@ describe("useFocusedArtifact", () => {
     act(() => result.current.selectCalibration(calibrationSelection()));
     act(() => result.current.clearCalibration());
     expect(result.current.selectedCalibration).toBeNull();
+
+    act(() => result.current.selectHandoff(handoffSelection()));
+    act(() => result.current.clearHandoff());
+    expect(result.current.selectedHandoff).toBeNull();
   });
 
-  it("clearAll clears all four (used on a unit change)", () => {
+  it("clearAll clears all five (used on a unit change)", () => {
     const { result } = renderHook(() => useFocusedArtifact());
 
-    act(() => result.current.selectCalibration(calibrationSelection()));
+    act(() => result.current.selectHandoff(handoffSelection()));
     act(() => result.current.clearAll());
     expect(result.current.selectedPr).toBeNull();
     expect(result.current.selectedRecord).toBeNull();
     expect(result.current.selectedIssue).toBeNull();
     expect(result.current.selectedCalibration).toBeNull();
+    expect(result.current.selectedHandoff).toBeNull();
   });
 });

--- a/clients/react/src/hooks/__tests__/useHandoffs.test.ts
+++ b/clients/react/src/hooks/__tests__/useHandoffs.test.ts
@@ -1,0 +1,158 @@
+// @vitest-environment jsdom
+//
+// useHandoffs / useHandoffContent — the fetch hooks behind the R₂ in-tmai
+// Hand-over viewer (operator-side half of tmai-core #473). We mock the
+// `api` helpers and assert the shared `{ data, loading, error }` contract:
+//
+//   - useHandoffs (list, mirrors useDecisions): a `null` unit parks (no
+//     fetch), a real unit fetches once and exposes the baton list, errors
+//     surface without fabricating data, and switching units re-fetches +
+//     clears the previous payload (generation guard).
+//   - useHandoffContent (content, mirrors usePrDetail): parks when EITHER
+//     arg is null, fetches once when both are set, surfaces errors, and
+//     re-fetches + clears on a baton change.
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { HandoffContentResponse, HandoffsResponse } from "@/lib/api";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    unitHandoffs: vi.fn(),
+    unitHandoff: vi.fn(),
+  },
+}));
+
+import { api } from "@/lib/api";
+import { useHandoffContent, useHandoffs } from "../useHandoffs";
+
+function listResponse(overrides: Partial<HandoffsResponse> = {}): HandoffsResponse {
+  return {
+    unit: "u",
+    handoffs: [
+      { name: "active", status: "active", composed_at: "2026-05-12T18:30:00Z", task: "ship it" },
+      {
+        name: "2026-05-10T09-00-00.000Z.md",
+        status: "archived",
+        composed_at: "2026-05-10T09:00:00Z",
+        task: null,
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function contentResponse(overrides: Partial<HandoffContentResponse> = {}): HandoffContentResponse {
+  return {
+    unit: "u",
+    name: "active",
+    content: "---\ncomposed-at: 2026-05-12T18:30:00Z\ntask: ship it\n---\n\n# Baton body",
+    ...overrides,
+  };
+}
+
+describe("useHandoffs (list)", () => {
+  beforeEach(() => {
+    vi.mocked(api.unitHandoffs).mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parks when the unit is null — no fetch, not loading", () => {
+    const { result } = renderHook(() => useHandoffs(null));
+    expect(api.unitHandoffs).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetches the baton list once on a real unit and exposes it", async () => {
+    vi.mocked(api.unitHandoffs).mockResolvedValue(listResponse());
+    const { result } = renderHook(() => useHandoffs("u"));
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(api.unitHandoffs).toHaveBeenCalledWith("u");
+    expect(result.current.data?.handoffs).toHaveLength(2);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a fetch error without fabricating data", async () => {
+    vi.mocked(api.unitHandoffs).mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useHandoffs("u"));
+    await waitFor(() => expect(result.current.error?.message).toBe("boom"));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("re-fetches when the unit changes and clears the previous payload", async () => {
+    vi.mocked(api.unitHandoffs).mockImplementation((unit: string) =>
+      Promise.resolve(listResponse({ unit, handoffs: [] })),
+    );
+    const { result, rerender } = renderHook(({ u }) => useHandoffs(u), {
+      initialProps: { u: "a" },
+    });
+    await waitFor(() => expect(result.current.data?.unit).toBe("a"));
+
+    rerender({ u: "b" });
+    // Cleared synchronously on unit change so the old unit's batons are
+    // never shown under the new unit.
+    expect(result.current.data).toBeNull();
+    await waitFor(() => expect(result.current.data?.unit).toBe("b"));
+  });
+});
+
+describe("useHandoffContent (content)", () => {
+  beforeEach(() => {
+    vi.mocked(api.unitHandoff).mockReset();
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parks when the unit is null — no fetch, not loading", () => {
+    const { result } = renderHook(() => useHandoffContent(null, "active"));
+    expect(api.unitHandoff).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+  });
+
+  it("parks when the name is null — no fetch, not loading", () => {
+    const { result } = renderHook(() => useHandoffContent("u", null));
+    expect(api.unitHandoff).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+  });
+
+  it("fetches the baton once when both args are set and exposes the content", async () => {
+    vi.mocked(api.unitHandoff).mockResolvedValue(contentResponse());
+    const { result } = renderHook(() => useHandoffContent("u", "active"));
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(api.unitHandoff).toHaveBeenCalledWith("u", "active");
+    expect(result.current.data?.content).toMatch(/Baton body/);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a fetch error without fabricating data", async () => {
+    vi.mocked(api.unitHandoff).mockRejectedValue(new Error("kaboom"));
+    const { result } = renderHook(() => useHandoffContent("u", "active"));
+    await waitFor(() => expect(result.current.error?.message).toBe("kaboom"));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("re-fetches when the baton name changes and clears the previous payload", async () => {
+    vi.mocked(api.unitHandoff).mockImplementation((_unit: string, name: string) =>
+      Promise.resolve(contentResponse({ name, content: `body-${name}` })),
+    );
+    const { result, rerender } = renderHook(({ n }) => useHandoffContent("u", n), {
+      initialProps: { n: "active" },
+    });
+    await waitFor(() => expect(result.current.data?.content).toBe("body-active"));
+
+    rerender({ n: "2026-05-10T09-00-00.000Z.md" });
+    expect(result.current.data).toBeNull();
+    await waitFor(() =>
+      expect(result.current.data?.content).toBe("body-2026-05-10T09-00-00.000Z.md"),
+    );
+  });
+});

--- a/clients/react/src/hooks/useFocusedArtifact.ts
+++ b/clients/react/src/hooks/useFocusedArtifact.ts
@@ -2,15 +2,17 @@
 //
 // The R₂ column (`doc/approaches/2026-05-29-artifact-content-viewer.md`)
 // hosts a single focused artifact: a PR, a record (decision/approach), an
-// issue, or the unit's calibration. Focusing one kind clears the other
-// three, so the PR viewer (`RPrViewer`), the record viewer
-// (`RRecordViewer`), the issue viewer (`RIssueViewer`), and the
-// calibration viewer (`RCalibrationViewer`) are never both/all mounted. The
-// invariant lives here — in one small testable hook — rather than spread
-// across App's render, so "exactly-one-focus" is provable in isolation.
+// issue, the unit's calibration, or a hand-over baton. Focusing one kind
+// clears the other four, so the PR viewer (`RPrViewer`), the record viewer
+// (`RRecordViewer`), the issue viewer (`RIssueViewer`), the calibration
+// viewer (`RCalibrationViewer`), and the hand-over viewer
+// (`RHandoverViewer`) are never more than one mounted. The invariant lives
+// here — in one small testable hook — rather than spread across App's
+// render, so "exactly-one-focus" is provable in isolation.
 
 import { useCallback, useState } from "react";
 import type { SelectedCalibration } from "@/components/producer-console/r-panel/r-viewer/RCalibrationViewer";
+import type { SelectedHandoff } from "@/components/producer-console/r-panel/r-viewer/RHandoverViewer";
 import type { SelectedIssue } from "@/components/producer-console/r-panel/r-viewer/RIssueViewer";
 import type { SelectedPr } from "@/components/producer-console/r-panel/r-viewer/RPrViewer";
 import type { SelectedRecord } from "@/components/producer-console/r-panel/r-viewer/RRecordViewer";
@@ -20,19 +22,23 @@ export interface FocusedArtifact {
   selectedRecord: SelectedRecord | null;
   selectedIssue: SelectedIssue | null;
   selectedCalibration: SelectedCalibration | null;
-  /** Focus a PR in R₂; clears any focused record + issue + calibration. */
+  selectedHandoff: SelectedHandoff | null;
+  /** Focus a PR in R₂; clears any focused record + issue + calibration + handoff. */
   selectPr: (sel: SelectedPr) => void;
-  /** Focus a decision/approach in R₂; clears any focused PR + issue + calibration. */
+  /** Focus a decision/approach in R₂; clears any focused PR + issue + calibration + handoff. */
   selectRecord: (sel: SelectedRecord) => void;
-  /** Focus an issue in R₂; clears any focused PR + record + calibration. */
+  /** Focus an issue in R₂; clears any focused PR + record + calibration + handoff. */
   selectIssue: (sel: SelectedIssue) => void;
-  /** Focus the unit's calibration in R₂; clears any focused PR + record + issue. */
+  /** Focus the unit's calibration in R₂; clears any focused PR + record + issue + handoff. */
   selectCalibration: (sel: SelectedCalibration) => void;
+  /** Focus a hand-over baton in R₂; clears any focused PR + record + issue + calibration. */
+  selectHandoff: (sel: SelectedHandoff) => void;
   clearPr: () => void;
   clearRecord: () => void;
   clearIssue: () => void;
   clearCalibration: () => void;
-  /** Clear all four — used on a unit change, where the previous unit's
+  clearHandoff: () => void;
+  /** Clear all five — used on a unit change, where the previous unit's
    *  artifact must not linger under a new unit's inventory. */
   clearAll: () => void;
 }
@@ -42,40 +48,54 @@ export function useFocusedArtifact(): FocusedArtifact {
   const [selectedRecord, setSelectedRecord] = useState<SelectedRecord | null>(null);
   const [selectedIssue, setSelectedIssue] = useState<SelectedIssue | null>(null);
   const [selectedCalibration, setSelectedCalibration] = useState<SelectedCalibration | null>(null);
+  const [selectedHandoff, setSelectedHandoff] = useState<SelectedHandoff | null>(null);
 
   const selectPr = useCallback((sel: SelectedPr) => {
     setSelectedRecord(null);
     setSelectedIssue(null);
     setSelectedCalibration(null);
+    setSelectedHandoff(null);
     setSelectedPr(sel);
   }, []);
   const selectRecord = useCallback((sel: SelectedRecord) => {
     setSelectedPr(null);
     setSelectedIssue(null);
     setSelectedCalibration(null);
+    setSelectedHandoff(null);
     setSelectedRecord(sel);
   }, []);
   const selectIssue = useCallback((sel: SelectedIssue) => {
     setSelectedPr(null);
     setSelectedRecord(null);
     setSelectedCalibration(null);
+    setSelectedHandoff(null);
     setSelectedIssue(sel);
   }, []);
   const selectCalibration = useCallback((sel: SelectedCalibration) => {
     setSelectedPr(null);
     setSelectedRecord(null);
     setSelectedIssue(null);
+    setSelectedHandoff(null);
     setSelectedCalibration(sel);
+  }, []);
+  const selectHandoff = useCallback((sel: SelectedHandoff) => {
+    setSelectedPr(null);
+    setSelectedRecord(null);
+    setSelectedIssue(null);
+    setSelectedCalibration(null);
+    setSelectedHandoff(sel);
   }, []);
   const clearPr = useCallback(() => setSelectedPr(null), []);
   const clearRecord = useCallback(() => setSelectedRecord(null), []);
   const clearIssue = useCallback(() => setSelectedIssue(null), []);
   const clearCalibration = useCallback(() => setSelectedCalibration(null), []);
+  const clearHandoff = useCallback(() => setSelectedHandoff(null), []);
   const clearAll = useCallback(() => {
     setSelectedPr(null);
     setSelectedRecord(null);
     setSelectedIssue(null);
     setSelectedCalibration(null);
+    setSelectedHandoff(null);
   }, []);
 
   return {
@@ -83,14 +103,17 @@ export function useFocusedArtifact(): FocusedArtifact {
     selectedRecord,
     selectedIssue,
     selectedCalibration,
+    selectedHandoff,
     selectPr,
     selectRecord,
     selectIssue,
     selectCalibration,
+    selectHandoff,
     clearPr,
     clearRecord,
     clearIssue,
     clearCalibration,
+    clearHandoff,
     clearAll,
   };
 }

--- a/clients/react/src/hooks/useHandoffs.ts
+++ b/clients/react/src/hooks/useHandoffs.ts
@@ -1,0 +1,149 @@
+// Fetch hooks for the R₂ in-tmai Hand-over viewer — the operator-side half
+// of tmai-core PR #473's handoffs endpoint.
+//
+// `useHandoffs(unit)` is the LIST hook (mirrors `useDecisions` /
+// `useCalibration`): a 60-second poll over the unit's baton inventory
+// (active first, then archived newest-first — the wire order). Batons
+// change only when a hand-over ritual completes (minutes to hours), so a
+// 60s poll is plenty; SSE is a deferred follow-up like the other R₁
+// sections. A `null` unit parks the hook (no fetch, no interval).
+//
+// `useHandoffContent(unit, name)` is the one-shot CONTENT hook (mirrors
+// `usePrDetail`'s `usePrResource`): it fetches a single baton's raw
+// markdown only after an explicit operator click on a row, with a
+// generation guard so a stale in-flight response from a previously selected
+// baton never stamps over the current one. It parks when EITHER arg is
+// null.
+
+import { useEffect, useRef, useState } from "react";
+import { api, type HandoffContentResponse, type HandoffsResponse } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface UseHandoffsResult {
+  data: HandoffsResponse | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * Poll the unit's hand-over baton list at `POLL_INTERVAL_MS`. Returns the
+ * latest response, an initial-load `loading` flag, and the most recent
+ * error (cleared on a successful fetch).
+ *
+ * `unit = null` parks the hook: no fetch, no interval, no data — the R₁
+ * section renders its "pick a project" placeholder rather than poll a
+ * non-existent unit.
+ */
+export function useHandoffs(unit: string | null): UseHandoffsResult {
+  const [data, setData] = useState<HandoffsResponse | null>(null);
+  const [loading, setLoading] = useState(unit !== null);
+  const [error, setError] = useState<Error | null>(null);
+  // Track the latest fetch so an in-flight response from a previous unit
+  // cannot stamp over a newer unit's data.
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    if (!unit) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    // Clear on unit *change* so a previous unit's batons are never shown
+    // under a new unit; the 60s same-unit re-poll keeps the last response
+    // visible (anti-flicker) through fetchOnce below.
+    setData(null);
+    setError(null);
+    setLoading(true);
+
+    const fetchOnce = async () => {
+      try {
+        const res = await api.unitHandoffs(unit);
+        if (myGen !== generationRef.current) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (myGen !== generationRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (myGen === generationRef.current) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [unit]);
+
+  return { data, loading, error };
+}
+
+export interface UseHandoffContentResult {
+  data: HandoffContentResponse | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+/**
+ * One-shot fetch of a single baton's raw markdown. Fetches once when both
+ * `unit` and `name` are non-null (an explicit row click drives the
+ * selection — the viewer never auto-opens), re-fetches on a baton change,
+ * and parks (no fetch) when EITHER arg is null.
+ *
+ * Mirrors `usePrDetail`'s `usePrResource`: a generation guard so a stale
+ * in-flight response from a previously selected baton never stamps over the
+ * current one, and the previous payload is cleared synchronously on change
+ * so a stale baton is never shown.
+ */
+export function useHandoffContent(
+  unit: string | null,
+  name: string | null,
+): UseHandoffContentResult {
+  const [data, setData] = useState<HandoffContentResponse | null>(null);
+  const [loading, setLoading] = useState(unit !== null && name !== null);
+  const [error, setError] = useState<Error | null>(null);
+  const generationRef = useRef(0);
+
+  // The stable identity of the request; the effect re-runs only when it
+  // changes. `null` exactly when either arg is null, which parks the hook.
+  const depKey = unit !== null && name !== null ? `${unit}/${name}` : null;
+
+  useEffect(() => {
+    if (depKey === null) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    setData(null);
+    setError(null);
+    setLoading(true);
+    void (async () => {
+      try {
+        // depKey is non-null exactly when both args are, so they are
+        // concrete here.
+        const res = await api.unitHandoff(unit as string, name as string);
+        if (myGen !== generationRef.current) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (myGen !== generationRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (myGen === generationRef.current) setLoading(false);
+      }
+    })();
+  }, [depKey, unit, name]);
+
+  return { data, loading, error };
+}

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -13,7 +13,10 @@ import type { Confidence } from "@/types/generated/Confidence";
 import type { DispatchBundle } from "@/types/generated/DispatchBundle";
 import type { DispatchSnapshot } from "@/types/generated/DispatchSnapshot";
 import type { EntityUpdateEnvelope } from "@/types/generated/EntityUpdateEnvelope";
+import type { HandoffContentResponse } from "@/types/generated/HandoffContentResponse";
+import type { HandoffEntryWire } from "@/types/generated/HandoffEntryWire";
 import type { HandoffRitualEvent } from "@/types/generated/HandoffRitualEvent";
+import type { HandoffsResponse } from "@/types/generated/HandoffsResponse";
 import type { Outcome } from "@/types/generated/Outcome";
 import type { PermissionMode } from "@/types/generated/PermissionMode";
 import type { PrDiffResponse } from "@/types/generated/PrDiffResponse";
@@ -52,7 +55,10 @@ export type {
   Confidence,
   DispatchBundle,
   EntityUpdateEnvelope,
+  HandoffContentResponse,
+  HandoffEntryWire,
   HandoffRitualEvent,
+  HandoffsResponse,
   Outcome,
   PermissionMode,
   PrDiffResponse,
@@ -1519,6 +1525,20 @@ export const api = {
   // without a Producer being attached.
   workingWithHuman: (unit: string) =>
     apiFetch<WorkingWithHumanResponse>(`/units/${encodeURIComponent(unit)}/working-with-human`),
+
+  // Hand-over batons (read-only) — the operator-side half of tmai-core PR
+  // #473's handoffs endpoint. `unitHandoffs` lists the unit's batons
+  // (active first, then archived newest-first — the wire order); each entry
+  // carries the baton name, an active/archived flag, and parsed-frontmatter
+  // `composed_at` / `task`. `unitHandoff` fetches one baton's raw markdown
+  // (frontmatter + body verbatim) by name ("active" or an archive
+  // filename). Thin wrappers, mirroring `calibration` / `decisions`.
+  unitHandoffs: (unit: string) =>
+    apiFetch<HandoffsResponse>(`/units/${encodeURIComponent(unit)}/handoffs`),
+  unitHandoff: (unit: string, name: string) =>
+    apiFetch<HandoffContentResponse>(
+      `/units/${encodeURIComponent(unit)}/handoffs/${encodeURIComponent(name)}`,
+    ),
 
   // Handoff-and-restart ritual (tmai-core PR #352, DR
   // `2026-05-14-handoff-lifecycle-and-kill-ux.md` §C/§F). Kicks off the

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -277,6 +277,11 @@ export const api = {
   // compose()'s ◐ section; no Tauri-specific path needed)
   workingWithHuman: (unit: string) => httpApi.workingWithHuman(unit),
 
+  // Hand-over batons (HTTP only — read-only file-backed baton store, the
+  // operator-side half of tmai-core #473; no Tauri-specific path needed)
+  unitHandoffs: (unit: string) => httpApi.unitHandoffs(unit),
+  unitHandoff: (unit: string, name: string) => httpApi.unitHandoff(unit, name),
+
   // Handoff-and-restart ritual (HTTP only — server-driven multi-step
   // ritual emits its own SSE phase events; no Tauri IPC equivalent).
   triggerHandoffRitual: (unit: string, body: TriggerHandoffRitualRequest) =>


### PR DESCRIPTION
## What

Adds the **5th R₂ focus kind** — the in-tmai Hand-over baton viewer — and wires the R₁ Hand-over section to the operator-side handoffs endpoint that tmai-core **#473** built. The exactly-one-R₂-focus invariant now spans **pr / record / issue / calibration / handoff**.

Serves the spine `2026-05-29-c-and-r-as-the-development-substrate` (the "📜 Hand-over" per-kind walk), `2026-05-29-artifact-content-viewer` (γ-lean R₂ viewer), and realizes the operator-side backend from tmai-core #473.

Until now `RHandoverSection` was a stub showing count `0` + a "no wire exposes the handoffs directory yet" TODO marker. That wire now exists; this PR consumes it.

## Changes (`clients/react/` only — no generated-file edits, no tmai-core)

- **API bindings** (`lib/api-http.ts` + `lib/api-tauri.ts`): `unitHandoffs(unit) → HandoffsResponse` and `unitHandoff(unit, name) → HandoffContentResponse` — thin wrappers mirroring `api.calibration` / `api.decisions`.
- **Hooks** (`hooks/useHandoffs.ts`): `useHandoffs(unit)` (60s poll list, mirrors `useDecisions`) + `useHandoffContent(unit, name)` (one-shot content, mirrors `usePrDetail`, parks when either arg is null).
- **`useFocusedArtifact`**: gains `selectedHandoff` / `selectHandoff` / `clearHandoff`; every `select*` clears handoff and `selectHandoff` clears the other four; `clearAll` clears all five.
- **`RHandoverViewer.tsx`** (new): focus-mode viewer — fills the R region (`flex-1`, no width clamp), `‹ Inventory` back affordance. Fetches via `useHandoffContent`; header shows unit · hand-over · baton name · `active`/`archived` marker (derived from the name) · `composed_at` + `task` (parsed from the baton's leading YAML frontmatter); body renders the baton markdown via the shared `PROSE_CLASSES` + `react-markdown` + `remark-gfm` ("Empty baton." when blank).
- **`RHandoverSection.tsx`**: replaces the TODO stub with the real baton list (active first, then archived newest-first — wire order). Each row is a plain select calling `onSelectHandoff({ unit, name })`, with `aria-current` on the focused row; honest `unit === null` / "No hand-overs." empty states; real baton count.
- **`RPanel` → `App`**: threaded `onSelectHandoff` / `selectedHandoffKey`; composed the handoff case into App's single `rViewer` node; unit-change `clearAll` covers it.

## Negative space
All facts plain (`text-foreground` / `text-muted-foreground` / `text-subtle-foreground`, no severity accents). Viewer mounts only on explicit operator click. No unread / "changed since" / TL;DR / auto-summary. No `any`.

## Scope / deferred
- **Read-only** — `[restore-as-active]` and `[→Producer brief]` need endpoints that don't exist server-side → **deferred** (the viewer mutates nothing).
- **`diff vs previous baton`** (the spine's transition-trace enrich) → **deferred follow-up**. This increment is: baton list (R₁) + baton content + meta (R₂).
- Operator-authored baton flow → out of scope.

## Tests
`RHandoverViewer` (header facts / markdown body / empty / loading / error / fills-region / back affordance), `useHandoffs` + `useHandoffContent` (fetch / loading / error / null-park / re-fetch), `RHandoverSection` (rows / click→select / aria-current / empty / null), `useFocusedArtifact` (exactly-one-focus across all five).

## Gate
`pnpm install` / `pnpm lint` / `pnpm build` / `pnpm test` — all green (83 files, 628 passing, 2 pre-existing skips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ハンドオーバー（引き継ぎ）機能の表示を実装しました。利用可能なバトンの一覧表示、選択、および詳細内容の閲覧が可能になりました。バトンのステータスや作成日時などのメタデータも表示されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->