### PR TITLE
feat(r-panel): surface R₁ attention signals inline (decision drift, approach review-trigger-ready + confidence)

### DIFF
--- a/clients/react/src/components/producer-console/r-panel/RApproachesSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RApproachesSection.tsx
@@ -15,6 +15,7 @@
 import { useApproaches } from "@/hooks/useApproaches";
 import type { ApproachStatus, ApproachWire, RepoApproachesWire } from "@/lib/api";
 import { type SelectedRecord, selectedRecordKey } from "./r-viewer/RRecordViewer";
+import { isReviewTriggerReady } from "./r-viewer/review-trigger";
 import { Section } from "./Section";
 
 interface RApproachesSectionProps {
@@ -200,7 +201,18 @@ function ApproachRow({
       >
         <span className="font-mono text-subtle-foreground">{approach.date}</span>{" "}
         <span className="text-foreground">{approach.title}</span>
-        <div className="text-[11px] text-subtle-foreground">{approach.slug}</div>
+        <div className="text-[11px] text-subtle-foreground">
+          {approach.slug} · {approach.status}
+          {/* confidence: present-only (`null` = none on record). */}
+          {approach.confidence !== null && <> · {approach.confidence}</>}
+          {/* review-trigger ready = a date trigger is due (verdict due).
+              Present-only and PLAIN — surfaced for "should I look?"
+              scanning, never an alarm. The specific triggers stay in R₂'s
+              ReviewTriggerIndicator. */}
+          {isReviewTriggerReady(approach) && (
+            <span className="text-foreground"> · review-trigger ready</span>
+          )}
+        </div>
       </button>
     </li>
   );

--- a/clients/react/src/components/producer-console/r-panel/RDecisionsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RDecisionsSection.tsx
@@ -147,6 +147,11 @@ function DecisionRow({
         <span className="text-foreground">{decision.title}</span>
         <div className="text-[11px] text-subtle-foreground">
           {decision.slug} · {decision.status}
+          {/* Drift = a `governs:` path changed after `last_verified`
+              (currency re-verify due). Present-only and PLAIN — surfaced
+              for "should I look?" scanning, never an alarm. The path/date
+              detail stays in R₂'s DriftIndicator. */}
+          {decision.stale_since !== null && <span className="text-foreground"> · drift</span>}
         </div>
       </button>
     </li>

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RApproachesSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RApproachesSection.test.tsx
@@ -124,6 +124,55 @@ describe("RApproachesSection", () => {
     expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
   });
 
+  // ── Inline attention signals (status, confidence, review-trigger ready) ──
+
+  it("renders status + confidence inline on the row", async () => {
+    approachesMock.mockResolvedValue(
+      responseStub([
+        approachStub({ slug: "with-conf", title: "With Conf", confidence: "low" }),
+        approachStub({ slug: "no-conf", title: "No Conf", confidence: null }),
+      ]),
+    );
+    render(<RApproachesSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+
+    const withConf = await screen.findByRole("button", { name: /With Conf/ });
+    // status ("running") + confidence ("low") both show inline.
+    expect(withConf.textContent).toMatch(/running/);
+    expect(withConf.textContent).toMatch(/low/);
+    // confidence is present-only — a null-confidence approach shows neither
+    // "high" nor "low".
+    const noConf = screen.getByRole("button", { name: /No Conf/ });
+    expect(noConf.textContent).not.toMatch(/\b(high|low)\b/);
+  });
+
+  it("renders the review-trigger-ready marker only when a date trigger is due (plain, no severity)", async () => {
+    approachesMock.mockResolvedValue(
+      responseStub([
+        approachStub({
+          slug: "past-trig",
+          title: "Past Trigger",
+          review_triggers: [{ kind: "date", value: "2020-01-01" }],
+        }),
+        approachStub({
+          slug: "future-trig",
+          title: "Future Trigger",
+          review_triggers: [{ kind: "date", value: "2099-01-01" }],
+        }),
+      ]),
+    );
+    const { container } = render(
+      <RApproachesSection unitName="u" expanded={true} onToggle={vi.fn()} />,
+    );
+
+    const due = await screen.findByRole("button", { name: /Past Trigger/ });
+    expect(due.textContent).toMatch(/review-trigger ready/);
+    // Future-dated trigger: silence (no "not due" / "all clear" reassurance).
+    const notDue = screen.getByRole("button", { name: /Future Trigger/ });
+    expect(notDue.textContent).not.toMatch(/review-trigger ready/);
+    // The marker is a plain fact, never a severity alarm.
+    expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
+  });
+
   // ── R₂ selection wiring (mirrors RPrsSection's onSelectPr/aria-current) ──
 
   it("clicking a row calls onSelect with the approach wire object", async () => {

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RDecisionsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RDecisionsSection.test.tsx
@@ -155,6 +155,46 @@ describe("RDecisionsSection", () => {
     expect(decisionsMock).not.toHaveBeenCalled();
   });
 
+  // ── Inline drift marker (the R₁ "should I look?" attention signal) ──
+
+  it("renders an inline drift marker for a decision with stale_since, none for a clean one", async () => {
+    decisionsMock.mockResolvedValue(
+      responseStub({
+        repos: [
+          {
+            ...responseStub().repos[0],
+            in_play: [
+              decisionStub({
+                slug: "drifted-d",
+                title: "Drifted D",
+                stale_since: {
+                  path: "src/foo.rs",
+                  change_date: "2026-05-20",
+                  change_sha: "abc1234",
+                  change_subject: "touch foo",
+                },
+              }),
+            ],
+            warm: [decisionStub({ slug: "clean-d", title: "Clean D", stale_since: null })],
+          },
+        ],
+      }),
+    );
+
+    const { container } = render(
+      <RDecisionsSection unitName="u" expanded={true} onToggle={vi.fn()} />,
+    );
+
+    // Drift marker present for the drifted decision.
+    const drifted = await screen.findByRole("button", { name: /Drifted D/ });
+    expect(drifted.textContent).toMatch(/drift/);
+    // Absent for the clean one (silence-is-not-neutral: no "no drift" text).
+    const clean = screen.getByRole("button", { name: /Clean D/ });
+    expect(clean.textContent).not.toMatch(/drift/);
+    // The marker is a plain fact, never a severity alarm.
+    expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
+  });
+
   // ── R₂ selection wiring (mirrors RPrsSection's onSelectPr/aria-current) ──
 
   it("clicking a row calls onSelect with the decision wire object", async () => {

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/RRecordViewer.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/RRecordViewer.tsx
@@ -49,6 +49,7 @@ import type {
 } from "@/lib/api";
 import { InventoryBackButton } from "./InventoryBackButton";
 import { PROSE_CLASSES } from "./prose";
+import { isDateTriggerReady, todayIso } from "./review-trigger";
 
 // What R₁ hands R₂ on a record row click. The full wire object rides
 // along (like `SelectedPr` carries the full `pr`) so the viewer renders
@@ -350,12 +351,6 @@ function DriftIndicator({ decision }: { decision: DecisionWire }) {
 // without a fired/not-fired claim, because tmai cannot auto-detect their
 // firing.
 
-// `YYYY-MM-DD` for today (UTC day boundary is immaterial for this plain
-// fact). ISO date strings compare correctly lexicographically.
-function todayIso(): string {
-  return new Date().toISOString().slice(0, 10);
-}
-
 function formatTrigger(t: ReviewTriggerWire): string {
   switch (t.kind) {
     case "date":
@@ -385,7 +380,7 @@ function ReviewTriggerIndicator({ approach }: { approach: ApproachWire }) {
           // trigger's kind + ref/value, and triggers are parse-validated
           // (no exact duplicates within a record).
           const text = formatTrigger(t);
-          const ready = t.kind === "date" && t.value <= today;
+          const ready = isDateTriggerReady(t, today);
           return (
             <li key={text} className="text-foreground">
               <span className="font-mono text-muted-foreground">{text}</span>

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/review-trigger.test.ts
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/__tests__/review-trigger.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import type { ApproachWire, ReviewTriggerWire } from "@/lib/api";
+import { isDateTriggerReady, isReviewTriggerReady } from "../review-trigger";
+
+const TODAY = "2026-05-31";
+
+function approachStub(triggers: ReviewTriggerWire[]): ApproachWire {
+  return {
+    slug: "2026-05-01-a",
+    title: "A",
+    date: "2026-05-01",
+    status: "running",
+    governs: [],
+    serves: ["base"],
+    success_signal: "works",
+    failure_signal: "broken",
+    review_triggers: triggers,
+    review_history: [],
+    confidence: "high",
+    replaced_by: [],
+    excerpt: "",
+  };
+}
+
+describe("isDateTriggerReady", () => {
+  it("past-dated date trigger is ready", () => {
+    expect(isDateTriggerReady({ kind: "date", value: "2020-01-01" }, TODAY)).toBe(true);
+  });
+  it("today-dated date trigger is ready (on-or-before today)", () => {
+    expect(isDateTriggerReady({ kind: "date", value: TODAY }, TODAY)).toBe(true);
+  });
+  it("future-dated date trigger is NOT ready", () => {
+    expect(isDateTriggerReady({ kind: "date", value: "2099-01-01" }, TODAY)).toBe(false);
+  });
+  it("non-date kinds are never ready (can't be auto-detected)", () => {
+    expect(isDateTriggerReady({ kind: "pr-merged", ref: "#1" }, TODAY)).toBe(false);
+    expect(isDateTriggerReady({ kind: "manual", description: "re-check" }, TODAY)).toBe(false);
+  });
+});
+
+describe("isReviewTriggerReady", () => {
+  it("true when any date trigger is past-dated", () => {
+    expect(
+      isReviewTriggerReady(
+        approachStub([
+          { kind: "manual", description: "re-check" },
+          { kind: "date", value: "2020-01-01" },
+        ]),
+        TODAY,
+      ),
+    ).toBe(true);
+  });
+  it("false when only future date triggers exist", () => {
+    expect(isReviewTriggerReady(approachStub([{ kind: "date", value: "2099-01-01" }]), TODAY)).toBe(
+      false,
+    );
+  });
+  it("false when no date triggers exist", () => {
+    expect(isReviewTriggerReady(approachStub([{ kind: "pr-merged", ref: "#1" }]), TODAY)).toBe(
+      false,
+    );
+  });
+});

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/review-trigger.ts
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/review-trigger.ts
@@ -1,0 +1,35 @@
+// Review-trigger readiness — the ONE re-evaluation cue tmai can auto-detect.
+//
+// Shared by R₁'s `ApproachRow` (the inline "should I look?" attention
+// marker) and R₂'s `ReviewTriggerIndicator` (the per-trigger annotation),
+// so the date logic lives in exactly one place. A `date`-kind trigger is
+// "ready" when its date is on or before today; the other trigger kinds
+// (pr-closed / pr-merged / issue-closed / *-status / manual) can't be
+// auto-detected and are never "ready" by this check.
+//
+// Posture (`2026-05-26-tmai-states-facts-not-appraisals`): readiness is a
+// plain fact surfaced for scanning, not an alarm — callers render it in
+// plain/muted colours only.
+
+import type { ApproachWire, ReviewTriggerWire } from "@/lib/api";
+
+// `YYYY-MM-DD` for today. The UTC day boundary is immaterial for this
+// plain fact, and ISO date strings compare correctly lexicographically,
+// so a string `<=` is a valid "on or before today".
+export function todayIso(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+// A single date-kind trigger is ready when its date is on or before today.
+export function isDateTriggerReady(
+  trigger: ReviewTriggerWire,
+  today: string = todayIso(),
+): boolean {
+  return trigger.kind === "date" && trigger.value <= today;
+}
+
+// An approach is review-trigger-ready when ANY of its date triggers is on
+// or before today.
+export function isReviewTriggerReady(approach: ApproachWire, today: string = todayIso()): boolean {
+  return approach.review_triggers.some((t) => isDateTriggerReady(t, today));
+}


### PR DESCRIPTION
## Why

Lived friction during effect-measurement (2026-05-31): the operator **can't judge "is this decision/approach worth opening?" from the R₁ inventory row** — the attention signals were trapped in the R₂ viewer, forcing them to open each one. This closes that "can't judge worth-opening from the row" friction.

Serves spine `2026-05-29-c-and-r-as-the-development-substrate` (its **silence-is-not-neutral** rule + the "📋 Approaches (i)" walk, which SPEC'd a `(review-trigger ready)` indicator inline in R₁ that the implementation had omitted; and refines the Decisions-(i) walk to surface drift inline too) + `2026-05-26-tmai-states-facts-not-appraisals`.

## What

- **`DecisionRow`** (`RDecisionsSection.tsx`): inline `drift` marker when `decision.stale_since !== null` (a `governs:` path changed after `last_verified` = currency re-verify due). The which-path/when detail stays in R₂'s `DriftIndicator`.
- **`ApproachRow`** (`RApproachesSection.tsx`): inline **status** + **confidence** (when non-null) + a **`review-trigger ready`** marker when any `date`-kind `review_triggers` entry is on-or-before today. The specific triggers stay in R₂'s `ReviewTriggerIndicator`.
- Extracted `isReviewTriggerReady` / `isDateTriggerReady` / `todayIso` into a shared `r-viewer/review-trigger.ts`, now used by **both** the R₁ row and R₂'s `ReviewTriggerIndicator` — no duplicate date logic.

Realizes the spine's **Approaches-(i)** review-trigger-indicator spec and **refines Decisions-(i)** to surface drift inline.

## Posture — plain / silence-is-not-neutral (facts for scanning, not alarms)

- Every added marker renders in `text-foreground` / `text-muted-foreground` / `text-subtle-foreground` **only** — never `text-warning` / `text-destructive` / `text-success`. A drifted decision / a ready trigger is a *fact surfaced for scanning*, not a red alarm.
- **Present-only**: marker shown when the condition holds, nothing when it doesn't — no "no drift" / "not due" reassurance.
- Rows stay compact scan-lines; full detail (drift path/date, the specific triggers, success/failure signals) stays in the R₂ viewers.
- Row click → R₂ selection, `aria-current`, grouping, and sort are untouched.

## Tests

- `RDecisionsSection`: a `stale_since` fixture renders the drift marker; a `stale_since: null` one does not; no severity classes on the output.
- `RApproachesSection`: status + confidence inline (confidence present-only); past-dated date trigger renders `review-trigger ready`, future-dated does not; no severity classes.
- `review-trigger.ts` unit test: past → ready, today → ready, future → not, non-date kinds → never.

## Gate (all green from `clients/react/`)

`pnpm install` · `pnpm lint` · `pnpm build` · `pnpm test` (638 passed | 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * アプローチ表示に信頼度と準備状態インジケーターを追加
  * 決定表示に未検証状態（ドリフト）マーカーを追加
  * レビュートリガーの準備状態判定ロジックを改善し、ユーザーがレビュー対象をより正確に把握可能に

* **Tests**
  * 準備状態表示とドリフトマーカーの表示条件に関するテストケースを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->