### PR TITLE
chore(gen): sync generated spec + types from tmai-core@edaaa4fa8e

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -265,11 +265,16 @@
         "level": {
           "$ref": "#/$defs/Level"
         },
+        "repo_path": {
+          "description": "The artifact's owning repo (a unit spans multiple repos, so this\ndiscriminates `tmai` PR#5 from `tmai-core` PR#5 — #493). Name matches\n[`crate::api::RepoPrsWire::repo_path`] so the UI's `repoPath` threads\nstraight through.",
+          "type": "string"
+        },
         "section": {
           "$ref": "#/$defs/Section"
         }
       },
       "required": [
+        "repo_path",
         "section",
         "id",
         "level"
@@ -286,11 +291,16 @@
         "level": {
           "$ref": "#/$defs/Level"
         },
+        "repo_path": {
+          "description": "The artifact's owning repo (#493). Carried in the request **body**, not\nthe URL path, because repo paths contain slashes. Name matches\n[`crate::api::RepoPrsWire::repo_path`] so the UI's `repoPath` threads\nstraight through.",
+          "type": "string"
+        },
         "section": {
           "$ref": "#/$defs/Section"
         }
       },
       "required": [
+        "repo_path",
         "section",
         "id",
         "level"

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -251,7 +251,7 @@
           "attention"
         ],
         "summary": "Documentation stub for `GET /api/units/{unit}/attention`.",
-        "description": "The full per-unit `(section, id)→level` attention map for the R panel\n(issue #489; approach `2026-06-04-attention-as-per-artifact-field` §2). Only\n`low`/`high` entries are listed — everything else is `null` by absence (the\nmachine pole / unset). Served from `<data_dir>/attention/<unit>.json`\n(crash-resilient atomic file). Real handler:\n`crate::web::api::get_unit_attention`.",
+        "description": "The full per-unit `(repo, section, id)→level` attention map for the R panel\n(issue #489; approach `2026-06-04-attention-as-per-artifact-field` §2; repo\ndiscriminator added in #493). Only `low`/`high` entries are listed —\neverything else is `null` by absence (the machine pole / unset). Served from\n`<data_dir>/attention/<unit>.json`\n(crash-resilient atomic file). Real handler:\n`crate::web::api::get_unit_attention`.",
         "operationId": "get_unit_attention_doc",
         "parameters": [
           {
@@ -288,7 +288,7 @@
           "attention"
         ],
         "summary": "Documentation stub for `POST /api/units/{unit}/attention`.",
-        "description": "The operator's attention write (issue #489 §2). `level` is `low`/`high`\nonly — `null` is the machine pole and is not expressible on the request, so\nthe **monotonic / non-repudiation** invariant (\"the operator can't un-see\")\nis enforced by the type. The handler additionally enforces **`high` ≤ 1 per\ndimension** across sections (`remote` = {PR, Issue} ⊥ `local` = {Decision,\nApproach, Observation}): a new `high` demotes the dimension's prior `high` to\n`low` (never to `null`). Returns the updated map. Real handler:\n`crate::web::api::post_unit_attention`.",
+        "description": "The operator's attention write (issue #489 §2). The artifact is identified\nby `(repo_path, section, id)` in the request **body** — `repo_path`\ndiscriminates artifacts across the unit's repos (#493); it rides the body\n(not the URL path) because repo paths contain slashes. `level` is `low`/`high`\nonly — `null` is the machine pole and is not expressible on the request, so\nthe **monotonic / non-repudiation** invariant (\"the operator can't un-see\")\nis enforced by the type. The handler additionally enforces **`high` ≤ 1 per\ndimension** across sections AND across repos (`remote` = {PR, Issue} ⊥\n`local` = {Decision, Approach, Observation}; one remote + one local high per\n*unit*): a new `high` demotes the dimension's prior `high` to `low` (never to\n`null`). Returns the updated map. Real handler:\n`crate::web::api::post_unit_attention`.",
         "operationId": "post_unit_attention_doc",
         "parameters": [
           {
@@ -1087,6 +1087,7 @@
         "type": "object",
         "description": "One operator-set attention marker in the [`AttentionStateResponse`] map.\n`null` artifacts are **not** emitted — absence = `null` (the R panel already\nholds the artifact inventory; it infers `null` for any listed artifact that\nis absent here).",
         "required": [
+          "repo_path",
           "section",
           "id",
           "level"
@@ -1098,6 +1099,10 @@
           },
           "level": {
             "$ref": "#/components/schemas/Level"
+          },
+          "repo_path": {
+            "type": "string",
+            "description": "The artifact's owning repo (a unit spans multiple repos, so this\ndiscriminates `tmai` PR#5 from `tmai-core` PR#5 — #493). Name matches\n[`crate::api::RepoPrsWire::repo_path`] so the UI's `repoPath` threads\nstraight through."
           },
           "section": {
             "$ref": "#/components/schemas/Section"
@@ -1108,6 +1113,7 @@
         "type": "object",
         "description": "`POST /api/units/{unit}/attention` request — the operator's attention write.\n`level` is `low`/`high` only ([`Level`] has no `null` variant), so the\noperator can never write `null`: the complementary write-pole and\nnon-repudiation invariants are enforced by the type itself, before the\nhandler runs.",
         "required": [
+          "repo_path",
           "section",
           "id",
           "level"
@@ -1119,6 +1125,10 @@
           },
           "level": {
             "$ref": "#/components/schemas/Level"
+          },
+          "repo_path": {
+            "type": "string",
+            "description": "The artifact's owning repo (#493). Carried in the request **body**, not\nthe URL path, because repo paths contain slashes. Name matches\n[`crate::api::RepoPrsWire::repo_path`] so the UI's `repoPath` threads\nstraight through."
           },
           "section": {
             "$ref": "#/components/schemas/Section"
@@ -5534,7 +5544,7 @@
     },
     {
       "name": "attention",
-      "description": "Per-artifact attention model (issue #489; approach 2026-06-04-attention-as-per-artifact-field §2). GET serves the per-unit (section,id)→level map for the R panel (only low/high; null = absence). POST is the operator write (low/high only), enforcing monotonic (no write-back to null) + high≤1/dimension (remote {PR,Issue} ⊥ local {Decision,Approach,Observation}) server-side. File is attention-exempt."
+      "description": "Per-artifact attention model (issue #489; approach 2026-06-04-attention-as-per-artifact-field §2). GET serves the per-unit (repo,section,id)→level map for the R panel (only low/high; null = absence; repo_path discriminates artifacts across the unit's repos, #493). POST is the operator write (low/high only), enforcing monotonic (no write-back to null) + high≤1/dimension (remote {PR,Issue} ⊥ local {Decision,Approach,Observation}) unit-wide across repos, server-side. File is attention-exempt."
     }
   ]
 }

--- a/clients/ratatui/src/types/generated/attention_entry_wire.rs
+++ b/clients/ratatui/src/types/generated/attention_entry_wire.rs
@@ -12,5 +12,6 @@ use std::collections::HashMap;
 pub struct AttentionEntryWire {
     pub id: String,
     pub level: Level,
+    pub repo_path: String,
     pub section: Section,
 }

--- a/clients/ratatui/src/types/generated/attention_set_request.rs
+++ b/clients/ratatui/src/types/generated/attention_set_request.rs
@@ -12,5 +12,6 @@ use std::collections::HashMap;
 pub struct AttentionSetRequest {
     pub id: String,
     pub level: Level,
+    pub repo_path: String,
     pub section: Section,
 }

--- a/clients/react/src/components/producer-console/r-panel/AttentionMarker.tsx
+++ b/clients/react/src/components/producer-console/r-panel/AttentionMarker.tsx
@@ -144,18 +144,22 @@ export function AttentionMarker({ level, onSet, busy = false, label }: Attention
   );
 }
 
-// Row binding — maps a (section,id) artifact onto its attention marker,
-// deriving the busy state from the shared `settingKey`. Renders nothing when
-// no attention controls are threaded (e.g. a section mounted in isolation),
-// so the marker is opt-in: `RPanel` threads the controls, so the live panel
-// always shows markers; standalone renders stay marker-free.
+// Row binding — maps a (repo_path,section,id) artifact onto its attention
+// marker, deriving the busy state from the shared `settingKey`. `repoPath`
+// scopes the key so two same-numbered artifacts in different repos (`tmai`
+// PR#5 vs `tmai-core` PR#5 — #493/#494) drive independent markers. Renders
+// nothing when no attention controls are threaded (e.g. a section mounted in
+// isolation), so the marker is opt-in: `RPanel` threads the controls, so the
+// live panel always shows markers; standalone renders stay marker-free.
 export function RowAttentionMarker({
   attention,
+  repoPath,
   section,
   id,
   label,
 }: {
   attention?: AttentionControls;
+  repoPath: string;
   section: Section;
   id: string;
   label: string;
@@ -163,9 +167,9 @@ export function RowAttentionMarker({
   if (!attention) return null;
   return (
     <AttentionMarker
-      level={attention.levelFor(section, id)}
-      onSet={(level) => attention.setAttention(section, id, level)}
-      busy={attention.settingKey === attentionKey(section, id)}
+      level={attention.levelFor(repoPath, section, id)}
+      onSet={(level) => attention.setAttention(repoPath, section, id, level)}
+      busy={attention.settingKey === attentionKey(repoPath, section, id)}
       label={label}
     />
   );

--- a/clients/react/src/components/producer-console/r-panel/RApproachesSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RApproachesSection.tsx
@@ -210,6 +210,7 @@ function ApproachRow({
       <span className="pt-0.5">
         <RowAttentionMarker
           attention={attention}
+          repoPath={repoPath}
           section="approach"
           id={approach.slug}
           label={approach.slug}

--- a/clients/react/src/components/producer-console/r-panel/RDecisionsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RDecisionsSection.tsx
@@ -151,6 +151,7 @@ function DecisionRow({
       <span className="pt-0.5">
         <RowAttentionMarker
           attention={attention}
+          repoPath={repoPath}
           section="decision"
           id={decision.slug}
           label={decision.slug}

--- a/clients/react/src/components/producer-console/r-panel/RIssuesSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RIssuesSection.tsx
@@ -189,6 +189,7 @@ function IssueRow({
       <span className="pt-0.5">
         <RowAttentionMarker
           attention={attention}
+          repoPath={repoPath}
           section="issue"
           id={String(issue.number)}
           label={`#${Number(issue.number)}`}

--- a/clients/react/src/components/producer-console/r-panel/RPrsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPrsSection.tsx
@@ -186,6 +186,7 @@ function PrRow({
       <span className="pt-0.5">
         <RowAttentionMarker
           attention={attention}
+          repoPath={repoPath}
           section="pr"
           id={String(pr.number)}
           label={`#${Number(pr.number)}`}

--- a/clients/react/src/components/producer-console/r-panel/__tests__/AttentionMarker.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/AttentionMarker.test.tsx
@@ -13,7 +13,9 @@
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import { AttentionMarker } from "../AttentionMarker";
+import { type AttentionControls, attentionKey } from "@/hooks/useUnitAttention";
+import type { Level } from "@/lib/api";
+import { AttentionMarker, RowAttentionMarker } from "../AttentionMarker";
 
 describe("AttentionMarker — authorship-scoped coloring", () => {
   it("null renders a neutral pending marker (machine fact — no heat)", () => {
@@ -95,5 +97,81 @@ describe("AttentionMarker — operator set (low/high only, never null)", () => {
     fireEvent.keyDown(document, { key: "Escape" });
     expect(screen.queryByRole("menu")).toBeNull();
     expect(onSet).not.toHaveBeenCalled();
+  });
+});
+
+// RowAttentionMarker — the row binding. It threads its row's owning `repoPath`
+// into every hook call so two same-numbered artifacts in different repos
+// (`tmai` PR#5 vs `tmai-core` PR#5 — #493/#494) drive independent markers.
+describe("RowAttentionMarker — threads repoPath to the hook", () => {
+  function controls(overrides: Partial<AttentionControls> = {}): AttentionControls {
+    return {
+      levelFor: () => null,
+      setAttention: vi.fn(),
+      settingKey: null,
+      ...overrides,
+    };
+  }
+
+  it("passes repoPath through to levelFor and renders the returned level", () => {
+    const levelFor = vi.fn((): Level | null => "high");
+    render(
+      <RowAttentionMarker
+        attention={controls({ levelFor })}
+        repoPath="tmai-core"
+        section="pr"
+        id="5"
+        label="#5"
+      />,
+    );
+    expect(levelFor).toHaveBeenCalledWith("tmai-core", "pr", "5");
+    expect(screen.getByTestId("attention-marker").getAttribute("data-level")).toBe("high");
+  });
+
+  it("passes repoPath through to setAttention on a write", () => {
+    const setAttention = vi.fn();
+    render(
+      <RowAttentionMarker
+        attention={controls({ setAttention })}
+        repoPath="tmai-core"
+        section="pr"
+        id="5"
+        label="#5"
+      />,
+    );
+    fireEvent.click(screen.getByTestId("attention-marker"));
+    fireEvent.click(screen.getByTestId("attention-set-high"));
+    expect(setAttention).toHaveBeenCalledWith("tmai-core", "pr", "5", "high");
+  });
+
+  it("derives busy from the repo-scoped key — same number, different repo is NOT busy", () => {
+    // `settingKey` points at `tmai-core` PR#5; this marker is `tmai` PR#5.
+    // Pre-fix (key = section+id) they collided and this row would falsely show
+    // busy. Now the repo scopes the key, so it stays enabled.
+    const marker = (repoPath: string) =>
+      render(
+        <RowAttentionMarker
+          attention={controls({ settingKey: attentionKey("tmai-core", "pr", "5") })}
+          repoPath={repoPath}
+          section="pr"
+          id="5"
+          label="#5"
+        />,
+      );
+
+    const other = marker("tmai");
+    expect((other.getByTestId("attention-marker") as HTMLButtonElement).disabled).toBe(false);
+    other.unmount();
+
+    // The actually-pending repo's marker IS busy.
+    const self = marker("tmai-core");
+    expect((self.getByTestId("attention-marker") as HTMLButtonElement).disabled).toBe(true);
+  });
+
+  it("renders nothing when no attention controls are threaded (opt-in)", () => {
+    const { container } = render(
+      <RowAttentionMarker repoPath="tmai" section="pr" id="5" label="#5" />,
+    );
+    expect(container.firstChild).toBeNull();
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RPrsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RPrsSection.test.tsx
@@ -185,7 +185,7 @@ describe("RPrsSection — per-artifact attention markers", () => {
     expect(screen.queryByTestId("attention-marker")).toBeNull();
   });
 
-  it("setting high on a row calls setAttention('pr', <number>, 'high')", async () => {
+  it("setting high on a row calls setAttention(<repoPath>, 'pr', <number>, 'high')", async () => {
     const setAttention = vi.fn();
     unitPrsMock.mockResolvedValue(response([pr()]));
     render(
@@ -200,7 +200,9 @@ describe("RPrsSection — per-artifact attention markers", () => {
 
     fireEvent.click(screen.getByTestId("attention-marker"));
     fireEvent.click(screen.getByTestId("attention-set-high"));
-    expect(setAttention).toHaveBeenCalledWith("pr", "100", "high");
+    // The marker threads its row's owning repo (`RepoPrsWire.repo_path`, here
+    // `/p/u`) so two same-numbered PRs in different repos stay independent.
+    expect(setAttention).toHaveBeenCalledWith("/p/u", "pr", "100", "high");
   });
 
   it("clicking the marker does NOT also open the row's R₂ viewer (stopPropagation)", async () => {

--- a/clients/react/src/hooks/__tests__/useUnitAttention.test.ts
+++ b/clients/react/src/hooks/__tests__/useUnitAttention.test.ts
@@ -7,11 +7,13 @@
 //   - the sibling-shaped poll contract (park on null, initial-fetch loading,
 //     error surfaced without fabricating data, the 60s poll keeps the last
 //     response visible);
-//   - `levelFor(section,id)` reads the map and treats absence as `null` (the
-//     machine fact pole — the wire never emits it);
-//   - `setAttention` POSTs `low`/`high` and re-renders from the RETURNED map,
-//     so a server-side demotion (a prior `high` knocked to `low`) lands even
-//     though the caller only wrote one artifact;
+//   - `levelFor(repo_path,section,id)` reads the map and treats absence as
+//     `null` (the machine fact pole — the wire never emits it), keyed by repo
+//     so two same-numbered artifacts in different repos stay independent
+//     (#493/#494 — the exact multi-repo collision this key fixes);
+//   - `setAttention` POSTs `{ repo_path, section, id, level }` and re-renders
+//     from the RETURNED map, so a server-side demotion (a prior `high` knocked
+//     to `low`) lands even though the caller only wrote one artifact;
 //   - `settingKey` reports the in-flight artifact for a busy marker.
 //
 // Timers stay real and the poll is exercised by capturing `window.setInterval`
@@ -32,12 +34,16 @@ import type { AttentionEntryWire, AttentionStateResponse, Level } from "@/lib/ap
 import { api } from "@/lib/api";
 import { attentionKey, useUnitAttention } from "../useUnitAttention";
 
+// repo_path is now part of the wire entry (and the cache key), so the helper
+// threads it as its first argument — mirroring the (repo_path,section,id) key
+// order. Tests that don't care about the repo pass a stable placeholder.
 function entry(
+  repoPath: string,
   section: AttentionEntryWire["section"],
   id: string,
   level: Level,
 ): AttentionEntryWire {
-  return { section, id, level };
+  return { repo_path: repoPath, section, id, level };
 }
 
 function response(unit: string, entries: AttentionEntryWire[]): AttentionStateResponse {
@@ -61,23 +67,42 @@ describe("useUnitAttention", () => {
     expect(result.current.data).toBeNull();
     expect(result.current.error).toBeNull();
     // Absence = null even with no data at all.
-    expect(result.current.levelFor("pr", "1")).toBeNull();
+    expect(result.current.levelFor("tmai", "pr", "1")).toBeNull();
   });
 
   it("fetches on a real unit and levelFor reads the map (absence = null)", async () => {
     vi.mocked(api.unitAttention).mockResolvedValue(
-      response("tmai", [entry("pr", "123", "high"), entry("decision", "d-slug", "low")]),
+      response("tmai", [
+        entry("tmai", "pr", "123", "high"),
+        entry("tmai", "decision", "d-slug", "low"),
+      ]),
     );
     const { result } = renderHook(() => useUnitAttention("tmai"));
     expect(result.current.loading).toBe(true);
     await waitFor(() => expect(result.current.loading).toBe(false));
 
     expect(api.unitAttention).toHaveBeenCalledWith("tmai");
-    expect(result.current.levelFor("pr", "123")).toBe("high");
-    expect(result.current.levelFor("decision", "d-slug")).toBe("low");
+    expect(result.current.levelFor("tmai", "pr", "123")).toBe("high");
+    expect(result.current.levelFor("tmai", "decision", "d-slug")).toBe("low");
     // Not in the map → null (a machine fact, never emitted on the wire).
-    expect(result.current.levelFor("issue", "999")).toBeNull();
+    expect(result.current.levelFor("tmai", "issue", "999")).toBeNull();
     expect(result.current.error).toBeNull();
+  });
+
+  it("keys attention by repo_path: two same-numbered PRs in different repos stay independent", async () => {
+    // THE #493/#494 bug: before repo_path joined the key, `tmai` PR#5 and
+    // `tmai-core` PR#5 collided on `(section,id)` and shared one marker.
+    vi.mocked(api.unitAttention).mockResolvedValue(
+      response("multi", [entry("tmai", "pr", "5", "high"), entry("tmai-core", "pr", "5", "low")]),
+    );
+    const { result } = renderHook(() => useUnitAttention("multi"));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    // Same PR number, different repo → independent levels (no collision).
+    expect(result.current.levelFor("tmai", "pr", "5")).toBe("high");
+    expect(result.current.levelFor("tmai-core", "pr", "5")).toBe("low");
+    // A repo with no entry for this number stays null (absence = null).
+    expect(result.current.levelFor("other", "pr", "5")).toBeNull();
   });
 
   it("surfaces a fetch error without fabricating data", async () => {
@@ -90,23 +115,25 @@ describe("useUnitAttention", () => {
   it("setAttention POSTs low/high and re-renders from the returned map", async () => {
     vi.mocked(api.unitAttention).mockResolvedValue(response("tmai", []));
     vi.mocked(api.setUnitAttention).mockResolvedValue(
-      response("tmai", [entry("pr", "123", "high")]),
+      response("tmai", [entry("tmai", "pr", "123", "high")]),
     );
     const { result } = renderHook(() => useUnitAttention("tmai"));
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(result.current.levelFor("pr", "123")).toBeNull();
+    expect(result.current.levelFor("tmai", "pr", "123")).toBeNull();
 
     await act(async () => {
-      await result.current.setAttention("pr", "123", "high");
+      await result.current.setAttention("tmai", "pr", "123", "high");
     });
 
+    // The POST body is the typed `AttentionSetRequest`, now carrying repo_path.
     expect(api.setUnitAttention).toHaveBeenCalledWith("tmai", {
+      repo_path: "tmai",
       section: "pr",
       id: "123",
       level: "high",
     });
     // Re-rendered straight from the POST response — no extra GET needed.
-    expect(result.current.levelFor("pr", "123")).toBe("high");
+    expect(result.current.levelFor("tmai", "pr", "123")).toBe("high");
   });
 
   it("reflects a server-side demotion carried on the returned map", async () => {
@@ -114,20 +141,22 @@ describe("useUnitAttention", () => {
     // `high` on a PR makes the backend demote the Issue to `low` to keep
     // `high`≤1/dimension; the POST returns the FULL updated map, so the demoted
     // Issue updates even though the caller only wrote the PR.
-    vi.mocked(api.unitAttention).mockResolvedValue(response("tmai", [entry("issue", "7", "high")]));
+    vi.mocked(api.unitAttention).mockResolvedValue(
+      response("tmai", [entry("tmai", "issue", "7", "high")]),
+    );
     vi.mocked(api.setUnitAttention).mockResolvedValue(
-      response("tmai", [entry("issue", "7", "low"), entry("pr", "123", "high")]),
+      response("tmai", [entry("tmai", "issue", "7", "low"), entry("tmai", "pr", "123", "high")]),
     );
     const { result } = renderHook(() => useUnitAttention("tmai"));
-    await waitFor(() => expect(result.current.levelFor("issue", "7")).toBe("high"));
+    await waitFor(() => expect(result.current.levelFor("tmai", "issue", "7")).toBe("high"));
 
     await act(async () => {
-      await result.current.setAttention("pr", "123", "high");
+      await result.current.setAttention("tmai", "pr", "123", "high");
     });
 
-    expect(result.current.levelFor("pr", "123")).toBe("high");
+    expect(result.current.levelFor("tmai", "pr", "123")).toBe("high");
     // The other artifact in the dimension demoted — never reset to null.
-    expect(result.current.levelFor("issue", "7")).toBe("low");
+    expect(result.current.levelFor("tmai", "issue", "7")).toBe("low");
   });
 
   it("reports settingKey while a POST is in flight and clears it after", async () => {
@@ -143,14 +172,14 @@ describe("useUnitAttention", () => {
 
     let pending: Promise<void> = Promise.resolve();
     act(() => {
-      pending = result.current.setAttention("pr", "123", "low");
+      pending = result.current.setAttention("tmai", "pr", "123", "low");
     });
     // In flight: the busy key matches the artifact (derived via the exported
-    // joiner so this survives any future separator change).
-    await waitFor(() => expect(result.current.settingKey).toBe(attentionKey("pr", "123")));
+    // joiner so this survives any future separator change), now repo-scoped.
+    await waitFor(() => expect(result.current.settingKey).toBe(attentionKey("tmai", "pr", "123")));
 
     await act(async () => {
-      resolvePost(response("tmai", [entry("pr", "123", "low")]));
+      resolvePost(response("tmai", [entry("tmai", "pr", "123", "low")]));
       await pending;
     });
     expect(result.current.settingKey).toBeNull();
@@ -158,26 +187,28 @@ describe("useUnitAttention", () => {
 
   it("re-fetches on unit change and clears the previous unit's attention", async () => {
     vi.mocked(api.unitAttention).mockImplementation((u: string) =>
-      Promise.resolve(response(u, u === "tmai" ? [entry("pr", "1", "high")] : [])),
+      Promise.resolve(response(u, u === "tmai" ? [entry("tmai", "pr", "1", "high")] : [])),
     );
     const { result, rerender } = renderHook(({ u }) => useUnitAttention(u), {
       initialProps: { u: "tmai" },
     });
-    await waitFor(() => expect(result.current.levelFor("pr", "1")).toBe("high"));
+    await waitFor(() => expect(result.current.levelFor("tmai", "pr", "1")).toBe("high"));
 
     rerender({ u: "other" });
     // Cleared synchronously so the old unit's attention is never shown under
     // the new unit's rows.
     expect(result.current.data).toBeNull();
     await waitFor(() => expect(result.current.data?.unit).toBe("other"));
-    expect(result.current.levelFor("pr", "1")).toBeNull();
+    expect(result.current.levelFor("tmai", "pr", "1")).toBeNull();
   });
 
   it("keeps the last response visible across the 60s poll", async () => {
     const setIntervalSpy = vi.spyOn(window, "setInterval");
-    vi.mocked(api.unitAttention).mockResolvedValue(response("tmai", [entry("pr", "1", "high")]));
+    vi.mocked(api.unitAttention).mockResolvedValue(
+      response("tmai", [entry("tmai", "pr", "1", "high")]),
+    );
     const { result } = renderHook(() => useUnitAttention("tmai"));
-    await waitFor(() => expect(result.current.levelFor("pr", "1")).toBe("high"));
+    await waitFor(() => expect(result.current.levelFor("tmai", "pr", "1")).toBe("high"));
 
     const tick = setIntervalSpy.mock.calls[0]?.[0] as (() => void) | undefined;
     expect(typeof tick).toBe("function");
@@ -187,7 +218,7 @@ describe("useUnitAttention", () => {
     });
     await waitFor(() => expect(api.unitAttention).toHaveBeenCalledTimes(2));
     // Last response stays visible (anti-flicker) — never cleared on a poll.
-    expect(result.current.levelFor("pr", "1")).toBe("high");
+    expect(result.current.levelFor("tmai", "pr", "1")).toBe("high");
   });
 
   it("a GET that resolves after parking (unit→null) does not revive stale data", async () => {
@@ -212,10 +243,10 @@ describe("useUnitAttention", () => {
 
     // The previous unit's GET now resolves — it must be dropped, not stamped.
     await act(async () => {
-      resolveGet(response("tmai", [entry("pr", "1", "high")]));
+      resolveGet(response("tmai", [entry("tmai", "pr", "1", "high")]));
     });
     expect(result.current.data).toBeNull();
-    expect(result.current.levelFor("pr", "1")).toBeNull();
+    expect(result.current.levelFor("tmai", "pr", "1")).toBeNull();
   });
 
   it("concurrent same-unit writes: a late older response does not overwrite the newer one", async () => {
@@ -235,26 +266,26 @@ describe("useUnitAttention", () => {
     let older: Promise<void> = Promise.resolve();
     let newer: Promise<void> = Promise.resolve();
     act(() => {
-      older = result.current.setAttention("pr", "1", "low"); // write seq 1
-      newer = result.current.setAttention("pr", "1", "high"); // write seq 2
+      older = result.current.setAttention("tmai", "pr", "1", "low"); // write seq 1
+      newer = result.current.setAttention("tmai", "pr", "1", "high"); // write seq 2
     });
     await waitFor(() => expect(deferred).toHaveLength(2));
 
     // The NEWER write (seq 2) resolves first and wins.
     await act(async () => {
-      deferred[1](response("tmai", [entry("pr", "1", "high")]));
+      deferred[1](response("tmai", [entry("tmai", "pr", "1", "high")]));
       await newer;
     });
-    expect(result.current.levelFor("pr", "1")).toBe("high");
+    expect(result.current.levelFor("tmai", "pr", "1")).toBe("high");
     expect(result.current.settingKey).toBeNull();
 
     // The OLDER write (seq 1) resolves LATE — it is stale and must be dropped,
     // never rolling the display back to `low`.
     await act(async () => {
-      deferred[0](response("tmai", [entry("pr", "1", "low")]));
+      deferred[0](response("tmai", [entry("tmai", "pr", "1", "low")]));
       await older;
     });
-    expect(result.current.levelFor("pr", "1")).toBe("high");
+    expect(result.current.levelFor("tmai", "pr", "1")).toBe("high");
     expect(result.current.settingKey).toBeNull();
   });
 });

--- a/clients/react/src/hooks/useUnitAttention.ts
+++ b/clients/react/src/hooks/useUnitAttention.ts
@@ -11,16 +11,16 @@
 // the initial fetch; `unit = null` parks the hook). It adds two
 // attention-specific affordances the inventory siblings do not need:
 //
-//   - `levelFor(section, id)` — the per-artifact lookup the R-panel rows
-//     render. Absence = `null` (the wire only emits `low`/`high`; `null` is a
-//     machine fact represented by absence, never sent).
-//   - `setAttention(section, id, level)` — the operator write. `level` is
-//     `Level` (`low`/`high`) — the operator can never set `null` (the type
-//     itself forbids it). The POST returns the full updated map, which we
-//     stamp over `data` so a server-side demotion (a prior `high` knocked to
-//     `low` to keep `high`≤1/dimension) is reflected across every section at
-//     once — the reason this hook is lifted to one instance in `RPanel`
-//     rather than one per section.
+//   - `levelFor(repo_path, section, id)` — the per-artifact lookup the R-panel
+//     rows render. Absence = `null` (the wire only emits `low`/`high`; `null`
+//     is a machine fact represented by absence, never sent).
+//   - `setAttention(repo_path, section, id, level)` — the operator write.
+//     `level` is `Level` (`low`/`high`) — the operator can never set `null`
+//     (the type itself forbids it). The POST returns the full updated map,
+//     which we stamp over `data` so a server-side demotion (a prior `high`
+//     knocked to `low` to keep `high`≤1/dimension) is reflected across every
+//     section at once — the reason this hook is lifted to one instance in
+//     `RPanel` rather than one per section.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
@@ -33,11 +33,15 @@ import {
 
 const POLL_INTERVAL_MS = 60_000;
 
-// Map key for the (section,id) composite. `Section` is a closed enum whose
-// variants contain no whitespace, so a space joiner is unambiguous (no id can
-// straddle the boundary).
-function attentionKey(section: Section, id: string): string {
-  return `${section} ${id}`;
+// Map key for the (repo_path,section,id) composite. `repo_path` is prepended
+// so two same-numbered artifacts in different repos (`tmai` PR#5 vs
+// `tmai-core` PR#5 — #493/#494) stay distinct. `Section` is a closed enum
+// whose variants contain no whitespace, so the space joiner is unambiguous
+// even if a repo path contained a space: the section token is always a fixed,
+// non-empty enum value flanked by spaces, so no other (repo_path,section,id)
+// split reproduces the same string.
+function attentionKey(repoPath: string, section: Section, id: string): string {
+  return `${repoPath} ${section} ${id}`;
 }
 
 export interface UseUnitAttentionResult {
@@ -45,13 +49,15 @@ export interface UseUnitAttentionResult {
   loading: boolean;
   error: Error | null;
   /** Operator-set attention for one artifact, or `null` (machine fact: the
-   *  wire emits only `low`/`high`, so absence = `null`). */
-  levelFor: (section: Section, id: string) => Level | null;
+   *  wire emits only `low`/`high`, so absence = `null`). Keyed by repo so two
+   *  same-numbered artifacts in different repos stay independent. */
+  levelFor: (repoPath: string, section: Section, id: string) => Level | null;
   /** Write `low`/`high` for one artifact (POST) and re-render from the
    *  returned map. No `null` pole — the operator cannot disclaim. */
-  setAttention: (section: Section, id: string, level: Level) => Promise<void>;
-  /** `attentionKey(section,id)` of the artifact whose POST is in flight, so a
-   *  row can show a busy/disabled marker; `null` when none is pending. */
+  setAttention: (repoPath: string, section: Section, id: string, level: Level) => Promise<void>;
+  /** `attentionKey(repoPath,section,id)` of the artifact whose POST is in
+   *  flight, so a row can show a busy/disabled marker; `null` when none is
+   *  pending. */
   settingKey: string | null;
 }
 
@@ -135,28 +141,29 @@ export function useUnitAttention(unit: string | null): UseUnitAttentionResult {
     const map = new Map<string, Level>();
     if (data !== null) {
       for (const entry of data.entries) {
-        map.set(attentionKey(entry.section, entry.id), entry.level);
+        map.set(attentionKey(entry.repo_path, entry.section, entry.id), entry.level);
       }
     }
     return map;
   }, [data]);
 
   const levelFor = useCallback(
-    (section: Section, id: string): Level | null => levelMap.get(attentionKey(section, id)) ?? null,
+    (repoPath: string, section: Section, id: string): Level | null =>
+      levelMap.get(attentionKey(repoPath, section, id)) ?? null,
     [levelMap],
   );
 
   const setAttention = useCallback(
-    async (section: Section, id: string, level: Level): Promise<void> => {
+    async (repoPath: string, section: Section, id: string, level: Level): Promise<void> => {
       if (!unit) return;
       const myGen = generationRef.current;
       const myWriteSeq = ++writeSeqRef.current;
       // Stale iff the unit changed (myGen) OR a newer write superseded this one
       // (myWriteSeq). Either invalidates this response.
       const isStale = () => myGen !== generationRef.current || myWriteSeq !== writeSeqRef.current;
-      const key = attentionKey(section, id);
+      const key = attentionKey(repoPath, section, id);
       setSettingKey(key);
-      const body: AttentionSetRequest = { section, id, level };
+      const body: AttentionSetRequest = { repo_path: repoPath, section, id, level };
       try {
         const res = await api.setUnitAttention(unit, body);
         if (isStale()) return;

--- a/clients/react/src/types/generated/AttentionEntryWire.ts
+++ b/clients/react/src/types/generated/AttentionEntryWire.ts
@@ -8,7 +8,14 @@ import type { Section } from "./Section";
  * holds the artifact inventory; it infers `null` for any listed artifact that
  * is absent here).
  */
-export type AttentionEntryWire = { section: Section, 
+export type AttentionEntryWire = { 
+/**
+ * The artifact's owning repo (a unit spans multiple repos, so this
+ * discriminates `tmai` PR#5 from `tmai-core` PR#5 — #493). Name matches
+ * [`crate::api::RepoPrsWire::repo_path`] so the UI's `repoPath` threads
+ * straight through.
+ */
+repo_path: string, section: Section, 
 /**
  * PR/Issue number rendered as a string, or Decision/Approach/Observation
  * slug.

--- a/clients/react/src/types/generated/AttentionSetRequest.ts
+++ b/clients/react/src/types/generated/AttentionSetRequest.ts
@@ -9,7 +9,14 @@ import type { Section } from "./Section";
  * non-repudiation invariants are enforced by the type itself, before the
  * handler runs.
  */
-export type AttentionSetRequest = { section: Section, 
+export type AttentionSetRequest = { 
+/**
+ * The artifact's owning repo (#493). Carried in the request **body**, not
+ * the URL path, because repo paths contain slashes. Name matches
+ * [`crate::api::RepoPrsWire::repo_path`] so the UI's `repoPath` threads
+ * straight through.
+ */
+repo_path: string, section: Section, 
 /**
  * PR/Issue number rendered as a string, or Decision/Approach/Observation
  * slug.


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@edaaa4fa8ea3fc7b7a504e3c38d0b329380b3309

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/corevents.schema.json                           | 10 ++++++++++
 api-spec/openapi.json                                    | 16 +++++++++++++---
 .../ratatui/src/types/generated/attention_entry_wire.rs  |  1 +
 .../ratatui/src/types/generated/attention_set_request.rs |  1 +
 clients/react/src/types/generated/AttentionEntryWire.ts  |  9 ++++++++-
 clients/react/src/types/generated/AttentionSetRequest.ts |  9 ++++++++-
 6 files changed, 41 insertions(+), 5 deletions(-)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **API 変更**
  * 注意（Attention）関連 API エンドポイントで `repo_path` パラメータが新たに必須となりました。`/api/units/{unit}/attention` の GET・POST リクエストで `repo_path` の指定が必要です。複数リポジトリを含むユニット内で注意レベルを正確に識別できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->