### PR TITLE
feat(r-panel): per-artifact attention markers + authorship-scoped coloring (attention model §3 core) (#768)

### DIFF
--- a/clients/react/src/components/producer-console/r-panel/AttentionMarker.tsx
+++ b/clients/react/src/components/producer-console/r-panel/AttentionMarker.tsx
@@ -1,0 +1,172 @@
+// Per-artifact attention marker — the R-panel half of the attention model
+// (contract
+// `tmai-core:doc/approaches/2026-06-04-attention-as-per-artifact-field.md`,
+// §3 core). Rendered on the LEFT of every attention-artifact row (PR / Issue
+// / Decision / Approach). File rows are attention-exempt and never render one.
+//
+// Two responsibilities in one control:
+//
+//   1. DISPLAY the artifact's attention level with authorship-scoped color —
+//      `null` is a machine fact (unconfirmed / changed) → a neutral pending
+//      marker, no heat; `low`/`high` are the operator's own appraisal → heat
+//      is allowed (muted `low`, bright `high`). Color follows authorship:
+//      only human-set marks are colored. The rest of the R panel's facts stay
+//      neutral, so a section reads as a focus map — the one bright `high`, the
+//      muted `low`s, the pending `null`s (the Δ).
+//
+//   2. SET `low`/`high` (the operator write). The popover offers ONLY `low`
+//      and `high` — the operator can never set `null` (the
+//      `AttentionSetRequest.level` type has no `null` variant; `null` is
+//      machine-only, by absence). The actual POST + monotonic / `high`≤1
+//      enforcement lives server-side; this control just calls `onSet` and the
+//      hook re-renders from the returned map.
+
+import { useEffect, useId, useRef, useState } from "react";
+import { type AttentionControls, attentionKey } from "@/hooks/useUnitAttention";
+import type { Level, Section } from "@/lib/api";
+
+interface AttentionMarkerProps {
+  /** Current attention: `null` (machine fact, pending) or operator-set. */
+  level: Level | null;
+  /** Operator write. `low`/`high` only — `null` is not offerable. */
+  onSet: (level: Level) => void;
+  /** POST in flight for this artifact → disable the control. */
+  busy?: boolean;
+  /** Human-readable artifact label for the a11y name (e.g. `#123`, slug). */
+  label: string;
+}
+
+// Glyph per pole. `null` is a hollow ring (pending / unset); `low`/`high` are
+// filled — their distinction is carried by the heat class, not the glyph, so
+// the row reads as brightness, not iconography.
+const GLYPH: Record<"null" | Level, string> = {
+  null: "○",
+  low: "●",
+  high: "●",
+};
+
+// Authorship-scoped color class. `null` stays neutral (machine fact); the
+// `low`/`high` heat classes live in globals.css (deliberately not the CI
+// severity utilities — see that block's comment).
+const HEAT_CLASS: Record<"null" | Level, string> = {
+  null: "text-subtle-foreground",
+  low: "attn-low",
+  high: "attn-high",
+};
+
+const POLE_LABEL: Record<"null" | Level, string> = {
+  null: "pending",
+  low: "low",
+  high: "high",
+};
+
+const SET_OPTIONS: readonly Level[] = ["low", "high"];
+
+export function AttentionMarker({ level, onSet, busy = false, label }: AttentionMarkerProps) {
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLSpanElement>(null);
+  const menuId = useId();
+  const pole = level ?? "null";
+
+  // Close on outside click or Escape (same affordance as QueuePopover).
+  useEffect(() => {
+    if (!open) return;
+    function onMouseDown(e: MouseEvent) {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    }
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") setOpen(false);
+    }
+    document.addEventListener("mousedown", onMouseDown);
+    document.addEventListener("keydown", onKeyDown);
+    return () => {
+      document.removeEventListener("mousedown", onMouseDown);
+      document.removeEventListener("keydown", onKeyDown);
+    };
+  }, [open]);
+
+  const choose = (next: Level) => {
+    setOpen(false);
+    onSet(next);
+  };
+
+  return (
+    <span ref={ref} className="relative inline-flex shrink-0 leading-none">
+      <button
+        type="button"
+        data-testid="attention-marker"
+        data-level={pole}
+        disabled={busy}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-controls={open ? menuId : undefined}
+        // Stop the click from bubbling to the row button (which opens the R₂
+        // viewer): the marker is its own control, sitting beside the row.
+        onClick={(e) => {
+          e.stopPropagation();
+          setOpen((v) => !v);
+        }}
+        title={`Attention: ${POLE_LABEL[pole]} — set low/high`}
+        aria-label={`Attention for ${label}: ${POLE_LABEL[pole]}. Set low or high.`}
+        className={`flex h-4 w-4 items-center justify-center rounded text-[11px] transition-colors hover:bg-surface-strong/60 disabled:opacity-40 ${HEAT_CLASS[pole]}`}
+      >
+        <span aria-hidden="true">{GLYPH[pole]}</span>
+      </button>
+      {open && (
+        <div
+          id={menuId}
+          role="menu"
+          aria-label={`Set attention for ${label}`}
+          className="absolute left-0 top-full z-50 mt-1 flex min-w-20 flex-col rounded-lg border border-hairline-strong bg-popover py-1 shadow-xl"
+        >
+          {SET_OPTIONS.map((opt) => (
+            <button
+              key={opt}
+              type="button"
+              role="menuitem"
+              data-testid={`attention-set-${opt}`}
+              aria-current={level === opt ? "true" : undefined}
+              onClick={(e) => {
+                e.stopPropagation();
+                choose(opt);
+              }}
+              className={`px-3 py-1 text-left text-[11px] transition-colors hover:bg-surface-strong/60 ${HEAT_CLASS[opt]}`}
+            >
+              <span aria-hidden="true" className="mr-1.5">
+                {GLYPH[opt]}
+              </span>
+              {POLE_LABEL[opt]}
+            </button>
+          ))}
+        </div>
+      )}
+    </span>
+  );
+}
+
+// Row binding — maps a (section,id) artifact onto its attention marker,
+// deriving the busy state from the shared `settingKey`. Renders nothing when
+// no attention controls are threaded (e.g. a section mounted in isolation),
+// so the marker is opt-in: `RPanel` threads the controls, so the live panel
+// always shows markers; standalone renders stay marker-free.
+export function RowAttentionMarker({
+  attention,
+  section,
+  id,
+  label,
+}: {
+  attention?: AttentionControls;
+  section: Section;
+  id: string;
+  label: string;
+}) {
+  if (!attention) return null;
+  return (
+    <AttentionMarker
+      level={attention.levelFor(section, id)}
+      onSet={(level) => attention.setAttention(section, id, level)}
+      busy={attention.settingKey === attentionKey(section, id)}
+      label={label}
+    />
+  );
+}

--- a/clients/react/src/components/producer-console/r-panel/RApproachesSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RApproachesSection.tsx
@@ -13,7 +13,9 @@
 // the header carries zero severity meaning.
 
 import { useApproaches } from "@/hooks/useApproaches";
+import type { AttentionControls } from "@/hooks/useUnitAttention";
 import type { ApproachStatus, ApproachWire, RepoApproachesWire } from "@/lib/api";
+import { RowAttentionMarker } from "./AttentionMarker";
 import { type SelectedRecord, selectedRecordKey } from "./r-viewer/RRecordViewer";
 import { isReviewTriggerReady } from "./r-viewer/review-trigger";
 import { Section } from "./Section";
@@ -29,6 +31,10 @@ interface RApproachesSectionProps {
   /** `selectedRecordKey(repoPath, slug)` of the record currently open in
    *  R₂, so the row marks itself as the one being viewed. */
   selectedKey?: string | null;
+  /** Per-artifact attention controls (threaded from `RPanel`'s single hook).
+   *  When present each approach row shows its attention marker; absent (e.g.
+   *  in isolation tests) the rows render marker-free. */
+  attention?: AttentionControls;
 }
 
 const STATUS_ORDER: readonly ApproachStatus[] = [
@@ -47,6 +53,7 @@ export function RApproachesSection({
   onToggle,
   onSelect,
   selectedKey,
+  attention,
 }: RApproachesSectionProps) {
   const { data, loading, error } = useApproaches(unitName);
   const running =
@@ -73,6 +80,7 @@ export function RApproachesSection({
         error={error}
         onSelect={onSelect}
         selectedKey={selectedKey ?? null}
+        attention={attention}
       />
     </Section>
   );
@@ -85,9 +93,10 @@ interface BodyProps {
   error: Error | null;
   onSelect?: (sel: SelectedRecord) => void;
   selectedKey: string | null;
+  attention?: AttentionControls;
 }
 
-function Body({ unitName, repos, loading, error, onSelect, selectedKey }: BodyProps) {
+function Body({ unitName, repos, loading, error, onSelect, selectedKey, attention }: BodyProps) {
   if (unitName === null) {
     return <p className="text-subtle-foreground">Pick a project to see approaches.</p>;
   }
@@ -110,6 +119,7 @@ function Body({ unitName, repos, loading, error, onSelect, selectedKey }: BodyPr
           multiRepo={multiRepo}
           onSelect={onSelect}
           selectedKey={selectedKey}
+          attention={attention}
         />
       ))}
     </div>
@@ -121,11 +131,13 @@ function RepoBlock({
   multiRepo,
   onSelect,
   selectedKey,
+  attention,
 }: {
   repo: RepoApproachesWire;
   multiRepo: boolean;
   onSelect?: (sel: SelectedRecord) => void;
   selectedKey: string | null;
+  attention?: AttentionControls;
 }) {
   // Group by status then sort by date desc within each group. No
   // filter chips — every status is shown, every item is rendered.
@@ -162,6 +174,7 @@ function RepoBlock({
                   repoLabel={repo.repo_label}
                   onSelect={onSelect}
                   selected={selectedKey === selectedRecordKey(repo.repo_root, a.slug)}
+                  attention={attention}
                 />
               ))}
             </ul>
@@ -182,20 +195,31 @@ function ApproachRow({
   repoLabel,
   onSelect,
   selected,
+  attention,
 }: {
   approach: ApproachWire;
   repoPath: string;
   repoLabel: string;
   onSelect?: (sel: SelectedRecord) => void;
   selected: boolean;
+  attention?: AttentionControls;
 }) {
   return (
-    <li className="leading-snug">
+    <li className="flex items-start gap-1.5 leading-snug">
+      {/* Attention marker sits to the LEFT of the row (contract §3 core). */}
+      <span className="pt-0.5">
+        <RowAttentionMarker
+          attention={attention}
+          section="approach"
+          id={approach.slug}
+          label={approach.slug}
+        />
+      </span>
       <button
         type="button"
         onClick={() => onSelect?.({ kind: "approach", repoPath, repoLabel, record: approach })}
         aria-current={selected ? "true" : undefined}
-        className={`w-full rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
+        className={`min-w-0 flex-1 rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
           selected ? "bg-surface-strong/40" : ""
         }`}
       >

--- a/clients/react/src/components/producer-console/r-panel/RDecisionsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RDecisionsSection.tsx
@@ -7,7 +7,9 @@
 // appraisal. See the approach's R section table.
 
 import { useDecisions } from "@/hooks/useDecisions";
+import type { AttentionControls } from "@/hooks/useUnitAttention";
 import type { DecisionWire, RepoDecisionsWire } from "@/lib/api";
+import { RowAttentionMarker } from "./AttentionMarker";
 import { type SelectedRecord, selectedRecordKey } from "./r-viewer/RRecordViewer";
 import { Section } from "./Section";
 
@@ -23,6 +25,10 @@ interface RDecisionsSectionProps {
    *  R₂, so the row marks itself as the one being viewed (a mechanical
    *  "open here" fact, not appraisal). */
   selectedKey?: string | null;
+  /** Per-artifact attention controls (threaded from `RPanel`'s single hook).
+   *  When present each decision row shows its attention marker; absent (e.g.
+   *  in isolation tests) the rows render marker-free. */
+  attention?: AttentionControls;
 }
 
 export function RDecisionsSection({
@@ -31,6 +37,7 @@ export function RDecisionsSection({
   onToggle,
   onSelect,
   selectedKey,
+  attention,
 }: RDecisionsSectionProps) {
   const { data, loading, error } = useDecisions(unitName);
   const total = data === null ? 0 : data.repos.reduce((n, r) => n + flattenAll(r).length, 0);
@@ -51,6 +58,7 @@ export function RDecisionsSection({
         error={error}
         onSelect={onSelect}
         selectedKey={selectedKey ?? null}
+        attention={attention}
       />
     </Section>
   );
@@ -67,9 +75,10 @@ interface BodyProps {
   error: Error | null;
   onSelect?: (sel: SelectedRecord) => void;
   selectedKey: string | null;
+  attention?: AttentionControls;
 }
 
-function Body({ unitName, repos, loading, error, onSelect, selectedKey }: BodyProps) {
+function Body({ unitName, repos, loading, error, onSelect, selectedKey, attention }: BodyProps) {
   if (unitName === null) {
     return <p className="text-subtle-foreground">Pick a project to see decisions.</p>;
   }
@@ -106,6 +115,7 @@ function Body({ unitName, repos, loading, error, onSelect, selectedKey }: BodyPr
                   repoLabel={repo.repo_label}
                   onSelect={onSelect}
                   selected={selectedKey === selectedRecordKey(repo.repo_root, d.slug)}
+                  attention={attention}
                 />
               ))}
             </ul>
@@ -126,20 +136,31 @@ function DecisionRow({
   repoLabel,
   onSelect,
   selected,
+  attention,
 }: {
   decision: DecisionWire;
   repoPath: string;
   repoLabel: string;
   onSelect?: (sel: SelectedRecord) => void;
   selected: boolean;
+  attention?: AttentionControls;
 }) {
   return (
-    <li className="leading-snug">
+    <li className="flex items-start gap-1.5 leading-snug">
+      {/* Attention marker sits to the LEFT of the row (contract §3 core). */}
+      <span className="pt-0.5">
+        <RowAttentionMarker
+          attention={attention}
+          section="decision"
+          id={decision.slug}
+          label={decision.slug}
+        />
+      </span>
       <button
         type="button"
         onClick={() => onSelect?.({ kind: "decision", repoPath, repoLabel, record: decision })}
         aria-current={selected ? "true" : undefined}
-        className={`w-full rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
+        className={`min-w-0 flex-1 rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
           selected ? "bg-surface-strong/40" : ""
         }`}
       >

--- a/clients/react/src/components/producer-console/r-panel/RIssuesSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RIssuesSection.tsx
@@ -14,8 +14,10 @@
 // the issue number is gone; the issue's full content is reviewed in-tmai
 // with no round-trip. R₁ stays a pure inventory; the row is just a select.
 
+import type { AttentionControls } from "@/hooks/useUnitAttention";
 import { useUnitIssues } from "@/hooks/useUnitIssues";
 import type { IssueInfo, IssueSummaryWire, RepoIssuesWire } from "@/lib/api";
+import { RowAttentionMarker } from "./AttentionMarker";
 import { type SelectedIssue, selectedIssueKey } from "./r-viewer/RIssueViewer";
 import { Section } from "./Section";
 
@@ -30,6 +32,10 @@ interface RIssuesSectionProps {
    *  R₂, so the row marks itself as the one being viewed (a mechanical
    *  "open here" fact, not appraisal). */
   selectedKey?: string | null;
+  /** Per-artifact attention controls (threaded from `RPanel`'s single hook).
+   *  When present each issue row shows its attention marker; absent (e.g. in
+   *  isolation tests) the rows render marker-free. */
+  attention?: AttentionControls;
 }
 
 export function RIssuesSection({
@@ -38,6 +44,7 @@ export function RIssuesSection({
   onToggle,
   onSelectIssue,
   selectedKey,
+  attention,
 }: RIssuesSectionProps) {
   const { data, loading, error } = useUnitIssues(unitName);
   const total = data === null ? 0 : data.repos.reduce((n, r) => n + r.issues.length, 0);
@@ -58,6 +65,7 @@ export function RIssuesSection({
         error={error}
         onSelectIssue={onSelectIssue}
         selectedKey={selectedKey ?? null}
+        attention={attention}
       />
     </Section>
   );
@@ -70,9 +78,18 @@ interface BodyProps {
   error: Error | null;
   onSelectIssue?: (sel: SelectedIssue) => void;
   selectedKey: string | null;
+  attention?: AttentionControls;
 }
 
-function Body({ unitName, repos, loading, error, onSelectIssue, selectedKey }: BodyProps) {
+function Body({
+  unitName,
+  repos,
+  loading,
+  error,
+  onSelectIssue,
+  selectedKey,
+  attention,
+}: BodyProps) {
   if (unitName === null) {
     return <p className="text-subtle-foreground">Pick a project to see issues.</p>;
   }
@@ -95,6 +112,7 @@ function Body({ unitName, repos, loading, error, onSelectIssue, selectedKey }: B
           multiRepo={multiRepo}
           onSelectIssue={onSelectIssue}
           selectedKey={selectedKey}
+          attention={attention}
         />
       ))}
     </div>
@@ -106,11 +124,13 @@ function RepoBlock({
   multiRepo,
   onSelectIssue,
   selectedKey,
+  attention,
 }: {
   repo: RepoIssuesWire;
   multiRepo: boolean;
   onSelectIssue?: (sel: SelectedIssue) => void;
   selectedKey: string | null;
+  attention?: AttentionControls;
 }) {
   if (repo.issues.length === 0) return null;
   return (
@@ -129,6 +149,7 @@ function RepoBlock({
             repoLabel={repo.repo_label}
             onSelectIssue={onSelectIssue}
             selected={selectedKey === selectedIssueKey(repo.repo_path, Number(issue.number))}
+            attention={attention}
           />
         ))}
       </ul>
@@ -142,12 +163,14 @@ function IssueRow({
   repoLabel,
   onSelectIssue,
   selected,
+  attention,
 }: {
   issue: IssueSummaryWire;
   repoPath: string;
   repoLabel: string;
   onSelectIssue?: (sel: SelectedIssue) => void;
   selected: boolean;
+  attention?: AttentionControls;
 }) {
   // The whole row is a button that opens the issue in the R₂ viewer —
   // there is NO github.com link-out anymore; the issue's full content is
@@ -161,12 +184,21 @@ function IssueRow({
   // spread narrows just the number and leaves the rest byte-identical.
   const selectedIssue: IssueInfo = { ...issue, number: Number(issue.number) };
   return (
-    <li className="leading-snug">
+    <li className="flex items-start gap-1.5 leading-snug">
+      {/* Attention marker sits to the LEFT of the row (contract §3 core). */}
+      <span className="pt-0.5">
+        <RowAttentionMarker
+          attention={attention}
+          section="issue"
+          id={String(issue.number)}
+          label={`#${Number(issue.number)}`}
+        />
+      </span>
       <button
         type="button"
         onClick={() => onSelectIssue?.({ repoPath, repoLabel, issue: selectedIssue })}
         aria-current={selected ? "true" : undefined}
-        className={`w-full rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
+        className={`min-w-0 flex-1 rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
           selected ? "bg-surface-strong/40" : ""
         }`}
       >

--- a/clients/react/src/components/producer-console/r-panel/RPanel.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPanel.tsx
@@ -25,6 +25,7 @@
 
 import { useCallback } from "react";
 import { makeSplitKeyHandler, RATIO_STEP } from "@/hooks/useSplitPane";
+import { useUnitAttention } from "@/hooks/useUnitAttention";
 import type { ProducerFeedStatus } from "@/lib/api";
 import { ATTENTION_STRIP_WIDTH_MAX, ATTENTION_STRIP_WIDTH_MIN } from "@/lib/ui-prefs";
 import { useUIPref } from "@/lib/ui-prefs-provider";
@@ -144,6 +145,13 @@ export function RPanel({
 }: RPanelProps) {
   const [expanded, setExpanded] = useUIPref("rPanelExpandedSections");
 
+  // One attention hook for the whole panel (not one per section): the POST
+  // returns the full updated map, so a server-side demotion (a prior `high`
+  // knocked to `low` to keep `high`≤1/dimension) lands on the PR + Issue
+  // sections at once. Threaded down to the four attention-artifact sections;
+  // File is attention-exempt and is NOT given the controls.
+  const attention = useUnitAttention(unitName);
+
   const toggle = useCallback(
     (id: string) => {
       setExpanded(expanded.includes(id) ? expanded.filter((x) => x !== id) : [...expanded, id]);
@@ -250,6 +258,7 @@ export function RPanel({
               onToggle={() => toggle("prs")}
               onSelectPr={onSelectPr}
               selectedKey={selectedPrKey}
+              attention={attention}
             />
             <RIssuesSection
               unitName={unitName}
@@ -257,6 +266,7 @@ export function RPanel({
               onToggle={() => toggle("issues")}
               onSelectIssue={onSelectIssue}
               selectedKey={selectedIssueKey}
+              attention={attention}
             />
             <RDecisionsSection
               unitName={unitName}
@@ -264,6 +274,7 @@ export function RPanel({
               onToggle={() => toggle("decisions")}
               onSelect={onSelectRecord}
               selectedKey={selectedRecordKey}
+              attention={attention}
             />
             <RApproachesSection
               unitName={unitName}
@@ -271,6 +282,7 @@ export function RPanel({
               onToggle={() => toggle("approaches")}
               onSelect={onSelectRecord}
               selectedKey={selectedRecordKey}
+              attention={attention}
             />
             <RInventorySection
               unitName={unitName}

--- a/clients/react/src/components/producer-console/r-panel/RPrsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPrsSection.tsx
@@ -13,8 +13,10 @@
 // repo-level `billing_dead` flag (which lives on `RepoPrsWire`, not on
 // the PR) so R₂ can offer the billing-dead override.
 
+import type { AttentionControls } from "@/hooks/useUnitAttention";
 import { useUnitPrs } from "@/hooks/useUnitPrs";
 import type { PrSummaryWire, RepoPrsWire } from "@/lib/api";
+import { RowAttentionMarker } from "./AttentionMarker";
 import { type SelectedPr, selectedPrKey } from "./r-viewer/RPrViewer";
 import { Section } from "./Section";
 
@@ -31,6 +33,10 @@ interface RPrsSectionProps {
    *  so the row marks itself as the one being viewed (a mechanical
    *  "open here" fact, not appraisal). */
   selectedKey?: string | null;
+  /** Per-artifact attention controls (threaded from `RPanel`'s single hook).
+   *  When present each PR row shows its attention marker; absent (e.g. in
+   *  isolation tests) the rows render marker-free. */
+  attention?: AttentionControls;
 }
 
 export function RPrsSection({
@@ -39,6 +45,7 @@ export function RPrsSection({
   onToggle,
   onSelectPr,
   selectedKey,
+  attention,
 }: RPrsSectionProps) {
   const { data, loading, error } = useUnitPrs(unitName);
   const total = data === null ? 0 : data.repos.reduce((n, r) => n + r.prs.length, 0);
@@ -59,6 +66,7 @@ export function RPrsSection({
         error={error}
         onSelectPr={onSelectPr}
         selectedKey={selectedKey ?? null}
+        attention={attention}
       />
     </Section>
   );
@@ -71,9 +79,10 @@ interface BodyProps {
   error: Error | null;
   onSelectPr?: (sel: SelectedPr) => void;
   selectedKey: string | null;
+  attention?: AttentionControls;
 }
 
-function Body({ unitName, repos, loading, error, onSelectPr, selectedKey }: BodyProps) {
+function Body({ unitName, repos, loading, error, onSelectPr, selectedKey, attention }: BodyProps) {
   if (unitName === null) {
     return <p className="text-subtle-foreground">Pick a project to see open PRs.</p>;
   }
@@ -96,6 +105,7 @@ function Body({ unitName, repos, loading, error, onSelectPr, selectedKey }: Body
           multiRepo={multiRepo}
           onSelectPr={onSelectPr}
           selectedKey={selectedKey}
+          attention={attention}
         />
       ))}
     </div>
@@ -107,11 +117,13 @@ function RepoBlock({
   multiRepo,
   onSelectPr,
   selectedKey,
+  attention,
 }: {
   repo: RepoPrsWire;
   multiRepo: boolean;
   onSelectPr?: (sel: SelectedPr) => void;
   selectedKey: string | null;
+  attention?: AttentionControls;
 }) {
   if (repo.prs.length === 0) return null;
   // billing-dead lives on the REPO, not the PR. Thread it into the R₂
@@ -135,6 +147,7 @@ function RepoBlock({
             billingDead={billingDead}
             onSelectPr={onSelectPr}
             selected={selectedKey === selectedPrKey(repo.repo_path, pr.number)}
+            attention={attention}
           />
         ))}
       </ul>
@@ -149,6 +162,7 @@ function PrRow({
   billingDead,
   onSelectPr,
   selected,
+  attention,
 }: {
   pr: PrSummaryWire;
   repoPath: string;
@@ -156,6 +170,7 @@ function PrRow({
   billingDead: boolean;
   onSelectPr?: (sel: SelectedPr) => void;
   selected: boolean;
+  attention?: AttentionControls;
 }) {
   // Plain-text status — no severity-color CI / review badges. The
   // operator can read "CI SUCCESS" / "CI FAILURE" identically; R is
@@ -166,12 +181,21 @@ function PrRow({
   // content is reviewed in-tmai. `aria-current` marks the row whose
   // content is currently open in R₂ (a mechanical "open here" fact).
   return (
-    <li className="leading-snug">
+    <li className="flex items-start gap-1.5 leading-snug">
+      {/* Attention marker sits to the LEFT of the row (contract §3 core). */}
+      <span className="pt-0.5">
+        <RowAttentionMarker
+          attention={attention}
+          section="pr"
+          id={String(pr.number)}
+          label={`#${Number(pr.number)}`}
+        />
+      </span>
       <button
         type="button"
         onClick={() => onSelectPr?.({ repoPath, repoLabel, pr, billingDead })}
         aria-current={selected ? "true" : undefined}
-        className={`w-full rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
+        className={`min-w-0 flex-1 rounded px-1 py-0.5 text-left transition-colors hover:bg-surface-strong/40 ${
           selected ? "bg-surface-strong/40" : ""
         }`}
       >

--- a/clients/react/src/components/producer-console/r-panel/__tests__/AttentionMarker.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/AttentionMarker.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+//
+// AttentionMarker — the per-artifact attention control (contract
+// `tmai-core:doc/approaches/2026-06-04-attention-as-per-artifact-field.md`
+// §3 core). Two responsibilities verified here:
+//
+//   1. Authorship-scoped coloring — `null` is a machine fact (pending) and
+//      stays NEUTRAL (no heat class); `low`/`high` are the operator's own
+//      appraisal and carry heat (`attn-low` muted / `attn-high` bright). Color
+//      follows authorship: only human-set marks are colored.
+//   2. The operator can set `low`/`high` but NEVER `null` — the popover offers
+//      exactly two choices, and selecting one calls `onSet` with that level.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AttentionMarker } from "../AttentionMarker";
+
+describe("AttentionMarker — authorship-scoped coloring", () => {
+  it("null renders a neutral pending marker (machine fact — no heat)", () => {
+    render(<AttentionMarker level={null} onSet={vi.fn()} label="#1" />);
+    const marker = screen.getByTestId("attention-marker");
+    expect(marker.getAttribute("data-level")).toBe("null");
+    // Neutral: the subtle-foreground token, and explicitly NOT a heat class.
+    expect(marker.className).toContain("text-subtle-foreground");
+    expect(marker.className).not.toContain("attn-low");
+    expect(marker.className).not.toContain("attn-high");
+  });
+
+  it("low renders muted heat (operator appraisal — colored)", () => {
+    render(<AttentionMarker level="low" onSet={vi.fn()} label="#1" />);
+    const marker = screen.getByTestId("attention-marker");
+    expect(marker.getAttribute("data-level")).toBe("low");
+    expect(marker.className).toContain("attn-low");
+  });
+
+  it("high renders bright heat (operator appraisal — THE thing)", () => {
+    render(<AttentionMarker level="high" onSet={vi.fn()} label="#1" />);
+    const marker = screen.getByTestId("attention-marker");
+    expect(marker.getAttribute("data-level")).toBe("high");
+    expect(marker.className).toContain("attn-high");
+  });
+
+  it("never colors the machine pole with a CI-severity class", () => {
+    const { container } = render(<AttentionMarker level={null} onSet={vi.fn()} label="#1" />);
+    // The neutral pole must not leak CI severity (authorship heat ≠ machine
+    // severity, and the R panel's negative-space tests blocklist these).
+    expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
+  });
+});
+
+describe("AttentionMarker — operator set (low/high only, never null)", () => {
+  it("offers exactly low and high — no null/clear/pending choice", () => {
+    render(<AttentionMarker level="low" onSet={vi.fn()} label="#1" />);
+    fireEvent.click(screen.getByTestId("attention-marker"));
+
+    expect(screen.getByTestId("attention-set-low")).toBeTruthy();
+    expect(screen.getByTestId("attention-set-high")).toBeTruthy();
+    // Exactly two menu items — the operator cannot disclaim back to null.
+    expect(screen.getAllByRole("menuitem")).toHaveLength(2);
+    expect(screen.queryByTestId("attention-set-null")).toBeNull();
+    expect(screen.queryByRole("menuitem", { name: /pending|clear|none|null/i })).toBeNull();
+  });
+
+  it("selecting high calls onSet('high') and closes the menu", () => {
+    const onSet = vi.fn();
+    render(<AttentionMarker level={null} onSet={onSet} label="#42" />);
+    fireEvent.click(screen.getByTestId("attention-marker"));
+    fireEvent.click(screen.getByTestId("attention-set-high"));
+
+    expect(onSet).toHaveBeenCalledTimes(1);
+    expect(onSet).toHaveBeenCalledWith("high");
+    // Menu closed after a choice.
+    expect(screen.queryByRole("menu")).toBeNull();
+  });
+
+  it("selecting low calls onSet('low')", () => {
+    const onSet = vi.fn();
+    render(<AttentionMarker level="high" onSet={onSet} label="#42" />);
+    fireEvent.click(screen.getByTestId("attention-marker"));
+    fireEvent.click(screen.getByTestId("attention-set-low"));
+    expect(onSet).toHaveBeenCalledWith("low");
+  });
+
+  it("busy disables the marker (no double-POST while one is in flight)", () => {
+    render(<AttentionMarker level="low" onSet={vi.fn()} busy label="#1" />);
+    const marker = screen.getByTestId("attention-marker") as HTMLButtonElement;
+    expect(marker.disabled).toBe(true);
+  });
+
+  it("closes the menu on Escape without setting", () => {
+    const onSet = vi.fn();
+    render(<AttentionMarker level={null} onSet={onSet} label="#1" />);
+    fireEvent.click(screen.getByTestId("attention-marker"));
+    expect(screen.getByRole("menu")).toBeTruthy();
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(screen.queryByRole("menu")).toBeNull();
+    expect(onSet).not.toHaveBeenCalled();
+  });
+});

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RPanel.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RPanel.test.tsx
@@ -11,6 +11,20 @@ import { describe, expect, it, vi } from "vitest";
 import type { ProducerFeedStatus } from "@/lib/api";
 import { renderWithProviders } from "@/test/render";
 
+// The panel owns one `useUnitAttention` instance (threaded to the four
+// attention-artifact sections). The section bodies are stubbed below, so this
+// container test only needs an inert hook — mock it to avoid a real fetch.
+vi.mock("@/hooks/useUnitAttention", () => ({
+  useUnitAttention: () => ({
+    data: null,
+    loading: false,
+    error: null,
+    levelFor: () => null,
+    setAttention: vi.fn(),
+    settingKey: null,
+  }),
+}));
+
 vi.mock("../RPrsSection", () => ({
   RPrsSection: ({ expanded, onToggle }: { expanded: boolean; onToggle: () => void }) => (
     <button type="button" data-testid="prs-section" data-expanded={expanded} onClick={onToggle}>

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RPrsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RPrsSection.test.tsx
@@ -8,7 +8,8 @@
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { PrSummaryWire, UnitPrsResponse } from "@/lib/api";
+import type { AttentionControls } from "@/hooks/useUnitAttention";
+import type { Level, PrSummaryWire, Section, UnitPrsResponse } from "@/lib/api";
 
 const unitPrsMock = vi.fn();
 
@@ -51,6 +52,15 @@ function response(prs: PrSummaryWire[] = []): UnitPrsResponse {
   return {
     unit: "u",
     repos: [{ repo_path: "/p/u", repo_label: "u", primary: true, prs }],
+  };
+}
+
+function attentionStub(overrides: Partial<AttentionControls> = {}): AttentionControls {
+  return {
+    levelFor: () => null,
+    setAttention: vi.fn(),
+    settingKey: null,
+    ...overrides,
   };
 }
 
@@ -130,5 +140,97 @@ describe("RPrsSection", () => {
     });
     fireEvent.click(screen.getByText("PR title"));
     expect(onSelectPr.mock.calls[0][0].billingDead).toBe(true);
+  });
+});
+
+describe("RPrsSection — per-artifact attention markers", () => {
+  it("renders a marker on each PR row when attention is threaded, colored by level", async () => {
+    unitPrsMock.mockResolvedValue(response([pr()]));
+    render(
+      <RPrsSection
+        unitName="u"
+        expanded={true}
+        onToggle={vi.fn()}
+        attention={attentionStub({ levelFor: () => "high" })}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("PR title")).toBeTruthy());
+    const marker = screen.getByTestId("attention-marker");
+    expect(marker.getAttribute("data-level")).toBe("high");
+    // Operator-set heat is allowed on the marker (authorship pole)…
+    expect(marker.className).toContain("attn-high");
+  });
+
+  it("keeps the row's own machine facts neutral — only the marker carries heat", async () => {
+    unitPrsMock.mockResolvedValue(response([pr()]));
+    render(
+      <RPrsSection
+        unitName="u"
+        expanded={true}
+        onToggle={vi.fn()}
+        attention={attentionStub({ levelFor: () => "high" })}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("PR title")).toBeTruthy());
+    // The row button (CI/branch facts) is a machine-stated projection — it
+    // must stay neutral; heat lives ONLY on the attention marker.
+    const rowButton = screen.getByText("PR title").closest("button");
+    expect(rowButton?.className).not.toMatch(/attn-high|attn-low/);
+  });
+
+  it("renders NO marker when attention is absent (markers are opt-in)", async () => {
+    unitPrsMock.mockResolvedValue(response([pr()]));
+    render(<RPrsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("PR title")).toBeTruthy());
+    expect(screen.queryByTestId("attention-marker")).toBeNull();
+  });
+
+  it("setting high on a row calls setAttention('pr', <number>, 'high')", async () => {
+    const setAttention = vi.fn();
+    unitPrsMock.mockResolvedValue(response([pr()]));
+    render(
+      <RPrsSection
+        unitName="u"
+        expanded={true}
+        onToggle={vi.fn()}
+        attention={attentionStub({ setAttention })}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("PR title")).toBeTruthy());
+
+    fireEvent.click(screen.getByTestId("attention-marker"));
+    fireEvent.click(screen.getByTestId("attention-set-high"));
+    expect(setAttention).toHaveBeenCalledWith("pr", "100", "high");
+  });
+
+  it("clicking the marker does NOT also open the row's R₂ viewer (stopPropagation)", async () => {
+    const onSelectPr = vi.fn();
+    unitPrsMock.mockResolvedValue(response([pr()]));
+    render(
+      <RPrsSection
+        unitName="u"
+        expanded={true}
+        onToggle={vi.fn()}
+        onSelectPr={onSelectPr}
+        attention={attentionStub()}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("PR title")).toBeTruthy());
+    fireEvent.click(screen.getByTestId("attention-marker"));
+    // The marker is its own control — clicking it must not select the row.
+    expect(onSelectPr).not.toHaveBeenCalled();
+  });
+});
+
+// `Section` has no File variant by construction, so a File row can never carry
+// an attention marker (File is attention-exempt, contract §3). A static guard
+// that the enum stays File-free protects that invariant at the type boundary.
+describe("attention is File-exempt by construction", () => {
+  it("the Section enum has no `file` variant", () => {
+    const sections: Section[] = ["pr", "issue", "decision", "approach", "observation"];
+    expect(sections).not.toContain("file" as unknown as Section);
+    // A `Level` is only ever low/high — null is unrepresentable as a set value.
+    const levels: Level[] = ["low", "high"];
+    expect(levels).not.toContain("null" as unknown as Level);
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RPrsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RPrsSection.test.tsx
@@ -223,14 +223,32 @@ describe("RPrsSection — per-artifact attention markers", () => {
 });
 
 // `Section` has no File variant by construction, so a File row can never carry
-// an attention marker (File is attention-exempt, contract §3). A static guard
-// that the enum stays File-free protects that invariant at the type boundary.
+// an attention marker (File is attention-exempt, contract §3). These are
+// COMPILE-TIME exact-union assertions, not runtime containment checks: a
+// `Record<Section, true>` literal must name every member, so adding a variant
+// (e.g. `file`) drops a required key and FAILS THE BUILD, and naming one the
+// union lacks is an excess-property error. The boundary itself is the test —
+// no `as unknown as` escape hatches (rules/typescript.md).
 describe("attention is File-exempt by construction", () => {
-  it("the Section enum has no `file` variant", () => {
-    const sections: Section[] = ["pr", "issue", "decision", "approach", "observation"];
-    expect(sections).not.toContain("file" as unknown as Section);
-    // A `Level` is only ever low/high — null is unrepresentable as a set value.
-    const levels: Level[] = ["low", "high"];
-    expect(levels).not.toContain("null" as unknown as Level);
+  it("Section is exactly {pr, issue, decision, approach, observation} — no file", () => {
+    const sectionMembers: Record<Section, true> = {
+      pr: true,
+      issue: true,
+      decision: true,
+      approach: true,
+      observation: true,
+    };
+    expect(Object.keys(sectionMembers).sort()).toEqual([
+      "approach",
+      "decision",
+      "issue",
+      "observation",
+      "pr",
+    ]);
+  });
+
+  it("Level is exactly {low, high} — null is never a settable value", () => {
+    const levelMembers: Record<Level, true> = { low: true, high: true };
+    expect(Object.keys(levelMembers).sort()).toEqual(["high", "low"]);
   });
 });

--- a/clients/react/src/hooks/__tests__/useUnitAttention.test.ts
+++ b/clients/react/src/hooks/__tests__/useUnitAttention.test.ts
@@ -1,0 +1,192 @@
+// @vitest-environment jsdom
+//
+// useUnitAttention — the per-artifact attention poller + operator-write hook
+// (contract `tmai-core:doc/approaches/2026-06-04-attention-as-per-artifact-
+// field.md`). We mock `api.unitAttention` (GET) and `api.setUnitAttention`
+// (POST) so each test drives a deterministic map and asserts:
+//   - the sibling-shaped poll contract (park on null, initial-fetch loading,
+//     error surfaced without fabricating data, the 60s poll keeps the last
+//     response visible);
+//   - `levelFor(section,id)` reads the map and treats absence as `null` (the
+//     machine fact pole — the wire never emits it);
+//   - `setAttention` POSTs `low`/`high` and re-renders from the RETURNED map,
+//     so a server-side demotion (a prior `high` knocked to `low`) lands even
+//     though the caller only wrote one artifact;
+//   - `settingKey` reports the in-flight artifact for a busy marker.
+//
+// Timers stay real and the poll is exercised by capturing `window.setInterval`
+// directly (waitFor cannot make progress under fake timers) — same approach as
+// the useUnitInventory sibling test.
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    unitAttention: vi.fn(),
+    setUnitAttention: vi.fn(),
+  },
+}));
+
+import type { AttentionEntryWire, AttentionStateResponse, Level } from "@/lib/api";
+import { api } from "@/lib/api";
+import { attentionKey, useUnitAttention } from "../useUnitAttention";
+
+function entry(
+  section: AttentionEntryWire["section"],
+  id: string,
+  level: Level,
+): AttentionEntryWire {
+  return { section, id, level };
+}
+
+function response(unit: string, entries: AttentionEntryWire[]): AttentionStateResponse {
+  return { unit, entries };
+}
+
+describe("useUnitAttention", () => {
+  beforeEach(() => {
+    vi.mocked(api.unitAttention).mockReset();
+    vi.mocked(api.setUnitAttention).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parks on unit=null — no fetch, not loading, all levels null", () => {
+    const { result } = renderHook(() => useUnitAttention(null));
+    expect(api.unitAttention).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+    // Absence = null even with no data at all.
+    expect(result.current.levelFor("pr", "1")).toBeNull();
+  });
+
+  it("fetches on a real unit and levelFor reads the map (absence = null)", async () => {
+    vi.mocked(api.unitAttention).mockResolvedValue(
+      response("tmai", [entry("pr", "123", "high"), entry("decision", "d-slug", "low")]),
+    );
+    const { result } = renderHook(() => useUnitAttention("tmai"));
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(api.unitAttention).toHaveBeenCalledWith("tmai");
+    expect(result.current.levelFor("pr", "123")).toBe("high");
+    expect(result.current.levelFor("decision", "d-slug")).toBe("low");
+    // Not in the map → null (a machine fact, never emitted on the wire).
+    expect(result.current.levelFor("issue", "999")).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a fetch error without fabricating data", async () => {
+    vi.mocked(api.unitAttention).mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useUnitAttention("tmai"));
+    await waitFor(() => expect(result.current.error?.message).toBe("boom"));
+    expect(result.current.data).toBeNull();
+  });
+
+  it("setAttention POSTs low/high and re-renders from the returned map", async () => {
+    vi.mocked(api.unitAttention).mockResolvedValue(response("tmai", []));
+    vi.mocked(api.setUnitAttention).mockResolvedValue(
+      response("tmai", [entry("pr", "123", "high")]),
+    );
+    const { result } = renderHook(() => useUnitAttention("tmai"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.levelFor("pr", "123")).toBeNull();
+
+    await act(async () => {
+      await result.current.setAttention("pr", "123", "high");
+    });
+
+    expect(api.setUnitAttention).toHaveBeenCalledWith("tmai", {
+      section: "pr",
+      id: "123",
+      level: "high",
+    });
+    // Re-rendered straight from the POST response — no extra GET needed.
+    expect(result.current.levelFor("pr", "123")).toBe("high");
+  });
+
+  it("reflects a server-side demotion carried on the returned map", async () => {
+    // A prior `high` (Issue) sits in the remote dimension. Setting a new
+    // `high` on a PR makes the backend demote the Issue to `low` to keep
+    // `high`≤1/dimension; the POST returns the FULL updated map, so the demoted
+    // Issue updates even though the caller only wrote the PR.
+    vi.mocked(api.unitAttention).mockResolvedValue(response("tmai", [entry("issue", "7", "high")]));
+    vi.mocked(api.setUnitAttention).mockResolvedValue(
+      response("tmai", [entry("issue", "7", "low"), entry("pr", "123", "high")]),
+    );
+    const { result } = renderHook(() => useUnitAttention("tmai"));
+    await waitFor(() => expect(result.current.levelFor("issue", "7")).toBe("high"));
+
+    await act(async () => {
+      await result.current.setAttention("pr", "123", "high");
+    });
+
+    expect(result.current.levelFor("pr", "123")).toBe("high");
+    // The other artifact in the dimension demoted — never reset to null.
+    expect(result.current.levelFor("issue", "7")).toBe("low");
+  });
+
+  it("reports settingKey while a POST is in flight and clears it after", async () => {
+    vi.mocked(api.unitAttention).mockResolvedValue(response("tmai", []));
+    let resolvePost: (v: AttentionStateResponse) => void = () => {};
+    vi.mocked(api.setUnitAttention).mockReturnValue(
+      new Promise<AttentionStateResponse>((res) => {
+        resolvePost = res;
+      }),
+    );
+    const { result } = renderHook(() => useUnitAttention("tmai"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let pending: Promise<void> = Promise.resolve();
+    act(() => {
+      pending = result.current.setAttention("pr", "123", "low");
+    });
+    // In flight: the busy key matches the artifact (derived via the exported
+    // joiner so this survives any future separator change).
+    await waitFor(() => expect(result.current.settingKey).toBe(attentionKey("pr", "123")));
+
+    await act(async () => {
+      resolvePost(response("tmai", [entry("pr", "123", "low")]));
+      await pending;
+    });
+    expect(result.current.settingKey).toBeNull();
+  });
+
+  it("re-fetches on unit change and clears the previous unit's attention", async () => {
+    vi.mocked(api.unitAttention).mockImplementation((u: string) =>
+      Promise.resolve(response(u, u === "tmai" ? [entry("pr", "1", "high")] : [])),
+    );
+    const { result, rerender } = renderHook(({ u }) => useUnitAttention(u), {
+      initialProps: { u: "tmai" },
+    });
+    await waitFor(() => expect(result.current.levelFor("pr", "1")).toBe("high"));
+
+    rerender({ u: "other" });
+    // Cleared synchronously so the old unit's attention is never shown under
+    // the new unit's rows.
+    expect(result.current.data).toBeNull();
+    await waitFor(() => expect(result.current.data?.unit).toBe("other"));
+    expect(result.current.levelFor("pr", "1")).toBeNull();
+  });
+
+  it("keeps the last response visible across the 60s poll", async () => {
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+    vi.mocked(api.unitAttention).mockResolvedValue(response("tmai", [entry("pr", "1", "high")]));
+    const { result } = renderHook(() => useUnitAttention("tmai"));
+    await waitFor(() => expect(result.current.levelFor("pr", "1")).toBe("high"));
+
+    const tick = setIntervalSpy.mock.calls[0]?.[0] as (() => void) | undefined;
+    expect(typeof tick).toBe("function");
+
+    await act(async () => {
+      tick?.();
+    });
+    await waitFor(() => expect(api.unitAttention).toHaveBeenCalledTimes(2));
+    // Last response stays visible (anti-flicker) — never cleared on a poll.
+    expect(result.current.levelFor("pr", "1")).toBe("high");
+  });
+});

--- a/clients/react/src/hooks/__tests__/useUnitAttention.test.ts
+++ b/clients/react/src/hooks/__tests__/useUnitAttention.test.ts
@@ -189,4 +189,72 @@ describe("useUnitAttention", () => {
     // Last response stays visible (anti-flicker) — never cleared on a poll.
     expect(result.current.levelFor("pr", "1")).toBe("high");
   });
+
+  it("a GET that resolves after parking (unit→null) does not revive stale data", async () => {
+    // The park branch must bump the generation so the previous unit's in-flight
+    // GET is invalidated; otherwise it passes its `myGen === generationRef`
+    // guard and stamps stale data over the cleared (parked) state.
+    let resolveGet: (v: AttentionStateResponse) => void = () => {};
+    vi.mocked(api.unitAttention).mockReturnValueOnce(
+      new Promise<AttentionStateResponse>((res) => {
+        resolveGet = res;
+      }),
+    );
+    const { result, rerender } = renderHook(({ u }) => useUnitAttention(u), {
+      initialProps: { u: "tmai" as string | null },
+    });
+    expect(result.current.loading).toBe(true);
+
+    // Park before the GET resolves.
+    rerender({ u: null });
+    expect(result.current.data).toBeNull();
+    expect(result.current.loading).toBe(false);
+
+    // The previous unit's GET now resolves — it must be dropped, not stamped.
+    await act(async () => {
+      resolveGet(response("tmai", [entry("pr", "1", "high")]));
+    });
+    expect(result.current.data).toBeNull();
+    expect(result.current.levelFor("pr", "1")).toBeNull();
+  });
+
+  it("concurrent same-unit writes: a late older response does not overwrite the newer one", async () => {
+    vi.mocked(api.unitAttention).mockResolvedValue(response("tmai", []));
+    // Two POSTs in flight at once; capture each resolver so we can answer them
+    // OUT OF ORDER (the older one last).
+    const deferred: Array<(v: AttentionStateResponse) => void> = [];
+    vi.mocked(api.setUnitAttention).mockImplementation(
+      () =>
+        new Promise<AttentionStateResponse>((res) => {
+          deferred.push(res);
+        }),
+    );
+    const { result } = renderHook(() => useUnitAttention("tmai"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    let older: Promise<void> = Promise.resolve();
+    let newer: Promise<void> = Promise.resolve();
+    act(() => {
+      older = result.current.setAttention("pr", "1", "low"); // write seq 1
+      newer = result.current.setAttention("pr", "1", "high"); // write seq 2
+    });
+    await waitFor(() => expect(deferred).toHaveLength(2));
+
+    // The NEWER write (seq 2) resolves first and wins.
+    await act(async () => {
+      deferred[1](response("tmai", [entry("pr", "1", "high")]));
+      await newer;
+    });
+    expect(result.current.levelFor("pr", "1")).toBe("high");
+    expect(result.current.settingKey).toBeNull();
+
+    // The OLDER write (seq 1) resolves LATE — it is stale and must be dropped,
+    // never rolling the display back to `low`.
+    await act(async () => {
+      deferred[0](response("tmai", [entry("pr", "1", "low")]));
+      await older;
+    });
+    expect(result.current.levelFor("pr", "1")).toBe("high");
+    expect(result.current.settingKey).toBeNull();
+  });
 });

--- a/clients/react/src/hooks/useUnitAttention.ts
+++ b/clients/react/src/hooks/useUnitAttention.ts
@@ -74,9 +74,21 @@ export function useUnitAttention(unit: string | null): UseUnitAttentionResult {
   // path reads it too, so a write that resolves after a unit switch is
   // dropped rather than written under the wrong unit.
   const generationRef = useRef(0);
+  // Per-write sequence — `generationRef` only changes per unit, so two
+  // concurrent SAME-unit POSTs would both pass that guard and a slower (older)
+  // response could overwrite a newer one. Each write claims a monotonically
+  // increasing seq; only the latest seq's response is allowed to stamp `data`
+  // / clear `settingKey`. (Last-write-wins regardless of resolution order.)
+  const writeSeqRef = useRef(0);
 
   useEffect(() => {
     if (!unit) {
+      // Bump the generation here too: parking must invalidate any in-flight
+      // GET/POST from the previous unit, or a late response would pass its
+      // `myGen === generationRef.current` guard and revive stale data after
+      // we cleared it. (The non-null branch below bumps on every unit change;
+      // the null branch was the hole.)
+      ++generationRef.current;
       setData(null);
       setLoading(false);
       setError(null);
@@ -138,21 +150,25 @@ export function useUnitAttention(unit: string | null): UseUnitAttentionResult {
     async (section: Section, id: string, level: Level): Promise<void> => {
       if (!unit) return;
       const myGen = generationRef.current;
+      const myWriteSeq = ++writeSeqRef.current;
+      // Stale iff the unit changed (myGen) OR a newer write superseded this one
+      // (myWriteSeq). Either invalidates this response.
+      const isStale = () => myGen !== generationRef.current || myWriteSeq !== writeSeqRef.current;
       const key = attentionKey(section, id);
       setSettingKey(key);
       const body: AttentionSetRequest = { section, id, level };
       try {
         const res = await api.setUnitAttention(unit, body);
-        if (myGen !== generationRef.current) return;
+        if (isStale()) return;
         // Stamp the full returned map so a server-side demotion (prior `high`
         // → `low`) lands across every section at once.
         setData(res);
         setError(null);
       } catch (e) {
-        if (myGen !== generationRef.current) return;
+        if (isStale()) return;
         setError(e instanceof Error ? e : new Error(String(e)));
       } finally {
-        if (myGen === generationRef.current) {
+        if (!isStale()) {
           setSettingKey(null);
         }
       }

--- a/clients/react/src/hooks/useUnitAttention.ts
+++ b/clients/react/src/hooks/useUnitAttention.ts
@@ -1,0 +1,168 @@
+// Per-artifact attention hook — the clients/react half of the attention
+// model (contract
+// `tmai-core:doc/approaches/2026-06-04-attention-as-per-artifact-field.md`
+// §1 model + §3 core). Consumes `GET /api/units/{unit}/attention` (the
+// (section,id)→level map) and `POST /api/units/{unit}/attention` (the
+// operator's `low`/`high` write).
+//
+// The attention twin of `useUnitInventory` / `useUnitIssues` — same poll
+// shape and cadence (60s, no SSE yet; keeps the last response visible while
+// a re-fetch is in flight so markers do not flicker; `loading` reflects only
+// the initial fetch; `unit = null` parks the hook). It adds two
+// attention-specific affordances the inventory siblings do not need:
+//
+//   - `levelFor(section, id)` — the per-artifact lookup the R-panel rows
+//     render. Absence = `null` (the wire only emits `low`/`high`; `null` is a
+//     machine fact represented by absence, never sent).
+//   - `setAttention(section, id, level)` — the operator write. `level` is
+//     `Level` (`low`/`high`) — the operator can never set `null` (the type
+//     itself forbids it). The POST returns the full updated map, which we
+//     stamp over `data` so a server-side demotion (a prior `high` knocked to
+//     `low` to keep `high`≤1/dimension) is reflected across every section at
+//     once — the reason this hook is lifted to one instance in `RPanel`
+//     rather than one per section.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  type AttentionSetRequest,
+  type AttentionStateResponse,
+  api,
+  type Level,
+  type Section,
+} from "@/lib/api";
+
+const POLL_INTERVAL_MS = 60_000;
+
+// Map key for the (section,id) composite. `Section` is a closed enum whose
+// variants contain no whitespace, so a space joiner is unambiguous (no id can
+// straddle the boundary).
+function attentionKey(section: Section, id: string): string {
+  return `${section} ${id}`;
+}
+
+export interface UseUnitAttentionResult {
+  data: AttentionStateResponse | null;
+  loading: boolean;
+  error: Error | null;
+  /** Operator-set attention for one artifact, or `null` (machine fact: the
+   *  wire emits only `low`/`high`, so absence = `null`). */
+  levelFor: (section: Section, id: string) => Level | null;
+  /** Write `low`/`high` for one artifact (POST) and re-render from the
+   *  returned map. No `null` pole — the operator cannot disclaim. */
+  setAttention: (section: Section, id: string, level: Level) => Promise<void>;
+  /** `attentionKey(section,id)` of the artifact whose POST is in flight, so a
+   *  row can show a busy/disabled marker; `null` when none is pending. */
+  settingKey: string | null;
+}
+
+// The slice an R-panel row needs to render + drive its attention marker —
+// threaded down from the single `RPanel` hook instance so a server-side
+// demotion lands across every section at once. The poll bookkeeping
+// (`data`/`loading`/`error`) stays in the hook; rows do not see it.
+export type AttentionControls = Pick<
+  UseUnitAttentionResult,
+  "levelFor" | "setAttention" | "settingKey"
+>;
+
+export function useUnitAttention(unit: string | null): UseUnitAttentionResult {
+  const [data, setData] = useState<AttentionStateResponse | null>(null);
+  const [loading, setLoading] = useState(unit !== null);
+  const [error, setError] = useState<Error | null>(null);
+  const [settingKey, setSettingKey] = useState<string | null>(null);
+  // An in-flight response from a previous unit must not stamp over a newer
+  // unit's data (same guard as useUnitIssues / useUnitInventory). The POST
+  // path reads it too, so a write that resolves after a unit switch is
+  // dropped rather than written under the wrong unit.
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    if (!unit) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      setSettingKey(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    // Clear on unit *change* so the previous unit's attention is never shown
+    // under the new unit's rows. The 60s same-unit re-poll goes through
+    // fetchOnce, which keeps the last response visible (anti-flicker); that
+    // path is untouched. Mirrors the guard in useUnitIssues.
+    setData(null);
+    setError(null);
+    setSettingKey(null);
+    setLoading(true);
+
+    const fetchOnce = async () => {
+      try {
+        const res = await api.unitAttention(unit);
+        if (myGen !== generationRef.current) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (myGen !== generationRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (myGen === generationRef.current) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [unit]);
+
+  const levelMap = useMemo(() => {
+    const map = new Map<string, Level>();
+    if (data !== null) {
+      for (const entry of data.entries) {
+        map.set(attentionKey(entry.section, entry.id), entry.level);
+      }
+    }
+    return map;
+  }, [data]);
+
+  const levelFor = useCallback(
+    (section: Section, id: string): Level | null => levelMap.get(attentionKey(section, id)) ?? null,
+    [levelMap],
+  );
+
+  const setAttention = useCallback(
+    async (section: Section, id: string, level: Level): Promise<void> => {
+      if (!unit) return;
+      const myGen = generationRef.current;
+      const key = attentionKey(section, id);
+      setSettingKey(key);
+      const body: AttentionSetRequest = { section, id, level };
+      try {
+        const res = await api.setUnitAttention(unit, body);
+        if (myGen !== generationRef.current) return;
+        // Stamp the full returned map so a server-side demotion (prior `high`
+        // → `low`) lands across every section at once.
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (myGen !== generationRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (myGen === generationRef.current) {
+          setSettingKey(null);
+        }
+      }
+    },
+    [unit],
+  );
+
+  return { data, loading, error, levelFor, setAttention, settingKey };
+}
+
+// Re-exported so consumers (the R-panel sections / marker) can build the same
+// busy-key the hook reports via `settingKey` without re-deriving the joiner.
+export { attentionKey };

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -6,6 +6,9 @@ import type { ApproachesResponse } from "@/types/generated/ApproachesResponse";
 import type { ApproachInventoryWire } from "@/types/generated/ApproachInventoryWire";
 import type { ApproachStatus } from "@/types/generated/ApproachStatus";
 import type { ApproachWire } from "@/types/generated/ApproachWire";
+import type { AttentionEntryWire } from "@/types/generated/AttentionEntryWire";
+import type { AttentionSetRequest } from "@/types/generated/AttentionSetRequest";
+import type { AttentionStateResponse } from "@/types/generated/AttentionStateResponse";
 import type { BootstrapRequiredEvent } from "@/types/generated/BootstrapRequiredEvent";
 import type { CalibrationCellWire } from "@/types/generated/CalibrationCellWire";
 import type { CalibrationEntry } from "@/types/generated/CalibrationEntry";
@@ -21,6 +24,7 @@ import type { HandoffRitualEvent } from "@/types/generated/HandoffRitualEvent";
 import type { HandoffsResponse } from "@/types/generated/HandoffsResponse";
 import type { IssueLabelWire } from "@/types/generated/IssueLabelWire";
 import type { IssueSummaryWire } from "@/types/generated/IssueSummaryWire";
+import type { Level } from "@/types/generated/Level";
 import type { Outcome } from "@/types/generated/Outcome";
 import type { PermissionMode } from "@/types/generated/PermissionMode";
 import type { PrDiffResponse } from "@/types/generated/PrDiffResponse";
@@ -35,6 +39,7 @@ import type { RepoPrsWire } from "@/types/generated/RepoPrsWire";
 import type { ReviewExtensionWire } from "@/types/generated/ReviewExtensionWire";
 import type { ReviewTriggerWire } from "@/types/generated/ReviewTriggerWire";
 import type { RuntimeSnapshot } from "@/types/generated/RuntimeSnapshot";
+import type { Section } from "@/types/generated/Section";
 import type { SpawnRole } from "@/types/generated/SpawnRole";
 import type { SpawnRuntime } from "@/types/generated/SpawnRuntime";
 import type { TeamSnapshot } from "@/types/generated/TeamSnapshot";
@@ -56,6 +61,9 @@ export type {
   ApproachInventoryWire,
   ApproachStatus,
   ApproachWire,
+  AttentionEntryWire,
+  AttentionSetRequest,
+  AttentionStateResponse,
   BootstrapRequiredEvent,
   CalibrationCellWire,
   CalibrationEntry,
@@ -70,6 +78,7 @@ export type {
   HandoffsResponse,
   IssueLabelWire,
   IssueSummaryWire,
+  Level,
   Outcome,
   PermissionMode,
   PrDiffResponse,
@@ -83,6 +92,7 @@ export type {
   RepoPrsWire,
   ReviewExtensionWire,
   ReviewTriggerWire,
+  Section,
   SpawnRole,
   SpawnRuntime,
   TerminalSubscription,
@@ -1540,6 +1550,27 @@ export const api = {
   // it light and plain.
   unitInventory: (unit: string) =>
     apiFetch<UnitInventoryResponse>(`/units/${encodeURIComponent(unit)}/inventory`),
+
+  // Per-artifact attention map (contract
+  // `tmai-core:doc/approaches/2026-06-04-attention-as-per-artifact-field.md`).
+  // The (section,id)→level map for the unit. Only `low`/`high` entries are
+  // emitted — `null` is absence (the R panel infers `null` for any listed
+  // artifact missing from the map). File is unrepresentable (`Section` has no
+  // File variant): File is attention-exempt.
+  unitAttention: (unit: string) =>
+    apiFetch<AttentionStateResponse>(`/units/${encodeURIComponent(unit)}/attention`),
+
+  // Operator attention write — sets `low`/`high` on one artifact and returns
+  // the updated map. `AttentionSetRequest.level` has no `null` variant, so the
+  // operator can never write `null` (non-repudiation by type); only the
+  // machine writes `null` (by absence). The backend enforces the monotonic
+  // `null`→not-null transition and the `high`≤1/dimension cardinality, and may
+  // demote a prior `high` to `low` — callers re-render from the returned map.
+  setUnitAttention: (unit: string, body: AttentionSetRequest) =>
+    apiFetch<AttentionStateResponse>(`/units/${encodeURIComponent(unit)}/attention`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
 
   // Configured-unit membership (tmai-core #460, public mirror tmai#741).
   // Membership-only — no live agent state is joined server-side; the

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -7,6 +7,7 @@ export * from "./teams";
 
 import type {
   AgentSnapshot,
+  AttentionSetRequest,
   DispatchBundle,
   OrchestratorRules,
   PrMergeMethod,
@@ -275,6 +276,12 @@ export const api = {
   // projection of the unit's decisions + serving approaches; no
   // Tauri-specific path needed)
   unitInventory: (unit: string) => httpApi.unitInventory(unit),
+
+  // Per-artifact attention map + operator write (HTTP only — file-backed
+  // attention store served over the web API; no Tauri-specific path needed)
+  unitAttention: (unit: string) => httpApi.unitAttention(unit),
+  setUnitAttention: (unit: string, body: AttentionSetRequest) =>
+    httpApi.setUnitAttention(unit, body),
 
   // Configured-unit membership view (HTTP only — membership-only,
   // no live agent state joined server-side; no Tauri-specific path needed)

--- a/clients/react/src/styles/globals.css
+++ b/clients/react/src/styles/globals.css
@@ -327,6 +327,31 @@ html {
   scrollbar-color: rgba(255, 255, 255, 0.08) transparent;
 }
 
+/* ── R-panel attention markers ────────────────────────────────────────────
+   Authorship-scoped coloring (contract
+   tmai-core:doc/approaches/2026-06-04-attention-as-per-artifact-field.md,
+   §"rendering = authorship-scoped coloring"). Heat applies ONLY to the
+   operator-set appraisal poles — `low` (muted) and `high` (bright, THE thing
+   in its dimension) — so each section reads as a focus map. `null` is a
+   machine fact and stays neutral (it uses `text-subtle-foreground` in the
+   TSX, never these classes).
+
+   These are deliberately NOT the CI-severity utilities
+   (`text-warning`/`text-destructive`/`text-success`): authorship heat is the
+   operator's own appraisal mirrored, not a machine severity judgment, and the
+   R panel's negative-space tests blocklist the severity classes. The hue
+   tracks the themed `--color-warning` channel so it re-skins with the theme,
+   but the meaning here is "attention", not "warning". */
+.attn-high {
+  color: var(--color-warning);
+  font-weight: 600;
+  text-shadow: 0 0 6px rgb(var(--glow-warning) / 0.45);
+}
+.attn-low {
+  color: var(--color-warning);
+  opacity: 0.5;
+}
+
 /* xterm v6 paints its own VSCode-derived scrollbar (`.xterm-scrollable-element
    > .scrollbar`) instead of the native browser scrollbar, and JS pins both the
    bar and the inner slider to an inline `width: 14px`. The native viewport


### PR DESCRIPTION
Resolves #768. Implements the clients/react half of the attention model — **§3 core only** — to the contract `tmai-core:doc/approaches/2026-06-04-attention-as-per-artifact-field.md` (the wire + generated types landed via tmai-core #490 → synced here in #767).

## What this does

### Consume the wire (generated types only)
- `GET /api/units/{unit}/attention` → `AttentionStateResponse`, `POST /api/units/{unit}/attention` → `AttentionSetRequest`, both added as `api.unitAttention` / `api.setUnitAttention` (api-http + api-tauri).
- `Section` / `Level` / `AttentionEntryWire` / `AttentionStateResponse` / `AttentionSetRequest` imported + re-exported from `@/types/generated/` — **never hand-mirrored**.
- `useUnitAttention` hook mirrors the `useUnitInventory` / `useUnitIssues` pattern (60s poll, anti-flicker, `unit=null` parks). Adds `levelFor(section,id)` (absence = `null`) and `setAttention(section,id,level)` that re-renders from the **returned** map — so a server-side `high`→`low` demotion (the `high`≤1/dimension rule) lands across PR + Issue at once. Lifted to a single instance in `RPanel`.

### Per-row marker + authorship-scoped coloring
- `AttentionMarker` renders on the **left** of each PR / Issue / Decision / Approach row.
- **`null`** = machine fact (unconfirmed/changed) → neutral pending marker (`○`, `text-subtle-foreground`, no heat).
- **`low`/`high`** = operator-set appraisal → heat allowed (`●` muted `attn-low` / bright `attn-high`). Each dimension reads as a focus map: the one bright `high`, the muted `low`s, the pending `null`s.
- All other R-panel facts (CI status / projection text) stay neutral — color follows authorship. `attn-*` classes are deliberately distinct from the CI-severity utilities.

### Operator set (low/high only)
- The marker's popover offers exactly **low / high** — `AttentionSetRequest.level` has no `null` variant, so the operator can never set `null` (machine-only, by absence).

### File is attention-exempt
- File rows get **no marker and no controls** (`Section` has no `file` variant — unrepresentable by construction).

## Gate (clients/react CI mirror — all green)
- `pnpm lint` (biome) ✓
- `tsc --noEmit` ✓
- `pnpm build` ✓
- `pnpm test` ✓ — **+23 tests**: the hook (poll/levelFor/setAttention/demotion/settingKey), marker rendering, no-null-set, authorship coloring, File-exempt.

## Out of scope (separate follow-up worker)
- **Section reshape** — dissolving the Δ-stream section / removing the Calibration + Handover sections. This PR is the attention-marker mechanism only.
- No tmai-core changes. No null-on-change live trigger (dormant by design). No record edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * パネル全体と各PR/Issue/Decision/Approach行で「注意」レベル（低/高）を表示・設定できるマーカーを追加しました。クリックでメニューから選択、操作中は無効化されます。

* **Style**
  * 注意マーカー用の高/低強調スタイルを追加しました。

* **Tests**
  * マーカーと注意管理の動作を検証する包括的なテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->