### PR TITLE
feat(r-panel): RAimsSection — real aim-tree read view (graduation Stage 1-B) (#780)

### DIFF
--- a/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
@@ -1,0 +1,443 @@
+// ◎ Aims — R panel's aim-tree read view (graduation Stage 1-B, #780). The
+// read-view validated in throwaway prototype #778 (`RAimTreePrototype`),
+// graduated into a real R-panel section backed by the live
+// `GET /api/units/{unit}/aims` endpoint (tmai-core #500).
+//
+// ONE job, READ-ONLY. No write affordance (frontmatter edit / new node —
+// Stage 2), no drift-mark (Stage 3). The prototype's `CreateForm` /
+// `patchNode` / `commitCreate` / in-memory mutation are deliberately NOT
+// carried.
+//
+// The view machinery carried intact from the prototype: the tidy-tree layout,
+// the blast-radius highlight (select a node → light its whole descendant
+// subtree, the set that would become drift-possible if that aim changed),
+// `depends_on` drawn as a visually distinct dashed cross-edge (NOT part of any
+// blast radius), the per-node state glyph, and the body-on-select detail pane.
+// The pure layout / traversal lives in `./aim-tree` (unit-tested separately);
+// this file is the React rendering, adapted from the prototype's full-screen
+// 2-pane layout to STACK (canvas above, detail below) so it fits the narrow
+// R-panel section column.
+//
+// `body` is rendered as raw markdown, read-only: line breaks preserved,
+// monospace so inline refs / markers stay legible. There is intentionally no
+// `[confirmed]` / `[claimed]` honesty-tag parser — those markers are free-form
+// prose in the wire body, not a structured field (the prototype's `BodyLine`
+// was a fixture invention).
+
+import { useMemo, useState } from "react";
+import { useUnitAims } from "@/hooks/useUnitAims";
+import type { AimWire } from "@/lib/api";
+import {
+  AIM_GLYPH,
+  AIM_STATE_LABEL,
+  type AimLayout,
+  buildChildren,
+  computeLayout,
+  dependsEdgePath,
+  descendantsOf,
+  flattenRepos,
+  NODE_W,
+  type NodePos,
+  parentEdgePath,
+} from "./aim-tree";
+import { Section } from "./Section";
+
+interface RAimsSectionProps {
+  unitName: string | null;
+  expanded: boolean;
+  onToggle: () => void;
+}
+
+export function RAimsSection({ unitName, expanded, onToggle }: RAimsSectionProps) {
+  const { data, loading, error } = useUnitAims(unitName);
+  // Flattened node set drives both the header count and the tree body.
+  const nodes = useMemo(() => flattenRepos(data), [data]);
+
+  return (
+    <Section
+      id="aims"
+      glyph="◎"
+      label="Aims"
+      count={`${nodes.length}`}
+      expanded={expanded}
+      onToggle={onToggle}
+    >
+      <Body unitName={unitName} nodes={nodes} loading={loading} error={error} />
+    </Section>
+  );
+}
+
+interface BodyProps {
+  unitName: string | null;
+  nodes: AimWire[];
+  loading: boolean;
+  error: Error | null;
+}
+
+function Body({ unitName, nodes, loading, error }: BodyProps) {
+  if (unitName === null) {
+    return <p className="text-subtle-foreground">Pick a project to see aims.</p>;
+  }
+  if (error !== null) {
+    return <p className="text-muted-foreground">Failed to load aims: {error.message}</p>;
+  }
+  if (nodes.length === 0 && loading) {
+    return <p className="text-subtle-foreground">Loading…</p>;
+  }
+  if (nodes.length === 0) {
+    return <p className="text-subtle-foreground">No aims.</p>;
+  }
+  return <AimTree nodes={nodes} />;
+}
+
+function AimTree({ nodes }: { nodes: AimWire[] }) {
+  const [selected, setSelected] = useState<string | null>(null);
+  const childrenOf = useMemo(() => buildChildren(nodes), [nodes]);
+  const layout = useMemo(() => computeLayout(nodes), [nodes]);
+
+  // Resolve the selection against the CURRENT node set: if a poll / unit
+  // change dropped the selected slug, the detail pane and highlight fall back
+  // to "nothing selected" rather than dangling on a vanished node.
+  const selectedNode = useMemo(
+    () => nodes.find((n) => n.slug === selected) ?? null,
+    [nodes, selected],
+  );
+
+  // Highlight set = the selected node plus its whole descendant subtree.
+  const blast = useMemo(
+    () =>
+      selectedNode === null ? new Set<string>() : descendantsOf(selectedNode.slug, childrenOf),
+    [selectedNode, childrenOf],
+  );
+  const highlighted = useMemo(() => {
+    if (selectedNode === null) return new Set<string>();
+    return new Set<string>([selectedNode.slug, ...blast]);
+  }, [selectedNode, blast]);
+  const hasSelection = selectedNode !== null;
+
+  return (
+    <div className="space-y-2">
+      <Legend
+        selectedSlug={selectedNode?.slug ?? null}
+        blastCount={blast.size}
+        onClear={() => setSelected(null)}
+      />
+      {/* The tree canvas. The tidy-tree lays out horizontally by depth, so in
+          the narrow R-panel column it overflows into this scroller rather than
+          cramping. SVG edges sit underneath; clickable node boxes on top. */}
+      <div className="max-h-[420px] overflow-auto rounded border border-hairline bg-surface/30">
+        <div className="relative" style={{ width: layout.width, height: layout.height }}>
+          <Edges
+            nodes={nodes}
+            layout={layout}
+            highlighted={highlighted}
+            hasSelection={hasSelection}
+          />
+          {nodes.map((node) => {
+            const pos = layout.positions.get(node.slug);
+            if (!pos) return null;
+            const lit = highlighted.has(node.slug);
+            return (
+              <NodeBox
+                key={node.slug}
+                node={node}
+                pos={pos}
+                isSelected={selectedNode?.slug === node.slug}
+                lit={lit}
+                dimmed={hasSelection && !lit}
+                onSelect={() => setSelected(node.slug)}
+              />
+            );
+          })}
+        </div>
+      </div>
+      {selectedNode !== null && (
+        <DetailPane node={selectedNode} blastCount={blast.size} onClose={() => setSelected(null)} />
+      )}
+    </div>
+  );
+}
+
+function Legend({
+  selectedSlug,
+  blastCount,
+  onClear,
+}: {
+  selectedSlug: string | null;
+  blastCount: number;
+  onClear: () => void;
+}) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-subtle-foreground">
+      <span className="flex items-center gap-1">
+        <span className="font-mono text-foreground">{AIM_GLYPH.open}</span> open
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="font-mono text-foreground">{AIM_GLYPH.done}</span> done
+      </span>
+      <span className="flex items-center gap-1">
+        <span className="font-mono text-foreground">{AIM_GLYPH.dead}</span> dead
+      </span>
+      <span className="flex items-center gap-1">
+        <svg width="22" height="8" aria-hidden="true">
+          <title>depends_on</title>
+          <line
+            x1="0"
+            y1="4"
+            x2="22"
+            y2="4"
+            stroke="var(--color-info)"
+            strokeWidth="1.5"
+            strokeDasharray="4 3"
+          />
+        </svg>
+        depends_on
+      </span>
+      {selectedSlug !== null ? (
+        <span className="flex items-center gap-2 text-muted-foreground">
+          <span>
+            blast radius: <span className="text-foreground">{blastCount}</span> descendant
+            {blastCount === 1 ? "" : "s"}
+          </span>
+          <button
+            type="button"
+            onClick={onClear}
+            className="rounded border border-hairline px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+          >
+            clear
+          </button>
+        </span>
+      ) : (
+        <span>click a node to light its blast radius</span>
+      )}
+    </div>
+  );
+}
+
+function Edges({
+  nodes,
+  layout,
+  highlighted,
+  hasSelection,
+}: {
+  nodes: readonly AimWire[];
+  layout: AimLayout;
+  highlighted: Set<string>;
+  hasSelection: boolean;
+}) {
+  return (
+    <svg
+      className="pointer-events-none absolute inset-0"
+      width={layout.width}
+      height={layout.height}
+      aria-hidden="true"
+    >
+      <defs>
+        <marker
+          id="aim-depends-arrow"
+          viewBox="0 0 8 8"
+          refX="7"
+          refY="4"
+          markerWidth="6"
+          markerHeight="6"
+          orient="auto-start-reverse"
+        >
+          <path d="M0 0 L8 4 L0 8 z" fill="var(--color-info)" />
+        </marker>
+      </defs>
+
+      {/* Solid parent=means edges. An edge is "in the blast radius" when both
+          endpoints are highlighted — then it shares the accent. */}
+      {nodes.map((node) => {
+        if (node.parent === null) return null;
+        const parent = layout.positions.get(node.parent);
+        const child = layout.positions.get(node.slug);
+        if (!parent || !child) return null;
+        const lit = highlighted.has(node.parent) && highlighted.has(node.slug);
+        const dimmed = hasSelection && !lit;
+        return (
+          <path
+            key={`p-${node.slug}`}
+            d={parentEdgePath(parent, child)}
+            fill="none"
+            stroke={lit ? "var(--color-primary)" : "var(--color-hairline-strong)"}
+            strokeWidth={lit ? 2 : 1.5}
+            opacity={dimmed ? 0.2 : 1}
+          />
+        );
+      })}
+
+      {/* `depends_on` cross-edges (an ARRAY per node on the wire): dashed,
+          info-hued, arrow-headed — deliberately NOT part of any blast radius
+          (kept constant). `serves` / `related` are intentionally NOT drawn
+          (listed as slug text in the detail pane instead). */}
+      {nodes.flatMap((node) => {
+        const src = layout.positions.get(node.slug);
+        if (!src) return [];
+        return node.depends_on.flatMap((targetSlug) => {
+          const tgt = layout.positions.get(targetSlug);
+          if (!tgt) return [];
+          return [
+            <path
+              key={`d-${node.slug}-${targetSlug}`}
+              d={dependsEdgePath(src, tgt)}
+              fill="none"
+              stroke="var(--color-info)"
+              strokeWidth="1.5"
+              strokeDasharray="4 3"
+              markerEnd="url(#aim-depends-arrow)"
+              opacity={hasSelection ? 0.55 : 0.9}
+            />,
+          ];
+        });
+      })}
+    </svg>
+  );
+}
+
+function NodeBox({
+  node,
+  pos,
+  isSelected,
+  lit,
+  dimmed,
+  onSelect,
+}: {
+  node: AimWire;
+  pos: NodePos;
+  isSelected: boolean;
+  lit: boolean;
+  dimmed: boolean;
+  onSelect: () => void;
+}) {
+  // Tier the styling: the selected node gets a solid primary ring; the rest of
+  // its blast radius gets a softer primary tint; everything else dims out when
+  // a selection is active so the highlighted region's size reads at a glance.
+  const tone = isSelected
+    ? "border-primary bg-primary/15 ring-1 ring-primary"
+    : lit
+      ? "border-primary/40 bg-primary/10"
+      : "border-hairline bg-surface";
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-pressed={isSelected}
+      title={`${node.slug} · ${AIM_STATE_LABEL[node.state]}`}
+      className={`absolute flex items-start gap-1.5 rounded border px-2 py-1.5 text-left transition-all ${tone} ${
+        dimmed ? "opacity-35" : "opacity-100"
+      }`}
+      style={{ left: pos.x, top: pos.cy, width: NODE_W, transform: "translateY(-50%)" }}
+    >
+      <span aria-hidden="true" className="pt-px font-mono text-sm leading-none text-foreground">
+        {AIM_GLYPH[node.state]}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block text-xs leading-snug text-foreground">{node.aim}</span>
+        <span className="mt-0.5 block truncate font-mono text-[10px] text-subtle-foreground">
+          {node.slug}
+        </span>
+      </span>
+    </button>
+  );
+}
+
+// Body-on-select detail pane — READ-ONLY. The prototype's editable frontmatter
+// inputs + create form are dropped (write is Stage 2). Frontmatter facts show
+// as a plain definition list; cross-edges (`depends_on` / `serves` / `related`)
+// list as slug text; the body renders raw.
+function DetailPane({
+  node,
+  blastCount,
+  onClose,
+}: {
+  node: AimWire;
+  blastCount: number;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      data-testid="aim-detail"
+      className="space-y-3 rounded border border-hairline bg-surface/30 p-3"
+    >
+      <div className="flex items-start justify-between gap-2">
+        <div className="min-w-0">
+          <span className="flex items-baseline gap-1.5">
+            <span aria-hidden="true" className="font-mono text-foreground">
+              {AIM_GLYPH[node.state]}
+            </span>
+            <span className="text-foreground">{node.aim}</span>
+          </span>
+          <span className="mt-0.5 block font-mono text-[10px] text-subtle-foreground">
+            {node.slug}
+          </span>
+        </div>
+        <button
+          type="button"
+          onClick={onClose}
+          title="Close detail"
+          aria-label="Close detail"
+          className="shrink-0 rounded px-1.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Frontmatter facts — read-only (the write affordance is Stage 2). */}
+      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px]">
+        <dt className="text-subtle-foreground">state</dt>
+        <dd className="text-foreground">{AIM_STATE_LABEL[node.state]}</dd>
+        <dt className="text-subtle-foreground">parent</dt>
+        <dd className="font-mono text-muted-foreground">{node.parent ?? "(root)"}</dd>
+        {node.depends_on.length > 0 && (
+          <>
+            <dt className="text-subtle-foreground">depends_on</dt>
+            <dd className="font-mono text-muted-foreground">{node.depends_on.join(", ")}</dd>
+          </>
+        )}
+        {node.serves.length > 0 && (
+          <>
+            <dt className="text-subtle-foreground">serves</dt>
+            <dd className="font-mono text-muted-foreground">{node.serves.join(", ")}</dd>
+          </>
+        )}
+        {node.related.length > 0 && (
+          <>
+            <dt className="text-subtle-foreground">related</dt>
+            <dd className="font-mono text-muted-foreground">{node.related.join(", ")}</dd>
+          </>
+        )}
+      </dl>
+
+      <section className="space-y-1">
+        <h4 className="text-[10px] uppercase tracking-wide text-subtle-foreground">Body</h4>
+        <AimBody body={node.body} />
+      </section>
+
+      <p className="border-t border-hairline pt-2 text-[11px] text-subtle-foreground">
+        blast radius from here: <span className="text-foreground">{blastCount}</span> descendant
+        {blastCount === 1 ? "" : "s"} drift-possible
+      </p>
+    </div>
+  );
+}
+
+// Render the raw markdown body verbatim, read-only: `whitespace-pre-wrap`
+// preserves the authored line breaks and `font-mono` keeps refs / paths /
+// inline `[confirmed: …]` / `[claimed]` markers legible. No markdown→HTML and
+// NO honesty-tag parsing (brief): the body is free-form prose. An empty body
+// is a valid frontmatter-only node.
+function AimBody({ body }: { body: string }) {
+  if (body.trim() === "") {
+    return (
+      <p className="rounded border border-dashed border-hairline px-2 py-3 text-center text-[11px] italic text-subtle-foreground">
+        (frontmatter-only — no body)
+      </p>
+    );
+  }
+  return (
+    <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded bg-surface/40 px-2 py-1.5 font-mono text-[11px] leading-snug text-muted-foreground">
+      {body}
+    </pre>
+  );
+}

--- a/clients/react/src/components/producer-console/r-panel/RPanel.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPanel.tsx
@@ -34,6 +34,7 @@ import { makeSplitKeyHandler, RATIO_STEP } from "@/hooks/useSplitPane";
 import { useUnitAttention } from "@/hooks/useUnitAttention";
 import { ATTENTION_STRIP_WIDTH_MAX, ATTENTION_STRIP_WIDTH_MIN } from "@/lib/ui-prefs";
 import { useUIPref } from "@/lib/ui-prefs-provider";
+import { RAimsSection } from "./RAimsSection";
 import { RApproachesSection } from "./RApproachesSection";
 import { RDecisionsSection } from "./RDecisionsSection";
 import { RFilesSection } from "./RFilesSection";
@@ -99,6 +100,7 @@ const SECTION_IDS = [
   "decisions",
   "approaches",
   "observations",
+  "aims",
   "inventory",
   "files",
 ] as const;
@@ -257,6 +259,14 @@ export function RPanel({
               expanded={isExpanded("observations")}
               onToggle={() => toggle("observations")}
               attention={attention}
+            />
+            {/* Aims — the aim-tree read view (#780). Not an attention-artifact
+                section (the 5 are pr / issue / decision / approach /
+                observation), so it is NOT given the attention controls. */}
+            <RAimsSection
+              unitName={unitName}
+              expanded={isExpanded("aims")}
+              onToggle={() => toggle("aims")}
             />
             <RInventorySection
               unitName={unitName}

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RAimsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RAimsSection.test.tsx
@@ -1,0 +1,205 @@
+// @vitest-environment jsdom
+//
+// RAimsSection — the aim-tree read view (graduation Stage 1-B, #780). Covers
+// the wire-backed states (render / loading / empty / error / parked) and the
+// view machinery carried from prototype #778: body-on-select detail pane,
+// blast-radius highlight, the distinct dashed `depends_on` cross-edge, and the
+// neutral `dead` glyph with no severity color. Read-only — there is NO write
+// affordance (frontmatter edit / new node are Stage 2).
+
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AimsResponse, AimWire } from "@/lib/api";
+
+const aimsMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      aims: (...args: unknown[]) => aimsMock(...args),
+    },
+  };
+});
+
+import { RAimsSection } from "../RAimsSection";
+
+function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
+  return {
+    aim: `aim ${overrides.slug}`,
+    parent: null,
+    state: "open",
+    depends_on: [],
+    serves: [],
+    related: [],
+    body: "",
+    ...overrides,
+  };
+}
+
+function responseStub(aims: AimWire[] = []): AimsResponse {
+  return {
+    unit: "u",
+    composed_at: "2026-06-07T00:00:00Z",
+    repos: [
+      {
+        repo_label: "tmai-core",
+        repo_root: "/p/tmai-core",
+        primary: true,
+        repo_head: null,
+        aims,
+      },
+    ],
+  };
+}
+
+// The validated probe shape: two roots, a nested subtree, a depends_on
+// cross-edge, a dead node, and a body.
+const TREE: AimWire[] = [
+  aimStub({ slug: "amplify-human-judgment", aim: "人間の判断を増幅する" }),
+  aimStub({
+    slug: "attention-per-artifact",
+    aim: "注意を per-artifact に",
+    parent: "amplify-human-judgment",
+    body: "観測 → 判断 → dispatch のループ。\n[confirmed: #769] storage + wire",
+  }),
+  aimStub({
+    slug: "attention-backend",
+    aim: "storage + wire",
+    parent: "attention-per-artifact",
+    state: "done",
+  }),
+  aimStub({ slug: "aim-system", aim: "records を書く構造に" }),
+  aimStub({
+    slug: "aim-authority",
+    aim: "authority = event-driven amendment",
+    parent: "aim-system",
+    depends_on: ["aim-honesty"],
+    serves: ["amplify-human-judgment"],
+    related: ["aim-shared-means"],
+  }),
+  aimStub({ slug: "aim-honesty", aim: "confirmed ⊥ claimed", parent: "aim-system", state: "dead" }),
+];
+
+beforeEach(() => {
+  aimsMock.mockReset();
+});
+
+describe("RAimsSection", () => {
+  it("renders each aim node (anchor + slug)", async () => {
+    aimsMock.mockResolvedValue(responseStub(TREE));
+
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("人間の判断を増幅する")).toBeTruthy();
+    });
+    expect(screen.getByText("records を書く構造に")).toBeTruthy();
+    // The slug shows under the anchor inside the node box.
+    expect(screen.getByText("attention-per-artifact")).toBeTruthy();
+  });
+
+  it("header count is the plain total node count (no severity styling)", async () => {
+    aimsMock.mockResolvedValue(responseStub(TREE));
+    const { container } = render(<RAimsSection unitName="u" expanded={false} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(`${TREE.length}`)).toBeTruthy();
+    });
+    expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
+  });
+
+  it("shows a loading placeholder during the initial fetch", () => {
+    // A pending promise keeps the hook in its initial loading state.
+    aimsMock.mockReturnValue(new Promise<AimsResponse>(() => {}));
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    expect(screen.getByText("Loading…")).toBeTruthy();
+  });
+
+  it("shows a placeholder when there are no aims", async () => {
+    aimsMock.mockResolvedValue(responseStub([]));
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText("No aims.")).toBeTruthy();
+    });
+  });
+
+  it("surfaces a fetch error", async () => {
+    aimsMock.mockRejectedValue(new Error("boom"));
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/Failed to load aims: boom/)).toBeTruthy();
+    });
+  });
+
+  it("parks with a placeholder when no project is selected (no fetch)", () => {
+    render(<RAimsSection unitName={null} expanded={true} onToggle={vi.fn()} />);
+    expect(screen.getByText(/Pick a project to see aims\./)).toBeTruthy();
+    expect(aimsMock).not.toHaveBeenCalled();
+  });
+
+  it("selecting a node opens its body in the detail pane and reports the blast radius", async () => {
+    aimsMock.mockResolvedValue(responseStub(TREE));
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+
+    const node = await screen.findByRole("button", {
+      name: /attention-per-artifact/,
+    });
+    fireEvent.click(node);
+
+    // Body-on-select: the raw markdown body renders read-only in the detail
+    // pane (scoped — the anchor/slug also appear in the tree node boxes).
+    const detail = await screen.findByTestId("aim-detail");
+    expect(within(detail).getByText(/storage \+ wire/)).toBeTruthy();
+    // Blast radius: attention-per-artifact has one descendant (attention-backend).
+    // The count is split into its own span, so assert on the pane's text.
+    expect(detail.textContent).toContain("1 descendant");
+  });
+
+  it("lists depends_on / serves / related as slug text in the detail pane", async () => {
+    aimsMock.mockResolvedValue(responseStub(TREE));
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+
+    const node = await screen.findByRole("button", { name: /aim-authority/ });
+    fireEvent.click(node);
+
+    const detail = await screen.findByTestId("aim-detail");
+    // Cross-edges list as slug text, scoped to the detail pane.
+    expect(within(detail).getByText("aim-honesty")).toBeTruthy(); // depends_on (drawn too)
+    expect(within(detail).getByText("amplify-human-judgment")).toBeTruthy(); // serves
+    expect(within(detail).getByText("aim-shared-means")).toBeTruthy(); // related
+  });
+
+  it("draws depends_on as a distinct dashed cross-edge path", async () => {
+    aimsMock.mockResolvedValue(responseStub(TREE));
+    const { container } = render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await screen.findByText("authority = event-driven amendment");
+    // The cross-edge is a <path> with a dasharray (the legend uses a <line>,
+    // so querying for path[stroke-dasharray] targets the edge specifically).
+    const dashed = container.querySelector('path[stroke-dasharray="4 3"]');
+    expect(dashed).not.toBeNull();
+  });
+
+  it("renders the dead state with a neutral glyph and no severity color", async () => {
+    aimsMock.mockResolvedValue(
+      responseStub([aimStub({ slug: "x", aim: "dead aim", state: "dead" })]),
+    );
+    const { container } = render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await screen.findByText("dead aim");
+    // Neutral shape glyph for dead — no heat / severity color anywhere.
+    expect(screen.getAllByText("⊘").length).toBeGreaterThan(0);
+    expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
+  });
+
+  it("does NOT render a write affordance (Stage 2 is out of scope)", async () => {
+    aimsMock.mockResolvedValue(responseStub(TREE));
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await screen.findByText("records を書く構造に");
+    // No "New node" / "Add child" / "Create" affordance carried from the
+    // prototype — this is the read-only view.
+    expect(screen.queryByText(/New node/i)).toBeNull();
+    expect(screen.queryByText(/Add child/i)).toBeNull();
+    expect(screen.queryByRole("button", { name: /Create/ })).toBeNull();
+  });
+});

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RPanel.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RPanel.test.tsx
@@ -75,6 +75,13 @@ vi.mock("../RObservationsSection", () => ({
     </button>
   ),
 }));
+vi.mock("../RAimsSection", () => ({
+  RAimsSection: ({ expanded, onToggle }: { expanded: boolean; onToggle: () => void }) => (
+    <button type="button" data-testid="aims-section" data-expanded={expanded} onClick={onToggle}>
+      Aims
+    </button>
+  ),
+}));
 vi.mock("../RFilesSection", () => ({
   RFilesSection: ({ expanded, onToggle }: { expanded: boolean; onToggle: () => void }) => (
     <button type="button" data-testid="files-section" data-expanded={expanded} onClick={onToggle}>
@@ -121,6 +128,7 @@ describe("RPanel — accordion shell", () => {
       "decisions-section",
       "approaches-section",
       "observations-section",
+      "aims-section",
       "files-section",
     ];
     for (const id of ids) {

--- a/clients/react/src/components/producer-console/r-panel/__tests__/aim-tree.test.ts
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/aim-tree.test.ts
@@ -1,0 +1,193 @@
+// Pure aim-tree layout + traversal — no React, no DOM. Covers the tree-build
+// (parent/slug grouping + tidy layout) and the blast-radius walk graduated
+// from prototype #778 and rewired onto the live `AimWire` model.
+
+import { describe, expect, it } from "vitest";
+import type { AimsResponse } from "@/lib/api";
+import type { AimWire } from "@/types/generated/AimWire";
+import {
+  buildChildren,
+  computeLayout,
+  dependsEdgePath,
+  descendantsOf,
+  flattenRepos,
+  NODE_W,
+  parentEdgePath,
+} from "../aim-tree";
+
+function aim(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
+  return {
+    aim: `aim ${overrides.slug}`,
+    parent: null,
+    state: "open",
+    depends_on: [],
+    serves: [],
+    related: [],
+    body: "",
+    ...overrides,
+  };
+}
+
+// A two-root tree:
+//   root-a
+//     child-1
+//       grand-1
+//     child-2  (depends_on: [child-1])
+//   root-b
+const NODES: AimWire[] = [
+  aim({ slug: "root-a" }),
+  aim({ slug: "child-1", parent: "root-a" }),
+  aim({ slug: "grand-1", parent: "child-1" }),
+  aim({ slug: "child-2", parent: "root-a", depends_on: ["child-1"] }),
+  aim({ slug: "root-b" }),
+];
+
+describe("buildChildren", () => {
+  it("groups nodes by parent slug, preserving array order", () => {
+    const childrenOf = buildChildren(NODES);
+    expect(childrenOf.get("root-a")?.map((n) => n.slug)).toEqual(["child-1", "child-2"]);
+    expect(childrenOf.get("child-1")?.map((n) => n.slug)).toEqual(["grand-1"]);
+    // Leaves and roots have no children entry.
+    expect(childrenOf.get("grand-1")).toBeUndefined();
+    expect(childrenOf.get("root-b")).toBeUndefined();
+  });
+
+  it("does not turn a depends_on edge into a parent edge", () => {
+    const childrenOf = buildChildren(NODES);
+    // child-2 depends_on child-1, but that must NOT make child-2 a child of
+    // child-1 — only `parent` builds the tree.
+    expect(childrenOf.get("child-1")?.map((n) => n.slug)).toEqual(["grand-1"]);
+  });
+});
+
+describe("computeLayout", () => {
+  it("identifies the explicit roots (parent === null)", () => {
+    const layout = computeLayout(NODES);
+    expect(layout.roots.map((r) => r.slug)).toEqual(["root-a", "root-b"]);
+  });
+
+  it("positions every node and assigns depth by tree level", () => {
+    const layout = computeLayout(NODES);
+    for (const n of NODES) {
+      expect(layout.positions.has(n.slug)).toBe(true);
+    }
+    expect(layout.positions.get("root-a")?.depth).toBe(0);
+    expect(layout.positions.get("child-1")?.depth).toBe(1);
+    expect(layout.positions.get("grand-1")?.depth).toBe(2);
+    expect(layout.positions.get("child-2")?.depth).toBe(1);
+    expect(layout.positions.get("root-b")?.depth).toBe(0);
+  });
+
+  it("centers an internal node between its first and last child", () => {
+    const layout = computeLayout(NODES);
+    const rootA = layout.positions.get("root-a");
+    const child1 = layout.positions.get("child-1");
+    const child2 = layout.positions.get("child-2");
+    expect(rootA && child1 && child2).toBeTruthy();
+    if (rootA && child1 && child2) {
+      expect(rootA.cy).toBeCloseTo((child1.cy + child2.cy) / 2);
+    }
+  });
+
+  it("sizes the canvas to the deepest column", () => {
+    const layout = computeLayout(NODES);
+    // maxDepth is 2 (grand-1); width includes one node width past the last col.
+    expect(layout.width).toBeGreaterThan(NODE_W);
+    expect(layout.height).toBeGreaterThan(0);
+  });
+
+  it("treats an orphan with a missing parent as a root (renders, never vanishes)", () => {
+    const orphan = aim({ slug: "lonely", parent: "does-not-exist" });
+    const layout = computeLayout([aim({ slug: "root-a" }), orphan]);
+    expect(layout.roots.map((r) => r.slug)).toContain("lonely");
+    expect(layout.positions.has("lonely")).toBe(true);
+    expect(layout.positions.get("lonely")?.depth).toBe(0);
+  });
+
+  it("returns empty roots/positions for an empty node set", () => {
+    const layout = computeLayout([]);
+    expect(layout.roots).toEqual([]);
+    expect(layout.positions.size).toBe(0);
+  });
+});
+
+describe("descendantsOf (blast radius)", () => {
+  it("returns the whole descendant subtree through parent edges", () => {
+    const childrenOf = buildChildren(NODES);
+    expect(descendantsOf("root-a", childrenOf)).toEqual(new Set(["child-1", "grand-1", "child-2"]));
+  });
+
+  it("does NOT include the other root's subtree", () => {
+    const childrenOf = buildChildren(NODES);
+    expect(descendantsOf("root-a", childrenOf).has("root-b")).toBe(false);
+  });
+
+  it("is empty for a leaf", () => {
+    const childrenOf = buildChildren(NODES);
+    expect(descendantsOf("grand-1", childrenOf)).toEqual(new Set());
+  });
+
+  it("does NOT follow depends_on cross-edges", () => {
+    const childrenOf = buildChildren(NODES);
+    // child-2 depends_on child-1; the blast radius of child-2 is its
+    // descendant subtree only (empty), NOT child-1.
+    expect(descendantsOf("child-2", childrenOf)).toEqual(new Set());
+  });
+});
+
+describe("flattenRepos", () => {
+  it("returns [] for a null response", () => {
+    expect(flattenRepos(null)).toEqual([]);
+  });
+
+  it("concatenates aims across repos", () => {
+    const res: AimsResponse = {
+      unit: "u",
+      composed_at: "2026-06-07T00:00:00Z",
+      repos: [
+        {
+          repo_label: "core",
+          repo_root: "/p/core",
+          primary: true,
+          repo_head: null,
+          aims: [aim({ slug: "a" }), aim({ slug: "b" })],
+        },
+        {
+          repo_label: "ui",
+          repo_root: "/p/ui",
+          primary: false,
+          repo_head: null,
+          aims: [aim({ slug: "c" })],
+        },
+      ],
+    };
+    expect(flattenRepos(res).map((n) => n.slug)).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("edge-path geometry", () => {
+  it("parentEdgePath starts at the parent's right edge and ends at the child's left edge", () => {
+    const layout = computeLayout(NODES);
+    const parent = layout.positions.get("root-a");
+    const child = layout.positions.get("child-1");
+    expect(parent && child).toBeTruthy();
+    if (parent && child) {
+      const d = parentEdgePath(parent, child);
+      expect(d.startsWith(`M ${parent.x + NODE_W} ${parent.cy}`)).toBe(true);
+      expect(d).toContain(`${child.x} ${child.cy}`);
+    }
+  });
+
+  it("dependsEdgePath bows out to the right of both endpoints", () => {
+    const layout = computeLayout(NODES);
+    const src = layout.positions.get("child-2");
+    const tgt = layout.positions.get("child-1");
+    expect(src && tgt).toBeTruthy();
+    if (src && tgt) {
+      const d = dependsEdgePath(src, tgt);
+      // Both anchors are on the right edge (x + NODE_W).
+      expect(d.startsWith(`M ${src.x + NODE_W} ${src.cy}`)).toBe(true);
+      expect(d).toContain(`${tgt.x + NODE_W} ${tgt.cy}`);
+    }
+  });
+});

--- a/clients/react/src/components/producer-console/r-panel/aim-tree.ts
+++ b/clients/react/src/components/producer-console/r-panel/aim-tree.ts
@@ -1,0 +1,173 @@
+// Pure aim-tree layout + traversal — the view machinery validated in the
+// throwaway prototype #778 (`RAimTreePrototype`), graduated and rewired onto
+// the LIVE wire model (`AimWire`: `slug` / `aim` / `parent` / `state` /
+// `depends_on` / `serves` / `related` / `body`). Kept framework-free so the
+// tidy-tree layout, blast-radius traversal, and edge-path geometry are
+// unit-testable without rendering React.
+//
+// Wire-vs-prototype rewire (the real work of #780): the prototype was a
+// hardcoded fixture with its OWN model (`id` / `label` / `means-done` /
+// `dependsOn` single). This module follows the wire: identity is `slug`, the
+// anchor is `aim`, the state enum is `open | done | dead` (no `means-done`;
+// `dead` exists), and `depends_on` is an ARRAY of slugs.
+
+import type { AimState } from "@/types/generated/AimState";
+import type { AimsResponse } from "@/types/generated/AimsResponse";
+import type { AimWire } from "@/types/generated/AimWire";
+
+// ── Layout constants ──────────────────────────────────────────────────
+//
+// Tuned smaller than the prototype's full-screen values (it had COL_W 232 /
+// NODE_W 200) so a shallow tree fits the NARROW R-panel section without
+// scrolling; a deep/wide tree overflows into the canvas's `overflow-auto`.
+export const COL_W = 196; // horizontal distance per depth level
+export const ROW_H = 48; // vertical slot per leaf row
+export const NODE_W = 168; // fixed node-box width (labels wrap within)
+const PAD_L = 16;
+const PAD_T = 16;
+const PAD_R = 28;
+const PAD_B = 16;
+const GAP_BETWEEN_TREES = 1; // blank leaf-slots inserted between roots
+
+// Per-node state glyph — SHAPE ONLY, one neutral hue, no heat / severity
+// color (the machine marks, it never appraises — `AimState` doc + brief).
+// `dead` is the wire's third state (self-death: the means failed, the lineage
+// stays, the parent is untouched); it gets a neutral struck circle, NOT a
+// warning glyph. The prototype's `◐` (`means-done`) is dropped — it was a
+// fixture invention, absent from the wire.
+export const AIM_GLYPH: Record<AimState, string> = {
+  open: "○",
+  done: "●",
+  dead: "⊘",
+};
+
+export const AIM_STATE_LABEL: Record<AimState, string> = {
+  open: "open",
+  done: "done",
+  dead: "dead",
+};
+
+// Flatten the per-repo wire response into a single node set. Aims currently
+// live only in the `tmai-core` repo (one repo), but the wire is already
+// multi-repo (`RepoAimsWire[]`); concatenating keeps it correct if a second
+// repo ever carries aims. Slugs are unique within a repo and the corpus is
+// single-repo today, so no cross-repo slug-collision handling is needed yet.
+export function flattenRepos(res: AimsResponse | null): AimWire[] {
+  if (res === null) return [];
+  return res.repos.flatMap((r) => r.aims);
+}
+
+export interface NodePos {
+  slug: string;
+  /** Left edge x of the node box. */
+  x: number;
+  /** Vertical CENTER of the node (edges anchor here; the box itself is
+   *  centered on this y via a translateY(-50%), so multi-line labels grow
+   *  symmetrically and never shift the edge anchor). */
+  cy: number;
+  depth: number;
+}
+
+export interface AimLayout {
+  positions: Map<string, NodePos>;
+  roots: AimWire[];
+  width: number;
+  height: number;
+}
+
+// Index helper — children grouped by parent slug, preserving array order.
+export function buildChildren(nodes: readonly AimWire[]): Map<string, AimWire[]> {
+  const childrenOf = new Map<string, AimWire[]>();
+  for (const n of nodes) {
+    if (n.parent === null) continue;
+    const list = childrenOf.get(n.parent) ?? [];
+    list.push(n);
+    childrenOf.set(n.parent, list);
+  }
+  return childrenOf;
+}
+
+// Classic tidy tree: leaves get sequential vertical slots; an internal node
+// is centered on the midpoint of its first and last child. Roots are stacked
+// top-to-bottom (a blank gap-slot between them).
+export function computeLayout(nodes: readonly AimWire[]): AimLayout {
+  const childrenOf = buildChildren(nodes);
+  const bySlug = new Set(nodes.map((n) => n.slug));
+  const positions = new Map<string, NodePos>();
+  let leafCursor = 0;
+  let maxDepth = 0;
+
+  function assign(slug: string, depth: number): number {
+    maxDepth = Math.max(maxDepth, depth);
+    const children = childrenOf.get(slug) ?? [];
+    let cy: number;
+    if (children.length === 0) {
+      cy = PAD_T + leafCursor * ROW_H + ROW_H / 2;
+      leafCursor += 1;
+    } else {
+      const childCenters = children.map((c) => assign(c.slug, depth + 1));
+      cy = (childCenters[0] + childCenters[childCenters.length - 1]) / 2;
+    }
+    positions.set(slug, { slug, x: PAD_L + depth * COL_W, cy, depth });
+    return cy;
+  }
+
+  // Roots = explicit roots (`parent === null`) PLUS orphans whose `parent`
+  // slug isn't a known node — so a dangling parent ref (a half-written /
+  // cross-repo reference) still renders rather than silently vanishing from
+  // the canvas.
+  const roots = nodes.filter((n) => n.parent === null || !bySlug.has(n.parent));
+  roots.forEach((root, i) => {
+    if (i > 0) leafCursor += GAP_BETWEEN_TREES;
+    assign(root.slug, 0);
+  });
+
+  return {
+    positions,
+    roots,
+    width: PAD_L + maxDepth * COL_W + NODE_W + PAD_R,
+    height: PAD_T + leafCursor * ROW_H + PAD_B,
+  };
+}
+
+// The blast radius: every descendant of `slug` reachable through `parent`
+// edges (NOT through `depends_on` — the cross-edge is a shared-means link,
+// drawn distinct, deliberately kept OUT of the descendant set a change would
+// cascade down). The `seen` guard makes the walk safe even against a
+// malformed `parent` cycle (the corpus is acyclic by construction, but a
+// read-only projection should never hang on bad data).
+export function descendantsOf(slug: string, childrenOf: Map<string, AimWire[]>): Set<string> {
+  const out = new Set<string>();
+  const stack = [...(childrenOf.get(slug) ?? [])];
+  while (stack.length > 0) {
+    const n = stack.pop();
+    if (!n) continue;
+    if (out.has(n.slug)) continue;
+    out.add(n.slug);
+    for (const c of childrenOf.get(n.slug) ?? []) stack.push(c);
+  }
+  return out;
+}
+
+// Smooth horizontal connector from a parent's right edge to a child's left
+// edge (S-curve via a cubic with control points at the x-midpoint).
+export function parentEdgePath(parent: NodePos, child: NodePos): string {
+  const x1 = parent.x + NODE_W;
+  const y1 = parent.cy;
+  const x2 = child.x;
+  const y2 = child.cy;
+  const mx = (x1 + x2) / 2;
+  return `M ${x1} ${y1} C ${mx} ${y1}, ${mx} ${y2}, ${x2} ${y2}`;
+}
+
+// A `depends_on` cross-edge bows out to the RIGHT of both endpoints (where
+// the node's right side is whitespace), so the dashed cross-edge never reads
+// as one of the leftward solid parent connectors.
+export function dependsEdgePath(src: NodePos, tgt: NodePos): string {
+  const x1 = src.x + NODE_W;
+  const y1 = src.cy;
+  const x2 = tgt.x + NODE_W;
+  const y2 = tgt.cy;
+  const bow = Math.max(x1, x2) + 48;
+  return `M ${x1} ${y1} C ${bow} ${y1}, ${bow} ${y2}, ${x2} ${y2}`;
+}

--- a/clients/react/src/hooks/__tests__/useUnitAims.test.ts
+++ b/clients/react/src/hooks/__tests__/useUnitAims.test.ts
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+//
+// useUnitAims — the aim-tree poller behind the R panel's ◎ Aims section (the
+// aim-tree twin of useUnitObservations / useUnitInventory). We mock
+// `api.aims` so each test drives a deterministic response and asserts the
+// sibling-shaped contract: `unit = null` parks (no fetch), the initial fetch
+// flips `loading`, errors surface without clearing into a fake success, a unit
+// change re-fetches, and the 60s poll keeps the last response visible
+// (anti-flicker).
+//
+// Timers stay real and the poll is exercised by capturing the
+// `window.setInterval` callback directly — `@testing-library`'s `waitFor`
+// cannot make progress under fake timers, and a real 60s wait is not viable in
+// a unit test.
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    aims: vi.fn(),
+  },
+}));
+
+import type { AimsResponse } from "@/lib/api";
+import { api } from "@/lib/api";
+import { useUnitAims } from "../useUnitAims";
+
+function response(unit: string, count: number): AimsResponse {
+  return {
+    unit,
+    composed_at: "2026-06-07T00:00:00Z",
+    repos: [
+      {
+        repo_label: "tmai-core",
+        repo_root: "/p/tmai-core",
+        primary: true,
+        repo_head: null,
+        aims: Array.from({ length: count }, (_, i) => ({
+          slug: `aim-${i + 1}`,
+          aim: `aim ${i + 1}`,
+          parent: i === 0 ? null : "aim-1",
+          state: "open" as const,
+          depends_on: [],
+          serves: [],
+          related: [],
+          body: "",
+        })),
+      },
+    ],
+  };
+}
+
+describe("useUnitAims", () => {
+  beforeEach(() => {
+    vi.mocked(api.aims).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parks on unit=null — no fetch, not loading", () => {
+    const { result } = renderHook(() => useUnitAims(null));
+    expect(api.aims).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetches on a real unit and exposes the response", async () => {
+    vi.mocked(api.aims).mockResolvedValue(response("tmai", 3));
+    const { result } = renderHook(() => useUnitAims("tmai"));
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(api.aims).toHaveBeenCalledWith("tmai");
+    expect(result.current.data?.repos[0]?.aims).toHaveLength(3);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a fetch error without fabricating data", async () => {
+    vi.mocked(api.aims).mockRejectedValue(new Error("boom"));
+    const { result } = renderHook(() => useUnitAims("tmai"));
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe("boom");
+    });
+    expect(result.current.data).toBeNull();
+  });
+
+  it("re-fetches when the unit changes and clears the previous aims", async () => {
+    vi.mocked(api.aims).mockImplementation((u: string) =>
+      Promise.resolve(response(u, u === "tmai" ? 4 : 1)),
+    );
+    const { result, rerender } = renderHook(({ u }) => useUnitAims(u), {
+      initialProps: { u: "tmai" },
+    });
+    await waitFor(() => expect(result.current.data?.repos[0]?.aims).toHaveLength(4));
+
+    rerender({ u: "other" });
+    // Cleared synchronously on unit change so the old unit's aims are never
+    // shown under the new header.
+    expect(result.current.data).toBeNull();
+    await waitFor(() => expect(result.current.data?.unit).toBe("other"));
+    expect(result.current.data?.repos[0]?.aims).toHaveLength(1);
+  });
+
+  it("keeps the last response visible across the 60s poll", async () => {
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+
+    vi.mocked(api.aims).mockResolvedValue(response("tmai", 2));
+    const { result } = renderHook(() => useUnitAims("tmai"));
+    await waitFor(() => expect(result.current.data?.repos[0]?.aims).toHaveLength(2));
+
+    const tick = setIntervalSpy.mock.calls[0]?.[0] as (() => void) | undefined;
+    expect(typeof tick).toBe("function");
+
+    await act(async () => {
+      tick?.();
+    });
+    await waitFor(() => expect(api.aims).toHaveBeenCalledTimes(2));
+    // Last response stays visible (anti-flicker) — never cleared on a poll.
+    expect(result.current.data?.repos[0]?.aims).toHaveLength(2);
+  });
+});

--- a/clients/react/src/hooks/useUnitAims.ts
+++ b/clients/react/src/hooks/useUnitAims.ts
@@ -1,0 +1,81 @@
+// Polling hook for the unit's aim-tree view (R panel's ◎ Aims section),
+// consuming `GET /api/units/{unit}/aims` (tmai-core #500): every aim record
+// in each repo's `doc/aims/`, carrying the full node (`slug` / `aim` /
+// `parent` / `state` / `depends_on` / `serves` / `related` / `body`).
+//
+// The aim-tree twin of `useUnitObservations` / `useApproaches` — same shape,
+// same cadence. Aims change on the timescale an operator edits an anchor or a
+// Producer files a node — rare, human-paced. A 60-second poll (same cadence as
+// the siblings) is ample for an operator-scan surface; no SSE here yet. Mirrors
+// the siblings' shape exactly: keeps the previous response visible while a
+// re-fetch is in flight so the tree does not flicker; `loading` reflects only
+// the initial fetch.
+//
+// `unit = null` parks the hook (no fetch, no interval) — used when no project
+// is selected so the section can render a placeholder rather than poll a
+// non-existent unit.
+
+import { useEffect, useRef, useState } from "react";
+import { type AimsResponse, api } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface UseUnitAimsResult {
+  data: AimsResponse | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useUnitAims(unit: string | null): UseUnitAimsResult {
+  const [data, setData] = useState<AimsResponse | null>(null);
+  const [loading, setLoading] = useState(unit !== null);
+  const [error, setError] = useState<Error | null>(null);
+  // An in-flight response from a previous unit must not stamp over a
+  // newer unit's data (same guard as useUnitObservations / useApproaches).
+  const generationRef = useRef(0);
+
+  useEffect(() => {
+    if (!unit) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    // Clear on unit *change* (this effect's only re-trigger — deps are
+    // [unit]) so the previous unit's aims are never shown under the new
+    // unit's header. The 60s same-unit re-poll goes through fetchOnce, which
+    // intentionally keeps the last response visible (anti-flicker); that path
+    // is untouched. Mirrors the guard in useUnitObservations.
+    setData(null);
+    setError(null);
+    setLoading(true);
+
+    const fetchOnce = async () => {
+      try {
+        const res = await api.aims(unit);
+        if (myGen !== generationRef.current) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (myGen !== generationRef.current) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (myGen === generationRef.current) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [unit]);
+
+  return { data, loading, error };
+}

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -2,6 +2,9 @@
 // Replaces Tauri IPC — all communication goes through the existing web API.
 
 import type { AgentCtxUsage } from "@/types/generated/AgentCtxUsage";
+import type { AimState } from "@/types/generated/AimState";
+import type { AimsResponse } from "@/types/generated/AimsResponse";
+import type { AimWire } from "@/types/generated/AimWire";
 import type { ApproachesResponse } from "@/types/generated/ApproachesResponse";
 import type { ApproachInventoryWire } from "@/types/generated/ApproachInventoryWire";
 import type { ApproachStatus } from "@/types/generated/ApproachStatus";
@@ -36,6 +39,7 @@ import type { ProducerPullTrigger } from "@/types/generated/ProducerPullTrigger"
 import type { PrSummaryWire } from "@/types/generated/PrSummaryWire";
 import type { QueueAgentEntry } from "@/types/generated/QueueAgentEntry";
 import type { QueueSnapshot } from "@/types/generated/QueueSnapshot";
+import type { RepoAimsWire } from "@/types/generated/RepoAimsWire";
 import type { RepoApproachesWire } from "@/types/generated/RepoApproachesWire";
 import type { RepoIssuesWire } from "@/types/generated/RepoIssuesWire";
 import type { RepoObservationsWire } from "@/types/generated/RepoObservationsWire";
@@ -61,6 +65,9 @@ import type { WorkflowSnapshot } from "@/types/generated/WorkflowSnapshot";
 
 export type {
   AgentCtxUsage,
+  AimState,
+  AimsResponse,
+  AimWire,
   ApproachesResponse,
   ApproachInventoryWire,
   ApproachStatus,
@@ -94,6 +101,7 @@ export type {
   PrSummaryWire,
   QueueAgentEntry,
   QueueSnapshot,
+  RepoAimsWire,
   RepoApproachesWire,
   RepoIssuesWire,
   RepoObservationsWire,
@@ -1539,6 +1547,14 @@ export const api = {
   // rich to open in R₂. Multi-repo follows tmai-core#340, same as approaches.
   observations: (unit: string) =>
     apiFetch<ObservationsResponse>(`/units/${encodeURIComponent(unit)}/observations`),
+
+  // Aims view (tmai-core #500) — every aim record per repo, the full node
+  // (slug / aim / parent / state / depends_on / serves / related / body).
+  // The R panel reconstructs the purpose=means tree client-side (by
+  // parent/slug) and renders the aim-tree read view. Aims currently live
+  // only in the `tmai-core` repo, but the wire is already multi-repo
+  // (`AimsResponse.repos[]`), same as decisions / approaches / observations.
+  aims: (unit: string) => apiFetch<AimsResponse>(`/units/${encodeURIComponent(unit)}/aims`),
 
   // Unit-scoped cross-repo open-PR list — Stage-1 in-tmai dev-loop
   // (DR `2026-05-16-dev-loop-completes-in-tmai.md` §A). One unified

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -268,6 +268,10 @@ export const api = {
   // doc/observations/ records; no Tauri-specific path needed)
   observations: (unit: string) => httpApi.observations(unit),
 
+  // Aims view (HTTP only — on-demand JSON projection of the unit's
+  // doc/aims/ records; no Tauri-specific path needed)
+  aims: (unit: string) => httpApi.aims(unit),
+
   // Unit-scoped cross-repo PR list (HTTP only — gh-CLI passthrough
   // fanned out over the unit's repos; no Tauri-specific path needed)
   unitPrs: (unit: string) => httpApi.unitPrs(unit),


### PR DESCRIPTION
Resolves #780. Graduates the read-view validated in throwaway prototype #778 (`RAimTreePrototype`) into a real R-panel section backed by the live `GET /api/units/{unit}/aims` endpoint (tmai-core #500). Branched off `main` after the prerequisite types-sync #779 merged (generated `Aim*` types are on `main`).

**One job, read-only.** No write affordance (Stage 2), no drift-mark (Stage 3).

## What changed
- **Rewire fixture → live wire model.** The prototype had its own model (`id`/`label`/`means-done`/`dependsOn` single/`BodyLine[]`); this follows the wire (`AimWire`): identity `slug`, anchor `aim`, state `open|done|dead` (no `means-done`), `depends_on`/`serves`/`related` arrays, raw markdown `body`, multi-repo `repos[]` flattened into one node set. Generated types imported from `@/types/generated/`, never hand-mirrored.
- **`dead` glyph.** Wire's third state gets a neutral shape glyph (`⊘`) — no heat/severity color (the machine marks, it never appraises). The prototype's `◐ means-done` is dropped.
- **Carry the validated view machinery, intact** (extracted pure + unit-tested in `aim-tree.ts`): tidy-tree layout (`computeLayout`/`parentEdgePath`), blast-radius highlight (`descendantsOf`, parent edges only), `depends_on` drawn as a distinct dashed info-hued cross-edge (NOT part of any blast radius), per-node state glyph, body-on-select detail pane. `serves`/`related` list as slug text in the detail pane (not drawn). Body rendered raw read-only (line breaks preserved, monospace) — **no `[confirmed]`/`[claimed]` honesty-tag parser** (the body is free-form prose; `BodyLine` was a fixture invention).
- **Data plumbing.** New `useUnitAims` hook (60s poll + generation guard, modeled on `useUnitObservations`) + `aims` api helper mirrored across `api-http.ts` / `api-tauri.ts` / `@/lib/api`, exactly like `observations`.
- **Layout adaptation** (the main integration work): the prototype's full-screen 2-pane layout is restacked (canvas above, detail below) to fit the narrow R-panel section column; the horizontal tidy-tree overflows into a scroller.
- **Integration.** New `RAimsSection` registered in `RPanel` next to the records family (Decisions / Approaches / Observations), mirroring the `rPanelExpandedSections` expanded-state wiring. Not an attention-artifact section (the 5 are pr/issue/decision/approach/observation), so it is **not** given the attention controls. `main.tsx`'s `#aim-tree` dev-mount is untouched (removed later when the prototype is reaped).

## Scope out (not built)
Write affordance (frontmatter edit / New node / Add child) → Stage 2. Drift-mark → Stage 3. The prototype's `CreateForm`/`patchNode`/`commitCreate`/`seq`/`creating` are not carried.

## Gate (clients/react — all green locally)
- `tsc -b` ✓ (no `any`)
- `biome check` ✓ (only a pre-existing warning in `ProducerFeedChip.tsx`, untouched here)
- `vitest run` ✓ — 684 passed | 2 skipped
- `vite build` ✓

New tests: `__tests__/aim-tree.test.ts` (pure tree-build + blast-radius), `__tests__/RAimsSection.test.tsx` (render / loading / empty / error / parked + selection→body, blast radius, dashed cross-edge, `dead` neutral glyph + no severity color, no write affordance), `hooks/__tests__/useUnitAims.test.ts`; `__tests__/RPanel.test.tsx` updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)