### PR TITLE
feat(r-panel): aim-tree write affordances — edit frontmatter + create node (graduation Stage 2-B)

### DIFF
--- a/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
@@ -32,10 +32,10 @@
 // prose in the wire body, not a structured field (the prototype's `BodyLine`
 // was a fixture invention).
 
-import { useEffect, useMemo, useState } from "react";
+import { type ReactNode, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { useUnitAims } from "@/hooks/useUnitAims";
-import type { AimWire } from "@/lib/api";
+import { type AimState, type AimWire, api } from "@/lib/api";
 import {
   AIM_GLYPH,
   AIM_STATE_LABEL,
@@ -52,6 +52,38 @@ import {
 } from "./aim-tree";
 import { Section } from "./Section";
 
+// Lifecycle states the operator can set, in glyph-legend order. Drives the
+// edit + create `state` selects. `AimState` is the generated wire enum.
+const AIM_STATES: readonly AimState[] = ["open", "done", "dead"];
+
+// Client-side slug validation for the create form — a fast-feedback MIRROR of
+// the backend's `validate_new_aim_slug` (tmai-core #501): non-empty, lowercase
+// kebab / filename-safe (`[a-z0-9-]`, no leading/trailing/doubled `-`), and
+// NON-dated (a `YYYY-MM-DD-` prefix is the decision/approach convention; aim
+// slugs are dateless stable identities). Returns an error string, or `null`
+// when valid. The backend stays authoritative (it owns the `409`/`422`); this
+// only spares the operator a round-trip on the obvious cases.
+export function validateAimSlug(slug: string): string | null {
+  if (slug === "") return "slug must not be empty";
+  if (!/^[a-z0-9-]+$/.test(slug)) {
+    return "lowercase kebab-case only ([a-z0-9-])";
+  }
+  if (slug.startsWith("-") || slug.endsWith("-") || slug.includes("--")) {
+    return "no leading / trailing / doubled '-'";
+  }
+  if (/^\d{4}-\d{2}-\d{2}/.test(slug)) {
+    return "must be NON-dated (no YYYY-MM-DD prefix)";
+  }
+  return null;
+}
+
+// Normalize a thrown API error into a short, operator-readable message. The
+// HTTP client throws `Error` whose message carries the backend's `409` / `422`
+// / `404` text; surface it verbatim, trimmed.
+function writeErrorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
 interface RAimsSectionProps {
   unitName: string | null;
   expanded: boolean;
@@ -59,7 +91,7 @@ interface RAimsSectionProps {
 }
 
 export function RAimsSection({ unitName, expanded, onToggle }: RAimsSectionProps) {
-  const { data, loading, error } = useUnitAims(unitName);
+  const { data, loading, error, refresh } = useUnitAims(unitName);
   // Flattened node set drives both the header count and the tree body.
   const nodes = useMemo(() => flattenRepos(data), [data]);
 
@@ -72,7 +104,7 @@ export function RAimsSection({ unitName, expanded, onToggle }: RAimsSectionProps
       expanded={expanded}
       onToggle={onToggle}
     >
-      <Body unitName={unitName} nodes={nodes} loading={loading} error={error} />
+      <Body unitName={unitName} nodes={nodes} loading={loading} error={error} refresh={refresh} />
     </Section>
   );
 }
@@ -82,29 +114,40 @@ interface BodyProps {
   nodes: AimWire[];
   loading: boolean;
   error: Error | null;
+  refresh: () => void;
 }
 
-function Body({ unitName, nodes, loading, error }: BodyProps) {
+function Body({ unitName, nodes, loading, error, refresh }: BodyProps) {
   if (unitName === null) {
     return <p className="text-subtle-foreground">Pick a project to see aims.</p>;
   }
   if (error !== null) {
     return <p className="text-muted-foreground">Failed to load aims: {error.message}</p>;
   }
+  // Unlike the read-only Stage 1-B, an empty tree is still actionable: the
+  // operator can author the first node. So the overlay (with its create
+  // affordance) is reachable even at zero aims — the thin entry shows the
+  // count and the ⤢ open, and the loading state only gates the very first
+  // fetch (nodes empty AND loading).
   if (nodes.length === 0 && loading) {
     return <p className="text-subtle-foreground">Loading…</p>;
   }
-  if (nodes.length === 0) {
-    return <p className="text-subtle-foreground">No aims.</p>;
-  }
-  return <AimsEntry nodes={nodes} />;
+  return <AimsEntry unitName={unitName} nodes={nodes} refresh={refresh} />;
 }
 
 // The thin R-panel entry: a compact summary + the glyph legend + an ⤢ open
 // affordance. Clicking open launches the maximized overlay; the open-state is
 // local and the overlay is portalled, so the section stays self-contained and
 // the narrow column is never widened.
-function AimsEntry({ nodes }: { nodes: AimWire[] }) {
+function AimsEntry({
+  unitName,
+  nodes,
+  refresh,
+}: {
+  unitName: string;
+  nodes: AimWire[];
+  refresh: () => void;
+}) {
   const [open, setOpen] = useState(false);
   const rootCount = useMemo(() => findRoots(nodes).length, [nodes]);
 
@@ -126,7 +169,14 @@ function AimsEntry({ nodes }: { nodes: AimWire[] }) {
         </button>
       </div>
       <GlyphLegend />
-      {open && <AimTreeOverlay nodes={nodes} onClose={() => setOpen(false)} />}
+      {open && (
+        <AimTreeOverlay
+          unitName={unitName}
+          nodes={nodes}
+          refresh={refresh}
+          onClose={() => setOpen(false)}
+        />
+      )}
     </div>
   );
 }
@@ -137,11 +187,26 @@ function AimsEntry({ nodes }: { nodes: AimWire[] }) {
 // (the Esc convention reused from `AttentionMarker` / `ConfirmDialog`).
 // Layout: the prototype's side-by-side 2-pane — a wide scrollable tree canvas
 // on the left, the body-on-select detail pane on the right.
-function AimTreeOverlay({ nodes, onClose }: { nodes: AimWire[]; onClose: () => void }) {
+function AimTreeOverlay({
+  unitName,
+  nodes,
+  refresh,
+  onClose,
+}: {
+  unitName: string;
+  nodes: AimWire[];
+  refresh: () => void;
+  onClose: () => void;
+}) {
   const [selected, setSelected] = useState<string | null>(null);
+  // Stage 2-B: the create form. Mutually exclusive with the detail pane (both
+  // live in the right aside) — opening it deselects so the operator authors a
+  // fresh node rather than reading one.
+  const [creating, setCreating] = useState(false);
   const childrenOf = useMemo(() => buildChildren(nodes), [nodes]);
   const layout = useMemo(() => computeLayout(nodes), [nodes]);
   const rootCount = layout.roots.length;
+  const allSlugs = useMemo(() => nodes.map((n) => n.slug), [nodes]);
 
   // Esc dismisses the whole overlay (the detail pane's ✕ / the legend's clear
   // handle deselect). Listener is document-level so it fires regardless of
@@ -194,15 +259,31 @@ function AimTreeOverlay({ nodes, onClose }: { nodes: AimWire[]; onClose: () => v
             onClear={() => setSelected(null)}
           />
         </div>
-        <button
-          type="button"
-          onClick={onClose}
-          title="Close aim-tree (Esc)"
-          aria-label="Close aim-tree"
-          className="shrink-0 rounded px-2 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
-        >
-          ✕
-        </button>
+        <div className="flex shrink-0 items-center gap-2">
+          {/* Stage 2-B create affordance. Opening the form clears any selection
+              so the right pane shows the form, not a node's body. */}
+          <button
+            type="button"
+            onClick={() => {
+              setSelected(null);
+              setCreating(true);
+            }}
+            title="Create a new aim node"
+            aria-label="New aim node"
+            className="rounded border border-hairline px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+          >
+            <span aria-hidden="true">＋</span> New node
+          </button>
+          <button
+            type="button"
+            onClick={onClose}
+            title="Close aim-tree (Esc)"
+            aria-label="Close aim-tree"
+            className="rounded px-2 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+          >
+            ✕
+          </button>
+        </div>
       </header>
 
       <div className="flex min-h-0 flex-1">
@@ -237,19 +318,38 @@ function AimTreeOverlay({ nodes, onClose }: { nodes: AimWire[]; onClose: () => v
           </div>
         </div>
 
-        {/* Right: the body-on-select detail pane (read-only). */}
+        {/* Right: the create form (Stage 2-B), the body-on-select detail pane
+            (with the inline edit affordance), or the click hint — in that
+            precedence. */}
         <aside className="flex w-[360px] shrink-0 flex-col overflow-y-auto border-l border-hairline">
-          {selectedNode !== null ? (
+          {creating ? (
+            <CreateForm
+              unitName={unitName}
+              existingSlugs={allSlugs}
+              refresh={refresh}
+              onClose={() => setCreating(false)}
+              onCreated={(slug) => {
+                setCreating(false);
+                setSelected(slug);
+              }}
+            />
+          ) : selectedNode !== null ? (
             <DetailPane
+              key={selectedNode.slug}
+              unitName={unitName}
               node={selectedNode}
               blastCount={blast.size}
+              parentOptions={allSlugs}
+              forbiddenParents={highlighted}
+              refresh={refresh}
               onClose={() => setSelected(null)}
             />
           ) : (
             <p className="p-6 text-xs text-subtle-foreground">
               Click a node to read its body and light its{" "}
               <span className="text-foreground">blast radius</span> — the descendant subtree that
-              would become drift-possible if that aim changed.
+              would become drift-possible if that aim changed. Or{" "}
+              <span className="text-foreground">＋ New node</span> to author one.
             </p>
           )}
         </aside>
@@ -459,19 +559,31 @@ function NodeBox({
   );
 }
 
-// Body-on-select detail pane — READ-ONLY. The prototype's editable frontmatter
-// inputs + create form are dropped (write is Stage 2). Frontmatter facts show
-// as a plain definition list; cross-edges (`depends_on` / `serves` / `related`)
-// list as slug text; the body renders raw.
+// Body-on-select detail pane. Stage 2-B adds an inline frontmatter EDIT
+// affordance (aim / parent / state only — cross-edges + body are preserved
+// server-side). When not editing, the frontmatter facts show as a plain
+// definition list (cross-edges as slug text) with an ✎ Edit button; the body
+// always renders raw, read-only (editing it is out of scope — the Producer
+// writes the body via normal file editing).
 function DetailPane({
+  unitName,
   node,
   blastCount,
+  parentOptions,
+  forbiddenParents,
+  refresh,
   onClose,
 }: {
+  unitName: string;
   node: AimWire;
   blastCount: number;
+  parentOptions: readonly string[];
+  forbiddenParents: ReadonlySet<string>;
+  refresh: () => void;
   onClose: () => void;
 }) {
+  const [editing, setEditing] = useState(false);
+
   return (
     <div data-testid="aim-detail" className="space-y-3 p-4">
       <div className="flex items-start justify-between gap-2">
@@ -497,31 +609,53 @@ function DetailPane({
         </button>
       </div>
 
-      {/* Frontmatter facts — read-only (the write affordance is Stage 2). */}
-      <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px]">
-        <dt className="text-subtle-foreground">state</dt>
-        <dd className="text-foreground">{AIM_STATE_LABEL[node.state]}</dd>
-        <dt className="text-subtle-foreground">parent</dt>
-        <dd className="font-mono text-muted-foreground">{node.parent ?? "(root)"}</dd>
-        {node.depends_on.length > 0 && (
-          <>
-            <dt className="text-subtle-foreground">depends_on</dt>
-            <dd className="font-mono text-muted-foreground">{node.depends_on.join(", ")}</dd>
-          </>
-        )}
-        {node.serves.length > 0 && (
-          <>
-            <dt className="text-subtle-foreground">serves</dt>
-            <dd className="font-mono text-muted-foreground">{node.serves.join(", ")}</dd>
-          </>
-        )}
-        {node.related.length > 0 && (
-          <>
-            <dt className="text-subtle-foreground">related</dt>
-            <dd className="font-mono text-muted-foreground">{node.related.join(", ")}</dd>
-          </>
-        )}
-      </dl>
+      {editing ? (
+        // Remount per node (`key`) so the draft always seeds from the current
+        // node, never a stale prior selection.
+        <AimEditForm
+          key={node.slug}
+          unitName={unitName}
+          node={node}
+          parentOptions={parentOptions}
+          forbiddenParents={forbiddenParents}
+          refresh={refresh}
+          onDone={() => setEditing(false)}
+        />
+      ) : (
+        <>
+          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px]">
+            <dt className="text-subtle-foreground">state</dt>
+            <dd className="text-foreground">{AIM_STATE_LABEL[node.state]}</dd>
+            <dt className="text-subtle-foreground">parent</dt>
+            <dd className="font-mono text-muted-foreground">{node.parent ?? "(root)"}</dd>
+            {node.depends_on.length > 0 && (
+              <>
+                <dt className="text-subtle-foreground">depends_on</dt>
+                <dd className="font-mono text-muted-foreground">{node.depends_on.join(", ")}</dd>
+              </>
+            )}
+            {node.serves.length > 0 && (
+              <>
+                <dt className="text-subtle-foreground">serves</dt>
+                <dd className="font-mono text-muted-foreground">{node.serves.join(", ")}</dd>
+              </>
+            )}
+            {node.related.length > 0 && (
+              <>
+                <dt className="text-subtle-foreground">related</dt>
+                <dd className="font-mono text-muted-foreground">{node.related.join(", ")}</dd>
+              </>
+            )}
+          </dl>
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            className="rounded border border-hairline px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+          >
+            <span aria-hidden="true">✎</span> Edit frontmatter
+          </button>
+        </>
+      )}
 
       <section className="space-y-1">
         <h4 className="text-[10px] uppercase tracking-wide text-subtle-foreground">Body</h4>
@@ -533,6 +667,332 @@ function DetailPane({
         {blastCount === 1 ? "" : "s"} drift-possible
       </p>
     </div>
+  );
+}
+
+// The inline frontmatter edit form (Stage 2-B): aim / parent / state ONLY. The
+// body and the cross-edges (`depends_on` / `serves` / `related`) are NOT touched
+// here — the backend preserves them byte-for-byte. Authority is operator-only,
+// soft: a plain Save, no draft/accept gate. The `parent` select excludes the
+// node itself and its descendants (`forbiddenParents`) so the operator can't
+// form a trivial cycle.
+function AimEditForm({
+  unitName,
+  node,
+  parentOptions,
+  forbiddenParents,
+  refresh,
+  onDone,
+}: {
+  unitName: string;
+  node: AimWire;
+  parentOptions: readonly string[];
+  forbiddenParents: ReadonlySet<string>;
+  refresh: () => void;
+  onDone: () => void;
+}) {
+  const [aim, setAim] = useState(node.aim);
+  const [parent, setParent] = useState<string>(node.parent ?? "");
+  const [state, setState] = useState<AimState>(node.state);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmedAim = aim.trim();
+  const canSave = trimmedAim !== "" && !submitting;
+
+  async function onSave() {
+    if (!canSave) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      await api.editAim(unitName, node.slug, {
+        aim: trimmedAim,
+        parent: parent === "" ? null : parent,
+        state,
+      });
+      refresh();
+      onDone();
+    } catch (e) {
+      setError(writeErrorMessage(e));
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form
+      className="space-y-2"
+      onSubmit={(e) => {
+        e.preventDefault();
+        void onSave();
+      }}
+    >
+      <AimField label="aim" htmlFor="aim-edit-aim">
+        <textarea
+          id="aim-edit-aim"
+          value={aim}
+          onChange={(e) => setAim(e.target.value)}
+          rows={2}
+          className="w-full resize-y rounded border border-hairline bg-surface px-2 py-1 text-xs text-foreground"
+        />
+      </AimField>
+      <AimField label="parent" htmlFor="aim-edit-parent">
+        <ParentSelect
+          id="aim-edit-parent"
+          value={parent}
+          onChange={setParent}
+          options={parentOptions}
+          forbidden={forbiddenParents}
+        />
+      </AimField>
+      <AimField label="state" htmlFor="aim-edit-state">
+        <StateSelect id="aim-edit-state" value={state} onChange={setState} />
+      </AimField>
+
+      {error !== null && (
+        <p role="alert" className="text-[11px] text-destructive">
+          {error}
+        </p>
+      )}
+
+      <div className="flex items-center gap-2">
+        <button
+          type="submit"
+          disabled={!canSave}
+          className="rounded border border-primary bg-primary/15 px-2 py-0.5 text-[11px] text-foreground transition-colors hover:bg-primary/25 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {submitting ? "Saving…" : "Save"}
+        </button>
+        <button
+          type="button"
+          onClick={onDone}
+          disabled={submitting}
+          className="rounded border border-hairline px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground disabled:opacity-40"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// The create form (Stage 2-B): author a new node — slug / aim / parent. `state`
+// starts `open`, the body starts empty, no cross-edges (the backend default).
+// Client-side slug validation gives fast feedback; the backend stays
+// authoritative (it owns the `409` duplicate / `422` dangling-parent verdicts,
+// surfaced inline). On success the parent re-fetches and selects the new node.
+function CreateForm({
+  unitName,
+  existingSlugs,
+  refresh,
+  onClose,
+  onCreated,
+}: {
+  unitName: string;
+  existingSlugs: readonly string[];
+  refresh: () => void;
+  onClose: () => void;
+  onCreated: (slug: string) => void;
+}) {
+  const [slug, setSlug] = useState("");
+  const [aim, setAim] = useState("");
+  const [parent, setParent] = useState("");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const trimmedSlug = slug.trim();
+  const trimmedAim = aim.trim();
+  const slugError = trimmedSlug === "" ? null : validateAimSlug(trimmedSlug);
+  const duplicate = existingSlugs.includes(trimmedSlug);
+  const canCreate =
+    trimmedSlug !== "" && trimmedAim !== "" && slugError === null && !duplicate && !submitting;
+
+  async function onCreate() {
+    if (!canCreate) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const created = await api.createAim(unitName, {
+        slug: trimmedSlug,
+        aim: trimmedAim,
+        parent: parent === "" ? null : parent,
+      });
+      refresh();
+      onCreated(created.slug);
+    } catch (e) {
+      setError(writeErrorMessage(e));
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <form
+      data-testid="aim-create"
+      className="space-y-2 p-4"
+      onSubmit={(e) => {
+        e.preventDefault();
+        void onCreate();
+      }}
+    >
+      <div className="flex items-center justify-between gap-2">
+        <h3 className="text-xs font-semibold text-foreground">＋ New aim node</h3>
+        <button
+          type="button"
+          onClick={onClose}
+          title="Cancel create"
+          aria-label="Cancel create"
+          className="shrink-0 rounded px-1.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+        >
+          ✕
+        </button>
+      </div>
+
+      <AimField label="slug" htmlFor="aim-create-slug">
+        <input
+          id="aim-create-slug"
+          value={slug}
+          onChange={(e) => setSlug(e.target.value)}
+          placeholder="kebab-case-identity"
+          className="w-full rounded border border-hairline bg-surface px-2 py-1 font-mono text-xs text-foreground"
+        />
+        {slugError !== null && <p className="mt-0.5 text-[10px] text-destructive">{slugError}</p>}
+        {slugError === null && duplicate && (
+          <p className="mt-0.5 text-[10px] text-destructive">slug already exists</p>
+        )}
+      </AimField>
+      <AimField label="aim" htmlFor="aim-create-aim">
+        <textarea
+          id="aim-create-aim"
+          value={aim}
+          onChange={(e) => setAim(e.target.value)}
+          rows={2}
+          placeholder="the human bearing, one line."
+          className="w-full resize-y rounded border border-hairline bg-surface px-2 py-1 text-xs text-foreground"
+        />
+      </AimField>
+      <AimField label="parent" htmlFor="aim-create-parent">
+        <ParentSelect
+          id="aim-create-parent"
+          value={parent}
+          onChange={setParent}
+          options={existingSlugs}
+          forbidden={EMPTY_FORBIDDEN}
+        />
+      </AimField>
+
+      {error !== null && (
+        <p role="alert" className="text-[11px] text-destructive">
+          {error}
+        </p>
+      )}
+
+      <div className="flex items-center gap-2">
+        <button
+          type="submit"
+          disabled={!canCreate}
+          className="rounded border border-primary bg-primary/15 px-2 py-0.5 text-[11px] text-foreground transition-colors hover:bg-primary/25 disabled:cursor-not-allowed disabled:opacity-40"
+        >
+          {submitting ? "Creating…" : "Create"}
+        </button>
+        <button
+          type="button"
+          onClick={onClose}
+          disabled={submitting}
+          className="rounded border border-hairline px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground disabled:opacity-40"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+// A stable empty set for the create form's parent select (no node to forbid —
+// a brand-new slug can't be its own ancestor). Module-level so it keeps a
+// constant identity across renders.
+const EMPTY_FORBIDDEN: ReadonlySet<string> = new Set<string>();
+
+// A labelled field row shared by the edit + create forms.
+function AimField({
+  label,
+  htmlFor,
+  children,
+}: {
+  label: string;
+  htmlFor: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="space-y-0.5">
+      <label
+        htmlFor={htmlFor}
+        className="block text-[10px] uppercase tracking-wide text-subtle-foreground"
+      >
+        {label}
+      </label>
+      {children}
+    </div>
+  );
+}
+
+// Parent slug select: "(root)" + every existing slug except those in
+// `forbidden` (self + descendants, for the edit form). A `value` not present in
+// the options still renders (the current parent is shown even if it were, in
+// some edge case, filtered) — but normal parents are always selectable.
+function ParentSelect({
+  id,
+  value,
+  onChange,
+  options,
+  forbidden,
+}: {
+  id: string;
+  value: string;
+  onChange: (next: string) => void;
+  options: readonly string[];
+  forbidden: ReadonlySet<string>;
+}) {
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(e) => onChange(e.target.value)}
+      className="w-full rounded border border-hairline bg-surface px-2 py-1 font-mono text-xs text-foreground"
+    >
+      <option value="">(root)</option>
+      {options
+        .filter((slug) => !forbidden.has(slug))
+        .map((slug) => (
+          <option key={slug} value={slug}>
+            {slug}
+          </option>
+        ))}
+    </select>
+  );
+}
+
+// State select — the three lifecycle states, labelled.
+function StateSelect({
+  id,
+  value,
+  onChange,
+}: {
+  id: string;
+  value: AimState;
+  onChange: (next: AimState) => void;
+}) {
+  return (
+    <select
+      id={id}
+      value={value}
+      onChange={(e) => onChange(e.target.value as AimState)}
+      className="w-full rounded border border-hairline bg-surface px-2 py-1 text-xs text-foreground"
+    >
+      {AIM_STATES.map((s) => (
+        <option key={s} value={s}>
+          {AIM_STATE_LABEL[s]}
+        </option>
+      ))}
+    </select>
   );
 }
 

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RAimsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RAimsSection.test.tsx
@@ -1,20 +1,24 @@
 // @vitest-environment jsdom
 //
-// RAimsSection — the aim-tree read view (graduation Stage 1-B, #780 + #782).
-// The section is now a THIN entry (summary + glyph legend + an ⤢ open
-// affordance); the actual 2D tree lives in a maximized overlay opened from it.
-// Covers the wire-backed states (render / loading / empty / error / parked),
-// the thin-entry summary, the overlay open / close (✕) / dismiss (Esc), and the
-// view machinery carried from prototype #778: body-on-select detail pane,
-// blast-radius highlight, the distinct dashed `depends_on` cross-edge, and the
-// neutral `dead` glyph with no severity color. Read-only — there is NO write
-// affordance (frontmatter edit / new node are Stage 2).
+// RAimsSection — the aim-tree read view (Stage 1-B, #780 + #782) PLUS the
+// write affordances (graduation Stage 2-B): create a node + edit a node's
+// frontmatter (aim/parent/state only), backed by tmai-core's #501 endpoints.
+// The section is a THIN entry (summary + glyph legend + an ⤢ open affordance);
+// the actual 2D tree + the write forms live in a maximized overlay opened from
+// it. Covers the wire-backed states (render / loading / empty / error / parked),
+// the thin-entry summary, the overlay open / close (✕) / dismiss (Esc), the
+// view machinery carried from prototype #778 (body-on-select detail pane,
+// blast-radius highlight, the distinct dashed `depends_on` cross-edge, the
+// neutral `dead` glyph), and the Stage 2-B write flows (create success +
+// client/backend validation, edit save / cancel).
 
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AimsResponse, AimWire } from "@/lib/api";
 
 const aimsMock = vi.fn();
+const createAimMock = vi.fn();
+const editAimMock = vi.fn();
 
 vi.mock("@/lib/api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
@@ -23,6 +27,8 @@ vi.mock("@/lib/api", async () => {
     api: {
       ...actual.api,
       aims: (...args: unknown[]) => aimsMock(...args),
+      createAim: (...args: unknown[]) => createAimMock(...args),
+      editAim: (...args: unknown[]) => editAimMock(...args),
     },
   };
 });
@@ -88,6 +94,8 @@ const TREE: AimWire[] = [
 
 beforeEach(() => {
   aimsMock.mockReset();
+  createAimMock.mockReset();
+  editAimMock.mockReset();
 });
 
 // Open the maximized overlay from the thin entry, returning the dialog element.
@@ -132,12 +140,19 @@ describe("RAimsSection — thin entry", () => {
     expect(screen.getByText("Loading…")).toBeTruthy();
   });
 
-  it("shows a placeholder when there are no aims", async () => {
+  it("stays actionable at zero aims (summary + open, so the first node can be authored)", async () => {
+    // Stage 2-B: unlike the read-only Stage 1-B's terminal "No aims."
+    // placeholder, an empty tree must still expose the create path so the
+    // operator can author the first node.
     aimsMock.mockResolvedValue(responseStub([]));
     render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
     await waitFor(() => {
-      expect(screen.getByText("No aims.")).toBeTruthy();
+      expect(screen.getByText(/0 aims/)).toBeTruthy();
     });
+    expect(screen.getByRole("button", { name: /Open aim-tree/ })).toBeTruthy();
+    // The overlay opens and exposes the create affordance even with no nodes.
+    await openOverlay();
+    expect(screen.getByRole("button", { name: /New aim node/ })).toBeTruthy();
   });
 
   it("surfaces a fetch error", async () => {
@@ -247,16 +262,161 @@ describe("RAimsSection — maximized overlay", () => {
     expect(screen.getAllByText("⊘").length).toBeGreaterThan(0);
     expect(document.body.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
   });
+});
 
-  it("does NOT render a write affordance (Stage 2 is out of scope)", async () => {
+describe("RAimsSection — Stage 2-B create", () => {
+  it("creates a node from the form and reflects it after the refresh", async () => {
+    const created = aimStub({ slug: "new-node", aim: "the new bearing" });
+    // Initial fetch is the base tree; the post-create refresh includes the new
+    // node so it lands in the canvas.
+    aimsMock.mockResolvedValueOnce(responseStub(TREE));
+    aimsMock.mockResolvedValue(responseStub([...TREE, created]));
+    createAimMock.mockResolvedValue(created);
+
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await openOverlay();
+
+    fireEvent.click(screen.getByRole("button", { name: /New aim node/ }));
+    fireEvent.change(screen.getByLabelText("slug"), { target: { value: "new-node" } });
+    fireEvent.change(screen.getByLabelText("aim"), { target: { value: "the new bearing" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(createAimMock).toHaveBeenCalledWith("u", {
+        slug: "new-node",
+        aim: "the new bearing",
+        parent: null,
+      });
+    });
+    // The refresh re-fetch surfaces the new node (in the canvas node box, and
+    // — since create selects it — the detail pane too, hence getAllByText).
+    await waitFor(() => {
+      expect(screen.getAllByText("the new bearing").length).toBeGreaterThan(0);
+    });
+  });
+
+  it("passes the selected parent through on create", async () => {
+    aimsMock.mockResolvedValue(responseStub(TREE));
+    createAimMock.mockResolvedValue(aimStub({ slug: "child", aim: "c", parent: "aim-system" }));
+
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await openOverlay();
+    fireEvent.click(screen.getByRole("button", { name: /New aim node/ }));
+    fireEvent.change(screen.getByLabelText("slug"), { target: { value: "child" } });
+    fireEvent.change(screen.getByLabelText("aim"), { target: { value: "c" } });
+    fireEvent.change(screen.getByLabelText("parent"), { target: { value: "aim-system" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(createAimMock).toHaveBeenCalledWith("u", {
+        slug: "child",
+        aim: "c",
+        parent: "aim-system",
+      });
+    });
+  });
+
+  it("blocks create on a client-invalid slug (dated) without calling the API", async () => {
     aimsMock.mockResolvedValue(responseStub(TREE));
     render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
     await openOverlay();
-    await screen.findByText("records を書く構造に");
-    // No "New node" / "Add child" / "Create" affordance carried from the
-    // prototype — this is the read-only view.
-    expect(screen.queryByText(/New node/i)).toBeNull();
-    expect(screen.queryByText(/Add child/i)).toBeNull();
-    expect(screen.queryByRole("button", { name: /Create/ })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /New aim node/ }));
+    fireEvent.change(screen.getByLabelText("slug"), { target: { value: "2026-01-02-x" } });
+    fireEvent.change(screen.getByLabelText("aim"), { target: { value: "a" } });
+
+    expect(screen.getByText(/NON-dated/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Create" })).toHaveProperty("disabled", true);
+    expect(createAimMock).not.toHaveBeenCalled();
+  });
+
+  it("flags a duplicate slug client-side before the API", async () => {
+    aimsMock.mockResolvedValue(responseStub(TREE));
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await openOverlay();
+    fireEvent.click(screen.getByRole("button", { name: /New aim node/ }));
+    // `aim-system` already exists in TREE.
+    fireEvent.change(screen.getByLabelText("slug"), { target: { value: "aim-system" } });
+    fireEvent.change(screen.getByLabelText("aim"), { target: { value: "a" } });
+
+    expect(screen.getByText(/already exists/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Create" })).toHaveProperty("disabled", true);
+    expect(createAimMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a backend rejection (409/422) inline", async () => {
+    aimsMock.mockResolvedValue(responseStub(TREE));
+    // Client-valid, non-duplicate slug that the backend nonetheless rejects
+    // (e.g. a race, or a rule the client mirror does not enforce).
+    createAimMock.mockRejectedValue(new Error("aim 'racy-node' already exists"));
+
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await openOverlay();
+    fireEvent.click(screen.getByRole("button", { name: /New aim node/ }));
+    fireEvent.change(screen.getByLabelText("slug"), { target: { value: "racy-node" } });
+    fireEvent.change(screen.getByLabelText("aim"), { target: { value: "a" } });
+    fireEvent.click(screen.getByRole("button", { name: "Create" }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert").textContent).toContain("already exists");
+    });
+  });
+});
+
+describe("RAimsSection — Stage 2-B edit", () => {
+  async function selectAndEdit(slug: string) {
+    aimsMock.mockResolvedValue(responseStub(TREE));
+    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await openOverlay();
+    fireEvent.click(await screen.findByRole("button", { name: new RegExp(slug) }));
+    const detail = await screen.findByTestId("aim-detail");
+    fireEvent.click(within(detail).getByRole("button", { name: /Edit frontmatter/ }));
+    return detail;
+  }
+
+  it("saves an edited aim / parent / state and re-fetches", async () => {
+    editAimMock.mockResolvedValue(aimStub({ slug: "aim-system", aim: "edited bearing" }));
+    const detail = await selectAndEdit("aim-system");
+
+    fireEvent.change(within(detail).getByLabelText("aim"), {
+      target: { value: "edited bearing" },
+    });
+    fireEvent.change(within(detail).getByLabelText("state"), { target: { value: "done" } });
+    fireEvent.click(within(detail).getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(editAimMock).toHaveBeenCalledWith("u", "aim-system", {
+        aim: "edited bearing",
+        parent: null,
+        state: "done",
+      });
+    });
+    // refresh() re-invokes the aims fetch after the write.
+    await waitFor(() => {
+      expect(aimsMock.mock.calls.length).toBeGreaterThan(1);
+    });
+  });
+
+  it("cancel leaves the node untouched (no API call)", async () => {
+    const detail = await selectAndEdit("aim-system");
+    fireEvent.change(within(detail).getByLabelText("aim"), { target: { value: "scrapped" } });
+    fireEvent.click(within(detail).getByRole("button", { name: "Cancel" }));
+
+    // Back to the read-only facts; no edit was sent.
+    expect(within(detail).getByText(/Edit frontmatter/)).toBeTruthy();
+    expect(editAimMock).not.toHaveBeenCalled();
+  });
+
+  it("excludes the node itself and its descendants from the parent options (no cycles)", async () => {
+    // Select amplify-human-judgment (root): its descendants are
+    // attention-per-artifact + attention-backend; none — nor itself — may
+    // become its parent.
+    const detail = await selectAndEdit("amplify-human-judgment");
+    const parentSelect = within(detail).getByLabelText("parent") as HTMLSelectElement;
+    const options = Array.from(parentSelect.options).map((o) => o.value);
+    expect(options).not.toContain("amplify-human-judgment");
+    expect(options).not.toContain("attention-per-artifact");
+    expect(options).not.toContain("attention-backend");
+    // A node outside the subtree is still a valid parent.
+    expect(options).toContain("aim-system");
   });
 });

--- a/clients/react/src/hooks/__tests__/useUnitAims.test.ts
+++ b/clients/react/src/hooks/__tests__/useUnitAims.test.ts
@@ -106,6 +106,29 @@ describe("useUnitAims", () => {
     expect(result.current.data?.repos[0]?.aims).toHaveLength(1);
   });
 
+  it("refresh() re-fetches the current unit without clearing (anti-flicker)", async () => {
+    vi.mocked(api.aims)
+      .mockResolvedValueOnce(response("tmai", 2))
+      .mockResolvedValue(response("tmai", 5));
+    const { result } = renderHook(() => useUnitAims("tmai"));
+    await waitFor(() => expect(result.current.data?.repos[0]?.aims).toHaveLength(2));
+
+    await act(async () => {
+      result.current.refresh();
+    });
+    await waitFor(() => expect(api.aims).toHaveBeenCalledTimes(2));
+    // The new response replaces the old in place — never cleared to null mid-refresh.
+    expect(result.current.data?.repos[0]?.aims).toHaveLength(5);
+  });
+
+  it("refresh() is a no-op while parked (unit=null)", async () => {
+    const { result } = renderHook(() => useUnitAims(null));
+    await act(async () => {
+      result.current.refresh();
+    });
+    expect(api.aims).not.toHaveBeenCalled();
+  });
+
   it("keeps the last response visible across the 60s poll", async () => {
     const setIntervalSpy = vi.spyOn(window, "setInterval");
 

--- a/clients/react/src/hooks/useUnitAims.ts
+++ b/clients/react/src/hooks/useUnitAims.ts
@@ -15,7 +15,7 @@
 // is selected so the section can render a placeholder rather than poll a
 // non-existent unit.
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { type AimsResponse, api } from "@/lib/api";
 
 const POLL_INTERVAL_MS = 60_000;
@@ -24,6 +24,14 @@ export interface UseUnitAimsResult {
   data: AimsResponse | null;
   loading: boolean;
   error: Error | null;
+  /**
+   * Imperatively re-fetch the current unit's aims, keeping the previous
+   * response visible while in flight (anti-flicker, same as the 60s poll). A
+   * no-op when the hook is parked (`unit = null`). Stage 2-B uses this so an
+   * operator write (create / edit) reflects the persisted record immediately
+   * instead of waiting on the next poll tick.
+   */
+  refresh: () => void;
 }
 
 export function useUnitAims(unit: string | null): UseUnitAimsResult {
@@ -33,6 +41,37 @@ export function useUnitAims(unit: string | null): UseUnitAimsResult {
   // An in-flight response from a previous unit must not stamp over a
   // newer unit's data (same guard as useUnitObservations / useApproaches).
   const generationRef = useRef(0);
+  // The live unit, so the stable `refresh` callback re-fetches the *current*
+  // unit without being re-created on every unit change.
+  const unitRef = useRef(unit);
+  unitRef.current = unit;
+
+  // One gen-guarded fetch against `targetUnit`, keeping the previous response
+  // visible (anti-flicker). Shared by the initial fetch, the 60s poll, and
+  // `refresh`. Stable identity (no deps) so it doesn't re-trigger the effect.
+  const fetchFor = useCallback(async (targetUnit: string, gen: number) => {
+    try {
+      const res = await api.aims(targetUnit);
+      if (gen !== generationRef.current) return;
+      setData(res);
+      setError(null);
+    } catch (e) {
+      if (gen !== generationRef.current) return;
+      setError(e instanceof Error ? e : new Error(String(e)));
+    } finally {
+      if (gen === generationRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  const refresh = useCallback(() => {
+    const u = unitRef.current;
+    if (!u) return;
+    // Re-fetch under the CURRENT generation, no data clear — the poll path's
+    // anti-flicker behaviour, triggered on demand after an operator write.
+    void fetchFor(u, generationRef.current);
+  }, [fetchFor]);
 
   useEffect(() => {
     if (!unit) {
@@ -44,38 +83,22 @@ export function useUnitAims(unit: string | null): UseUnitAimsResult {
     const myGen = ++generationRef.current;
     // Clear on unit *change* (this effect's only re-trigger — deps are
     // [unit]) so the previous unit's aims are never shown under the new
-    // unit's header. The 60s same-unit re-poll goes through fetchOnce, which
-    // intentionally keeps the last response visible (anti-flicker); that path
-    // is untouched. Mirrors the guard in useUnitObservations.
+    // unit's header. The 60s same-unit re-poll and `refresh` go through
+    // fetchFor, which intentionally keeps the last response visible
+    // (anti-flicker); those paths are untouched. Mirrors useUnitObservations.
     setData(null);
     setError(null);
     setLoading(true);
 
-    const fetchOnce = async () => {
-      try {
-        const res = await api.aims(unit);
-        if (myGen !== generationRef.current) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (myGen !== generationRef.current) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (myGen === generationRef.current) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void fetchOnce();
+    void fetchFor(unit, myGen);
     const id = window.setInterval(() => {
-      void fetchOnce();
+      void fetchFor(unit, myGen);
     }, POLL_INTERVAL_MS);
 
     return () => {
       window.clearInterval(id);
     };
-  }, [unit]);
+  }, [unit, fetchFor]);
 
-  return { data, loading, error };
+  return { data, loading, error, refresh };
 }

--- a/clients/react/src/lib/__tests__/api-aim-write.test.ts
+++ b/clients/react/src/lib/__tests__/api-aim-write.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+//
+// api.createAim / api.editAim — the aim-tree write surface (tmai-core #501,
+// graduation Stage 2-A; consumed by the WebUI Stage 2-B). Asserts the wire
+// contract: create POSTs the body to the collection path, edit PUTs the body to
+// the per-node path (slug URL-encoded), each returns the persisted `AimWire`,
+// and a backend rejection (409 / 422 / 404) propagates as an Error. Mirrors the
+// fetch-mock shape of `api-subscribe-terminal.test.ts`.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub window.location before module import so getConfig() resolves correctly.
+Object.defineProperty(window, "location", {
+  value: { origin: "http://localhost", search: "?token=tok" },
+  writable: true,
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import type { AimWire } from "../api-http";
+import { api } from "../api-http";
+
+const NODE: AimWire = {
+  slug: "aim-system",
+  aim: "records を書く構造に",
+  parent: null,
+  state: "open",
+  depends_on: [],
+  serves: [],
+  related: [],
+  body: "",
+};
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("api.createAim", () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValue(jsonResponse(NODE, 201));
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("POSTs the create body to /units/{unit}/aims and returns the node", async () => {
+    const body = { slug: "aim-system", aim: "records を書く構造に", parent: null };
+    const result = await api.createAim("tmai", body);
+    expect(result).toEqual(NODE);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toMatch(/\/api\/units\/tmai\/aims$/);
+    expect((init as RequestInit).method).toBe("POST");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual(body);
+  });
+
+  it("propagates a duplicate (409) as Error", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("aim 'x' already exists", { status: 409 }));
+    await expect(api.createAim("tmai", { slug: "x", aim: "a", parent: null })).rejects.toThrow(
+      /API error 409/,
+    );
+  });
+});
+
+describe("api.editAim", () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValue(jsonResponse(NODE));
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("PUTs the edit body to /units/{unit}/aims/{slug} and returns the node", async () => {
+    const body = { aim: "edited", parent: "aim-system", state: "done" as const };
+    const result = await api.editAim("tmai", "attention-backend", body);
+    expect(result).toEqual(NODE);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toMatch(/\/api\/units\/tmai\/aims\/attention-backend$/);
+    expect((init as RequestInit).method).toBe("PUT");
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual(body);
+  });
+
+  it("URL-encodes the slug", async () => {
+    await api.editAim("tmai", "a/b", { aim: "x", parent: null, state: "open" });
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toMatch(/\/aims\/a%2Fb$/);
+  });
+
+  it("propagates a missing node (404) as Error", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("not found", { status: 404 }));
+    await expect(
+      api.editAim("tmai", "ghost", { aim: "x", parent: null, state: "open" }),
+    ).rejects.toThrow(/API error 404/);
+  });
+});

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -2,6 +2,8 @@
 // Replaces Tauri IPC — all communication goes through the existing web API.
 
 import type { AgentCtxUsage } from "@/types/generated/AgentCtxUsage";
+import type { AimCreateRequest } from "@/types/generated/AimCreateRequest";
+import type { AimEditRequest } from "@/types/generated/AimEditRequest";
 import type { AimState } from "@/types/generated/AimState";
 import type { AimsResponse } from "@/types/generated/AimsResponse";
 import type { AimWire } from "@/types/generated/AimWire";
@@ -65,6 +67,8 @@ import type { WorkflowSnapshot } from "@/types/generated/WorkflowSnapshot";
 
 export type {
   AgentCtxUsage,
+  AimCreateRequest,
+  AimEditRequest,
   AimState,
   AimsResponse,
   AimWire,
@@ -1555,6 +1559,30 @@ export const api = {
   // only in the `tmai-core` repo, but the wire is already multi-repo
   // (`AimsResponse.repos[]`), same as decisions / approaches / observations.
   aims: (unit: string) => apiFetch<AimsResponse>(`/units/${encodeURIComponent(unit)}/aims`),
+
+  // Aim-tree write surface (tmai-core #501, graduation Stage 2-A). Operator-only,
+  // soft authority (like the in-tmai merge button — no draft/accept gate). Both
+  // return the persisted `AimWire`, re-parsed server-side, so callers re-render
+  // from the authoritative record.
+  //
+  // Create a node — `state` defaults to `open`, empty body, no cross-edges.
+  // `409` if the slug already exists; `422` for a dated/bad slug or a dangling
+  // parent (the backend stays authoritative over the client-side slug check).
+  createAim: (unit: string, body: AimCreateRequest) =>
+    apiFetch<AimWire>(`/units/${encodeURIComponent(unit)}/aims`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
+
+  // Edit a node's frontmatter — `aim` / `parent` / `state` ONLY. The backend
+  // preserves the body and the cross-edges (`depends_on` / `serves` / `related`)
+  // byte-for-byte (cross-edge editing is a deferred increment). `404` if the
+  // slug is absent.
+  editAim: (unit: string, slug: string, body: AimEditRequest) =>
+    apiFetch<AimWire>(`/units/${encodeURIComponent(unit)}/aims/${encodeURIComponent(slug)}`, {
+      method: "PUT",
+      body: JSON.stringify(body),
+    }),
 
   // Unit-scoped cross-repo open-PR list — Stage-1 in-tmai dev-loop
   // (DR `2026-05-16-dev-loop-completes-in-tmai.md` §A). One unified

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -7,6 +7,8 @@ export * from "./teams";
 
 import type {
   AgentSnapshot,
+  AimCreateRequest,
+  AimEditRequest,
   AttentionSetRequest,
   DispatchBundle,
   OrchestratorRules,
@@ -271,6 +273,11 @@ export const api = {
   // Aims view (HTTP only — on-demand JSON projection of the unit's
   // doc/aims/ records; no Tauri-specific path needed)
   aims: (unit: string) => httpApi.aims(unit),
+
+  // Aim-tree write surface (tmai-core #501; HTTP only — file-backed
+  // doc/aims/ records served over the web API, no Tauri-specific path needed)
+  createAim: (unit: string, body: AimCreateRequest) => httpApi.createAim(unit, body),
+  editAim: (unit: string, slug: string, body: AimEditRequest) => httpApi.editAim(unit, slug, body),
 
   // Unit-scoped cross-repo PR list (HTTP only — gh-CLI passthrough
   // fanned out over the unit's repos; no Tauri-specific path needed)


### PR DESCRIPTION
The WebUI half of the aim-tree write surface. Stage 1-B landed the **read** view (#780/#782); tmai-core #501 added the typed **write** endpoints + frontmatter serialization, and the gen-synced request types (`AimEditRequest` / `AimCreateRequest`) landed in `clients/react/src/types/generated/` via the gen-spec bot PR #784. This re-introduces the prototype's write affordances (#778), now backed by the real endpoints instead of in-memory mutation.

## Scope (mirrors the backend)
**edit + create, frontmatter ONLY** (`aim` / `parent` / `state`). Cross-edge editing (`depends_on` / `serves` / `related`) is **deferred** — the form does not touch them and the backend preserves them byte-for-byte. No drift-mark (Stage 3). Authority is **operator-only, soft** (like the in-tmai merge button — no draft/accept gate).

## Changes
- **api client** (`api-http.ts` + `api-tauri.ts`): `createAim` (POST `/units/{unit}/aims`) + `editAim` (PUT `/units/{unit}/aims/{slug}`), typed by the generated `AimCreateRequest` / `AimEditRequest`, returning `AimWire`.
- **`useUnitAims`**: a `refresh()` that re-fetches the current unit in place (anti-flicker), so a write reflects immediately instead of waiting on the 60s poll.
- **`RAimsSection` overlay**:
  - **Create** — a "＋ New node" form (slug / aim / parent) with client-side slug validation (mirrors `validate_new_aim_slug`: non-empty, lowercase kebab, NON-dated; duplicate flagged) for fast feedback; the backend stays authoritative on `409` / `422`, surfaced inline. On success the tree re-fetches and the new node is selected.
  - **Edit** — the `DetailPane` gains an inline edit mode (aim / parent / state). The `parent` select excludes the node itself and its descendants to prevent trivial cycles. Save → `editAim` → refresh; Cancel reverts.
  - The empty state is now **actionable** (the first node can be authored) instead of a terminal "No aims." placeholder.

## Gate (all green)
`clients/react`: biome `check` + `tsc -b` + `vitest` (711 passed / 2 skipped) + `vite build`. Generated artifacts (`src/types/generated/**`) are **not** hand-edited — they arrived via the #784 gen-spec bot PR.

## Notes
- No tracking issue was filed for S2-B (issue creation was permission-gated); this PR references tmai-core #501 (backend) directly.
- Backend contract: tmai-core #501 (PR trust-delta/tmai-core#502).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 目標ツリーに新しい目標ノードを作成・編集できる機能を追加しました
  * 目標ツリーオーバーレイに「＋ New node」ボタンを追加しました
  * 目標スラッグのクライアント側バリデーション機能を実装しました

* **改善**
  * 目標一覧が空の場合でも、目標作成画面への遷移が可能になりました
  * 目標の作成・編集後に自動的に最新データを再読み込みするようにしました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->