### PR TITLE
feat(r-panel): RInventorySection — cross-record in-play inventory (R₁) consuming GET /api/units/{unit}/inventory (#765)

### DIFF
--- a/clients/react/src/components/producer-console/r-panel/RInventorySection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RInventorySection.tsx
@@ -1,0 +1,256 @@
+// 📦 In-play — R panel's cross-record in-play inventory (R₁).
+//
+// The operator's "what's in-play / what's outstanding" view, fed by
+// `useUnitInventory` → `api.unitInventory` (the projection wire from
+// tmai-core #485/#486). Each decision is a row (`display`,
+// `frontmatter_status`, `serving_health`, `running_count`) with its serving
+// approaches nested under it, then a trailing unanchored-approaches
+// subsection. Each approach row carries its fact-projected status, its
+// work-residual (count + the outstanding ids), and its liveness (stalled +
+// last fact).
+//
+// R₁ is a lens, not a dashboard (the serving
+// `2026-05-26-tmai-states-facts-not-appraisals` posture): the inventory is
+// light, plain-text, mechanical fact (count / state / date). NO severity
+// coloring, NO appraisal form — `stalled` / `overflow` / `orphaned` /
+// residual-count render as plain neutral labels
+// (`text-foreground` / `text-muted-foreground` / `text-subtle-foreground`
+// only), never warning / destructive / success accents. The data is
+// mechanical; the operator judges. This mirrors the restraint of the other
+// R-panel sections.
+//
+// A row click opens the record in the R₂ `RRecordViewer`, reusing the same
+// R₁⇄R₂ focus-mode the Decisions / Approaches sections use. The inventory
+// projection carries only `slug` + `display`, so the section also reads the
+// unit's decisions + approaches (the cheap 60s polls R₁ already uses) and
+// resolves each entry's slug through `buildRecordIndex` to the full record
+// (with its `repoPath` / `repoLabel`) the viewer needs. A slug that has not
+// resolved yet renders plain and inert — not an error.
+
+import { useMemo } from "react";
+import { useApproaches } from "@/hooks/useApproaches";
+import { useDecisions } from "@/hooks/useDecisions";
+import { useUnitInventory } from "@/hooks/useUnitInventory";
+import type {
+  ApproachInventoryWire,
+  DecisionInventoryWire,
+  UnitInventoryResponse,
+} from "@/lib/api";
+import { type SelectedRecord, selectedRecordKey } from "./r-viewer/RRecordViewer";
+import { buildRecordIndex } from "./r-viewer/record-index";
+import { Section } from "./Section";
+
+interface RInventorySectionProps {
+  unitName: string | null;
+  expanded: boolean;
+  onToggle: () => void;
+  /** Open a decision/approach in the R₂ record viewer column (mirrors
+   *  `RApproachesSection.onSelect`). Optional so the section still renders
+   *  standalone in isolation. */
+  onSelect?: (sel: SelectedRecord) => void;
+  /** `selectedRecordKey(repoPath, slug)` of the record currently open in
+   *  R₂, so the row marks itself as the one being viewed. */
+  selectedKey?: string | null;
+}
+
+export function RInventorySection({
+  unitName,
+  expanded,
+  onToggle,
+  onSelect,
+  selectedKey,
+}: RInventorySectionProps) {
+  const { data, loading, error } = useUnitInventory(unitName);
+  // The inventory projection carries only slug/display; resolve each
+  // entry's slug to the full record (with repoPath/repoLabel) so a row
+  // click can open R₂'s RRecordViewer — the same index RRecordViewer uses
+  // for its own cross-refs.
+  const { data: decisions } = useDecisions(unitName);
+  const { data: approaches } = useApproaches(unitName);
+  const index = useMemo(() => buildRecordIndex(decisions, approaches), [decisions, approaches]);
+
+  // Counts are the wire's own (mechanical fact), rendered plain by Section.
+  const count =
+    data === null ? "" : `${data.decision_count} decisions · ${data.approach_count} approaches`;
+
+  return (
+    <Section
+      id="inventory"
+      glyph="📦"
+      label="In-play"
+      count={count}
+      expanded={expanded}
+      onToggle={onToggle}
+    >
+      <Body
+        unitName={unitName}
+        data={data}
+        loading={loading}
+        error={error}
+        index={index}
+        onSelect={onSelect}
+        selectedKey={selectedKey ?? null}
+      />
+    </Section>
+  );
+}
+
+interface BodyProps {
+  unitName: string | null;
+  data: UnitInventoryResponse | null;
+  loading: boolean;
+  error: Error | null;
+  index: Map<string, SelectedRecord>;
+  onSelect?: (sel: SelectedRecord) => void;
+  selectedKey: string | null;
+}
+
+function Body({ unitName, data, loading, error, index, onSelect, selectedKey }: BodyProps) {
+  if (unitName === null) {
+    return <p className="text-subtle-foreground">Pick a project to see the in-play inventory.</p>;
+  }
+  if (error !== null) {
+    return <p className="text-muted-foreground">Failed to load inventory: {error.message}</p>;
+  }
+  if (data === null && loading) {
+    return <p className="text-subtle-foreground">Loading…</p>;
+  }
+  if (data === null || (data.decisions.length === 0 && data.unanchored_approaches.length === 0)) {
+    return <p className="text-subtle-foreground">No in-play records.</p>;
+  }
+  return (
+    <div className="space-y-2">
+      {/* The ISO date liveness was computed against — a plain "as of" so the
+          stalled / last-fact facts read against a known reference, not a
+          guessed client clock. */}
+      <p className="text-[11px] text-subtle-foreground">as of {data.today}</p>
+      {data.decisions.map((decision) => (
+        <DecisionBlock
+          key={decision.slug}
+          decision={decision}
+          index={index}
+          onSelect={onSelect}
+          selectedKey={selectedKey}
+        />
+      ))}
+      {data.unanchored_approaches.length > 0 && (
+        <div data-testid="r-inventory-unanchored">
+          <p className="text-[11px] uppercase tracking-wide text-subtle-foreground">
+            Unanchored approaches
+          </p>
+          <ul className="space-y-0.5">
+            {data.unanchored_approaches.map((approach) => (
+              <ApproachRow
+                key={approach.slug}
+                approach={approach}
+                index={index}
+                onSelect={onSelect}
+                selectedKey={selectedKey}
+              />
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// A decision row (its mechanical projection facts) with its serving
+// approaches nested under it. The whole row is a button that opens the
+// decision in R₂ — `aria-current` marks the row whose content is open
+// there. `serving_health` (`orphaned` / `no-running-means` / `healthy` /
+// `overflow`) and `running_count` are plain neutral text, never appraised.
+function DecisionBlock({
+  decision,
+  index,
+  onSelect,
+  selectedKey,
+}: {
+  decision: DecisionInventoryWire;
+  index: Map<string, SelectedRecord>;
+  onSelect?: (sel: SelectedRecord) => void;
+  selectedKey: string | null;
+}) {
+  const resolved = index.get(decision.slug);
+  const selected =
+    resolved !== undefined && selectedKey === selectedRecordKey(resolved.repoPath, decision.slug);
+  return (
+    <div data-testid="r-inventory-decision">
+      <button
+        type="button"
+        onClick={() => {
+          if (resolved !== undefined) onSelect?.(resolved);
+        }}
+        aria-current={selected ? "true" : undefined}
+        className={`w-full rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
+          selected ? "bg-surface-strong/40" : ""
+        }`}
+      >
+        <span className="text-foreground">{decision.display}</span>
+        <div className="text-[11px] text-subtle-foreground">
+          {decision.frontmatter_status} · {decision.serving_health} · {decision.running_count}{" "}
+          running
+        </div>
+      </button>
+      {decision.serving.length > 0 && (
+        <ul className="mt-0.5 space-y-0.5 pl-3">
+          {decision.serving.map((approach) => (
+            <ApproachRow
+              key={approach.slug}
+              approach={approach}
+              index={index}
+              onSelect={onSelect}
+              selectedKey={selectedKey}
+            />
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
+
+// One approach row — its `projected_status`, work-residual (count + the
+// outstanding ids), and liveness (`stalled` present-only + the last-fact
+// date). All plain neutral text: residual-count and `stalled` are
+// mechanical facts, never alarms. The whole row is a button that opens the
+// approach in R₂.
+function ApproachRow({
+  approach,
+  index,
+  onSelect,
+  selectedKey,
+}: {
+  approach: ApproachInventoryWire;
+  index: Map<string, SelectedRecord>;
+  onSelect?: (sel: SelectedRecord) => void;
+  selectedKey: string | null;
+}) {
+  const resolved = index.get(approach.slug);
+  const selected =
+    resolved !== undefined && selectedKey === selectedRecordKey(resolved.repoPath, approach.slug);
+  const { work_residual, liveness } = approach;
+  return (
+    <li className="leading-snug" data-testid="r-inventory-approach">
+      <button
+        type="button"
+        onClick={() => {
+          if (resolved !== undefined) onSelect?.(resolved);
+        }}
+        aria-current={selected ? "true" : undefined}
+        className={`w-full rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
+          selected ? "bg-surface-strong/40" : ""
+        }`}
+      >
+        <span className="text-foreground">{approach.display}</span>
+        <div className="text-[11px] text-subtle-foreground">
+          {approach.projected_status} · {work_residual.count} outstanding
+          {work_residual.count > 0 && (
+            <span className="text-muted-foreground"> ({work_residual.outstanding.join(", ")})</span>
+          )}{" "}
+          · {liveness.stalled && <span className="text-foreground">stalled · </span>}
+          last fact {liveness.last_fact ?? "—"}
+        </div>
+      </button>
+    </li>
+  );
+}

--- a/clients/react/src/components/producer-console/r-panel/RPanel.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPanel.tsx
@@ -34,6 +34,7 @@ import { RCalibrationSection } from "./RCalibrationSection";
 import { RDecisionsSection } from "./RDecisionsSection";
 import { RFilesSection } from "./RFilesSection";
 import { RHandoverSection } from "./RHandoverSection";
+import { RInventorySection } from "./RInventorySection";
 import { RIssuesSection } from "./RIssuesSection";
 import { RPrsSection } from "./RPrsSection";
 import type { SelectedCalibration } from "./r-viewer/RCalibrationViewer";
@@ -114,6 +115,7 @@ const SECTION_IDS = [
   "issues",
   "decisions",
   "approaches",
+  "inventory",
   "calibration",
   "handover",
   "files",
@@ -267,6 +269,13 @@ export function RPanel({
               unitName={unitName}
               expanded={isExpanded("approaches")}
               onToggle={() => toggle("approaches")}
+              onSelect={onSelectRecord}
+              selectedKey={selectedRecordKey}
+            />
+            <RInventorySection
+              unitName={unitName}
+              expanded={isExpanded("inventory")}
+              onToggle={() => toggle("inventory")}
               onSelect={onSelectRecord}
               selectedKey={selectedRecordKey}
             />

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RInventorySection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RInventorySection.test.tsx
@@ -1,0 +1,364 @@
+// @vitest-environment jsdom
+//
+// RInventorySection — cross-record in-play inventory (R₁), fed by
+// `useUnitInventory` → `api.unitInventory`. Each decision is a row with its
+// serving approaches nested under it, plus a trailing unanchored-approaches
+// subsection. R₁ is a lens, not a dashboard: every projection fact
+// (`stalled` / `overflow` / `orphaned` / residual-count) renders as plain
+// neutral text — no severity-color badges. A row click opens the record in
+// the R₂ `RRecordViewer`, so the section resolves each entry's slug (the
+// projection carries only slug/display) against the unit's decisions +
+// approaches — hence the three mocked endpoints.
+
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  ApproachesResponse,
+  ApproachInventoryWire,
+  ApproachWire,
+  DecisionInventoryWire,
+  DecisionsResponse,
+  DecisionWire,
+  UnitInventoryResponse,
+} from "@/lib/api";
+
+const unitInventoryMock = vi.fn();
+const decisionsMock = vi.fn();
+const approachesMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      unitInventory: (...args: unknown[]) => unitInventoryMock(...args),
+      decisions: (...args: unknown[]) => decisionsMock(...args),
+      approaches: (...args: unknown[]) => approachesMock(...args),
+    },
+  };
+});
+
+import { RInventorySection } from "../RInventorySection";
+
+// ── Inventory projection fixtures (slug/display only — the wire shape) ──
+
+function approachEntry(overrides: Partial<ApproachInventoryWire> = {}): ApproachInventoryWire {
+  return {
+    slug: "2026-02-01-an-approach",
+    display: "an-approach",
+    projected_status: "running",
+    work_residual: { outstanding: [], count: 0 },
+    liveness: { stalled: false, last_fact: "2026-06-01", days_since: 2n },
+    ...overrides,
+  };
+}
+
+function decisionEntry(overrides: Partial<DecisionInventoryWire> = {}): DecisionInventoryWire {
+  return {
+    slug: "2026-01-01-a-decision",
+    display: "a-decision",
+    frontmatter_status: "accepted",
+    serving_health: "healthy",
+    running_count: 1,
+    serving: [],
+    ...overrides,
+  };
+}
+
+function inventory(overrides: Partial<UnitInventoryResponse> = {}): UnitInventoryResponse {
+  return {
+    unit: "u",
+    today: "2026-06-03",
+    decision_count: 0,
+    approach_count: 0,
+    decisions: [],
+    unanchored_approaches: [],
+    ...overrides,
+  };
+}
+
+// ── Full-record fixtures (for slug → record resolution on a row click) ──
+
+function decisionWire(slug: string): DecisionWire {
+  return {
+    slug,
+    title: `Decision ${slug}`,
+    status: "accepted",
+    category: "scoped",
+    governs: [],
+    last_verified: "2026-06-01",
+    contract_surface: false,
+    stale_since: null,
+    superseded_by: [],
+    strengthened_by: [],
+    excerpt: "",
+  };
+}
+
+function decisionsResponse(slugs: string[]): DecisionsResponse {
+  return {
+    unit: "u",
+    composed_at: "2026-06-03T00:00:00Z",
+    repos: [
+      {
+        repo_label: "tmai",
+        repo_root: "/p/tmai",
+        primary: true,
+        repo_head: null,
+        counts: {
+          total: 0,
+          in_play: 0,
+          warm: 0,
+          cold: 0,
+          foundations: 0,
+          superseded: 0,
+          stale_suspect: 0,
+        },
+        currency_sweep: [],
+        foundational_due: [],
+        foundations: [],
+        in_play: slugs.map(decisionWire),
+        warm: [],
+        cold: [],
+        superseded: [],
+      },
+    ],
+  };
+}
+
+function approachWire(slug: string): ApproachWire {
+  return {
+    slug,
+    title: `Approach ${slug}`,
+    date: "2026-02-01",
+    status: "running",
+    governs: [],
+    serves: [],
+    success_signal: "",
+    failure_signal: "",
+    review_triggers: [],
+    review_history: [],
+    confidence: null,
+    replaced_by: [],
+    excerpt: "",
+  };
+}
+
+function approachesResponse(slugs: string[]): ApproachesResponse {
+  return {
+    unit: "u",
+    composed_at: "2026-06-03T00:00:00Z",
+    repos: [
+      {
+        repo_label: "tmai",
+        repo_root: "/p/tmai",
+        primary: true,
+        repo_head: null,
+        approaches: slugs.map(approachWire),
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  unitInventoryMock.mockReset();
+  decisionsMock.mockReset();
+  approachesMock.mockReset();
+  // Default the resolution sources to empty so the section never reads an
+  // undefined response; focus tests override these with matching slugs.
+  decisionsMock.mockResolvedValue(decisionsResponse([]));
+  approachesMock.mockResolvedValue(approachesResponse([]));
+});
+
+describe("RInventorySection", () => {
+  it("renders each decision with its serving approaches nested under it", async () => {
+    unitInventoryMock.mockResolvedValue(
+      inventory({
+        decision_count: 1,
+        approach_count: 1,
+        decisions: [
+          decisionEntry({
+            slug: "2026-01-01-a-decision",
+            display: "a-decision",
+            serving: [approachEntry({ slug: "2026-02-01-an-approach", display: "an-approach" })],
+          }),
+        ],
+      }),
+    );
+    render(<RInventorySection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    const block = await screen.findByTestId("r-inventory-decision");
+    // The decision display and its serving approach both live in the block.
+    expect(within(block).getByText("a-decision")).toBeTruthy();
+    expect(within(block).getByText("an-approach")).toBeTruthy();
+  });
+
+  it("renders a trailing unanchored-approaches subsection", async () => {
+    unitInventoryMock.mockResolvedValue(
+      inventory({
+        approach_count: 1,
+        unanchored_approaches: [
+          approachEntry({ slug: "2026-02-02-loose-approach", display: "loose-approach" }),
+        ],
+      }),
+    );
+    render(<RInventorySection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    const unanchored = await screen.findByTestId("r-inventory-unanchored");
+    expect(within(unanchored).getByText(/Unanchored approaches/i)).toBeTruthy();
+    expect(within(unanchored).getByText("loose-approach")).toBeTruthy();
+  });
+
+  it("header count is the wire's own decision/approach counts", async () => {
+    unitInventoryMock.mockResolvedValue(
+      inventory({
+        decision_count: 4,
+        approach_count: 7,
+        decisions: [decisionEntry()],
+      }),
+    );
+    render(<RInventorySection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/4 decisions · 7 approaches/)).toBeTruthy();
+    });
+  });
+
+  it("renders stalled / overflow / orphaned as plain neutral facts (no severity color)", async () => {
+    unitInventoryMock.mockResolvedValue(
+      inventory({
+        decision_count: 2,
+        approach_count: 1,
+        decisions: [
+          decisionEntry({
+            slug: "2026-01-01-overflowing",
+            display: "overflowing",
+            serving_health: "overflow",
+            running_count: 3,
+            serving: [
+              approachEntry({
+                slug: "2026-02-01-stale-approach",
+                display: "stale-approach",
+                work_residual: { outstanding: ["#42", "#43"], count: 2 },
+                liveness: { stalled: true, last_fact: "2026-04-01", days_since: 63n },
+              }),
+            ],
+          }),
+          decisionEntry({
+            slug: "2026-01-02-orphan",
+            display: "orphan",
+            serving_health: "orphaned",
+            running_count: 0,
+            serving: [],
+          }),
+        ],
+      }),
+    );
+    const { container } = render(
+      <RInventorySection unitName="u" expanded={true} onToggle={vi.fn()} />,
+    );
+    await screen.findByText("overflowing");
+    // The mechanical projection labels are present as plain text…
+    const text = container.textContent ?? "";
+    expect(text).toContain("overflow");
+    expect(text).toContain("orphaned");
+    expect(text).toContain("stalled");
+    expect(text).toContain("2 outstanding");
+    expect(text).toContain("#42, #43");
+    // …and NO severity-color classes appear anywhere.
+    expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
+  });
+
+  it("clicking a decision row opens it in R₂ with the resolved full record", async () => {
+    decisionsMock.mockResolvedValue(decisionsResponse(["2026-01-01-a-decision"]));
+    unitInventoryMock.mockResolvedValue(
+      inventory({
+        decision_count: 1,
+        decisions: [decisionEntry({ slug: "2026-01-01-a-decision", display: "a-decision" })],
+      }),
+    );
+    const onSelect = vi.fn();
+    render(
+      <RInventorySection unitName="u" expanded={true} onToggle={vi.fn()} onSelect={onSelect} />,
+    );
+    // Click within waitFor so the click lands once the slug→record index has
+    // resolved (decisions/approaches are separate polls from the inventory).
+    await waitFor(() => {
+      fireEvent.click(screen.getByText("a-decision"));
+      expect(onSelect).toHaveBeenCalled();
+    });
+    const sel = onSelect.mock.calls[0][0];
+    expect(sel.kind).toBe("decision");
+    expect(sel.repoPath).toBe("/p/tmai");
+    expect(sel.repoLabel).toBe("tmai");
+    expect(sel.record.slug).toBe("2026-01-01-a-decision");
+  });
+
+  it("clicking a nested serving approach opens it in R₂ with the resolved full record", async () => {
+    approachesMock.mockResolvedValue(approachesResponse(["2026-02-01-an-approach"]));
+    unitInventoryMock.mockResolvedValue(
+      inventory({
+        decision_count: 1,
+        approach_count: 1,
+        decisions: [
+          decisionEntry({
+            slug: "2026-01-01-a-decision",
+            display: "a-decision",
+            serving: [approachEntry({ slug: "2026-02-01-an-approach", display: "an-approach" })],
+          }),
+        ],
+      }),
+    );
+    const onSelect = vi.fn();
+    render(
+      <RInventorySection unitName="u" expanded={true} onToggle={vi.fn()} onSelect={onSelect} />,
+    );
+    await waitFor(() => {
+      fireEvent.click(screen.getByText("an-approach"));
+      expect(onSelect).toHaveBeenCalled();
+    });
+    const sel = onSelect.mock.calls[0][0];
+    expect(sel.kind).toBe("approach");
+    expect(sel.repoPath).toBe("/p/tmai");
+    expect(sel.record.slug).toBe("2026-02-01-an-approach");
+  });
+
+  it("marks the focused row with aria-current (and no others)", async () => {
+    decisionsMock.mockResolvedValue(decisionsResponse(["2026-01-01-a-decision"]));
+    unitInventoryMock.mockResolvedValue(
+      inventory({
+        decision_count: 1,
+        decisions: [
+          decisionEntry({ slug: "2026-01-01-a-decision", display: "a-decision" }),
+          decisionEntry({ slug: "2026-01-02-other", display: "other" }),
+        ],
+      }),
+    );
+    render(
+      <RInventorySection
+        unitName="u"
+        expanded={true}
+        onToggle={vi.fn()}
+        selectedKey="/p/tmai#2026-01-01-a-decision"
+      />,
+    );
+    await waitFor(() => {
+      const row = screen.getByText("a-decision").closest("button");
+      expect(row?.getAttribute("aria-current")).toBe("true");
+    });
+    const other = screen.getByText("other").closest("button");
+    expect(other?.getAttribute("aria-current")).toBeNull();
+  });
+
+  it("empty state — no in-play records", async () => {
+    unitInventoryMock.mockResolvedValue(inventory());
+    render(<RInventorySection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/No in-play records/i)).toBeTruthy();
+    });
+  });
+
+  it("prompts to pick a project when no unit is selected", () => {
+    render(<RInventorySection unitName={null} expanded={true} onToggle={vi.fn()} />);
+    expect(screen.getByText(/Pick a project/i)).toBeTruthy();
+    expect(unitInventoryMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/RRecordViewer.tsx
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/RRecordViewer.tsx
@@ -40,15 +40,10 @@ import Markdown, { type Components, defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
 import { useApproaches } from "@/hooks/useApproaches";
 import { useDecisions } from "@/hooks/useDecisions";
-import type {
-  ApproachesResponse,
-  ApproachWire,
-  DecisionsResponse,
-  DecisionWire,
-  ReviewTriggerWire,
-} from "@/lib/api";
+import type { ApproachWire, DecisionWire, ReviewTriggerWire } from "@/lib/api";
 import { InventoryBackButton } from "./InventoryBackButton";
 import { PROSE_CLASSES } from "./prose";
+import { buildRecordIndex } from "./record-index";
 import { isDateTriggerReady, todayIso } from "./review-trigger";
 
 // What R₁ hands R₂ on a record row click. The full wire object rides
@@ -106,58 +101,6 @@ export function RRecordViewer({ selected, unitName, onSelectRecord, onClose }: R
       </div>
     </div>
   );
-}
-
-// ── Cross-ref index — slug → the SelectedRecord that owns it ──
-//
-// Decisions are indexed first so a slug colliding across kinds (rare —
-// the two live in different directories) resolves to the decision. A
-// slug absent from the index is a not-yet-existing ref, rendered plain.
-
-function flattenDecisions(decisions: DecisionsResponse | null): {
-  repoPath: string;
-  repoLabel: string;
-  record: DecisionWire;
-}[] {
-  if (decisions === null) return [];
-  return decisions.repos.flatMap((repo) =>
-    [...repo.foundations, ...repo.in_play, ...repo.warm, ...repo.cold, ...repo.superseded].map(
-      (record) => ({ repoPath: repo.repo_root, repoLabel: repo.repo_label, record }),
-    ),
-  );
-}
-
-function flattenApproaches(approaches: ApproachesResponse | null): {
-  repoPath: string;
-  repoLabel: string;
-  record: ApproachWire;
-}[] {
-  if (approaches === null) return [];
-  return approaches.repos.flatMap((repo) =>
-    repo.approaches.map((record) => ({
-      repoPath: repo.repo_root,
-      repoLabel: repo.repo_label,
-      record,
-    })),
-  );
-}
-
-function buildRecordIndex(
-  decisions: DecisionsResponse | null,
-  approaches: ApproachesResponse | null,
-): Map<string, SelectedRecord> {
-  const index = new Map<string, SelectedRecord>();
-  for (const { repoPath, repoLabel, record } of flattenDecisions(decisions)) {
-    if (!index.has(record.slug)) {
-      index.set(record.slug, { kind: "decision", repoPath, repoLabel, record });
-    }
-  }
-  for (const { repoPath, repoLabel, record } of flattenApproaches(approaches)) {
-    if (!index.has(record.slug)) {
-      index.set(record.slug, { kind: "approach", repoPath, repoLabel, record });
-    }
-  }
-  return index;
 }
 
 // ── Header — mechanical identity facts, all plain (no severity tint) ──

--- a/clients/react/src/components/producer-console/r-panel/r-viewer/record-index.ts
+++ b/clients/react/src/components/producer-console/r-panel/r-viewer/record-index.ts
@@ -1,0 +1,64 @@
+// Cross-ref index — slug → the `SelectedRecord` that owns it.
+//
+// Shared by `RRecordViewer` (resolving `serves:` / `[[slug]]` cross-refs in
+// a focused record) and `RInventorySection` (resolving an in-play inventory
+// row's slug to the full decision/approach so a click can open R₂'s
+// `RRecordViewer`). The inventory projection carries only `slug` + `display`,
+// so the section re-reads the unit's decisions + approaches (the same cheap
+// 60s polls R₁ uses) and resolves each entry through this index — the full
+// wire + `repoPath` / `repoLabel` ride in `SelectedRecord` so the viewer
+// renders without re-fetching.
+//
+// Decisions are indexed first so a slug colliding across kinds (rare — the
+// two live in different directories) resolves to the decision. A slug absent
+// from the index is a not-yet-loaded / not-yet-existing ref, NOT an error —
+// callers render it plain and non-clickable.
+
+import type { ApproachesResponse, ApproachWire, DecisionsResponse, DecisionWire } from "@/lib/api";
+import type { SelectedRecord } from "./RRecordViewer";
+
+function flattenDecisions(decisions: DecisionsResponse | null): {
+  repoPath: string;
+  repoLabel: string;
+  record: DecisionWire;
+}[] {
+  if (decisions === null) return [];
+  return decisions.repos.flatMap((repo) =>
+    [...repo.foundations, ...repo.in_play, ...repo.warm, ...repo.cold, ...repo.superseded].map(
+      (record) => ({ repoPath: repo.repo_root, repoLabel: repo.repo_label, record }),
+    ),
+  );
+}
+
+function flattenApproaches(approaches: ApproachesResponse | null): {
+  repoPath: string;
+  repoLabel: string;
+  record: ApproachWire;
+}[] {
+  if (approaches === null) return [];
+  return approaches.repos.flatMap((repo) =>
+    repo.approaches.map((record) => ({
+      repoPath: repo.repo_root,
+      repoLabel: repo.repo_label,
+      record,
+    })),
+  );
+}
+
+export function buildRecordIndex(
+  decisions: DecisionsResponse | null,
+  approaches: ApproachesResponse | null,
+): Map<string, SelectedRecord> {
+  const index = new Map<string, SelectedRecord>();
+  for (const { repoPath, repoLabel, record } of flattenDecisions(decisions)) {
+    if (!index.has(record.slug)) {
+      index.set(record.slug, { kind: "decision", repoPath, repoLabel, record });
+    }
+  }
+  for (const { repoPath, repoLabel, record } of flattenApproaches(approaches)) {
+    if (!index.has(record.slug)) {
+      index.set(record.slug, { kind: "approach", repoPath, repoLabel, record });
+    }
+  }
+  return index;
+}

--- a/clients/react/src/hooks/__tests__/useUnitInventory.test.ts
+++ b/clients/react/src/hooks/__tests__/useUnitInventory.test.ts
@@ -1,0 +1,131 @@
+// @vitest-environment jsdom
+//
+// useUnitInventory — the cross-record in-play inventory poller behind the R
+// panel's 📦 In-play section (the inventory twin of useUnitIssues). We mock
+// `api.unitInventory` so each test drives a deterministic response and
+// asserts the sibling-shaped contract: `unit = null` parks (no fetch), the
+// initial fetch flips `loading`, errors surface without clearing into a fake
+// success, a unit change re-fetches, and the 60s poll keeps the last
+// response visible (anti-flicker).
+//
+// Timers stay real and the poll is exercised by capturing the
+// `window.setInterval` callback directly — `@testing-library`'s `waitFor`
+// cannot make progress under fake timers, and a real 60s wait is not viable
+// in a unit test.
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    unitInventory: vi.fn(),
+  },
+}));
+
+import type { UnitInventoryResponse } from "@/lib/api";
+import { api } from "@/lib/api";
+import { useUnitInventory } from "../useUnitInventory";
+
+function response(unit: string, decisionCount: number): UnitInventoryResponse {
+  return {
+    unit,
+    today: "2026-06-03",
+    decision_count: decisionCount,
+    approach_count: decisionCount,
+    decisions: Array.from({ length: decisionCount }, (_, i) => ({
+      slug: `2026-01-0${i + 1}-decision-${i + 1}`,
+      display: `decision-${i + 1}`,
+      frontmatter_status: "accepted",
+      serving_health: "healthy",
+      running_count: 1,
+      serving: [
+        {
+          slug: `2026-02-0${i + 1}-approach-${i + 1}`,
+          display: `approach-${i + 1}`,
+          projected_status: "running",
+          work_residual: { outstanding: [], count: 0 },
+          liveness: { stalled: false, last_fact: "2026-06-01", days_since: 2n },
+        },
+      ],
+    })),
+    unanchored_approaches: [],
+  };
+}
+
+describe("useUnitInventory", () => {
+  beforeEach(() => {
+    vi.mocked(api.unitInventory).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parks on unit=null — no fetch, not loading", () => {
+    const { result } = renderHook(() => useUnitInventory(null));
+    expect(api.unitInventory).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetches on a real unit and exposes the response", async () => {
+    vi.mocked(api.unitInventory).mockResolvedValue(response("tmai", 2));
+    const { result } = renderHook(() => useUnitInventory("tmai"));
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(api.unitInventory).toHaveBeenCalledWith("tmai");
+    expect(result.current.data?.decisions).toHaveLength(2);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a fetch error without fabricating data", async () => {
+    vi.mocked(api.unitInventory).mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useUnitInventory("tmai"));
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe("boom");
+    });
+    expect(result.current.data).toBeNull();
+  });
+
+  it("re-fetches when the unit changes and clears the previous inventory", async () => {
+    vi.mocked(api.unitInventory).mockImplementation((u: string) =>
+      Promise.resolve(response(u, u === "tmai" ? 3 : 1)),
+    );
+    const { result, rerender } = renderHook(({ u }) => useUnitInventory(u), {
+      initialProps: { u: "tmai" },
+    });
+    await waitFor(() => expect(result.current.data?.decisions).toHaveLength(3));
+
+    rerender({ u: "other" });
+    // Cleared synchronously on unit change so the old unit's inventory is
+    // never shown under the new header.
+    expect(result.current.data).toBeNull();
+    await waitFor(() => expect(result.current.data?.unit).toBe("other"));
+    expect(result.current.data?.decisions).toHaveLength(1);
+  });
+
+  it("keeps the last response visible across the 60s poll", async () => {
+    // Spy only — `vi.spyOn` calls through, so `waitFor`'s own internal
+    // `setInterval` polling still works (a `mockImplementation` here would
+    // deadlock waitFor). We read the captured callback and fire it by hand
+    // instead of waiting a real 60s.
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+
+    vi.mocked(api.unitInventory).mockResolvedValue(response("tmai", 2));
+    const { result } = renderHook(() => useUnitInventory("tmai"));
+    await waitFor(() => expect(result.current.data?.decisions).toHaveLength(2));
+
+    const tick = setIntervalSpy.mock.calls[0]?.[0] as (() => void) | undefined;
+    expect(typeof tick).toBe("function");
+
+    await act(async () => {
+      tick?.();
+    });
+    await waitFor(() => expect(api.unitInventory).toHaveBeenCalledTimes(2));
+    // Last response stays visible (anti-flicker) — never cleared on a poll.
+    expect(result.current.data?.decisions).toHaveLength(2);
+  });
+});

--- a/clients/react/src/hooks/useUnitInventory.ts
+++ b/clients/react/src/hooks/useUnitInventory.ts
@@ -1,0 +1,84 @@
+// Polling hook for the unit's in-play inventory (R₁) — the cross-record
+// "what's in-play / what's outstanding" projection behind the R panel's
+// in-play section, consuming `GET /api/units/{unit}/inventory` (the
+// projection wire from tmai-core #485/#486): every decision with its
+// serving approaches nested, plus the unanchored approaches, each carrying
+// its fact-projected status / work-residual / liveness.
+//
+// The inventory twin of `useUnitIssues` / `useApproaches` — same shape,
+// same cadence. The inventory tracks records + their fact-logs, which move
+// on the timescale a Producer raises/closes an approach or files a fact —
+// human-paced. A 60-second poll (same cadence as the siblings) is ample
+// for an operator-review surface; no SSE here yet. Mirrors the siblings'
+// shape exactly: keeps the previous response visible while a re-fetch is in
+// flight so the list does not flicker; `loading` reflects only the initial
+// fetch.
+//
+// `unit = null` parks the hook (no fetch, no interval) — used when no
+// project is selected so the section can render a placeholder rather than
+// poll a non-existent unit.
+
+import { useEffect, useRef, useState } from "react";
+import { api, type UnitInventoryResponse } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface UseUnitInventoryResult {
+  data: UnitInventoryResponse | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useUnitInventory(unit: string | null): UseUnitInventoryResult {
+  const [data, setData] = useState<UnitInventoryResponse | null>(null);
+  const [loading, setLoading] = useState(unit !== null);
+  const [error, setError] = useState<Error | null>(null);
+  // An in-flight response from a previous unit must not stamp over a
+  // newer unit's data (same guard as useUnitIssues / useApproaches).
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    if (!unit) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    // Clear on unit *change* (this effect's only re-trigger — deps are
+    // [unit]) so the previous unit's inventory is never shown under the new
+    // unit's header. The 60s same-unit re-poll goes through fetchOnce,
+    // which intentionally keeps the last response visible (anti-flicker);
+    // that path is untouched. Mirrors the same guard in useUnitIssues.
+    setData(null);
+    setError(null);
+    setLoading(true);
+
+    const fetchOnce = async () => {
+      try {
+        const res = await api.unitInventory(unit);
+        if (myGen !== generationRef.current) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (myGen !== generationRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (myGen === generationRef.current) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [unit]);
+
+  return { data, loading, error };
+}

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -3,6 +3,7 @@
 
 import type { AgentCtxUsage } from "@/types/generated/AgentCtxUsage";
 import type { ApproachesResponse } from "@/types/generated/ApproachesResponse";
+import type { ApproachInventoryWire } from "@/types/generated/ApproachInventoryWire";
 import type { ApproachStatus } from "@/types/generated/ApproachStatus";
 import type { ApproachWire } from "@/types/generated/ApproachWire";
 import type { BootstrapRequiredEvent } from "@/types/generated/BootstrapRequiredEvent";
@@ -10,6 +11,7 @@ import type { CalibrationCellWire } from "@/types/generated/CalibrationCellWire"
 import type { CalibrationEntry } from "@/types/generated/CalibrationEntry";
 import type { CalibrationResponse } from "@/types/generated/CalibrationResponse";
 import type { Confidence } from "@/types/generated/Confidence";
+import type { DecisionInventoryWire } from "@/types/generated/DecisionInventoryWire";
 import type { DispatchBundle } from "@/types/generated/DispatchBundle";
 import type { DispatchSnapshot } from "@/types/generated/DispatchSnapshot";
 import type { EntityUpdateEnvelope } from "@/types/generated/EntityUpdateEnvelope";
@@ -38,6 +40,7 @@ import type { SpawnRuntime } from "@/types/generated/SpawnRuntime";
 import type { TeamSnapshot } from "@/types/generated/TeamSnapshot";
 import type { TerminalSubscription } from "@/types/generated/TerminalSubscription";
 import type { TriageVerdict } from "@/types/generated/TriageVerdict";
+import type { UnitInventoryResponse } from "@/types/generated/UnitInventoryResponse";
 import type { UnitIssuesResponse } from "@/types/generated/UnitIssuesResponse";
 import type { UnitPrsResponse } from "@/types/generated/UnitPrsResponse";
 import type { UnitRepoWire } from "@/types/generated/UnitRepoWire";
@@ -50,6 +53,7 @@ import type { WorkflowSnapshot } from "@/types/generated/WorkflowSnapshot";
 export type {
   AgentCtxUsage,
   ApproachesResponse,
+  ApproachInventoryWire,
   ApproachStatus,
   ApproachWire,
   BootstrapRequiredEvent,
@@ -57,6 +61,7 @@ export type {
   CalibrationEntry,
   CalibrationResponse,
   Confidence,
+  DecisionInventoryWire,
   DispatchBundle,
   EntityUpdateEnvelope,
   HandoffContentResponse,
@@ -82,6 +87,7 @@ export type {
   SpawnRuntime,
   TerminalSubscription,
   TriageVerdict,
+  UnitInventoryResponse,
   UnitIssuesResponse,
   UnitPrsResponse,
   UnitRepoWire,
@@ -1525,6 +1531,15 @@ export const api = {
   // merge/CI gate to override.
   unitIssues: (unit: string) =>
     apiFetch<UnitIssuesResponse>(`/units/${encodeURIComponent(unit)}/issues`),
+
+  // Unit-scoped cross-record in-play inventory (tmai-core #485/#486) — the
+  // nested projection behind the R panel's in-play section: every decision
+  // (serving approaches nested) followed by the unanchored approaches, with
+  // each approach's fact-projected status, work-residual, and liveness. A
+  // pure projection (mechanical facts, no appraisal); the React side renders
+  // it light and plain.
+  unitInventory: (unit: string) =>
+    apiFetch<UnitInventoryResponse>(`/units/${encodeURIComponent(unit)}/inventory`),
 
   // Configured-unit membership (tmai-core #460, public mirror tmai#741).
   // Membership-only — no live agent state is joined server-side; the

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -271,6 +271,11 @@ export const api = {
   // (HTTP only — gh-CLI passthrough fanned out over the unit's repos)
   unitIssues: (unit: string) => httpApi.unitIssues(unit),
 
+  // Unit-scoped cross-record in-play inventory (HTTP only — on-demand JSON
+  // projection of the unit's decisions + serving approaches; no
+  // Tauri-specific path needed)
+  unitInventory: (unit: string) => httpApi.unitInventory(unit),
+
   // Configured-unit membership view (HTTP only — membership-only,
   // no live agent state joined server-side; no Tauri-specific path needed)
   units: () => httpApi.units(),


### PR DESCRIPTION
Resolves #765.

Adds the R-panel **`RInventorySection`** (R₁ `📦 In-play`) — the operator's cross-record "what's in-play / what's outstanding" view — consuming `GET /api/units/{unit}/inventory` (the projection wire from tmai-core #485/#486; wire + generated types already on main). UI half only.

## Layout (cross-record nested)
- Each **decision** is a row: `display`, `frontmatter_status`, `serving_health`, `running_count`.
- Its **serving approaches** nest under it: `display`, `projected_status`, `work_residual.count` + the outstanding ids, `liveness.stalled` + `last_fact`.
- A trailing **Unanchored approaches** subsection.
- A plain `as of {today}` line so the liveness facts read against the wire's reference date.

## Facts-not-appraisals (R₁ is a lens, not a dashboard)
Every projection fact (`stalled` / `overflow` / `orphaned` / residual-count) renders as **plain neutral text** — `text-foreground` / `text-muted-foreground` / `text-subtle-foreground` only, **no** severity coloring, no appraisal form. Mirrors the restraint of the existing R-panel sections.

## focus-mode
A row click opens the record in the R₂ `RRecordViewer`, reusing the existing R₁⇄R₂ focus-mode + `InventoryBackButton`. The inventory projection carries only `slug`/`display`, so the section resolves each entry against the unit's decisions + approaches via `buildRecordIndex` — **extracted from `RRecordViewer` into a shared `r-viewer/record-index` module** (single source of truth; `RRecordViewer` behavior unchanged). Because it opens the same record viewer, it reuses RPanel's existing `onSelectRecord` / `selectedRecordKey` threading — no new RPanel props or App wiring.

## Changes (clients/react only)
- `hooks/useUnitInventory.ts` (mirrors `useUnitIssues`) + test
- `lib/api-http.ts` / `lib/api-tauri.ts`: `unitInventory` fetch (`import type` the generated `UnitInventoryResponse` — no hand-mirror)
- `r-panel/RInventorySection.tsx` + test; wired into `RPanel.tsx` after Approaches
- `r-viewer/record-index.ts`: shared `buildRecordIndex` (extracted from `RRecordViewer`)

## Gate
- ✅ `pnpm lint` (biome) — clean (1 pre-existing warning in `ProducerFeedChip.tsx`, unrelated)
- ✅ `pnpm tsc -b` typecheck
- ✅ `pnpm test` — 658 passed / 2 pre-existing skips (87 files), incl. 14 new
- ✅ `pnpm build`

Tested against mocked API data (`RInventorySection.test.tsx`: nested decisions+serving, unanchored, plain rendering of stalled/overflow/orphaned, focus-mode click → viewer; `useUnitInventory.test.ts`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)