### PR TITLE
chore(gen): sync generated spec + types from tmai-core@36659babf5

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -411,7 +411,7 @@
           "type": "string"
         },
         "tier_routed": {
-          "description": "Tier the verdict was routed to (`1` = human-gated tripwire, `2` =\nProducer may handle). Matches `DecisionFrontmatter::tier`.",
+          "description": "Which authority the friction was routed to, encoded as a `u8` so the\ndormant on-disk store and the ts-rs/openapi wire stay byte-stable:\n`1` = the friction implies a *decision-act* → human-gated tripwire\n(the Producer flags, never decides); `2` = *approach-execution* → the\nProducer may handle. The `DecisionFrontmatter::tier` field this once\nmirrored has been removed — authority now derives from slot + category\n+ act, per `doc/decisions/2026-05-16-authority-attaches-to-the-act.md`.",
           "format": "int32",
           "minimum": 0,
           "type": "integer"

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -1251,7 +1251,7 @@
           "tier_routed": {
             "type": "integer",
             "format": "int32",
-            "description": "Tier the verdict was routed to (`1` = human-gated tripwire, `2` =\nProducer may handle). Matches `DecisionFrontmatter::tier`.",
+            "description": "Which authority the friction was routed to, encoded as a `u8` so the\ndormant on-disk store and the ts-rs/openapi wire stay byte-stable:\n`1` = the friction implies a *decision-act* → human-gated tripwire\n(the Producer flags, never decides); `2` = *approach-execution* → the\nProducer may handle. The `DecisionFrontmatter::tier` field this once\nmirrored has been removed — authority now derives from slot + category\n+ act, per `doc/decisions/2026-05-16-authority-attaches-to-the-act.md`.",
             "minimum": 0
           },
           "verdict": {

--- a/clients/react/src/types/generated/CalibrationEntry.ts
+++ b/clients/react/src/types/generated/CalibrationEntry.ts
@@ -20,8 +20,13 @@ synthesis_pass_id: string,
  */
 note_source: string, verdict: TriageVerdict, confidence: Confidence, 
 /**
- * Tier the verdict was routed to (`1` = human-gated tripwire, `2` =
- * Producer may handle). Matches `DecisionFrontmatter::tier`.
+ * Which authority the friction was routed to, encoded as a `u8` so the
+ * dormant on-disk store and the ts-rs/openapi wire stay byte-stable:
+ * `1` = the friction implies a *decision-act* → human-gated tripwire
+ * (the Producer flags, never decides); `2` = *approach-execution* → the
+ * Producer may handle. The `DecisionFrontmatter::tier` field this once
+ * mirrored has been removed — authority now derives from slot + category
+ * + act, per `doc/decisions/2026-05-16-authority-attaches-to-the-act.md`.
  */
 tier_routed: number, 
 /**


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@36659babf58ec71cd0f75591b42d4fd9851784ff

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/corevents.schema.json                        | 2 +-
 api-spec/openapi.json                                 | 2 +-
 clients/react/src/types/generated/CalibrationEntry.ts | 9 +++++++--
 3 files changed, 9 insertions(+), 4 deletions(-)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated API documentation for the `tier_routed` field in `CalibrationEntry` to clarify how authority values are derived and encoded. This improves clarity around the authority routing logic without affecting API functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->