### PR TITLE
Stage C: UI shells — unit tabs + PR/Issue status pills + worker session headers (#788)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -8,6 +8,7 @@ import { TripwireBanner } from "@/components/calibration/TripwireBanner";
 import { HelpOverlay } from "@/components/layout/HelpOverlay";
 import { StatusBar } from "@/components/layout/StatusBar";
 import { ToastContainer, useToast } from "@/components/layout/ToastContainer";
+import { UnitTabs } from "@/components/layout/UnitTabs";
 import { HandoffRitualFailureDialog } from "@/components/producer-console/HandoffRitualFailureDialog";
 import { HandoffRitualOverlay } from "@/components/producer-console/HandoffRitualOverlay";
 import { ProducerConsole } from "@/components/producer-console/ProducerConsole";
@@ -42,7 +43,14 @@ import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
 import { useSplitPane } from "@/hooks/useSplitPane";
 import { useUnits } from "@/hooks/useUnits";
 import { useWorktrees } from "@/hooks/useWorktrees";
-import { api, groupByProject, isAiAgentLoose, type Selection, setCallerCwd } from "@/lib/api";
+import {
+  api,
+  groupByProject,
+  isAiAgentLoose,
+  type Selection,
+  setCallerCwd,
+  type UnitResponse,
+} from "@/lib/api";
 import { findProducerForUnit } from "@/lib/producer";
 import { useSSE } from "@/lib/sse-provider";
 import { ATTENTION_STRIP_WIDTH_DEFAULT, clampAttentionStripWidth } from "@/lib/ui-prefs";
@@ -517,6 +525,31 @@ export function App() {
     [closeMobileDrawer],
   );
 
+  // C1 unit-tab click → re-scope the focused unit. A unit is addressed by
+  // its PRIMARY repo path (where the Producer runs) — the same path
+  // `currentProject` carries — so we resolve that and reuse the existing
+  // project re-scope. Falls back to the first repo if no `primary` flag.
+  const handleSelectUnit = useCallback(
+    (unit: UnitResponse) => {
+      const repo = unit.repos.find((r) => r.primary) ?? unit.repos[0];
+      if (!repo) return;
+      handleSelectProject(repo.path, unit.name);
+    },
+    [handleSelectProject],
+  );
+
+  // C1 `+` affordance — "add unit = launch Producer". v1 placeholder: copy
+  // the canonical launch command to the clipboard (secure-context only;
+  // localhost qualifies) and toast it, mirroring the Phase-A "Open Producer
+  // terminal" clipboard fallback. NO new launch endpoint (issue #788 scope).
+  const handleAddUnit = useCallback(() => {
+    const cmd = "tmai producer <path-to-unit-primary-repo>";
+    navigator.clipboard
+      ?.writeText(cmd)
+      .then(() => toastSuccess(`Copied: ${cmd} — run it in a repo to add a unit`))
+      .catch(() => toastInfo(`Add a unit by launching a Producer: ${cmd}`));
+  }, [toastSuccess, toastInfo]);
+
   // Keyboard shortcuts handlers
   useKeyboardShortcuts([
     {
@@ -592,6 +625,20 @@ export function App() {
       <UsagePanel />
     </>
   );
+
+  // C1 unit-tab strip — rendered in the StatusBar (top bar) when the engine
+  // reports configured `[[unit]]` membership. A single configured unit
+  // collapses to one tab; the component renders N. Omitted when the units
+  // wire is empty (cwd-synthesized units aren't enumerated there).
+  const unitTabsNode =
+    (unitsData?.units.length ?? 0) > 0 ? (
+      <UnitTabs
+        units={unitsData?.units ?? []}
+        activeUnitName={unitName}
+        onSelectUnit={handleSelectUnit}
+        onAddUnit={handleAddUnit}
+      />
+    ) : null;
 
   // Focus-mode viewer node (spine `2026-05-29-c-and-r-as-the-development-
   // substrate`). At most one of the three is non-null (`useFocusedArtifact`
@@ -687,6 +734,7 @@ export function App() {
             onReturnToConsole={
               selection !== null || mainPanel !== "agents" ? returnToConsole : undefined
             }
+            unitTabs={sidebarCollapsed ? undefined : unitTabsNode}
           />
           {!sidebarCollapsed && (
             <div className="flex flex-1 flex-col overflow-y-auto">{sidebarContent}</div>
@@ -739,6 +787,7 @@ export function App() {
             onReturnToConsole={
               selection !== null || mainPanel !== "agents" ? returnToConsole : undefined
             }
+            unitTabs={unitTabsNode}
           />
         )}
 

--- a/clients/react/src/components/layout/StatusBar.tsx
+++ b/clients/react/src/components/layout/StatusBar.tsx
@@ -24,6 +24,10 @@ interface StatusBarProps {
   /** Mobile: show hamburger button instead of collapse arrow */
   isMobile?: boolean;
   onMobileMenuClick?: () => void;
+  /** Unit-tab strip (C1) rendered as a second row below the brand row in
+   *  the desktop (expanded) and mobile variants. Omitted in the collapsed
+   *  sidebar (too narrow). Composed by App from `useUnits`. */
+  unitTabs?: ReactNode;
 }
 
 // Top status bar with glassmorphism
@@ -38,69 +42,73 @@ export function StatusBar({
   onReturnToConsole,
   isMobile,
   onMobileMenuClick,
+  unitTabs,
 }: StatusBarProps) {
   if (isMobile) {
     return (
-      <div className="flex items-center justify-between border-b border-hairline px-3 py-2">
-        <div className="flex items-center gap-2">
-          <button
-            type="button"
-            onClick={onMobileMenuClick}
-            className="touch-target flex items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
-            title="Open navigation"
-            aria-label="Open navigation menu"
-          >
-            <svg
-              width="20"
-              height="20"
-              viewBox="0 0 20 20"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              strokeLinecap="round"
-            >
-              <title>Menu</title>
-              <path d="M3 5h14M3 10h14M3 15h14" />
-            </svg>
-          </button>
-          <span className="bg-gradient-to-r from-[var(--brand-from)] to-[var(--brand-to)] bg-clip-text text-sm font-bold tracking-wide text-transparent">
-            tmai
-          </span>
-          {attentionCount > 0 && (
-            <span className="glow-amber rounded-full bg-warning/15 px-2 py-0.5 text-xs text-warning">
-              {attentionCount}
-            </span>
-          )}
-        </div>
-        <div className="flex items-center gap-1">
-          {onReturnToConsole && (
+      <div className="border-b border-hairline">
+        <div className="flex items-center justify-between px-3 py-2">
+          <div className="flex items-center gap-2">
             <button
               type="button"
-              onClick={onReturnToConsole}
+              onClick={onMobileMenuClick}
               className="touch-target flex items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
-              title="Return to Producer console"
-              aria-label="Return to Producer console"
+              title="Open navigation"
+              aria-label="Open navigation menu"
             >
-              🏠
+              <svg
+                width="20"
+                height="20"
+                viewBox="0 0 20 20"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+                strokeLinecap="round"
+              >
+                <title>Menu</title>
+                <path d="M3 5h14M3 10h14M3 15h14" />
+              </svg>
             </button>
-          )}
-          <button
-            type="button"
-            onClick={onSecurityClick}
-            className="touch-target flex items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
-            title="Config Audit"
-          >
-            🛡
-          </button>
-          <button
-            type="button"
-            onClick={onSettingsClick}
-            className="touch-target flex items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
-            title="Settings"
-          >
-            ⚙
-          </button>
+            <span className="bg-gradient-to-r from-[var(--brand-from)] to-[var(--brand-to)] bg-clip-text text-sm font-bold tracking-wide text-transparent">
+              tmai
+            </span>
+            {attentionCount > 0 && (
+              <span className="glow-amber rounded-full bg-warning/15 px-2 py-0.5 text-xs text-warning">
+                {attentionCount}
+              </span>
+            )}
+          </div>
+          <div className="flex items-center gap-1">
+            {onReturnToConsole && (
+              <button
+                type="button"
+                onClick={onReturnToConsole}
+                className="touch-target flex items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
+                title="Return to Producer console"
+                aria-label="Return to Producer console"
+              >
+                🏠
+              </button>
+            )}
+            <button
+              type="button"
+              onClick={onSecurityClick}
+              className="touch-target flex items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
+              title="Config Audit"
+            >
+              🛡
+            </button>
+            <button
+              type="button"
+              onClick={onSettingsClick}
+              className="touch-target flex items-center justify-center rounded-lg text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
+              title="Settings"
+            >
+              ⚙
+            </button>
+          </div>
         </div>
+        {unitTabs && <div className="overflow-x-auto px-2 pb-2">{unitTabs}</div>}
       </div>
     );
   }
@@ -150,68 +158,71 @@ export function StatusBar({
   }
 
   return (
-    <div className="flex items-center justify-between border-b border-hairline px-4 py-3">
-      <div className="flex items-center gap-2">
-        {onToggleCollapse && (
-          <button
-            type="button"
-            onClick={onToggleCollapse}
-            className="rounded px-1 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
-            title="Collapse sidebar"
-          >
-            <svg
-              width="16"
-              height="16"
-              viewBox="0 0 16 16"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="1.5"
+    <div className="border-b border-hairline">
+      <div className="flex items-center justify-between px-4 py-3">
+        <div className="flex items-center gap-2">
+          {onToggleCollapse && (
+            <button
+              type="button"
+              onClick={onToggleCollapse}
+              className="rounded px-1 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
+              title="Collapse sidebar"
             >
-              <title>Collapse sidebar</title>
-              <path d="M10 3l-5 5 5 5" />
-            </svg>
-          </button>
-        )}
-        <span className="bg-gradient-to-r from-[var(--brand-from)] to-[var(--brand-to)] bg-clip-text text-sm font-bold tracking-wide text-transparent">
-          tmai
-        </span>
-      </div>
-      <div className="flex items-center gap-2 text-xs">
-        <span className="text-muted-foreground">{agentCount} agents</span>
-        {attentionCount > 0 && (
-          <span className="glow-amber rounded-full bg-warning/15 px-2.5 py-0.5 text-warning">
-            {attentionCount}
+              <svg
+                width="16"
+                height="16"
+                viewBox="0 0 16 16"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="1.5"
+              >
+                <title>Collapse sidebar</title>
+                <path d="M10 3l-5 5 5 5" />
+              </svg>
+            </button>
+          )}
+          <span className="bg-gradient-to-r from-[var(--brand-from)] to-[var(--brand-to)] bg-clip-text text-sm font-bold tracking-wide text-transparent">
+            tmai
           </span>
-        )}
-        {indicatorSlot}
-        {onReturnToConsole && (
+        </div>
+        <div className="flex items-center gap-2 text-xs">
+          <span className="text-muted-foreground">{agentCount} agents</span>
+          {attentionCount > 0 && (
+            <span className="glow-amber rounded-full bg-warning/15 px-2.5 py-0.5 text-warning">
+              {attentionCount}
+            </span>
+          )}
+          {indicatorSlot}
+          {onReturnToConsole && (
+            <button
+              type="button"
+              onClick={onReturnToConsole}
+              className="rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
+              title="Return to Producer console"
+              aria-label="Return to Producer console"
+            >
+              🏠
+            </button>
+          )}
           <button
             type="button"
-            onClick={onReturnToConsole}
+            onClick={onSecurityClick}
             className="rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
-            title="Return to Producer console"
-            aria-label="Return to Producer console"
+            title="Config Audit"
           >
-            🏠
+            🛡
           </button>
-        )}
-        <button
-          type="button"
-          onClick={onSecurityClick}
-          className="rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
-          title="Config Audit"
-        >
-          🛡
-        </button>
-        <button
-          type="button"
-          onClick={onSettingsClick}
-          className="rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
-          title="Settings"
-        >
-          ⚙
-        </button>
+          <button
+            type="button"
+            onClick={onSettingsClick}
+            className="rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
+            title="Settings"
+          >
+            ⚙
+          </button>
+        </div>
       </div>
+      {unitTabs && <div className="overflow-x-auto px-2 pb-2">{unitTabs}</div>}
     </div>
   );
 }

--- a/clients/react/src/components/layout/UnitTabs.tsx
+++ b/clients/react/src/components/layout/UnitTabs.tsx
@@ -1,0 +1,123 @@
+// Unit-tab strip for the top bar (C1, Stage C aim-console convergence).
+//
+// One tab per configured `[[unit]]` (from `useUnits` → `UnitsResponse`),
+// each showing the unit's repos as pills (primary highlighted vs secondary)
+// plus an attention rollup badge (⚠N). The active unit is highlighted;
+// clicking a tab re-scopes the focused unit. A trailing `+` conveys "add
+// unit = launch Producer" (a clipboard/toast placeholder — no new launch
+// endpoint, mirroring the existing Phase-A "Open Producer terminal"
+// pattern). Mock reference: `origin/mock/aim-ui-sample` top bar.
+//
+// Built to render N units; one configured unit today collapses to a single
+// tab. The attention rollup lives in a per-unit child (`UnitTab`) so each
+// tab can call `useUnitAttention(unit)` on its own — scaling to N without a
+// rules-of-hooks violation.
+
+import { useUnitAttention } from "@/hooks/useUnitAttention";
+import type { UnitResponse } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+function repoBasename(path: string): string {
+  return path.split("/").filter(Boolean).pop() ?? path;
+}
+
+interface UnitTabsProps {
+  units: UnitResponse[];
+  /** Name of the currently focused unit (App derives it from the selected
+   *  project's basename), so the matching tab highlights. */
+  activeUnitName: string | null;
+  /** Re-scope the focused unit to the clicked one. */
+  onSelectUnit: (unit: UnitResponse) => void;
+  /** "Add unit = launch Producer" affordance (placeholder/clipboard). */
+  onAddUnit: () => void;
+}
+
+export function UnitTabs({ units, activeUnitName, onSelectUnit, onAddUnit }: UnitTabsProps) {
+  return (
+    <div data-testid="unit-tabs" className="flex flex-wrap items-center gap-1">
+      {units.map((unit) => (
+        <UnitTab
+          key={unit.name}
+          unit={unit}
+          active={unit.name === activeUnitName}
+          onSelect={() => onSelectUnit(unit)}
+        />
+      ))}
+      <button
+        type="button"
+        onClick={onAddUnit}
+        title="Add unit = launch a Producer in a unit's primary repo"
+        aria-label="Add unit — launch Producer"
+        className="flex h-6 w-6 shrink-0 items-center justify-center rounded border border-hairline-strong/40 text-muted-foreground transition-colors hover:border-primary/40 hover:text-primary"
+      >
+        +
+      </button>
+    </div>
+  );
+}
+
+function UnitTab({
+  unit,
+  active,
+  onSelect,
+}: {
+  unit: UnitResponse;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  // Per-unit attention rollup: count the operator-set `high` markers across
+  // this unit's artifacts (the ⚠N "owed attention" badge). Reuses the
+  // existing `useUnitAttention` wire — no new endpoint (issue #788 C1).
+  const { data } = useUnitAttention(unit.name);
+  const highCount = data?.entries.filter((e) => e.level === "high").length ?? 0;
+
+  return (
+    <button
+      type="button"
+      onClick={onSelect}
+      aria-current={active ? "true" : undefined}
+      // Explicit label so the tab's accessible name is the unit (the
+      // content is just repo-basename pills + an icon badge).
+      aria-label={`unit: ${unit.name}`}
+      title={`unit: ${unit.name}`}
+      className={cn(
+        "flex shrink-0 items-center gap-1.5 rounded-t border-b-2 px-2 py-1 transition-colors",
+        active
+          ? "border-primary text-foreground"
+          : "border-transparent text-muted-foreground hover:bg-surface-strong hover:text-foreground",
+      )}
+    >
+      {unit.repos.map((repo) => (
+        <RepoPill key={repo.path} label={repoBasename(repo.path)} primary={repo.primary} />
+      ))}
+      {highCount > 0 && (
+        <span
+          data-testid="unit-attention-rollup"
+          title={`${highCount} owed attention`}
+          className="rounded bg-warning/15 px-1 font-mono text-[9px] text-warning"
+        >
+          ⚠{highCount}
+        </span>
+      )}
+    </button>
+  );
+}
+
+function RepoPill({ label, primary }: { label: string; primary: boolean }) {
+  return (
+    <span
+      data-testid="repo-pill"
+      data-primary={primary ? "true" : "false"}
+      className={cn(
+        "rounded border px-1 font-mono text-[9px] tracking-wide",
+        // Primary repo (where the Producer launches) gets the themed accent
+        // ring; secondary repos stay quiet. Categorical, not severity.
+        primary
+          ? "border-info/40 bg-info/10 text-info"
+          : "border-hairline-strong/40 text-muted-foreground",
+      )}
+    >
+      {label}
+    </span>
+  );
+}

--- a/clients/react/src/components/layout/__tests__/UnitTabs.test.tsx
+++ b/clients/react/src/components/layout/__tests__/UnitTabs.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+//
+// UnitTabs (C1) — one tab per configured unit: repo pills (primary
+// highlighted), active highlight, ⚠N attention rollup (from the existing
+// `useUnitAttention` wire), select + add affordances.
+
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AttentionStateResponse, UnitResponse } from "@/lib/api";
+
+const unitAttentionMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      unitAttention: (...args: unknown[]) => unitAttentionMock(...args),
+    },
+  };
+});
+
+import { UnitTabs } from "../UnitTabs";
+
+function unit(overrides: Partial<UnitResponse> = {}): UnitResponse {
+  return {
+    name: "tmai",
+    repos: [
+      { path: "/home/me/works/tmai", primary: true },
+      { path: "/home/me/works/tmai-core", primary: false },
+    ],
+    ...overrides,
+  };
+}
+
+function attention(entries: AttentionStateResponse["entries"] = []): AttentionStateResponse {
+  return { unit: "tmai", entries };
+}
+
+beforeEach(() => {
+  unitAttentionMock.mockReset();
+  unitAttentionMock.mockResolvedValue(attention());
+});
+
+describe("UnitTabs", () => {
+  it("renders a tab per unit with repo pills, primary highlighted", () => {
+    render(
+      <UnitTabs
+        units={[unit()]}
+        activeUnitName="tmai"
+        onSelectUnit={vi.fn()}
+        onAddUnit={vi.fn()}
+      />,
+    );
+    const pills = screen.getAllByTestId("repo-pill");
+    expect(pills.map((p) => p.textContent)).toEqual(["tmai", "tmai-core"]);
+    // The primary repo carries the highlight flag; the secondary does not.
+    expect(pills[0].getAttribute("data-primary")).toBe("true");
+    expect(pills[1].getAttribute("data-primary")).toBe("false");
+  });
+
+  it("marks the active unit's tab with aria-current", () => {
+    render(
+      <UnitTabs
+        units={[unit(), unit({ name: "infra", repos: [{ path: "/p/infra", primary: true }] })]}
+        activeUnitName="infra"
+        onSelectUnit={vi.fn()}
+        onAddUnit={vi.fn()}
+      />,
+    );
+    const active = screen.getByRole("button", { name: /unit: infra/ });
+    expect(active.getAttribute("aria-current")).toBe("true");
+    const inactive = screen.getByRole("button", { name: /unit: tmai/ });
+    expect(inactive.getAttribute("aria-current")).toBeNull();
+  });
+
+  it("clicking a tab calls onSelectUnit with that unit", () => {
+    const onSelectUnit = vi.fn();
+    render(
+      <UnitTabs
+        units={[unit()]}
+        activeUnitName={null}
+        onSelectUnit={onSelectUnit}
+        onAddUnit={vi.fn()}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /unit: tmai/ }));
+    expect(onSelectUnit).toHaveBeenCalledTimes(1);
+    expect(onSelectUnit.mock.calls[0][0].name).toBe("tmai");
+  });
+
+  it("clicking + calls onAddUnit", () => {
+    const onAddUnit = vi.fn();
+    render(
+      <UnitTabs
+        units={[unit()]}
+        activeUnitName="tmai"
+        onSelectUnit={vi.fn()}
+        onAddUnit={onAddUnit}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Add unit/ }));
+    expect(onAddUnit).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders a ⚠N rollup of the unit's high-attention markers", async () => {
+    unitAttentionMock.mockResolvedValue(
+      attention([
+        { repo_path: "/home/me/works/tmai", section: "pr", id: "1", level: "high" },
+        { repo_path: "/home/me/works/tmai", section: "issue", id: "2", level: "high" },
+        { repo_path: "/home/me/works/tmai", section: "pr", id: "3", level: "low" },
+      ]),
+    );
+    render(
+      <UnitTabs
+        units={[unit()]}
+        activeUnitName="tmai"
+        onSelectUnit={vi.fn()}
+        onAddUnit={vi.fn()}
+      />,
+    );
+    const tab = screen.getByRole("button", { name: /unit: tmai/ });
+    await waitFor(() => {
+      // Only the two `high` markers count toward the owed-attention rollup.
+      expect(within(tab).getByTestId("unit-attention-rollup").textContent).toBe("⚠2");
+    });
+  });
+
+  it("shows no rollup badge when nothing is owed attention", async () => {
+    unitAttentionMock.mockResolvedValue(attention([]));
+    render(
+      <UnitTabs
+        units={[unit()]}
+        activeUnitName="tmai"
+        onSelectUnit={vi.fn()}
+        onAddUnit={vi.fn()}
+      />,
+    );
+    // Let the (empty) attention fetch resolve, then assert no badge.
+    await waitFor(() => expect(unitAttentionMock).toHaveBeenCalled());
+    expect(screen.queryByTestId("unit-attention-rollup")).toBeNull();
+  });
+});

--- a/clients/react/src/components/producer-console/r-panel/RIssuesSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RIssuesSection.tsx
@@ -1,10 +1,10 @@
 // 📋 Issues — R panel's raw issue inventory (R₁).
 //
 // Reuses `useUnitIssues` (one source — the issues twin of `useUnitPrs`).
-// Shows open issues grouped by repo across the whole unit, no
-// severity-color badges. R₁ intentionally carries NO appraisal-flavoured
-// badges (no `text-warning` / `text-success` / `text-destructive`) — an
-// issue's state / labels are facts, not triage. The unit-scoped endpoint
+// Shows open issues grouped by repo across the whole unit. Each row carries
+// a colour-coded lifecycle status pill (open / closed) from the wire
+// `state` (C2, Stage C aim-console convergence) — categorical state colour,
+// NOT severity appraisal (see `status-pills.tsx`). The unit-scoped endpoint
 // returns OPEN issues already, so there is no client-side `state` filter
 // (matching `RPrsSection`); the header count is the sum across repos.
 //
@@ -12,7 +12,7 @@
 // mirroring `RPrsSection`'s `onSelectIssue` / `selectedKey` /
 // `aria-current` exactly — the github.com link-out that used to live on
 // the issue number is gone; the issue's full content is reviewed in-tmai
-// with no round-trip. R₁ stays a pure inventory; the row is just a select.
+// with no round-trip.
 
 import type { AttentionControls } from "@/hooks/useUnitAttention";
 import { useUnitIssues } from "@/hooks/useUnitIssues";
@@ -20,6 +20,7 @@ import type { IssueInfo, IssueSummaryWire, RepoIssuesWire } from "@/lib/api";
 import { RowAttentionMarker } from "./AttentionMarker";
 import { type SelectedIssue, selectedIssueKey } from "./r-viewer/RIssueViewer";
 import { Section } from "./Section";
+import { ExternalSourceBadge, issueStatusPills, StatusPills } from "./status-pills";
 
 interface RIssuesSectionProps {
   unitName: string | null;
@@ -57,6 +58,7 @@ export function RIssuesSection({
       count={`${total} open`}
       expanded={expanded}
       onToggle={onToggle}
+      headerNote={<ExternalSourceBadge />}
     >
       <Body
         unitName={unitName}
@@ -207,9 +209,11 @@ function IssueRow({
           <span className="font-mono text-foreground">#{Number(issue.number)}</span>{" "}
           <span className="text-foreground">{issue.title}</span>
         </span>
-        <div className="text-[11px] text-subtle-foreground">
-          {issue.state.toLowerCase()}
-          {issue.labels.length > 0 && ` · ${issue.labels.map((l) => l.name).join(", ")}`}
+        <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-subtle-foreground">
+          <StatusPills pills={issueStatusPills(issue)} />
+          {issue.labels.length > 0 && (
+            <span className="font-mono">{issue.labels.map((l) => l.name).join(", ")}</span>
+          )}
         </div>
       </button>
     </li>

--- a/clients/react/src/components/producer-console/r-panel/RPrsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPrsSection.tsx
@@ -1,17 +1,22 @@
 // 🔀 PRs — R panel's raw PR inventory (R₁).
 //
-// Reuses `useUnitPrs` (one source). Shows open PRs grouped by repo, no
-// severity-color badges. Mechanical CI / review state is plain text:
-// R₁ intentionally carries NO appraisal-flavoured badges (no
-// `text-warning` / `text-success` / `text-destructive`) — see the
-// approach's "tmai は何を絶対しない" rules 2 and 4. The C-column
-// `UnitPrsSection` that once mirrored this inventory (and held the merge
-// action) is retired; R is now the single PR surface. The merge /
-// override / CI-rerun action layer lives in R₂ (`RPrViewer`), where the
-// soft-valve's severity accents are load-bearing affordances — distinct
-// from this plain inventory. A row click hands R₂ the PR plus the
-// repo-level `billing_dead` flag (which lives on `RepoPrsWire`, not on
-// the PR) so R₂ can offer the billing-dead override.
+// Reuses `useUnitPrs` (one source). Shows open PRs grouped by repo. Each
+// row carries colour-coded lifecycle / review / CI status pills (C2, Stage
+// C aim-console convergence) so the operator scans the inventory's shape
+// without opening every R₂ viewer (where these facts used to live only).
+//
+// Those pill colours are CATEGORICAL (which state), NOT appraisal — see
+// `status-pills.tsx`'s header for why this is consistent with the R₁
+// "tmai states facts, not appraisals" posture
+// (`2026-05-26-tmai-states-facts-not-appraisals`): the colour names a
+// lifecycle state, it never ranks urgency/importance. The operator's own
+// attention heat stays a separate axis (the `RowAttentionMarker`).
+//
+// The C-column `UnitPrsSection` that once mirrored this inventory (and held
+// the merge action) is retired; R is now the single PR surface. The merge /
+// override / CI-rerun action layer lives in R₂ (`RPrViewer`). A row click
+// hands R₂ the PR plus the repo-level `billing_dead` flag (which lives on
+// `RepoPrsWire`, not on the PR) so R₂ can offer the billing-dead override.
 
 import type { AttentionControls } from "@/hooks/useUnitAttention";
 import { useUnitPrs } from "@/hooks/useUnitPrs";
@@ -19,6 +24,7 @@ import type { PrSummaryWire, RepoPrsWire } from "@/lib/api";
 import { RowAttentionMarker } from "./AttentionMarker";
 import { type SelectedPr, selectedPrKey } from "./r-viewer/RPrViewer";
 import { Section } from "./Section";
+import { ExternalSourceBadge, prStatusPills, StatusPills } from "./status-pills";
 
 interface RPrsSectionProps {
   unitName: string | null;
@@ -58,6 +64,7 @@ export function RPrsSection({
       count={`${total} open`}
       expanded={expanded}
       onToggle={onToggle}
+      headerNote={<ExternalSourceBadge />}
     >
       <Body
         unitName={unitName}
@@ -172,14 +179,12 @@ function PrRow({
   selected: boolean;
   attention?: AttentionControls;
 }) {
-  // Plain-text status — no severity-color CI / review badges. The
-  // operator can read "CI SUCCESS" / "CI FAILURE" identically; R is
-  // inventory, not triage.
-  //
-  // The whole row is a button that opens the PR in the R₂ viewer
-  // (#749) — there is NO github.com link-out anymore; the PR's full
-  // content is reviewed in-tmai. `aria-current` marks the row whose
-  // content is currently open in R₂ (a mechanical "open here" fact).
+  // Colour-coded status pills (C2) — categorical lifecycle / review / CI
+  // state, NOT severity appraisal (see `status-pills.tsx`). The whole row
+  // is a button that opens the PR in the R₂ viewer (#749) — there is NO
+  // github.com link-out anymore; the PR's full content is reviewed
+  // in-tmai. `aria-current` marks the row whose content is currently open
+  // in R₂ (a mechanical "open here" fact).
   return (
     <li className="flex items-start gap-1.5 leading-snug">
       {/* Attention marker sits to the LEFT of the row (contract §3 core). */}
@@ -204,11 +209,11 @@ function PrRow({
           <span className="font-mono text-foreground">#{Number(pr.number)}</span>{" "}
           <span className="text-foreground">{pr.title}</span>
         </span>
-        <div className="text-[11px] text-subtle-foreground">
-          {pr.head_branch} → {pr.base_branch}
-          {pr.check_status !== null && ` · CI ${pr.check_status}`}
-          {pr.review_decision !== null && ` · ${pr.review_decision}`}
-          {pr.is_draft && " · draft"}
+        <div className="mt-0.5 flex flex-wrap items-center gap-x-2 gap-y-1 text-[11px] text-subtle-foreground">
+          <span className="font-mono">
+            {pr.head_branch} → {pr.base_branch}
+          </span>
+          <StatusPills pills={prStatusPills(pr)} />
         </div>
       </button>
     </li>

--- a/clients/react/src/components/producer-console/r-panel/Section.tsx
+++ b/clients/react/src/components/producer-console/r-panel/Section.tsx
@@ -28,9 +28,23 @@ interface SectionProps {
   expanded: boolean;
   onToggle: () => void;
   children: ReactNode;
+  /** Optional trailing note rendered in the header, right of the count
+   *  (the badge supplies its own `ml-auto`). Used by the PR / Issue
+   *  sections to carry the "EXTERNAL · github = source of truth" framing
+   *  (C2) — those are the github-resident artifacts on this panel. */
+  headerNote?: ReactNode;
 }
 
-export function Section({ id, glyph, label, count, expanded, onToggle, children }: SectionProps) {
+export function Section({
+  id,
+  glyph,
+  label,
+  count,
+  expanded,
+  onToggle,
+  children,
+  headerNote,
+}: SectionProps) {
   return (
     <section data-testid={`r-section-${id}`} data-expanded={expanded ? "true" : "false"}>
       <button
@@ -48,6 +62,7 @@ export function Section({ id, glyph, label, count, expanded, onToggle, children 
         </span>
         <h3 className="text-sm font-semibold text-foreground">{label}</h3>
         <span className="text-[11px] text-subtle-foreground">{count}</span>
+        {headerNote}
       </button>
       {expanded && (
         <div id={`r-section-body-${id}`} className="mt-1 pl-6 text-xs text-muted-foreground">

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RIssuesSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RIssuesSection.test.tsx
@@ -2,10 +2,12 @@
 //
 // RIssuesSection — open issue inventory (R₁), unit-scoped and grouped by
 // repo (the issues twin of RPrsSection, fed by `useUnitIssues` →
-// `api.unitIssues`). R₁ is pure inventory: no severity-color badges, no
-// github.com link-out — the row is an in-tmai select that opens the R₂
-// viewer with the wire's `repo_path` + `repo_label`. The endpoint returns
-// open issues already, so the header count is just the sum across repos.
+// `api.unitIssues`). Each row carries a colour-coded lifecycle status pill
+// (open / closed) from the wire `state` (C2, Stage C) — categorical state
+// colour, NOT severity appraisal. No github.com link-out — the row is an
+// in-tmai select that opens the R₂ viewer with the wire's `repo_path` +
+// `repo_label`. The endpoint returns open issues already, so the header
+// count is just the sum across repos.
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
@@ -119,15 +121,26 @@ describe("RIssuesSection", () => {
     expect(screen.getByText(/No issues/i)).toBeTruthy();
   });
 
-  it("uses no severity colors", async () => {
-    unitIssuesMock.mockResolvedValue(response([repo({ issues: [issue()] })]));
-    const { container } = render(
-      <RIssuesSection unitName="u" expanded={true} onToggle={vi.fn()} />,
+  it("renders a colour-coded lifecycle status pill from the wire state (C2)", async () => {
+    unitIssuesMock.mockResolvedValue(
+      response([
+        repo({ issues: [issue(), issue({ number: 2n, title: "Closed", state: "closed" })] }),
+      ]),
     );
-    await waitFor(() => {
-      expect(screen.getByText("Issue 1")).toBeTruthy();
-    });
-    expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
+    render(<RIssuesSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Issue 1")).toBeTruthy());
+    // open issue → `open` pill (categorical-`ok`); closed → `closed` (muted).
+    const open = screen.getByText("open").closest("[data-testid='status-pill']");
+    expect(open?.getAttribute("data-tone")).toBe("ok");
+    const closed = screen.getByText("closed").closest("[data-testid='status-pill']");
+    expect(closed?.getAttribute("data-tone")).toBe("muted");
+  });
+
+  it("renders the EXTERNAL · github framing badge on the section header", async () => {
+    unitIssuesMock.mockResolvedValue(response([repo({ issues: [issue()] })]));
+    render(<RIssuesSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Issue 1")).toBeTruthy());
+    expect(screen.getByTestId("external-source-badge")).toBeTruthy();
   });
 
   it("has NO github.com link-out — the row is an in-tmai select", async () => {

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RPrsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RPrsSection.test.tsx
@@ -1,9 +1,9 @@
 // @vitest-environment jsdom
 //
-// RPrsSection — open PR list (R₁) with NO severity-color CI / review
-// badges. R₁ is pure inventory; the merge/override action layer (with
-// its load-bearing soft-valve accents) lives in R₂. A row click threads
-// the repo-level `billing_dead` flag into the R₂ selection so the
+// RPrsSection — open PR list (R₁) with colour-coded lifecycle / review /
+// CI status pills (C2, Stage C). Those pill colours are CATEGORICAL (which
+// state), NOT severity appraisal — see `status-pills.tsx`. A row click
+// threads the repo-level `billing_dead` flag into the R₂ selection so the
 // override-merge affordance knows whether the PR's repo is flagged.
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
@@ -69,16 +69,50 @@ beforeEach(() => {
 });
 
 describe("RPrsSection", () => {
-  it("renders open PRs with plain (no-severity) CI / review status text", async () => {
+  it("renders colour-coded lifecycle / review / CI status pills (C2)", async () => {
+    // Fixture pr() is OPEN + APPROVED + SUCCESS → open / approved / CI pass
+    // pills, all categorical-`ok` (success) toned.
     unitPrsMock.mockResolvedValue(response([pr()]));
-    const { container } = render(<RPrsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    render(<RPrsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
 
     await waitFor(() => {
       expect(screen.getByText("PR title")).toBeTruthy();
     });
-    // Plain text: "CI SUCCESS · APPROVED" — no severity badge classes.
-    expect(screen.getByText(/CI SUCCESS/)).toBeTruthy();
-    expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
+    expect(screen.getByText("open")).toBeTruthy();
+    expect(screen.getByText("approved")).toBeTruthy();
+    expect(screen.getByText("CI pass")).toBeTruthy();
+    // Categorical colour IS allowed on these state pills (Stage C).
+    for (const pill of screen.getAllByTestId("status-pill")) {
+      expect(pill.getAttribute("data-tone")).toBe("ok");
+    }
+  });
+
+  it("maps draft / changes-requested / CI-failure to the right pill tones", async () => {
+    unitPrsMock.mockResolvedValue(
+      response([
+        pr({
+          number: 200n,
+          title: "draft PR",
+          is_draft: true,
+          review_decision: "CHANGES_REQUESTED",
+          check_status: "FAILURE",
+        }),
+      ]),
+    );
+    render(<RPrsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("draft PR")).toBeTruthy());
+    const tones = screen.getAllByTestId("status-pill").map((p) => p.getAttribute("data-tone"));
+    // draft → muted, changes requested → warn, CI fail → danger.
+    expect(tones).toEqual(["muted", "warn", "danger"]);
+    expect(screen.getByText("changes requested")).toBeTruthy();
+    expect(screen.getByText("CI fail")).toBeTruthy();
+  });
+
+  it("renders the EXTERNAL · github framing badge on the section header", async () => {
+    unitPrsMock.mockResolvedValue(response([pr()]));
+    render(<RPrsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("PR title")).toBeTruthy());
+    expect(screen.getByTestId("external-source-badge")).toBeTruthy();
   });
 
   it("header count shows `N open` from the wire (no aggregation)", async () => {
@@ -161,7 +195,7 @@ describe("RPrsSection — per-artifact attention markers", () => {
     expect(marker.className).toContain("attn-high");
   });
 
-  it("keeps the row's own machine facts neutral — only the marker carries heat", async () => {
+  it("keeps the operator attention-heat OFF the row button (orthogonal to status pills)", async () => {
     unitPrsMock.mockResolvedValue(response([pr()]));
     render(
       <RPrsSection
@@ -172,8 +206,9 @@ describe("RPrsSection — per-artifact attention markers", () => {
       />,
     );
     await waitFor(() => expect(screen.getByText("PR title")).toBeTruthy());
-    // The row button (CI/branch facts) is a machine-stated projection — it
-    // must stay neutral; heat lives ONLY on the attention marker.
+    // Operator-authored attention heat (`attn-high`/`attn-low`) is a
+    // separate axis from the C2 categorical status pills — it lives ONLY on
+    // the attention marker, never on the row button.
     const rowButton = screen.getByText("PR title").closest("button");
     expect(rowButton?.className).not.toMatch(/attn-high|attn-low/);
   });

--- a/clients/react/src/components/producer-console/r-panel/__tests__/status-pills.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/status-pills.test.tsx
@@ -1,0 +1,132 @@
+// @vitest-environment jsdom
+//
+// status-pills — the pure PR/Issue → pill derivation + the pill / EXTERNAL
+// badge rendering (C2). Categorical lifecycle / review / CI colour, NOT
+// severity appraisal.
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { IssueSummaryWire, PrSummaryWire } from "@/lib/api";
+import { ExternalSourceBadge, issueStatusPills, prStatusPills, StatusPills } from "../status-pills";
+
+function pr(overrides: Partial<PrSummaryWire> = {}): PrSummaryWire {
+  return {
+    number: 1n,
+    title: "t",
+    state: "OPEN",
+    head_branch: "feat/x",
+    head_sha: "abc",
+    base_branch: "main",
+    url: "u",
+    review_decision: null,
+    check_status: null,
+    is_draft: false,
+    additions: 0n,
+    deletions: 0n,
+    comments: 0n,
+    reviews: 0n,
+    author: "me",
+    merge_commit_sha: null,
+    ...overrides,
+  };
+}
+
+function issue(overrides: Partial<IssueSummaryWire> = {}): IssueSummaryWire {
+  return {
+    number: 1n,
+    title: "t",
+    state: "open",
+    url: "u",
+    labels: [],
+    assignees: [],
+    ...overrides,
+  };
+}
+
+describe("prStatusPills", () => {
+  it("open PR with no review / CI → a single `open` (ok) pill", () => {
+    expect(prStatusPills(pr())).toEqual([{ key: "lifecycle", label: "open", tone: "ok" }]);
+  });
+
+  it("draft takes precedence over the open lifecycle", () => {
+    expect(prStatusPills(pr({ is_draft: true }))[0]).toEqual({
+      key: "lifecycle",
+      label: "draft",
+      tone: "muted",
+    });
+  });
+
+  it("merged lifecycle from state OR a merge_commit_sha → info (accent) tone", () => {
+    expect(prStatusPills(pr({ state: "MERGED" }))[0].label).toBe("merged");
+    expect(prStatusPills(pr({ state: "OPEN", merge_commit_sha: "deadbeef" }))[0]).toEqual({
+      key: "lifecycle",
+      label: "merged",
+      tone: "info",
+    });
+  });
+
+  it("closed lifecycle → muted", () => {
+    expect(prStatusPills(pr({ state: "CLOSED" }))[0]).toEqual({
+      key: "lifecycle",
+      label: "closed",
+      tone: "muted",
+    });
+  });
+
+  it("maps the raw gh review_decision strings to short labels + tones", () => {
+    const tone = (d: string) =>
+      prStatusPills(pr({ review_decision: d })).find((p) => p.key === "review");
+    expect(tone("APPROVED")).toEqual({ key: "review", label: "approved", tone: "ok" });
+    expect(tone("CHANGES_REQUESTED")).toEqual({
+      key: "review",
+      label: "changes requested",
+      tone: "warn",
+    });
+    expect(tone("REVIEW_REQUIRED")).toEqual({ key: "review", label: "review", tone: "warn" });
+    // Unknown values pass through lowercased + muted (no lockstep with gh).
+    expect(tone("DISMISSED")).toEqual({ key: "review", label: "dismissed", tone: "muted" });
+  });
+
+  it("maps the raw gh check_status strings to CI pill tones", () => {
+    const ci = (s: string) => prStatusPills(pr({ check_status: s })).find((p) => p.key === "ci");
+    expect(ci("SUCCESS")).toEqual({ key: "ci", label: "CI pass", tone: "ok" });
+    expect(ci("FAILURE")).toEqual({ key: "ci", label: "CI fail", tone: "danger" });
+    expect(ci("PENDING")).toEqual({ key: "ci", label: "CI pending", tone: "warn" });
+  });
+
+  it("emits at most one pill per category (lifecycle, review, CI)", () => {
+    const pills = prStatusPills(pr({ review_decision: "APPROVED", check_status: "SUCCESS" }));
+    expect(pills.map((p) => p.key)).toEqual(["lifecycle", "review", "ci"]);
+  });
+});
+
+describe("issueStatusPills", () => {
+  it("open → ok, closed → muted (case-insensitive)", () => {
+    expect(issueStatusPills(issue())).toEqual([{ key: "lifecycle", label: "open", tone: "ok" }]);
+    expect(issueStatusPills(issue({ state: "CLOSED" }))).toEqual([
+      { key: "lifecycle", label: "closed", tone: "muted" },
+    ]);
+  });
+});
+
+describe("StatusPills / ExternalSourceBadge rendering", () => {
+  it("renders each pill with its tone and label; nothing for an empty set", () => {
+    const { rerender, container } = render(
+      <StatusPills pills={[{ key: "lifecycle", label: "open", tone: "ok" }]} />,
+    );
+    const pill = screen.getByTestId("status-pill");
+    expect(pill.getAttribute("data-tone")).toBe("ok");
+    expect(pill.textContent).toBe("open");
+    expect(pill.className).toMatch(/text-success/);
+
+    rerender(<StatusPills pills={[]} />);
+    expect(container.querySelector("[data-testid='status-pill']")).toBeNull();
+  });
+
+  it("ExternalSourceBadge states github = source of truth", () => {
+    render(<ExternalSourceBadge />);
+    const badge = screen.getByTestId("external-source-badge");
+    expect(badge.getAttribute("title")).toMatch(/source of truth/i);
+    expect(badge.textContent).toMatch(/github/i);
+  });
+});

--- a/clients/react/src/components/producer-console/r-panel/status-pills.tsx
+++ b/clients/react/src/components/producer-console/r-panel/status-pills.tsx
@@ -1,0 +1,148 @@
+// PR / Issue status pills + the EXTERNAL-source framing badge — the R₁
+// inventory's Stage-C shells (aim-console destination convergence,
+// tmai-core `doc/approaches/2026-06-09-aim-console-destination-convergence.md`
+// Stage C; mock `origin/mock/aim-ui-sample` PR rail = colour-coded `.pst`
+// pills + an EXTERNAL framing).
+//
+// WHY colour HERE when the R₁ header comments say "no severity colour":
+// these pills are CATEGORICAL, not appraisal. The colour names *which*
+// lifecycle state a PR/Issue is in (open / merged / draft / under review /
+// CI state) — it is a fact rendered glanceable, the same way the diff
+// viewer's +/- red/green is the diff fact's conventional representation,
+// NOT a tmai-side ranking of urgency/importance. The earlier R₁ posture
+// (`2026-05-26-tmai-states-facts-not-appraisals`) forbids *severity /
+// priority / relevance* tinting; Stage C's destination mock deliberately
+// renders lifecycle state in categorical colour, so the operator can scan
+// the inventory's shape without opening each R₂ viewer (where these facts
+// used to live only). The operator-authored attention heat (the
+// `RowAttentionMarker`) stays a separate, orthogonal axis.
+
+import type { IssueSummaryWire, PrSummaryWire } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+// Tone = colour-intent, NOT the state word — so two different states that
+// share a colour (e.g. `open` and `approved`, both `ok`) reuse one class.
+export type PillTone = "ok" | "warn" | "danger" | "info" | "muted";
+
+// Semantic theme tokens only (the repo-wide `no-raw-palette` lock forbids
+// raw Tailwind palette families). `accent` is the themed violet — the mock's
+// merged colour; `success`/`warning`/`destructive` are the themed
+// green/amber/red; `muted` (draft/closed) is the quiet dim pill.
+const TONE_CLASS: Record<PillTone, string> = {
+  ok: "border-success/30 bg-success/10 text-success",
+  warn: "border-warning/30 bg-warning/10 text-warning",
+  danger: "border-destructive/30 bg-destructive/10 text-destructive",
+  info: "border-accent/30 bg-accent/10 text-accent",
+  muted: "border-hairline-strong/40 text-subtle-foreground",
+};
+
+export interface StatusPill {
+  /** Stable React key within one row's pill set (one per category). */
+  key: string;
+  label: string;
+  tone: PillTone;
+}
+
+// `review_decision` is the raw uppercased `gh` string
+// (`APPROVED` / `CHANGES_REQUESTED` / `REVIEW_REQUIRED`) — see
+// `PrSummaryWire`'s header comment. Map the common cases to short labels;
+// fall back to a lowercased passthrough for any value `gh` adds later.
+function reviewPill(decision: string): StatusPill {
+  switch (decision.toUpperCase()) {
+    case "APPROVED":
+      return { key: "review", label: "approved", tone: "ok" };
+    case "CHANGES_REQUESTED":
+      return { key: "review", label: "changes requested", tone: "warn" };
+    case "REVIEW_REQUIRED":
+      return { key: "review", label: "review", tone: "warn" };
+    default:
+      return { key: "review", label: decision.toLowerCase().replace(/_/g, " "), tone: "muted" };
+  }
+}
+
+// `check_status` is the raw rolled-up `gh` string (`SUCCESS` / `FAILURE` /
+// `PENDING`); same passthrough discipline as `reviewPill`.
+function ciPill(checkStatus: string): StatusPill {
+  switch (checkStatus.toUpperCase()) {
+    case "SUCCESS":
+      return { key: "ci", label: "CI pass", tone: "ok" };
+    case "FAILURE":
+      return { key: "ci", label: "CI fail", tone: "danger" };
+    case "PENDING":
+      return { key: "ci", label: "CI pending", tone: "warn" };
+    default:
+      return { key: "ci", label: `CI ${checkStatus.toLowerCase()}`, tone: "muted" };
+  }
+}
+
+// One PR row's pills: exactly one lifecycle pill (draft / merged / closed /
+// open), plus a review pill and a CI pill when those fields are present.
+// Derived purely from fields already on the wire (`state` / `is_draft` /
+// `merge_commit_sha` / `review_decision` / `check_status`).
+export function prStatusPills(pr: PrSummaryWire): StatusPill[] {
+  const pills: StatusPill[] = [];
+  const state = pr.state.toUpperCase();
+  if (pr.is_draft) {
+    pills.push({ key: "lifecycle", label: "draft", tone: "muted" });
+  } else if (state === "MERGED" || pr.merge_commit_sha !== null) {
+    pills.push({ key: "lifecycle", label: "merged", tone: "info" });
+  } else if (state === "CLOSED") {
+    pills.push({ key: "lifecycle", label: "closed", tone: "muted" });
+  } else {
+    pills.push({ key: "lifecycle", label: "open", tone: "ok" });
+  }
+  if (pr.review_decision !== null) {
+    pills.push(reviewPill(pr.review_decision));
+  }
+  if (pr.check_status !== null) {
+    pills.push(ciPill(pr.check_status));
+  }
+  return pills;
+}
+
+// One Issue row's pills: a single lifecycle pill from `state`. The
+// unit-scoped issue list is open-only in practice, but `closed` is handled
+// for shape parity. Labels stay plain text in the row (not pills).
+export function issueStatusPills(issue: IssueSummaryWire): StatusPill[] {
+  return issue.state.toLowerCase() === "closed"
+    ? [{ key: "lifecycle", label: "closed", tone: "muted" }]
+    : [{ key: "lifecycle", label: "open", tone: "ok" }];
+}
+
+export function StatusPills({ pills }: { pills: StatusPill[] }) {
+  if (pills.length === 0) return null;
+  return (
+    <span className="inline-flex flex-wrap items-center gap-1">
+      {pills.map((p) => (
+        <span
+          key={p.key}
+          data-testid="status-pill"
+          data-tone={p.tone}
+          className={cn(
+            "inline-flex items-center rounded border px-1.5 font-mono text-[10px] leading-relaxed",
+            TONE_CLASS[p.tone],
+          )}
+        >
+          {p.label}
+        </span>
+      ))}
+    </span>
+  );
+}
+
+// "EXTERNAL · github = source of truth" framing for the PR / Issue rail
+// headers (C2). PRs and Issues are the GitHub-resident artifacts on the R
+// panel (vs the git-resident decisions / approaches / aims), so this tag
+// states that github — not tmai — is their source of truth. Subtle / mono,
+// pushed to the right edge of the section header.
+export function ExternalSourceBadge() {
+  return (
+    <span
+      data-testid="external-source-badge"
+      title="github = source of truth"
+      className="ml-auto inline-flex items-center rounded border border-hairline-strong/40 px-1.5 font-mono text-[9px] uppercase tracking-wide text-subtle-foreground"
+    >
+      EXTERNAL · github
+    </span>
+  );
+}

--- a/clients/react/src/components/terminal/TerminalPanel.tsx
+++ b/clients/react/src/components/terminal/TerminalPanel.tsx
@@ -1,17 +1,10 @@
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useAgents } from "@/hooks/useAgents";
 import { useAutoScrollPerAgent } from "@/hooks/useAutoScrollPerAgent";
 import { useTerminal } from "@/hooks/useTerminal";
 import "@xterm/xterm/css/xterm.css";
 import { AutoScrollToggleButton, ModeHint, ModeToggleButton } from "./controls";
-
-// Trim the canonical id (`<scheme>:<id>`) to `<scheme>:<first-8-chars>`
-// for the panel header. `provisional:abcd1234` is more useful than the
-// raw 8-char prefix of the whole string ("provisi…").
-function agentIdShort(agentId: string): string {
-  const colon = agentId.indexOf(":");
-  if (colon < 0) return agentId.slice(0, 8);
-  return `${agentId.slice(0, colon)}:${agentId.slice(colon + 1, colon + 9)}`;
-}
+import { TerminalSessionHeader } from "./TerminalSessionHeader";
 
 interface TerminalPanelProps {
   /** Canonical agent id (`<scheme>:<id>`). The terminal-plane stream
@@ -28,6 +21,16 @@ export function TerminalPanel({ agentId }: TerminalPanelProps) {
   const [inputMode, setInputMode] = useState(true);
   const [hasFocus, setHasFocus] = useState(false);
   const [autoScroll, setAutoScroll] = useAutoScrollPerAgent(agentId);
+
+  // C3: resolve this session's snapshot from the shared SSE agent cache so
+  // the header can show model + cwd + ctx% (mirrors ProducerConversationHeader
+  // for worker sessions). `target` is the stable key across the
+  // provisional→canonical id re-key; fall back to matching `id` too.
+  const { agents } = useAgents();
+  const agent = useMemo(
+    () => agents.find((a) => a.target === agentId || a.id === agentId),
+    [agents, agentId],
+  );
 
   const { setAttachable } = useTerminal({ agentId, containerRef, autoScroll });
 
@@ -88,9 +91,7 @@ export function TerminalPanel({ agentId }: TerminalPanelProps) {
           : "shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)]"
       }`}
     >
-      <div className="flex items-center justify-between border-b border-hairline-strong px-3 py-1.5">
-        <span className="text-xs text-muted-foreground">{agentIdShort(agentId)}</span>
-      </div>
+      <TerminalSessionHeader agentId={agentId} agent={agent} />
       {/* biome-ignore lint/a11y/noStaticElementInteractions: terminal container needs pointer events for selection mode */}
       <div
         ref={containerRef}

--- a/clients/react/src/components/terminal/TerminalSessionHeader.tsx
+++ b/clients/react/src/components/terminal/TerminalSessionHeader.tsx
@@ -1,0 +1,83 @@
+// Worker-session header (C3, Stage C aim-console convergence).
+//
+// A worker session's terminal panel used to show only its agent id. This
+// header mirrors the Producer's `ProducerConversationHeader` for any
+// session — model + cwd + a context-% readout — so a worker session is no
+// longer opaque (mock `origin/mock/aim-ui-sample` session `.shead` = per-
+// session model / unit / cwd + a ctx warning). It reads the
+// `AgentSnapshot` the SSE cache already holds (threaded from `useAgents` in
+// `TerminalPanel`); no new fetch, no new endpoint.
+//
+// The ctx% warning colour is a STATIC convention here, not the Producer's
+// `auto_handoff_threshold_pct`: workers have no auto-handoff ritual, so
+// there is no per-project threshold to fetch — the bar just warns (amber)
+// as context fills and turns red near full. The ctx readout reuses
+// `ProducerCtxHeader`'s `formatThousands` / `renderBar` so the two surfaces
+// render identically.
+
+import { formatThousands, renderBar } from "@/components/producer-console/ProducerCtxHeader";
+import type { AgentSnapshot } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+// Trim the canonical id (`<scheme>:<id>`) to `<scheme>:<first-8-chars>`
+// for the header. `provisional:abcd1234` is more useful than the raw 8-char
+// prefix of the whole string ("provisi…").
+export function agentIdShort(agentId: string): string {
+  const colon = agentId.indexOf(":");
+  if (colon < 0) return agentId.slice(0, 8);
+  return `${agentId.slice(0, colon)}:${agentId.slice(colon + 1, colon + 9)}`;
+}
+
+// Static ctx-fill warning bands (workers have no auto-handoff threshold):
+// red near full, amber as it fills, muted otherwise.
+function ctxWarningClass(pct: number): string {
+  if (pct >= 90) return "text-destructive";
+  if (pct >= 75) return "text-warning";
+  return "text-muted-foreground";
+}
+
+interface TerminalSessionHeaderProps {
+  /** Canonical agent id (`<scheme>:<id>`), always shown as the fallback
+   *  identity even when the snapshot hasn't resolved yet. */
+  agentId: string;
+  /** The live snapshot for this session, resolved from `useAgents` by the
+   *  parent. `undefined` (not yet in the cache / isolation tests) degrades
+   *  gracefully to the id-only header this panel showed before C3. */
+  agent: AgentSnapshot | undefined;
+}
+
+export function TerminalSessionHeader({ agentId, agent }: TerminalSessionHeaderProps) {
+  const model = agent?.model_display_name ?? agent?.model_id ?? null;
+  const cwd = agent?.display_cwd ?? agent?.cwd ?? null;
+  const ctx = agent?.ctx_usage ?? null;
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-0.5 border-b border-hairline-strong px-3 py-1.5 text-xs">
+      <span className="shrink-0 font-mono text-muted-foreground">{agentIdShort(agentId)}</span>
+      {model && (
+        <span className="shrink-0 font-mono text-foreground" title={`model: ${model}`}>
+          {model}
+        </span>
+      )}
+      {cwd && (
+        <span className="min-w-0 truncate font-mono text-subtle-foreground" title={cwd}>
+          {cwd}
+        </span>
+      )}
+      {ctx && (
+        <span
+          className={cn(
+            "ml-auto flex shrink-0 items-center gap-1.5 font-mono",
+            ctxWarningClass(ctx.pct),
+          )}
+          title={`ctx: ${formatThousands(ctx.used)} / ${formatThousands(ctx.total)} (${ctx.pct}%)`}
+        >
+          <span>{ctx.pct}%</span>
+          <span className="text-muted-foreground" aria-hidden="true">
+            {renderBar(ctx.pct).chars}
+          </span>
+        </span>
+      )}
+    </div>
+  );
+}

--- a/clients/react/src/components/terminal/__tests__/TerminalSessionHeader.test.tsx
+++ b/clients/react/src/components/terminal/__tests__/TerminalSessionHeader.test.tsx
@@ -1,0 +1,91 @@
+// @vitest-environment jsdom
+//
+// TerminalSessionHeader (C3) — model + cwd + ctx% for a worker session,
+// resolved from the shared `AgentSnapshot`. Tested in isolation (not
+// through TerminalPanel, which mounts xterm).
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { AgentSnapshot } from "@/lib/api";
+import { agentIdShort, TerminalSessionHeader } from "../TerminalSessionHeader";
+
+function agent(overrides: Partial<AgentSnapshot> = {}): AgentSnapshot {
+  return {
+    id: "claude:11112222333344445555",
+    target: "pty:abc",
+    agent_type: "ClaudeCode",
+    title: "worker",
+    cwd: "/home/me/works/tmai-wt-attn-ui",
+    display_cwd: "~/works/tmai-wt-attn-ui",
+    display_name: "attention-ui",
+    detection_source: "HttpHook",
+    git_branch: "feat/x",
+    git_dirty: false,
+    is_worktree: true,
+    git_common_dir: "/home/me/works/tmai/.git",
+    worktree_name: "tmai-wt-attn-ui",
+    worktree_base_branch: "main",
+    effort_level: null,
+    active_subagents: 0,
+    compaction_count: 0,
+    pty_session_id: "abc",
+    send_capability: "PtyInject",
+    is_virtual: false,
+    team_info: null,
+    model_id: "claude-sonnet-4-6",
+    model_display_name: "sonnet-4.6",
+    ...overrides,
+  };
+}
+
+describe("agentIdShort", () => {
+  it("keeps the scheme and trims the id to 8 chars", () => {
+    expect(agentIdShort("provisional:abcd1234efgh")).toBe("provisional:abcd1234");
+    expect(agentIdShort("noscheme")).toBe("noscheme");
+  });
+});
+
+describe("TerminalSessionHeader", () => {
+  it("shows the model display name + cwd", () => {
+    render(<TerminalSessionHeader agentId="claude:11112222333344445555" agent={agent()} />);
+    expect(screen.getByText("sonnet-4.6")).toBeTruthy();
+    expect(screen.getByText("~/works/tmai-wt-attn-ui")).toBeTruthy();
+  });
+
+  it("falls back to model_id when there is no display name", () => {
+    render(
+      <TerminalSessionHeader
+        agentId="claude:x"
+        agent={agent({ model_display_name: null, model_id: "claude-opus-4-8" })}
+      />,
+    );
+    expect(screen.getByText("claude-opus-4-8")).toBeTruthy();
+  });
+
+  it("renders a ctx% readout coloured by fill (warn ≥75, danger ≥90)", () => {
+    const { rerender } = render(
+      <TerminalSessionHeader
+        agentId="claude:x"
+        agent={agent({ ctx_usage: { used: 160000n, total: 200000n, pct: 80, updated_at: "t" } })}
+      />,
+    );
+    const warn = screen.getByText("80%");
+    expect(warn.parentElement?.className).toMatch(/text-warning/);
+
+    rerender(
+      <TerminalSessionHeader
+        agentId="claude:x"
+        agent={agent({ ctx_usage: { used: 184000n, total: 200000n, pct: 92, updated_at: "t" } })}
+      />,
+    );
+    const danger = screen.getByText("92%");
+    expect(danger.parentElement?.className).toMatch(/text-destructive/);
+  });
+
+  it("degrades to the id only when no snapshot is resolved", () => {
+    render(<TerminalSessionHeader agentId="provisional:deadbeef0000" agent={undefined} />);
+    expect(screen.getByText("provisional:deadbeef")).toBeTruthy();
+    // No model / cwd / ctx rows when the snapshot is absent.
+    expect(screen.queryByText("sonnet-4.6")).toBeNull();
+  });
+});


### PR DESCRIPTION
Resolves #788. Part of the aim-console destination convergence (tmai-core `doc/approaches/2026-06-09-aim-console-destination-convergence.md`, **Stage C** — UI shells, backend-independent). Three small, independent additions to the React console, consuming hooks/types that already exist. **No tmai-core/backend change, no endpoint added, no generated-type edits.**

## C1 — unit tabs (top bar)
- New `UnitTabs` strip rendered in the `StatusBar` (top bar), consuming `useUnits`.
- One tab per configured `[[unit]]`: the unit's repos as pills (primary highlighted vs secondary), active unit highlighted, click → re-scope the focused unit.
- Per-tab `⚠N` attention rollup derived from the existing `useUnitAttention` high-marker count (per-unit child hook, so it scales to N units; one configured unit collapses to a single tab).
- `+` affordance ("add unit = launch Producer") as a clipboard placeholder — **no new launch endpoint** (mirrors the Phase-A "Open Producer terminal" pattern).

## C2 — PR/Issue status pills + EXTERNAL framing
- Colour-coded lifecycle / review / CI pills on each `RPrsSection` / `RIssuesSection` row, from fields already on the wire (`state` / `is_draft` / `merge_commit_sha` / `review_decision` / `check_status`). These previously showed only in the R₂ viewer header.
- "EXTERNAL · github" framing badge on the PR/Issue section headers (new optional `Section` `headerNote` slot).
- **Design note:** the pill colour is *categorical* (which lifecycle state), **not** severity/appraisal — a deliberate Stage-C evolution of R₁'s plain-text inventory. This narrows the documented `2026-05-26-tmai-states-facts-not-appraisals` R₁ posture (rationale in `status-pills.tsx`); the two R₁ no-severity-colour test assertions were updated to the new categorical-pill behaviour. See the friction note for the upstream reconcile this wants.

## C3 — worker session headers
- New `TerminalSessionHeader` (model + cwd + ctx%-warning) on `TerminalPanel`, mirroring `ProducerConversationHeader`, resolved from the shared `useAgents` snapshot. Worker sessions previously showed only the agent id.

## Gate
- `pnpm lint` ✅ (0 errors; one pre-existing unrelated warning)
- `pnpm build` ✅ (`tsc -b && vite build`)
- `pnpm test` ✅ (733 passed, 2 pre-existing skips)
- Component tests added for each of C1/C2/C3 (`UnitTabs.test`, `status-pills.test` + updated `RPrsSection`/`RIssuesSection` tests, `TerminalSessionHeader.test`).

## Out of scope (untouched)
- Aim panel rebuild (Stage B), bash footer (Stage D), any tmai-core/backend/endpoint, generated types.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ユニットタブUIを追加：複数ユニット間の切り替えが可能に。各ユニットの注意マーカー（⚠）を表示。新規ユニット追加時はコマンドをクリップボードにコピー
  * PR・Issue のステータス表示を改善：カテゴリー化されたステータスピルで視認性向上
  * ターミナルセッションヘッダーを強化：エージェント情報とコンテキスト使用量を詳細表示

* **テスト**
  * ユニットタブ、ステータスピル、ターミナルセッションヘッダーの動作検証テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->