### PR TITLE
feat(r-panel): RObservationsSection — the 5th attention-artifact section (#776)

### DIFF
--- a/clients/react/src/components/producer-console/r-panel/RObservationsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RObservationsSection.tsx
@@ -1,0 +1,169 @@
+// ◇ Observations — R panel's raw observation inventory; the 5th
+// attention-artifact section (`pr | issue | decision | approach |
+// observation`), the local-dimension peer of decisions / approaches.
+//
+// Contract: `tmai-core:doc/approaches/2026-06-04-attention-as-per-artifact-field.md`
+// §key (observation = local-dimension attention-artifact). Each row carries
+// its own `RowAttentionMarker` (`section="observation"`, `repoPath=repo_root`
+// — same keying as decisions / approaches, #493).
+//
+// Deliberately FLATTER than RApproachesSection: an observation has no
+// lifecycle and nothing rich to open in R₂ (`ObservationWire` carries only
+// `slug` / `summary` / `status`), so rows are NOT clickable-to-viewer and the
+// row's `status` (`high | medium | low`) shows as a plain inline badge rather
+// than a status-group header. The badge is the author's appraisal weight, but
+// it is rendered with zero severity styling (subtle-foreground only) — R is
+// inventory, tmai does not weight it.
+
+import type { AttentionControls } from "@/hooks/useUnitAttention";
+import { useUnitObservations } from "@/hooks/useUnitObservations";
+import type { ObservationWire, RepoObservationsWire } from "@/lib/api";
+import { RowAttentionMarker } from "./AttentionMarker";
+import { Section } from "./Section";
+
+interface RObservationsSectionProps {
+  unitName: string | null;
+  expanded: boolean;
+  onToggle: () => void;
+  /** Per-artifact attention controls (threaded from `RPanel`'s single hook).
+   *  When present each observation row shows its attention marker; absent
+   *  (e.g. in isolation tests) the rows render marker-free. */
+  attention?: AttentionControls;
+}
+
+export function RObservationsSection({
+  unitName,
+  expanded,
+  onToggle,
+  attention,
+}: RObservationsSectionProps) {
+  const { data, loading, error } = useUnitObservations(unitName);
+  const total = data === null ? 0 : data.repos.reduce((n, r) => n + r.observations.length, 0);
+
+  return (
+    <Section
+      id="observations"
+      glyph="◇"
+      label="Observations"
+      count={`${total}`}
+      expanded={expanded}
+      onToggle={onToggle}
+    >
+      <Body
+        unitName={unitName}
+        repos={data?.repos ?? null}
+        loading={loading}
+        error={error}
+        attention={attention}
+      />
+    </Section>
+  );
+}
+
+interface BodyProps {
+  unitName: string | null;
+  repos: RepoObservationsWire[] | null;
+  loading: boolean;
+  error: Error | null;
+  attention?: AttentionControls;
+}
+
+function Body({ unitName, repos, loading, error, attention }: BodyProps) {
+  if (unitName === null) {
+    return <p className="text-subtle-foreground">Pick a project to see observations.</p>;
+  }
+  if (error !== null) {
+    return <p className="text-muted-foreground">Failed to load observations: {error.message}</p>;
+  }
+  if (repos === null && loading) {
+    return <p className="text-subtle-foreground">Loading…</p>;
+  }
+  if (repos === null || repos.length === 0 || repos.every((r) => r.observations.length === 0)) {
+    return <p className="text-subtle-foreground">No observations.</p>;
+  }
+  const multiRepo = repos.length > 1;
+  return (
+    <div className="space-y-2">
+      {repos.map((repo) => (
+        <RepoBlock key={repo.repo_root} repo={repo} multiRepo={multiRepo} attention={attention} />
+      ))}
+    </div>
+  );
+}
+
+function RepoBlock({
+  repo,
+  multiRepo,
+  attention,
+}: {
+  repo: RepoObservationsWire;
+  multiRepo: boolean;
+  attention?: AttentionControls;
+}) {
+  // Flat list, no status grouping — sorted most-recent-first by slug. The
+  // wire already arrives in this order; we sort defensively so the order is
+  // self-evident from the component, not assumed from the server.
+  const observations = [...repo.observations].sort((a, b) => b.slug.localeCompare(a.slug));
+  return (
+    <div>
+      {multiRepo && (
+        <p className="text-[11px] uppercase tracking-wide text-subtle-foreground">
+          {repo.repo_label}
+        </p>
+      )}
+      <ul className="space-y-0.5">
+        {observations.map((o) => (
+          <ObservationRow
+            key={o.slug}
+            observation={o}
+            repoPath={repo.repo_root}
+            attention={attention}
+          />
+        ))}
+      </ul>
+    </div>
+  );
+}
+
+// One observation row: attention marker + summary + status badge. Unlike
+// `ApproachRow` the row is NOT a button — an observation has no record viewer
+// to open (the wire carries no body), so there is nothing to select into R₂.
+function ObservationRow({
+  observation,
+  repoPath,
+  attention,
+}: {
+  observation: ObservationWire;
+  repoPath: string;
+  attention?: AttentionControls;
+}) {
+  return (
+    <li className="flex items-start gap-1.5 leading-snug">
+      {/* Attention marker sits to the LEFT of the row (contract §3 core). */}
+      <span className="pt-0.5">
+        <RowAttentionMarker
+          attention={attention}
+          repoPath={repoPath}
+          section="observation"
+          id={observation.slug}
+          label={observation.slug}
+        />
+      </span>
+      <div className="min-w-0 flex-1 px-1 py-0.5">
+        <div className="flex items-baseline gap-1.5">
+          <span className="min-w-0 flex-1 text-foreground">{observation.summary}</span>
+          {/* status badge — the author's appraisal weight, rendered plain
+              (subtle-foreground, no severity accent): R shows it, tmai does
+              not weight it. */}
+          <span
+            data-testid="observation-status"
+            className="shrink-0 rounded bg-surface-strong/40 px-1 text-[10px] uppercase tracking-wide text-subtle-foreground"
+          >
+            {observation.status}
+          </span>
+        </div>
+        <div className="text-[11px] text-subtle-foreground">{observation.slug}</div>
+      </div>
+    </li>
+  );
+}

--- a/clients/react/src/components/producer-console/r-panel/RPanel.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPanel.tsx
@@ -39,6 +39,7 @@ import { RDecisionsSection } from "./RDecisionsSection";
 import { RFilesSection } from "./RFilesSection";
 import { RInventorySection } from "./RInventorySection";
 import { RIssuesSection } from "./RIssuesSection";
+import { RObservationsSection } from "./RObservationsSection";
 import { RPrsSection } from "./RPrsSection";
 import type { SelectedIssue } from "./r-viewer/RIssueViewer";
 import type { SelectedPr } from "./r-viewer/RPrViewer";
@@ -92,7 +93,15 @@ interface RPanelProps {
   viewer?: React.ReactNode;
 }
 
-const SECTION_IDS = ["prs", "issues", "decisions", "approaches", "inventory", "files"] as const;
+const SECTION_IDS = [
+  "prs",
+  "issues",
+  "decisions",
+  "approaches",
+  "observations",
+  "inventory",
+  "files",
+] as const;
 
 export function RPanel({
   currentProjectPath,
@@ -113,8 +122,9 @@ export function RPanel({
   // One attention hook for the whole panel (not one per section): the POST
   // returns the full updated map, so a server-side demotion (a prior `high`
   // knocked to `low` to keep `high`≤1/dimension) lands on the PR + Issue
-  // sections at once. Threaded down to the four attention-artifact sections;
-  // File is attention-exempt and is NOT given the controls.
+  // sections at once. Threaded down to the five attention-artifact sections
+  // (pr / issue / decision / approach / observation); File is attention-exempt
+  // and is NOT given the controls.
   const attention = useUnitAttention(unitName);
 
   const toggle = useCallback(
@@ -240,6 +250,12 @@ export function RPanel({
               onToggle={() => toggle("approaches")}
               onSelect={onSelectRecord}
               selectedKey={selectedRecordKey}
+              attention={attention}
+            />
+            <RObservationsSection
+              unitName={unitName}
+              expanded={isExpanded("observations")}
+              onToggle={() => toggle("observations")}
               attention={attention}
             />
             <RInventorySection

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RObservationsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RObservationsSection.test.tsx
@@ -1,0 +1,196 @@
+// @vitest-environment jsdom
+//
+// RObservationsSection — flat per-repo list, summary + plain status badge,
+// no record viewer (rows are not clickable), no severity styling. The 5th
+// attention-artifact section, local-dimension peer of approaches.
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AttentionControls } from "@/hooks/useUnitAttention";
+import type { ObservationsResponse, ObservationWire } from "@/lib/api";
+
+const observationsMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      observations: (...args: unknown[]) => observationsMock(...args),
+    },
+  };
+});
+
+import { RObservationsSection } from "../RObservationsSection";
+
+function observationStub(overrides: Partial<ObservationWire> = {}): ObservationWire {
+  return {
+    slug: "2026-06-01-o",
+    summary: "Observation O",
+    status: "medium",
+    ...overrides,
+  };
+}
+
+function responseStub(observations: ObservationWire[] = []): ObservationsResponse {
+  return {
+    unit: "u",
+    composed_at: "2026-06-04T00:00:00Z",
+    repos: [
+      {
+        repo_label: "u",
+        repo_root: "/p/u",
+        primary: true,
+        repo_head: null,
+        observations,
+      },
+    ],
+  };
+}
+
+beforeEach(() => {
+  observationsMock.mockReset();
+});
+
+describe("RObservationsSection", () => {
+  it("renders one row per observation with summary + status badge", async () => {
+    observationsMock.mockResolvedValue(
+      responseStub([
+        observationStub({ slug: "2026-06-02-high", summary: "High one", status: "high" }),
+        observationStub({ slug: "2026-06-01-low", summary: "Low one", status: "low" }),
+      ]),
+    );
+
+    render(<RObservationsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("High one")).toBeTruthy();
+    });
+    expect(screen.getByText("Low one")).toBeTruthy();
+    // The status badge surfaces the appraisal weight inline.
+    const badges = screen.getAllByTestId("observation-status");
+    const badgeText = badges.map((b) => b.textContent);
+    expect(badgeText).toContain("high");
+    expect(badgeText).toContain("low");
+  });
+
+  it("sorts rows most-recent-first by slug", async () => {
+    observationsMock.mockResolvedValue(
+      responseStub([
+        observationStub({ slug: "2026-05-01-old", summary: "Old note" }),
+        observationStub({ slug: "2026-06-15-new", summary: "New note" }),
+      ]),
+    );
+
+    render(<RObservationsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+
+    const newRow = await screen.findByText("New note");
+    const oldRow = screen.getByText("Old note");
+    // New (later slug) comes before Old.
+    expect(newRow.compareDocumentPosition(oldRow) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+  });
+
+  it("header count is the plain total (no severity styling)", async () => {
+    observationsMock.mockResolvedValue(
+      responseStub([
+        observationStub({ slug: "a", status: "high" }),
+        observationStub({ slug: "b", status: "medium" }),
+        observationStub({ slug: "c", status: "low" }),
+      ]),
+    );
+    const { container } = render(
+      <RObservationsSection unitName="u" expanded={false} onToggle={vi.fn()} />,
+    );
+    await waitFor(() => {
+      expect(screen.getByText("3")).toBeTruthy();
+    });
+    expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
+  });
+
+  it("rows are NOT clickable-to-viewer (no buttons in the body)", async () => {
+    observationsMock.mockResolvedValue(
+      responseStub([observationStub({ slug: "2026-06-01-o", summary: "Observation O" })]),
+    );
+    render(<RObservationsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+
+    await screen.findByText("Observation O");
+    // The only button in the section is the accordion header toggle — the
+    // observation row itself is plain text, not a button (no record viewer).
+    const buttons = screen.getAllByRole("button");
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0].textContent).toMatch(/Observations/);
+  });
+
+  it("renders a per-row attention marker keyed by section=observation when controls are threaded", async () => {
+    observationsMock.mockResolvedValue(
+      responseStub([observationStub({ slug: "2026-06-01-o", summary: "Observation O" })]),
+    );
+    // The marker only reads `level` for the (repoPath, "observation", slug)
+    // triple — the load-bearing wiring this issue adds (the 5th artifact).
+    const attention: AttentionControls = {
+      levelFor: (repoPath, section, id) =>
+        repoPath === "/p/u" && section === "observation" && id === "2026-06-01-o" ? "high" : null,
+      setAttention: vi.fn(),
+      settingKey: null,
+    };
+    render(
+      <RObservationsSection
+        unitName="u"
+        expanded={true}
+        onToggle={vi.fn()}
+        attention={attention}
+      />,
+    );
+
+    await screen.findByText("Observation O");
+    const marker = screen.getByTestId("attention-marker");
+    expect(marker.getAttribute("data-level")).toBe("high");
+  });
+
+  it("shows a placeholder when there are no observations", async () => {
+    observationsMock.mockResolvedValue(responseStub([]));
+    render(<RObservationsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText("No observations.")).toBeTruthy();
+    });
+  });
+
+  it("parks with a placeholder when no project is selected", () => {
+    render(<RObservationsSection unitName={null} expanded={true} onToggle={vi.fn()} />);
+    expect(screen.getByText(/Pick a project to see observations\./)).toBeTruthy();
+    // Parked hook does not fetch.
+    expect(observationsMock).not.toHaveBeenCalled();
+  });
+
+  it("renders a per-repo label only when the unit spans multiple repos", async () => {
+    observationsMock.mockResolvedValue({
+      unit: "u",
+      composed_at: "2026-06-04T00:00:00Z",
+      repos: [
+        {
+          repo_label: "core",
+          repo_root: "/p/core",
+          primary: true,
+          repo_head: null,
+          observations: [observationStub({ slug: "2026-06-01-c", summary: "Core note" })],
+        },
+        {
+          repo_label: "ui",
+          repo_root: "/p/ui",
+          primary: false,
+          repo_head: null,
+          observations: [observationStub({ slug: "2026-06-01-u", summary: "Ui note" })],
+        },
+      ],
+    } satisfies ObservationsResponse);
+
+    render(<RObservationsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Core note")).toBeTruthy();
+    });
+    expect(screen.getByText("core")).toBeTruthy();
+    expect(screen.getByText("ui")).toBeTruthy();
+  });
+});

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RPanel.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RPanel.test.tsx
@@ -63,6 +63,18 @@ vi.mock("../RApproachesSection", () => ({
     </button>
   ),
 }));
+vi.mock("../RObservationsSection", () => ({
+  RObservationsSection: ({ expanded, onToggle }: { expanded: boolean; onToggle: () => void }) => (
+    <button
+      type="button"
+      data-testid="observations-section"
+      data-expanded={expanded}
+      onClick={onToggle}
+    >
+      Observations
+    </button>
+  ),
+}));
 vi.mock("../RFilesSection", () => ({
   RFilesSection: ({ expanded, onToggle }: { expanded: boolean; onToggle: () => void }) => (
     <button type="button" data-testid="files-section" data-expanded={expanded} onClick={onToggle}>
@@ -108,6 +120,7 @@ describe("RPanel — accordion shell", () => {
       "issues-section",
       "decisions-section",
       "approaches-section",
+      "observations-section",
       "files-section",
     ];
     for (const id of ids) {

--- a/clients/react/src/hooks/useUnitObservations.ts
+++ b/clients/react/src/hooks/useUnitObservations.ts
@@ -1,0 +1,82 @@
+// Polling hook for the unit's observations view (R panel's ◇ section) —
+// the cross-repo "what did we notice" salvage surface, consuming
+// `GET /api/units/{unit}/observations` (tmai-core #498): every observation
+// record in each repo's `doc/observations/`, carrying only the row fields
+// (`slug` / `summary` / `status`).
+//
+// The observations twin of `useApproaches` / `useUnitInventory` — same shape,
+// same cadence. Observations change on the timescale a Producer files a note
+// — rare, human-paced. A 60-second poll (same cadence as the siblings) is
+// ample for an operator-scan surface; no SSE here yet. Mirrors the siblings'
+// shape exactly: keeps the previous response visible while a re-fetch is in
+// flight so the list does not flicker; `loading` reflects only the initial
+// fetch.
+//
+// `unit = null` parks the hook (no fetch, no interval) — used when no project
+// is selected so the section can render a placeholder rather than poll a
+// non-existent unit.
+
+import { useEffect, useRef, useState } from "react";
+import { api, type ObservationsResponse } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface UseUnitObservationsResult {
+  data: ObservationsResponse | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useUnitObservations(unit: string | null): UseUnitObservationsResult {
+  const [data, setData] = useState<ObservationsResponse | null>(null);
+  const [loading, setLoading] = useState(unit !== null);
+  const [error, setError] = useState<Error | null>(null);
+  // An in-flight response from a previous unit must not stamp over a
+  // newer unit's data (same guard as useApproaches / useUnitInventory).
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    if (!unit) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    // Clear on unit *change* (this effect's only re-trigger — deps are
+    // [unit]) so the previous unit's observations are never shown under the
+    // new unit's header. The 60s same-unit re-poll goes through fetchOnce,
+    // which intentionally keeps the last response visible (anti-flicker);
+    // that path is untouched. Mirrors the guard in useApproaches.
+    setData(null);
+    setError(null);
+    setLoading(true);
+
+    const fetchOnce = async () => {
+      try {
+        const res = await api.observations(unit);
+        if (myGen !== generationRef.current) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (myGen !== generationRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (myGen === generationRef.current) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [unit]);
+
+  return { data, loading, error };
+}

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -25,6 +25,9 @@ import type { HandoffsResponse } from "@/types/generated/HandoffsResponse";
 import type { IssueLabelWire } from "@/types/generated/IssueLabelWire";
 import type { IssueSummaryWire } from "@/types/generated/IssueSummaryWire";
 import type { Level } from "@/types/generated/Level";
+import type { ObservationStatus } from "@/types/generated/ObservationStatus";
+import type { ObservationsResponse } from "@/types/generated/ObservationsResponse";
+import type { ObservationWire } from "@/types/generated/ObservationWire";
 import type { Outcome } from "@/types/generated/Outcome";
 import type { PermissionMode } from "@/types/generated/PermissionMode";
 import type { PrDiffResponse } from "@/types/generated/PrDiffResponse";
@@ -35,6 +38,7 @@ import type { QueueAgentEntry } from "@/types/generated/QueueAgentEntry";
 import type { QueueSnapshot } from "@/types/generated/QueueSnapshot";
 import type { RepoApproachesWire } from "@/types/generated/RepoApproachesWire";
 import type { RepoIssuesWire } from "@/types/generated/RepoIssuesWire";
+import type { RepoObservationsWire } from "@/types/generated/RepoObservationsWire";
 import type { RepoPrsWire } from "@/types/generated/RepoPrsWire";
 import type { ReviewExtensionWire } from "@/types/generated/ReviewExtensionWire";
 import type { ReviewTriggerWire } from "@/types/generated/ReviewTriggerWire";
@@ -79,6 +83,9 @@ export type {
   IssueLabelWire,
   IssueSummaryWire,
   Level,
+  ObservationStatus,
+  ObservationsResponse,
+  ObservationWire,
   Outcome,
   PermissionMode,
   PrDiffResponse,
@@ -89,6 +96,7 @@ export type {
   QueueSnapshot,
   RepoApproachesWire,
   RepoIssuesWire,
+  RepoObservationsWire,
   RepoPrsWire,
   ReviewExtensionWire,
   ReviewTriggerWire,
@@ -1523,6 +1531,14 @@ export const api = {
   // tmai-core#340, same as decisions.
   approaches: (unit: string) =>
     apiFetch<ApproachesResponse>(`/units/${encodeURIComponent(unit)}/approaches`),
+
+  // Observations view (tmai-core #498) — every observation record per repo,
+  // sorted most-recent-first by slug. The R panel renders one row per
+  // observation (summary + status badge); there is no record viewer —
+  // `ObservationWire` carries only `slug` / `summary` / `status`, nothing
+  // rich to open in R₂. Multi-repo follows tmai-core#340, same as approaches.
+  observations: (unit: string) =>
+    apiFetch<ObservationsResponse>(`/units/${encodeURIComponent(unit)}/observations`),
 
   // Unit-scoped cross-repo open-PR list — Stage-1 in-tmai dev-loop
   // (DR `2026-05-16-dev-loop-completes-in-tmai.md` §A). One unified

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -264,6 +264,10 @@ export const api = {
   // compose()'s ▣ section; no Tauri-specific path needed)
   approaches: (unit: string) => httpApi.approaches(unit),
 
+  // Observations view (HTTP only — on-demand JSON projection of the unit's
+  // doc/observations/ records; no Tauri-specific path needed)
+  observations: (unit: string) => httpApi.observations(unit),
+
   // Unit-scoped cross-repo PR list (HTTP only — gh-CLI passthrough
   // fanned out over the unit's repos; no Tauri-specific path needed)
   unitPrs: (unit: string) => httpApi.unitPrs(unit),


### PR DESCRIPTION
## What

Adds `RObservationsSection` to the R panel — the clients/react half of the Observations attention-artifact, closing the 5-attention-artifact model (`pr | issue | decision | approach | observation`) in the UI. PR / Issue / Decision / Approach already rendered per-row attention markers; Observation was the only one missing.

Backend landed in tmai-core #498 (`GET /api/units/{unit}/observations`); wire types synced in #775. Contract: `tmai-core:doc/approaches/2026-06-04-attention-as-per-artifact-field.md` §key (observation = local-dimension attention-artifact, peer of decision / approach).

## How (mirrors RApproachesSection)

- **`api.observations(unit)`** helper in `api-http.ts` (+ `api-tauri.ts` passthrough) → `GET /units/{unit}/observations` → `ObservationsResponse`, mirroring `api.approaches`. Wire types are imported from `@/types/generated/` (`ObservationsResponse` / `RepoObservationsWire` / `ObservationWire` / `ObservationStatus`) and re-exported from `@/lib/api` — **never hand-mirrored** (the api-http shadow trap).
- **`useUnitObservations(unit)`** hook mirroring `useApproaches` / `useUnitInventory`: 60s poll, anti-flicker keep-last, unit-park, generation guard.
- **`RObservationsSection.tsx`** mirroring `RApproachesSection`'s per-repo grouping (keyed by `repo.repo_root`), with each row's `RowAttentionMarker` (`section="observation"`, `repoPath=repo_root` per #493, `id=slug`, label = slug). Deliberately **flatter**: rows show `summary` + a plain `status` badge (`high | medium | low`) and are **not** clickable-to-viewer — `ObservationWire` carries no body, so there is nothing rich to open in R₂.
- **`RPanel.tsx`** wiring: `"observations"` added to `SECTION_IDS` and rendered in the local dimension (after `approaches`, before `inventory`), threading the single shared `useUnitAttention` controls exactly as the other sections do.

## Out of scope (per the issue)

No observations record viewer; no tmai-core changes; no decision/approach records authored.

## Gate (all green locally)

- ✅ `pnpm tsc --noEmit`
- ✅ `pnpm lint` (biome check src/ — 1 pre-existing unrelated warning)
- ✅ `pnpm test` (652 passed | 2 skipped)
- ✅ `pnpm build`

Closes #776

🤖 Generated with [Claude Code](https://claude.com/claude-code)