### PR TITLE
fix(r-panel): aim-tree → maximized canvas + variable-height layout (Stage 1-B follow-up) (#782)

### DIFF
--- a/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
@@ -1,5 +1,5 @@
-// ◎ Aims — R panel's aim-tree read view (graduation Stage 1-B, #780). The
-// read-view validated in throwaway prototype #778 (`RAimTreePrototype`),
+// ◎ Aims — R panel's aim-tree read view (graduation Stage 1-B, #780 + #782).
+// The read-view validated in throwaway prototype #778 (`RAimTreePrototype`),
 // graduated into a real R-panel section backed by the live
 // `GET /api/units/{unit}/aims` endpoint (tmai-core #500).
 //
@@ -8,15 +8,23 @@
 // `patchNode` / `commitCreate` / in-memory mutation are deliberately NOT
 // carried.
 //
-// The view machinery carried intact from the prototype: the tidy-tree layout,
-// the blast-radius highlight (select a node → light its whole descendant
-// subtree, the set that would become drift-possible if that aim changed),
-// `depends_on` drawn as a visually distinct dashed cross-edge (NOT part of any
-// blast radius), the per-node state glyph, and the body-on-select detail pane.
-// The pure layout / traversal lives in `./aim-tree` (unit-tested separately);
-// this file is the React rendering, adapted from the prototype's full-screen
-// 2-pane layout to STACK (canvas above, detail below) so it fits the narrow
-// R-panel section column.
+// CONTAINER (#782): a 2D spatial tree of long-text nodes does not fit the
+// narrow R-panel accordion column, and widening the column would fight the
+// console-rebuild "central conversation primary" constraint. So the section
+// itself stays a thin accordion entry — a compact `N aims · M roots` summary +
+// the glyph legend + an ⤢ "open" affordance — and the actual tree lives in a
+// DEDICATED FULL-WINDOW OVERLAY (`AimTreeOverlay`, mounted via `createPortal`,
+// dismissible by ✕ and Esc). The overlay uses the prototype's SIDE-BY-SIDE
+// 2-pane layout (wide canvas + side detail), with the room to let the variable-
+// height tidy-tree (`computeLayout`, the #782 overlap fix) breathe.
+//
+// The view machinery carried intact from the prototype: the variable-height
+// tidy-tree layout, the blast-radius highlight (select a node → light its whole
+// descendant subtree, the set that would become drift-possible if that aim
+// changed), `depends_on` drawn as a visually distinct dashed cross-edge (NOT
+// part of any blast radius), the per-node state glyph, and the body-on-select
+// detail pane. The pure layout / traversal lives in `./aim-tree` (unit-tested
+// separately); this file is the React rendering.
 //
 // `body` is rendered as raw markdown, read-only: line breaks preserved,
 // monospace so inline refs / markers stay legible. There is intentionally no
@@ -24,7 +32,8 @@
 // prose in the wire body, not a structured field (the prototype's `BodyLine`
 // was a fixture invention).
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import { createPortal } from "react-dom";
 import { useUnitAims } from "@/hooks/useUnitAims";
 import type { AimWire } from "@/lib/api";
 import {
@@ -35,6 +44,7 @@ import {
   computeLayout,
   dependsEdgePath,
   descendantsOf,
+  findRoots,
   flattenRepos,
   NODE_W,
   type NodePos,
@@ -87,13 +97,62 @@ function Body({ unitName, nodes, loading, error }: BodyProps) {
   if (nodes.length === 0) {
     return <p className="text-subtle-foreground">No aims.</p>;
   }
-  return <AimTree nodes={nodes} />;
+  return <AimsEntry nodes={nodes} />;
 }
 
-function AimTree({ nodes }: { nodes: AimWire[] }) {
+// The thin R-panel entry: a compact summary + the glyph legend + an ⤢ open
+// affordance. Clicking open launches the maximized overlay; the open-state is
+// local and the overlay is portalled, so the section stays self-contained and
+// the narrow column is never widened.
+function AimsEntry({ nodes }: { nodes: AimWire[] }) {
+  const [open, setOpen] = useState(false);
+  const rootCount = useMemo(() => findRoots(nodes).length, [nodes]);
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <span className="text-[11px] text-subtle-foreground">
+          {nodes.length} aim{nodes.length === 1 ? "" : "s"} ·{" "}
+          <span className="text-foreground">{rootCount}</span> root{rootCount === 1 ? "" : "s"}
+        </span>
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          title="Open aim-tree (maximized)"
+          aria-label="Open aim-tree"
+          className="flex shrink-0 items-center gap-1 rounded border border-hairline px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+        >
+          <span aria-hidden="true">⤢</span> Open
+        </button>
+      </div>
+      <GlyphLegend />
+      {open && <AimTreeOverlay nodes={nodes} onClose={() => setOpen(false)} />}
+    </div>
+  );
+}
+
+// The maximized aim-tree overlay — a full-window surface modelled on
+// `HelpOverlay` / `HandoffRitualOverlay`, mounted via `createPortal` so it
+// escapes the R-panel column's clipping/stacking. Dismissible by ✕ and Esc
+// (the Esc convention reused from `AttentionMarker` / `ConfirmDialog`).
+// Layout: the prototype's side-by-side 2-pane — a wide scrollable tree canvas
+// on the left, the body-on-select detail pane on the right.
+function AimTreeOverlay({ nodes, onClose }: { nodes: AimWire[]; onClose: () => void }) {
   const [selected, setSelected] = useState<string | null>(null);
   const childrenOf = useMemo(() => buildChildren(nodes), [nodes]);
   const layout = useMemo(() => computeLayout(nodes), [nodes]);
+  const rootCount = layout.roots.length;
+
+  // Esc dismisses the whole overlay (the detail pane's ✕ / the legend's clear
+  // handle deselect). Listener is document-level so it fires regardless of
+  // focus, mirroring AttentionMarker's popover.
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
 
   // Resolve the selection against the CURRENT node set: if a poll / unit
   // change dropped the selected slug, the detail pane and highlight fall back
@@ -115,58 +174,98 @@ function AimTree({ nodes }: { nodes: AimWire[] }) {
   }, [selectedNode, blast]);
   const hasSelection = selectedNode !== null;
 
-  return (
-    <div className="space-y-2">
-      <Legend
-        selectedSlug={selectedNode?.slug ?? null}
-        blastCount={blast.size}
-        onClear={() => setSelected(null)}
-      />
-      {/* The tree canvas. The tidy-tree lays out horizontally by depth, so in
-          the narrow R-panel column it overflows into this scroller rather than
-          cramping. SVG edges sit underneath; clickable node boxes on top. */}
-      <div className="max-h-[420px] overflow-auto rounded border border-hairline bg-surface/30">
-        <div className="relative" style={{ width: layout.width, height: layout.height }}>
-          <Edges
-            nodes={nodes}
-            layout={layout}
-            highlighted={highlighted}
-            hasSelection={hasSelection}
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Aim-tree"
+      className="fixed inset-0 z-50 flex flex-col bg-background"
+    >
+      <header className="flex shrink-0 items-center justify-between gap-3 border-b border-hairline px-4 py-3">
+        <div className="flex min-w-0 items-baseline gap-3">
+          <h2 className="text-sm font-semibold text-foreground">◎ Aims · aim-tree</h2>
+          <span className="text-[11px] text-subtle-foreground">
+            {nodes.length} aim{nodes.length === 1 ? "" : "s"} · {rootCount} root
+            {rootCount === 1 ? "" : "s"}
+          </span>
+          <SelectionStatus
+            selectedSlug={selectedNode?.slug ?? null}
+            blastCount={blast.size}
+            onClear={() => setSelected(null)}
           />
-          {nodes.map((node) => {
-            const pos = layout.positions.get(node.slug);
-            if (!pos) return null;
-            const lit = highlighted.has(node.slug);
-            return (
-              <NodeBox
-                key={node.slug}
-                node={node}
-                pos={pos}
-                isSelected={selectedNode?.slug === node.slug}
-                lit={lit}
-                dimmed={hasSelection && !lit}
-                onSelect={() => setSelected(node.slug)}
-              />
-            );
-          })}
         </div>
+        <button
+          type="button"
+          onClick={onClose}
+          title="Close aim-tree (Esc)"
+          aria-label="Close aim-tree"
+          className="shrink-0 rounded px-2 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+        >
+          ✕
+        </button>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        {/* Left: the tree canvas. The tidy-tree lays out horizontally by depth
+            and variable-height vertically (the #782 overlap fix); SVG edges sit
+            underneath, clickable node boxes on top. The wide window lets it
+            overflow into this scroller without cramping. */}
+        <div className="min-w-0 flex-1 overflow-auto p-4">
+          <div className="relative" style={{ width: layout.width, height: layout.height }}>
+            <Edges
+              nodes={nodes}
+              layout={layout}
+              highlighted={highlighted}
+              hasSelection={hasSelection}
+            />
+            {nodes.map((node) => {
+              const pos = layout.positions.get(node.slug);
+              if (!pos) return null;
+              const lit = highlighted.has(node.slug);
+              return (
+                <NodeBox
+                  key={node.slug}
+                  node={node}
+                  pos={pos}
+                  isSelected={selectedNode?.slug === node.slug}
+                  lit={lit}
+                  dimmed={hasSelection && !lit}
+                  onSelect={() => setSelected(node.slug)}
+                />
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Right: the body-on-select detail pane (read-only). */}
+        <aside className="flex w-[360px] shrink-0 flex-col overflow-y-auto border-l border-hairline">
+          {selectedNode !== null ? (
+            <DetailPane
+              node={selectedNode}
+              blastCount={blast.size}
+              onClose={() => setSelected(null)}
+            />
+          ) : (
+            <p className="p-6 text-xs text-subtle-foreground">
+              Click a node to read its body and light its{" "}
+              <span className="text-foreground">blast radius</span> — the descendant subtree that
+              would become drift-possible if that aim changed.
+            </p>
+          )}
+        </aside>
       </div>
-      {selectedNode !== null && (
-        <DetailPane node={selectedNode} blastCount={blast.size} onClose={() => setSelected(null)} />
-      )}
-    </div>
+
+      <footer className="shrink-0 border-t border-hairline px-4 py-2">
+        <GlyphLegend />
+      </footer>
+    </div>,
+    document.body,
   );
 }
 
-function Legend({
-  selectedSlug,
-  blastCount,
-  onClear,
-}: {
-  selectedSlug: string | null;
-  blastCount: number;
-  onClear: () => void;
-}) {
+// The static glyph key — open / done / dead state glyphs + the dashed
+// `depends_on` swatch. Shown in both the thin entry and the overlay footer.
+function GlyphLegend() {
   return (
     <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-subtle-foreground">
       <span className="flex items-center gap-1">
@@ -193,24 +292,42 @@ function Legend({
         </svg>
         depends_on
       </span>
-      {selectedSlug !== null ? (
-        <span className="flex items-center gap-2 text-muted-foreground">
-          <span>
-            blast radius: <span className="text-foreground">{blastCount}</span> descendant
-            {blastCount === 1 ? "" : "s"}
-          </span>
-          <button
-            type="button"
-            onClick={onClear}
-            className="rounded border border-hairline px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
-          >
-            clear
-          </button>
-        </span>
-      ) : (
-        <span>click a node to light its blast radius</span>
-      )}
     </div>
+  );
+}
+
+// The selection status — blast-radius count + a clear button when a node is
+// selected, or a hint to click otherwise. Lives in the overlay header.
+function SelectionStatus({
+  selectedSlug,
+  blastCount,
+  onClear,
+}: {
+  selectedSlug: string | null;
+  blastCount: number;
+  onClear: () => void;
+}) {
+  if (selectedSlug === null) {
+    return (
+      <span className="text-[11px] text-subtle-foreground">
+        click a node to light its blast radius
+      </span>
+    );
+  }
+  return (
+    <span className="flex items-center gap-2 text-[11px] text-muted-foreground">
+      <span>
+        blast radius: <span className="text-foreground">{blastCount}</span> descendant
+        {blastCount === 1 ? "" : "s"}
+      </span>
+      <button
+        type="button"
+        onClick={onClear}
+        className="rounded border border-hairline px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+      >
+        clear
+      </button>
+    </span>
   );
 }
 
@@ -356,10 +473,7 @@ function DetailPane({
   onClose: () => void;
 }) {
   return (
-    <div
-      data-testid="aim-detail"
-      className="space-y-3 rounded border border-hairline bg-surface/30 p-3"
-    >
+    <div data-testid="aim-detail" className="space-y-3 p-4">
       <div className="flex items-start justify-between gap-2">
         <div className="min-w-0">
           <span className="flex items-baseline gap-1.5">
@@ -436,7 +550,7 @@ function AimBody({ body }: { body: string }) {
     );
   }
   return (
-    <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded bg-surface/40 px-2 py-1.5 font-mono text-[11px] leading-snug text-muted-foreground">
+    <pre className="max-h-[60vh] overflow-auto whitespace-pre-wrap break-words rounded bg-surface/40 px-2 py-1.5 font-mono text-[11px] leading-snug text-muted-foreground">
       {body}
     </pre>
   );

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RAimsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RAimsSection.test.tsx
@@ -1,7 +1,10 @@
 // @vitest-environment jsdom
 //
-// RAimsSection — the aim-tree read view (graduation Stage 1-B, #780). Covers
-// the wire-backed states (render / loading / empty / error / parked) and the
+// RAimsSection — the aim-tree read view (graduation Stage 1-B, #780 + #782).
+// The section is now a THIN entry (summary + glyph legend + an ⤢ open
+// affordance); the actual 2D tree lives in a maximized overlay opened from it.
+// Covers the wire-backed states (render / loading / empty / error / parked),
+// the thin-entry summary, the overlay open / close (✕) / dismiss (Esc), and the
 // view machinery carried from prototype #778: body-on-select detail pane,
 // blast-radius highlight, the distinct dashed `depends_on` cross-edge, and the
 // neutral `dead` glyph with no severity color. Read-only — there is NO write
@@ -87,18 +90,30 @@ beforeEach(() => {
   aimsMock.mockReset();
 });
 
-describe("RAimsSection", () => {
-  it("renders each aim node (anchor + slug)", async () => {
-    aimsMock.mockResolvedValue(responseStub(TREE));
+// Open the maximized overlay from the thin entry, returning the dialog element.
+async function openOverlay() {
+  const openBtn = await screen.findByRole("button", { name: /Open aim-tree/ });
+  fireEvent.click(openBtn);
+  return screen.findByRole("dialog", { name: "Aim-tree" });
+}
 
+describe("RAimsSection — thin entry", () => {
+  it("shows a compact summary (aim + root count) and an open affordance, not the canvas", async () => {
+    aimsMock.mockResolvedValue(responseStub(TREE));
     render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
 
+    // Summary: 6 aims across 2 roots (amplify-human-judgment + aim-system).
+    // The root count sits in its own foreground span, so assert on the full
+    // summary text rather than a single contiguous text node.
     await waitFor(() => {
-      expect(screen.getByText("人間の判断を増幅する")).toBeTruthy();
+      expect(screen.getByText(/6 aims/)).toBeTruthy();
     });
-    expect(screen.getByText("records を書く構造に")).toBeTruthy();
-    // The slug shows under the anchor inside the node box.
-    expect(screen.getByText("attention-per-artifact")).toBeTruthy();
+    expect(screen.getByText(/6 aims/).textContent).toContain("2 root");
+    // The open affordance is present…
+    expect(screen.getByRole("button", { name: /Open aim-tree/ })).toBeTruthy();
+    // …but the maximized tree is NOT mounted until it is clicked.
+    expect(screen.queryByRole("dialog", { name: "Aim-tree" })).toBeNull();
+    expect(screen.queryByText("人間の判断を増幅する")).toBeNull();
   });
 
   it("header count is the plain total node count (no severity styling)", async () => {
@@ -138,10 +153,47 @@ describe("RAimsSection", () => {
     expect(screen.getByText(/Pick a project to see aims\./)).toBeTruthy();
     expect(aimsMock).not.toHaveBeenCalled();
   });
+});
+
+describe("RAimsSection — maximized overlay", () => {
+  it("opens the overlay on ⤢ click, rendering every aim node (anchor + slug)", async () => {
+    aimsMock.mockResolvedValue(responseStub(TREE));
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+
+    await openOverlay();
+
+    expect(screen.getByText("人間の判断を増幅する")).toBeTruthy();
+    expect(screen.getByText("records を書く構造に")).toBeTruthy();
+    // The slug shows under the anchor inside the node box.
+    expect(screen.getByText("attention-per-artifact")).toBeTruthy();
+  });
+
+  it("dismisses via the ✕ close button", async () => {
+    aimsMock.mockResolvedValue(responseStub(TREE));
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+
+    await openOverlay();
+    fireEvent.click(screen.getByRole("button", { name: /Close aim-tree/ }));
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Aim-tree" })).toBeNull();
+    });
+  });
+
+  it("dismisses via Esc", async () => {
+    aimsMock.mockResolvedValue(responseStub(TREE));
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+
+    await openOverlay();
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: "Aim-tree" })).toBeNull();
+    });
+  });
 
   it("selecting a node opens its body in the detail pane and reports the blast radius", async () => {
     aimsMock.mockResolvedValue(responseStub(TREE));
     render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await openOverlay();
 
     const node = await screen.findByRole("button", {
       name: /attention-per-artifact/,
@@ -160,6 +212,7 @@ describe("RAimsSection", () => {
   it("lists depends_on / serves / related as slug text in the detail pane", async () => {
     aimsMock.mockResolvedValue(responseStub(TREE));
     render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await openOverlay();
 
     const node = await screen.findByRole("button", { name: /aim-authority/ });
     fireEvent.click(node);
@@ -173,11 +226,13 @@ describe("RAimsSection", () => {
 
   it("draws depends_on as a distinct dashed cross-edge path", async () => {
     aimsMock.mockResolvedValue(responseStub(TREE));
-    const { container } = render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await openOverlay();
     await screen.findByText("authority = event-driven amendment");
     // The cross-edge is a <path> with a dasharray (the legend uses a <line>,
     // so querying for path[stroke-dasharray] targets the edge specifically).
-    const dashed = container.querySelector('path[stroke-dasharray="4 3"]');
+    // The overlay is portalled to document.body, so query the document.
+    const dashed = document.querySelector('path[stroke-dasharray="4 3"]');
     expect(dashed).not.toBeNull();
   });
 
@@ -185,16 +240,18 @@ describe("RAimsSection", () => {
     aimsMock.mockResolvedValue(
       responseStub([aimStub({ slug: "x", aim: "dead aim", state: "dead" })]),
     );
-    const { container } = render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await openOverlay();
     await screen.findByText("dead aim");
     // Neutral shape glyph for dead — no heat / severity color anywhere.
     expect(screen.getAllByText("⊘").length).toBeGreaterThan(0);
-    expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
+    expect(document.body.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
   });
 
   it("does NOT render a write affordance (Stage 2 is out of scope)", async () => {
     aimsMock.mockResolvedValue(responseStub(TREE));
     render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await openOverlay();
     await screen.findByText("records を書く構造に");
     // No "New node" / "Add child" / "Create" affordance carried from the
     // prototype — this is the read-only view.

--- a/clients/react/src/components/producer-console/r-panel/__tests__/aim-tree.test.ts
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/aim-tree.test.ts
@@ -10,8 +10,10 @@ import {
   computeLayout,
   dependsEdgePath,
   descendantsOf,
+  findRoots,
   flattenRepos,
   NODE_W,
+  nodeHeight,
   parentEdgePath,
 } from "../aim-tree";
 
@@ -108,6 +110,94 @@ describe("computeLayout", () => {
     const layout = computeLayout([]);
     expect(layout.roots).toEqual([]);
     expect(layout.positions.size).toBe(0);
+  });
+
+  it("gives every node a positive estimated height", () => {
+    const layout = computeLayout(NODES);
+    for (const n of NODES) {
+      expect((layout.positions.get(n.slug)?.height ?? 0) > 0).toBe(true);
+    }
+  });
+});
+
+describe("findRoots", () => {
+  it("returns explicit roots (parent === null)", () => {
+    expect(findRoots(NODES).map((r) => r.slug)).toEqual(["root-a", "root-b"]);
+  });
+
+  it("treats an orphan with a missing parent as a root", () => {
+    const orphan = aim({ slug: "lonely", parent: "ghost" });
+    expect(findRoots([aim({ slug: "root-a" }), orphan]).map((r) => r.slug)).toContain("lonely");
+  });
+});
+
+describe("nodeHeight (the variable-height estimate)", () => {
+  it("is taller for a longer label (more wrapped lines)", () => {
+    const short = nodeHeight("短い");
+    const long = nodeHeight("あ".repeat(130));
+    expect(long).toBeGreaterThan(short);
+  });
+
+  it("floors a 1-line label at a comfortable minimum", () => {
+    // A short label must still get a readable box, not collapse to one line of
+    // text height.
+    expect(nodeHeight("x")).toBeGreaterThanOrEqual(40);
+  });
+});
+
+// THE #782 overlap fix. Adjacent depth columns are >NODE_W apart horizontally
+// (COL_W > NODE_W), so two boxes can only share screen space when they share a
+// depth. Assert that within every depth column, the `[cy ± height/2]` vertical
+// ranges never overlap — for any node set, including long-label and tall-
+// internal-node fixtures that broke the old fixed-ROW_H layout.
+function assertNoColumnOverlap(layout: ReturnType<typeof computeLayout>) {
+  const byDepth = new Map<number, { cy: number; height: number; slug: string }[]>();
+  for (const pos of layout.positions.values()) {
+    const list = byDepth.get(pos.depth) ?? [];
+    list.push(pos);
+    byDepth.set(pos.depth, list);
+  }
+  for (const list of byDepth.values()) {
+    const sorted = [...list].sort((a, b) => a.cy - b.cy);
+    for (let i = 1; i < sorted.length; i++) {
+      const prev = sorted[i - 1];
+      const cur = sorted[i];
+      const prevBottom = prev.cy + prev.height / 2;
+      const curTop = cur.cy - cur.height / 2;
+      // curTop must sit at or below prevBottom — no vertical overlap.
+      expect(curTop).toBeGreaterThanOrEqual(prevBottom);
+    }
+  }
+}
+
+describe("computeLayout — variable-height no-overlap invariant (#782)", () => {
+  it("never overlaps nodes in a depth column for the canonical tree", () => {
+    assertNoColumnOverlap(computeLayout(NODES));
+  });
+
+  it("never overlaps leaf siblings even with a 130+ char label", () => {
+    const longLabel = "あ".repeat(135); // 135 full-width chars — wraps to many lines
+    expect(longLabel.length).toBeGreaterThanOrEqual(130);
+    const set: AimWire[] = [
+      aim({ slug: "root" }),
+      aim({ slug: "leaf-long", parent: "root", aim: longLabel }),
+      aim({ slug: "leaf-short", parent: "root", aim: "x" }),
+      aim({ slug: "leaf-mid", parent: "root", aim: "あ".repeat(40) }),
+      aim({ slug: "leaf-long2", parent: "root", aim: "drift-possible ".repeat(9) }),
+    ];
+    assertNoColumnOverlap(computeLayout(set));
+  });
+
+  it("keeps a tall internal node (long label, one short child) clear of its sibling", () => {
+    // The overhang case: an internal node whose OWN box is taller than its
+    // single child's span must not bleed into the adjacent depth-1 sibling.
+    const set: AimWire[] = [
+      aim({ slug: "root" }),
+      aim({ slug: "tall-internal", parent: "root", aim: "あ".repeat(135) }),
+      aim({ slug: "tiny-child", parent: "tall-internal", aim: "x" }),
+      aim({ slug: "sibling-leaf", parent: "root", aim: "あ".repeat(50) }),
+    ];
+    assertNoColumnOverlap(computeLayout(set));
   });
 });
 

--- a/clients/react/src/components/producer-console/r-panel/aim-tree.ts
+++ b/clients/react/src/components/producer-console/r-panel/aim-tree.ts
@@ -17,17 +17,51 @@ import type { AimWire } from "@/types/generated/AimWire";
 
 // ── Layout constants ──────────────────────────────────────────────────
 //
-// Tuned smaller than the prototype's full-screen values (it had COL_W 232 /
-// NODE_W 200) so a shallow tree fits the NARROW R-panel section without
-// scrolling; a deep/wide tree overflows into the canvas's `overflow-auto`.
-export const COL_W = 196; // horizontal distance per depth level
-export const ROW_H = 48; // vertical slot per leaf row
-export const NODE_W = 168; // fixed node-box width (labels wrap within)
-const PAD_L = 16;
-const PAD_T = 16;
-const PAD_R = 28;
-const PAD_B = 16;
-const GAP_BETWEEN_TREES = 1; // blank leaf-slots inserted between roots
+// Generous full-window values — the aim-tree now lives in a maximized overlay
+// (#782), not the narrow R-panel column, so labels get the room the prototype
+// (#778) validated (COL_W 232 / NODE_W 200) and then some. COL_W stays wider
+// than NODE_W so adjacent depth columns never overlap horizontally; that is
+// what lets the no-overlap invariant reduce to a per-depth-column vertical
+// check (only same-depth boxes share an x-range).
+export const COL_W = 248; // horizontal distance per depth level
+export const NODE_W = 216; // fixed node-box width (labels wrap within)
+const PAD_L = 24;
+const PAD_T = 24;
+const PAD_R = 40;
+const PAD_B = 24;
+const ROOT_GAP = 28; // vertical gap inserted between root subtrees
+const NODE_GAP = 16; // vertical breathing room between adjacent boxes
+
+// ── Node-height estimation ────────────────────────────────────────────
+//
+// THE overlap fix (#782): a node's box height is NOT fixed — real `aim:`
+// anchors are long sentences (up to ~132 chars) that wrap to many lines inside
+// the fixed-width box. A fixed ROW_H let tall boxes overlap their neighbours.
+// `computeLayout` instead lays nodes out with a CUMULATIVE vertical advance
+// proportional to each box's estimated rendered height (`nodeHeight`).
+//
+// We can't DOM-measure in a pure function, so estimate the wrapped line count
+// from label length against a CONSERVATIVE chars-per-line. The corpus is mostly
+// Japanese / full-width, whose glyphs are ~1em wide (≈ the font size), so we
+// assume one full-width glyph per `LABEL_FONT_PX` of inner width. That UPPER-
+// bounds the line count for any Latin-or-mixed label too (Latin glyphs are
+// narrower → fewer wrapped lines than estimated), so a box is never under-
+// allocated and the no-overlap invariant holds regardless of script.
+const LABEL_FONT_PX = 12; // text-xs label glyph advance (full-width ≈ 1em)
+const LABEL_LINE_H = 18; // text-xs × leading-snug (~1.375), rounded up
+const NODE_PAD_X = 16; // px-2 → 8px each side
+const GLYPH_COL = 22; // state glyph + gap-1.5 gutter left of the label
+const NODE_CHROME_V = 28; // py-1.5 (12) + slug line (~14) + label/slug gap (~2)
+const MIN_NODE_H = 46; // floor so a 1-line box still reads comfortably
+
+// Estimated rendered height (px) of a node box for a given `aim` label. Pure
+// and deterministic — the layout's whole no-overlap guarantee rides on it.
+export function nodeHeight(label: string): number {
+  const textW = Math.max(LABEL_FONT_PX, NODE_W - NODE_PAD_X - GLYPH_COL);
+  const charsPerLine = Math.max(1, Math.floor(textW / LABEL_FONT_PX));
+  const lines = Math.max(1, Math.ceil(label.length / charsPerLine));
+  return Math.max(MIN_NODE_H, NODE_CHROME_V + lines * LABEL_LINE_H);
+}
 
 // Per-node state glyph — SHAPE ONLY, one neutral hue, no heat / severity
 // color (the machine marks, it never appraises — `AimState` doc + brief).
@@ -65,6 +99,10 @@ export interface NodePos {
    *  centered on this y via a translateY(-50%), so multi-line labels grow
    *  symmetrically and never shift the edge anchor). */
   cy: number;
+  /** Estimated rendered box height (`nodeHeight`). The box's vertical extent
+   *  is `[cy - height/2, cy + height/2]`; the layout spaces siblings so these
+   *  ranges never overlap within a depth column. */
+  height: number;
   depth: number;
 }
 
@@ -87,46 +125,101 @@ export function buildChildren(nodes: readonly AimWire[]): Map<string, AimWire[]>
   return childrenOf;
 }
 
-// Classic tidy tree: leaves get sequential vertical slots; an internal node
-// is centered on the midpoint of its first and last child. Roots are stacked
-// top-to-bottom (a blank gap-slot between them).
+// Roots = explicit roots (`parent === null`) PLUS orphans whose `parent` slug
+// isn't a known node — so a dangling parent ref (a half-written / cross-repo
+// reference) still renders rather than silently vanishing from the canvas.
+// Shared by `computeLayout` and the R-panel thin-entry root count.
+export function findRoots(nodes: readonly AimWire[]): AimWire[] {
+  const bySlug = new Set(nodes.map((n) => n.slug));
+  return nodes.filter((n) => n.parent === null || !bySlug.has(n.parent));
+}
+
+// Variable-height tidy tree (the #782 overlap fix). Each node reserves vertical
+// room proportional to its estimated box height (`nodeHeight`) instead of a
+// fixed ROW_H, so long-label boxes never overlap their neighbours.
+//
+// The walk lays each subtree into a contiguous, non-overlapping vertical band:
+//   - a LEAF occupies exactly its own box height;
+//   - an INTERNAL node lays its children out sequentially (each child's band +
+//     a gap), centres itself on the midpoint of its first/last child as the
+//     classic tidy tree does, then — if its OWN (possibly tall) box would stick
+//     out above the band — shifts the whole subtree down so the parent's top
+//     aligns with the band's top. The subtree's reported bottom is the max of
+//     the children's bottom and the parent box's bottom.
+// Because each subtree owns a disjoint vertical band and adjacent depth columns
+// are >NODE_W apart horizontally, no two boxes that share a depth column can
+// overlap, regardless of label length.
 export function computeLayout(nodes: readonly AimWire[]): AimLayout {
   const childrenOf = buildChildren(nodes);
-  const bySlug = new Set(nodes.map((n) => n.slug));
+  const bySlug = new Map(nodes.map((n) => [n.slug, n] as const));
   const positions = new Map<string, NodePos>();
-  let leafCursor = 0;
   let maxDepth = 0;
 
-  function assign(slug: string, depth: number): number {
-    maxDepth = Math.max(maxDepth, depth);
-    const children = childrenOf.get(slug) ?? [];
-    let cy: number;
-    if (children.length === 0) {
-      cy = PAD_T + leafCursor * ROW_H + ROW_H / 2;
-      leafCursor += 1;
-    } else {
-      const childCenters = children.map((c) => assign(c.slug, depth + 1));
-      cy = (childCenters[0] + childCenters[childCenters.length - 1]) / 2;
-    }
-    positions.set(slug, { slug, x: PAD_L + depth * COL_W, cy, depth });
-    return cy;
+  // Translate a whole subtree's `cy` by `delta` (used for the parent-overhang
+  // correction). `seen` guards against a malformed `parent` cycle.
+  function shiftSubtree(slug: string, delta: number, seen: Set<string>): void {
+    if (seen.has(slug)) return;
+    seen.add(slug);
+    const p = positions.get(slug);
+    if (p) p.cy += delta;
+    for (const c of childrenOf.get(slug) ?? []) shiftSubtree(c.slug, delta, seen);
   }
 
-  // Roots = explicit roots (`parent === null`) PLUS orphans whose `parent`
-  // slug isn't a known node — so a dangling parent ref (a half-written /
-  // cross-repo reference) still renders rather than silently vanishing from
-  // the canvas.
-  const roots = nodes.filter((n) => n.parent === null || !bySlug.has(n.parent));
+  // Lay `slug`'s subtree starting at vertical `top`; set positions and return
+  // the subtree's center y and the next free y below it.
+  function layout(slug: string, depth: number, top: number): { cy: number; bottom: number } {
+    maxDepth = Math.max(maxDepth, depth);
+    const node = bySlug.get(slug);
+    const h = nodeHeight(node?.aim ?? slug);
+    const x = PAD_L + depth * COL_W;
+    const children = childrenOf.get(slug) ?? [];
+
+    if (children.length === 0) {
+      const cy = top + h / 2;
+      positions.set(slug, { slug, x, cy, height: h, depth });
+      return { cy, bottom: top + h };
+    }
+
+    let cursor = top;
+    let firstCy = 0;
+    let lastCy = 0;
+    children.forEach((c, i) => {
+      if (i > 0) cursor += NODE_GAP;
+      const r = layout(c.slug, depth + 1, cursor);
+      if (i === 0) firstCy = r.cy;
+      lastCy = r.cy;
+      cursor = r.bottom;
+    });
+    let childrenBottom = cursor;
+    let cy = (firstCy + lastCy) / 2;
+    positions.set(slug, { slug, x, cy, height: h, depth });
+
+    // Parent-overhang correction: if this box (centred on its children) would
+    // stick out above the band top, push the whole subtree down so nothing
+    // crosses into the previous sibling's band.
+    const overhang = top - (cy - h / 2);
+    if (overhang > 0) {
+      shiftSubtree(slug, overhang, new Set<string>());
+      cy += overhang;
+      childrenBottom += overhang;
+    }
+    // The band extends to whichever is lower: the last child or this box.
+    return { cy, bottom: Math.max(childrenBottom, cy + h / 2) };
+  }
+
+  const roots = findRoots(nodes);
+  let cursor = PAD_T;
   roots.forEach((root, i) => {
-    if (i > 0) leafCursor += GAP_BETWEEN_TREES;
-    assign(root.slug, 0);
+    if (i > 0) cursor += ROOT_GAP;
+    const r = layout(root.slug, 0, cursor);
+    cursor = r.bottom;
   });
 
   return {
     positions,
     roots,
     width: PAD_L + maxDepth * COL_W + NODE_W + PAD_R,
-    height: PAD_T + leafCursor * ROW_H + PAD_B,
+    height: cursor + PAD_B,
   };
 }
 


### PR DESCRIPTION
Resolves #782 — Stage 1-B follow-up to #780/#781.

Lived dogfood of #781 surfaced two coupled problems: long `aim:` anchors (up to ~132 chars, mostly full-width Japanese) wrapped to many lines inside the fixed-height node boxes and **overlapped vertically**, and a 2D spatial tree of long-text nodes never fit the narrow R-panel accordion column.

## Part 1 — R-panel entry becomes thin
`RAimsSection.tsx` stays an accordion `Section`, but its body is now a compact summary (`N aims · M roots`) + the glyph legend + an **⤢ open** affordance. The cramped in-section 2D canvas and stacked detail pane are removed. Clicking open launches the maximized overlay (local open-state + `createPortal` keeps it self-contained). The R-panel column is **not** widened (keeps the console-rebuild "central conversation primary" constraint).

## Part 2 — Maximized canvas overlay
A full-window overlay modelled on the existing `HelpOverlay` / `HandoffRitualOverlay`, mounted via `createPortal` to `document.body`. Dismissible by **✕** and **Esc** (document-level Esc convention reused from `AttentionMarker` / `ConfirmDialog`). Inside: the prototype's **side-by-side 2-pane** layout — wide scrollable tree canvas + body-on-select detail pane on the side — with generous constants (COL_W 248 / NODE_W 216). Carried intact: blast-radius highlight, `depends_on` dashed cross-edge (NOT in the blast radius), per-node state glyphs (open/done/dead), raw-markdown read-only body, `serves` / `related` slug lists. Hook + api helper + generated types unchanged.

## Part 3 — Variable-height layout (the overlap fix), `aim-tree.ts`
Replaces the fixed `ROW_H` tidy-tree with a variable-height layout:
- `nodeHeight(label)` — pure estimate of a box's rendered height from label length against a **conservative full-width chars-per-line** (≈1em per glyph), which upper-bounds CJK and mixed/Latin labels so a box is never under-allocated.
- `computeLayout` lays each subtree into a **disjoint vertical band**: leaves advance cumulatively by their own height + a gap; internal nodes center on their children's span, with a **parent-overhang shift** so a tall internal box (long label, short children) never bleeds into its sibling. Adjacent depth columns are >NODE_W apart, so no two boxes that share a depth can overlap — **for any node set, regardless of label length**.
- `NodePos` now carries the estimated `height`; `findRoots` extracted and shared with the thin-entry root count.

## Scope (unchanged)
Read-only. No write affordance (Stage 2), no drift-mark (Stage 3), no markdown→HTML, no honesty-tag parser. No `any`.

## Tests
- `aim-tree.test.ts`: no-overlap invariant over **every same-depth pair**, with a **130+ char label fixture** and a tall-internal-node (overhang) case; plus `nodeHeight` / `findRoots` coverage.
- `RAimsSection.test.tsx`: thin entry summary + overlay **open / ✕ / Esc**; the carried view machinery (body-on-select, blast radius, dashed cross-edge, neutral `dead` glyph, no write affordance) re-asserted through the opened overlay.
- `RPanel.test.tsx` stays green (it mocks `RAimsSection`).

## Gate (clients/react — all green)
`tsc -b` ✅ · `biome check` ✅ · `vitest run` (695 passed, 2 skipped) ✅ · `vite build` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Aimsの詳細表示をフルウィンドウのオーバーレイに変更
  * オーバーレイ内でのノード選択と右側詳細ペイン表示に対応
  * ノード間の関連性をビジュアルで表示

* **改善**
  * ノードの重なり問題を解決し、レイアウトの表示精度を向上
  * 選択状態インジケーターを追加
  * Escキーまたは閉じるボタンでオーバーレイを閉じられるように対応

<!-- end of auto-generated comment: release notes by coderabbit.ai -->