### PR TITLE
Stage B: Aim panel rebuild — Frontier⊥Tree, ledger, ruler, inspector with drift + is[] (#791)

### DIFF
--- a/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
@@ -1,60 +1,79 @@
-// ◎ Aims — R panel's aim-tree read view (graduation Stage 1-B, #780 + #782).
-// The read-view validated in throwaway prototype #778 (`RAimTreePrototype`),
-// graduated into a real R-panel section backed by the live
-// `GET /api/units/{unit}/aims` endpoint (tmai-core #500).
+// ◎ Aims — the destination Aim panel (Stage B convergence, #791). Rebuilt from
+// the read-only tidy-tree view into the attention-economical WRITE surface the
+// mock (`origin/mock/aim-ui-sample`) compose: a segmented Frontier⊥Tree panel
+// with a ledger strip, a per-repo collapsible navigator + branch rollups, an
+// overview ruler, and an inspector that carries drift + the interior `is[]`.
 //
-// ONE job, READ-ONLY. No write affordance (frontmatter edit / new node —
-// Stage 2), no drift-mark (Stage 3). The prototype's `CreateForm` /
-// `patchNode` / `commitCreate` / in-memory mutation are deliberately NOT
-// carried.
+// LOAD-BEARING THESIS (do not lose this): the panel does NOT render the whole
+// tree. Default = the owed FRONTIER worklist (drifted OR carrying a `claimed`
+// mark, drift-first, breadcrumbed); the full tree is a collapsed Tree
+// navigator with branch-level rollups + an overview ruler. This is the "scale
+// answer" — the panel stays a write surface, never a passive full-tree dump
+// (the approach's named failure-signal). Pure model in `./aim-tree`.
 //
-// CONTAINER (#782): a 2D spatial tree of long-text nodes does not fit the
-// narrow R-panel accordion column, and widening the column would fight the
-// console-rebuild "central conversation primary" constraint. So the section
-// itself stays a thin accordion entry — a compact `N aims · M roots` summary +
-// the glyph legend + an ⤢ "open" affordance — and the actual tree lives in a
-// DEDICATED FULL-WINDOW OVERLAY (`AimTreeOverlay`, mounted via `createPortal`,
-// dismissible by ✕ and Esc). The overlay uses the prototype's SIDE-BY-SIDE
-// 2-pane layout (wide canvas + side detail), with the room to let the variable-
-// height tidy-tree (`computeLayout`, the #782 overlap fix) breathe.
+// Design pins honoured:
+//   #1 mark-only — the `is[]` marks (confirmed / claimed) render as the author
+//      wrote them; we never re-judge / re-order / appraise (only the wire's
+//      `kind` drives styling).
+//   #2 done+drift distinct — a `state: done` node that is ALSO drifted gets the
+//      `done-drift` tone (a done ✓ AND a drift ⚠ badge), surfaced in its own
+//      Frontier cluster + the Tree, never suppressed or folded into plain owed.
+//   #3 drift mirrors the engine — after an ought edit we REFETCH the forest and
+//      render whatever drift the wire reports; there is NO client-side
+//      transitive cascade (the engine is the single source of truth).
 //
-// The view machinery carried intact from the prototype: the variable-height
-// tidy-tree layout, the blast-radius highlight (select a node → light its whole
-// descendant subtree, the set that would become drift-possible if that aim
-// changed), `depends_on` drawn as a visually distinct dashed cross-edge (NOT
-// part of any blast radius), the per-node state glyph, and the body-on-select
-// detail pane. The pure layout / traversal lives in `./aim-tree` (unit-tested
-// separately); this file is the React rendering.
+// Theme: the mock is the STRUCTURE/BEHAVIOUR reference, not its raw CSS. The
+// panel speaks the app's design tokens — drift = `warning`, claimed = `warning`
+// hollow (◌ vs ⚠ + gutter weight distinguish the two owed kinds), confirmed /
+// done = `success` (calm), root / selection = `info` / `primary`.
 //
-// `body` is rendered as raw markdown, read-only: line breaks preserved,
-// monospace so inline refs / markers stay legible. There is intentionally no
-// `[confirmed]` / `[claimed]` honesty-tag parser — those markers are free-form
-// prose in the wire body, not a structured field (the prototype's `BodyLine`
-// was a fixture invention).
+// UI-only state: the mode (Frontier/Tree) persists in `ui-prefs` (browser-side,
+// not tmai-core config). The expanded-branch set + the search filter stay
+// component-local — a persisted filter would silently hide rows on next open,
+// and the branch set re-seeds to the mock's default (repos + roots open) each
+// session.
 
-import { type ReactNode, useEffect, useMemo, useState } from "react";
+import { type ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { createPortal } from "react-dom";
 import { useUnitAims } from "@/hooks/useUnitAims";
-import { type AimState, type AimWire, api } from "@/lib/api";
+import { type AimsResponse, api } from "@/lib/api";
+import { useUIPref } from "@/lib/ui-prefs-provider";
+import type { AimDriftWire } from "@/types/generated/AimDriftWire";
+import type { AimInteriorKind } from "@/types/generated/AimInteriorKind";
+import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
+import type { AimState } from "@/types/generated/AimState";
+import type { AimWire } from "@/types/generated/AimWire";
+import type { RepoAimsWire } from "@/types/generated/RepoAimsWire";
 import {
-  AIM_GLYPH,
   AIM_STATE_LABEL,
-  type AimLayout,
+  type AimTone,
+  aimTone,
+  ancestry,
+  breadcrumbText,
   buildChildren,
-  computeLayout,
-  dependsEdgePath,
+  bySlugMap,
   descendantsOf,
+  doneDriftedRows,
   findRoots,
   flattenRepos,
-  NODE_W,
-  type NodePos,
-  parentEdgePath,
+  frontierRows,
+  type LedgerCounts,
+  ledgerCounts,
+  type RollupStats,
+  type RulerTick,
+  repoForests,
+  repoStats,
+  rulerOrder,
+  subtreeStats,
 } from "./aim-tree";
 import { Section } from "./Section";
 
 // Lifecycle states the operator can set, in glyph-legend order. Drives the
 // edit + create `state` selects. `AimState` is the generated wire enum.
 const AIM_STATES: readonly AimState[] = ["open", "done", "dead"];
+
+// Stable identity key for a repo group (root is unique per unit).
+const repoKey = (r: RepoAimsWire): string => `repo:${r.repo_root}`;
 
 // Client-side slug validation for the create form — a fast-feedback MIRROR of
 // the backend's `validate_new_aim_slug` (tmai-core #501): non-empty, lowercase
@@ -84,6 +103,56 @@ function writeErrorMessage(e: unknown): string {
   return e instanceof Error ? e.message : String(e);
 }
 
+// ── tone → presentation (mark-only: only the wire-derived tone drives this) ──
+
+const TONE_GLYPH: Record<AimTone, string> = {
+  "done-drift": "✓",
+  done: "✓",
+  dead: "⊘",
+  drift: "⚠",
+  claimed: "◌",
+  confirmed: "○",
+  root: "○",
+  neutral: "○",
+};
+
+const TONE_GLYPH_CLASS: Record<AimTone, string> = {
+  "done-drift": "text-success",
+  done: "text-success",
+  dead: "text-subtle-foreground",
+  drift: "text-warning",
+  claimed: "text-warning",
+  confirmed: "text-subtle-foreground",
+  root: "text-info",
+  neutral: "text-subtle-foreground",
+};
+
+// Left gutter colour. done-drift uses the warning gutter (surfacing the owed
+// drift) even though its glyph is the done ✓ — together with the trailing ⚠
+// badge that is what makes done+drift read DISTINCTLY from plain done (pin #2).
+const TONE_GUTTER: Record<AimTone, string> = {
+  "done-drift": "bg-warning",
+  done: "bg-success/40",
+  dead: "bg-subtle-foreground/40",
+  drift: "bg-warning",
+  claimed: "bg-warning/55",
+  confirmed: "bg-success/30",
+  root: "bg-info/60",
+  neutral: "bg-hairline-strong",
+};
+
+// Ought-text styling per tone — calm for resolved/abandoned, lit for drift.
+const TONE_OUGHT_CLASS: Record<AimTone, string> = {
+  "done-drift": "text-warning/90",
+  done: "text-subtle-foreground",
+  dead: "text-subtle-foreground line-through",
+  drift: "text-warning/90",
+  claimed: "text-foreground",
+  confirmed: "text-muted-foreground",
+  root: "text-foreground",
+  neutral: "text-foreground",
+};
+
 interface RAimsSectionProps {
   unitName: string | null;
   expanded: boolean;
@@ -92,7 +161,6 @@ interface RAimsSectionProps {
 
 export function RAimsSection({ unitName, expanded, onToggle }: RAimsSectionProps) {
   const { data, loading, error, refresh } = useUnitAims(unitName);
-  // Flattened node set drives both the header count and the tree body.
   const nodes = useMemo(() => flattenRepos(data), [data]);
 
   return (
@@ -104,75 +172,107 @@ export function RAimsSection({ unitName, expanded, onToggle }: RAimsSectionProps
       expanded={expanded}
       onToggle={onToggle}
     >
-      <Body unitName={unitName} nodes={nodes} loading={loading} error={error} refresh={refresh} />
+      <Body
+        unitName={unitName}
+        data={data}
+        nodes={nodes}
+        loading={loading}
+        error={error}
+        refresh={refresh}
+      />
     </Section>
   );
 }
 
 interface BodyProps {
   unitName: string | null;
+  data: AimsResponse | null;
   nodes: AimWire[];
   loading: boolean;
   error: Error | null;
   refresh: () => void;
 }
 
-function Body({ unitName, nodes, loading, error, refresh }: BodyProps) {
+function Body({ unitName, data, nodes, loading, error, refresh }: BodyProps) {
   if (unitName === null) {
     return <p className="text-subtle-foreground">Pick a project to see aims.</p>;
   }
   if (error !== null) {
     return <p className="text-muted-foreground">Failed to load aims: {error.message}</p>;
   }
-  // Unlike the read-only Stage 1-B, an empty tree is still actionable: the
-  // operator can author the first node. So the overlay (with its create
-  // affordance) is reachable even at zero aims — the thin entry shows the
-  // count and the ⤢ open, and the loading state only gates the very first
-  // fetch (nodes empty AND loading).
+  // An empty tree is still actionable (the operator can author the first node),
+  // so the panel is reachable at zero aims; only the very first fetch gates.
   if (nodes.length === 0 && loading) {
     return <p className="text-subtle-foreground">Loading…</p>;
   }
-  return <AimsEntry unitName={unitName} nodes={nodes} refresh={refresh} />;
+  return <AimsEntry unitName={unitName} data={data} nodes={nodes} refresh={refresh} />;
 }
 
-// The thin R-panel entry: a compact summary + the glyph legend + an ⤢ open
-// affordance. Clicking open launches the maximized overlay; the open-state is
-// local and the overlay is portalled, so the section stays self-contained and
+// The thin R-panel entry: a compact summary with an at-a-glance owed badge +
+// an ⤢ open affordance. Opening launches the maximized panel; the open-state
+// is local and the panel is portalled, so the section stays self-contained and
 // the narrow column is never widened.
 function AimsEntry({
   unitName,
+  data,
   nodes,
   refresh,
 }: {
   unitName: string;
+  data: AimsResponse | null;
   nodes: AimWire[];
   refresh: () => void;
 }) {
   const [open, setOpen] = useState(false);
-  const rootCount = useMemo(() => findRoots(nodes).length, [nodes]);
+  const repoCount = useMemo(() => repoForests(data).length, [data]);
+  const ledger = useMemo(() => ledgerCounts(nodes), [nodes]);
+  const owed = ledger.drift + ledger.claimed;
 
   return (
     <div className="space-y-2">
       <div className="flex items-center justify-between gap-2">
         <span className="text-[11px] text-subtle-foreground">
-          {nodes.length} aim{nodes.length === 1 ? "" : "s"} ·{" "}
-          <span className="text-foreground">{rootCount}</span> root{rootCount === 1 ? "" : "s"}
+          {nodes.length} aim{nodes.length === 1 ? "" : "s"}
+          {repoCount > 0 && (
+            <>
+              {" · "}
+              <span className="text-foreground">{repoCount}</span> repo{repoCount === 1 ? "" : "s"}
+            </>
+          )}
         </span>
         <button
           type="button"
           onClick={() => setOpen(true)}
-          title="Open aim-tree (maximized)"
-          aria-label="Open aim-tree"
+          title="Open the Aim panel (maximized)"
+          aria-label="Open aim panel"
           className="flex shrink-0 items-center gap-1 rounded border border-hairline px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
         >
           <span aria-hidden="true">⤢</span> Open
         </button>
       </div>
-      <GlyphLegend />
+      {/* At-a-glance owed badge so the entry surfaces attention without opening. */}
+      {owed > 0 ? (
+        <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px]">
+          {ledger.drift > 0 && (
+            <span className="flex items-center gap-1 text-warning">
+              <span aria-hidden="true">⚠</span>
+              {ledger.drift} drift
+            </span>
+          )}
+          {ledger.claimed > 0 && (
+            <span className="flex items-center gap-1 text-warning/80">
+              <span aria-hidden="true">◌</span>
+              {ledger.claimed} claimed
+            </span>
+          )}
+        </div>
+      ) : (
+        <span className="text-[11px] text-subtle-foreground">calm — nothing owed</span>
+      )}
       {open && (
-        <AimTreeOverlay
+        <AimPanelOverlay
           unitName={unitName}
-          nodes={nodes}
+          data={data}
           refresh={refresh}
           onClose={() => setOpen(false)}
         />
@@ -181,36 +281,45 @@ function AimsEntry({
   );
 }
 
-// The maximized aim-tree overlay — a full-window surface modelled on
-// `HelpOverlay` / `HandoffRitualOverlay`, mounted via `createPortal` so it
-// escapes the R-panel column's clipping/stacking. Dismissible by ✕ and Esc
-// (the Esc convention reused from `AttentionMarker` / `ConfirmDialog`).
-// Layout: the prototype's side-by-side 2-pane — a wide scrollable tree canvas
-// on the left, the body-on-select detail pane on the right.
-function AimTreeOverlay({
+// What the create flow is creating — a root in `repoRoot`, optionally under
+// `initialParent`. (`repoRoot` scopes the parent options / slug uniqueness; the
+// #501 create endpoint resolves the write repo from the unit + parent, so it
+// is not on the wire — see the friction note re: a per-repo create wire gap.)
+interface Creating {
+  repoRoot: string;
+  initialParent: string;
+}
+
+// The maximized Aim panel — a full-window surface (portalled past the R-panel
+// column's clipping, dismissible by ✕ / Esc) holding the destination layout.
+function AimPanelOverlay({
   unitName,
-  nodes,
+  data,
   refresh,
   onClose,
 }: {
   unitName: string;
-  nodes: AimWire[];
+  data: AimsResponse | null;
   refresh: () => void;
   onClose: () => void;
 }) {
-  const [selected, setSelected] = useState<string | null>(null);
-  // Stage 2-B: the create form. Mutually exclusive with the detail pane (both
-  // live in the right aside) — opening it deselects so the operator authors a
-  // fresh node rather than reading one.
-  const [creating, setCreating] = useState(false);
-  const childrenOf = useMemo(() => buildChildren(nodes), [nodes]);
-  const layout = useMemo(() => computeLayout(nodes), [nodes]);
-  const rootCount = layout.roots.length;
-  const allSlugs = useMemo(() => nodes.map((n) => n.slug), [nodes]);
+  const repos = useMemo(() => repoForests(data), [data]);
+  const allNodes = useMemo(() => flattenRepos(data), [data]);
+  const ledger = useMemo(() => ledgerCounts(allNodes), [allNodes]);
+  const ticks = useMemo(() => rulerOrder(repos), [repos]);
 
-  // Esc dismisses the whole overlay (the detail pane's ✕ / the legend's clear
-  // handle deselect). Listener is document-level so it fires regardless of
-  // focus, mirroring AttentionMarker's popover.
+  const [mode, setMode] = useUIPref("aimMode");
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<string | null>(null);
+  const [creating, setCreating] = useState<Creating | null>(null);
+
+  // Branch-expansion state, seeded once to the mock's default (every repo group
+  // + every root open; deeper branches collapsed behind a rollup). Survives
+  // polls; new nodes get expanded explicitly on create / reveal.
+  const [expanded, setExpanded] = useState<Set<string>>(() => seedExpanded(repos));
+
+  // Esc dismisses the whole panel. Document-level so it fires regardless of
+  // focus (mirrors the prior overlay / AttentionMarker popover).
   useEffect(() => {
     function onKeyDown(e: KeyboardEvent) {
       if (e.key === "Escape") onClose();
@@ -219,399 +328,883 @@ function AimTreeOverlay({
     return () => document.removeEventListener("keydown", onKeyDown);
   }, [onClose]);
 
-  // Resolve the selection against the CURRENT node set: if a poll / unit
-  // change dropped the selected slug, the detail pane and highlight fall back
-  // to "nothing selected" rather than dangling on a vanished node.
-  const selectedNode = useMemo(
-    () => nodes.find((n) => n.slug === selected) ?? null,
-    [nodes, selected],
+  // Resolve the selection against the CURRENT forest, with its repo context, so
+  // a poll / unit change that drops the slug falls back to "nothing selected"
+  // rather than dangling on a vanished node.
+  const sel = useMemo(() => resolveSelection(selected, repos), [selected, repos]);
+
+  const toggleExpanded = useCallback((key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  // Reveal a node in Tree mode: open its repo group + every ancestor, switch to
+  // Tree, select it. (The ruler / cross-mode jumps land here.) When the slug is
+  // not yet in the loaded forest — e.g. a node just created, before the refetch
+  // lands — we still switch to Tree and select it; the selection resolves once
+  // the refreshed wire arrives (no ancestor-expansion then, since the chain
+  // isn't known yet).
+  const reveal = useCallback(
+    (slug: string) => {
+      const found = resolveSelection(slug, repos);
+      if (found) {
+        setExpanded((prev) => {
+          const next = new Set(prev);
+          next.add(repoKey(found.repo));
+          for (const a of ancestry(slug, found.bySlug)) next.add(a.slug);
+          return next;
+        });
+      }
+      setMode("tree");
+      setSelected(slug);
+    },
+    [repos, setMode],
   );
 
-  // Highlight set = the selected node plus its whole descendant subtree.
-  const blast = useMemo(
-    () =>
-      selectedNode === null ? new Set<string>() : descendantsOf(selectedNode.slug, childrenOf),
-    [selectedNode, childrenOf],
-  );
-  const highlighted = useMemo(() => {
-    if (selectedNode === null) return new Set<string>();
-    return new Set<string>([selectedNode.slug, ...blast]);
-  }, [selectedNode, blast]);
-  const hasSelection = selectedNode !== null;
+  const select = useCallback((slug: string) => {
+    setCreating(null);
+    setSelected(slug);
+  }, []);
+
+  const openCreate = useCallback((repoRoot: string, initialParent: string) => {
+    setSelected(null);
+    setCreating({ repoRoot, initialParent });
+  }, []);
+
+  const primaryRepo = repos.find((r) => r.primary) ?? repos[0] ?? null;
 
   return createPortal(
     <div
       role="dialog"
       aria-modal="true"
-      aria-label="Aim-tree"
+      aria-label="Aim panel"
       className="fixed inset-0 z-50 flex flex-col bg-background"
     >
       <header className="flex shrink-0 items-center justify-between gap-3 border-b border-hairline px-4 py-3">
         <div className="flex min-w-0 items-baseline gap-3">
-          <h2 className="text-sm font-semibold text-foreground">◎ Aims · aim-tree</h2>
-          <span className="text-[11px] text-subtle-foreground">
-            {nodes.length} aim{nodes.length === 1 ? "" : "s"} · {rootCount} root
-            {rootCount === 1 ? "" : "s"}
+          <h2 className="text-sm font-semibold text-foreground">◎ Aim</h2>
+          <span className="font-mono text-[11px] text-subtle-foreground">
+            {allNodes.length} aim{allNodes.length === 1 ? "" : "s"} · {repos.length} repo
+            {repos.length === 1 ? "" : "s"}
           </span>
-          <SelectionStatus
-            selectedSlug={selectedNode?.slug ?? null}
-            blastCount={blast.size}
-            onClear={() => setSelected(null)}
-          />
-        </div>
-        <div className="flex shrink-0 items-center gap-2">
-          {/* Stage 2-B create affordance. Opening the form clears any selection
-              so the right pane shows the form, not a node's body. */}
-          <button
-            type="button"
-            onClick={() => {
-              setSelected(null);
-              setCreating(true);
-            }}
-            title="Create a new aim node"
-            aria-label="New aim node"
-            className="rounded border border-hairline px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+          <span
+            className="rounded border border-info/40 px-2 py-0.5 font-mono text-[9px] uppercase tracking-wide text-info"
+            title="The owed frontier is the panel's premise — not a full-tree dump"
           >
-            <span aria-hidden="true">＋</span> New node
-          </button>
-          <button
-            type="button"
-            onClick={onClose}
-            title="Close aim-tree (Esc)"
-            aria-label="Close aim-tree"
-            className="rounded px-2 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
-          >
-            ✕
-          </button>
-        </div>
-      </header>
-
-      <div className="flex min-h-0 flex-1">
-        {/* Left: the tree canvas. The tidy-tree lays out horizontally by depth
-            and variable-height vertically (the #782 overlap fix); SVG edges sit
-            underneath, clickable node boxes on top. The wide window lets it
-            overflow into this scroller without cramping. */}
-        <div className="min-w-0 flex-1 overflow-auto p-4">
-          <div className="relative" style={{ width: layout.width, height: layout.height }}>
-            <Edges
-              nodes={nodes}
-              layout={layout}
-              highlighted={highlighted}
-              hasSelection={hasSelection}
-            />
-            {nodes.map((node) => {
-              const pos = layout.positions.get(node.slug);
-              if (!pos) return null;
-              const lit = highlighted.has(node.slug);
-              return (
-                <NodeBox
-                  key={node.slug}
-                  node={node}
-                  pos={pos}
-                  isSelected={selectedNode?.slug === node.slug}
-                  lit={lit}
-                  dimmed={hasSelection && !lit}
-                  onSelect={() => setSelected(node.slug)}
-                />
-              );
-            })}
-          </div>
-        </div>
-
-        {/* Right: the create form (Stage 2-B), the body-on-select detail pane
-            (with the inline edit affordance), or the click hint — in that
-            precedence. */}
-        <aside className="flex w-[360px] shrink-0 flex-col overflow-y-auto border-l border-hairline">
-          {creating ? (
-            <CreateForm
-              unitName={unitName}
-              existingSlugs={allSlugs}
-              refresh={refresh}
-              onClose={() => setCreating(false)}
-              onCreated={(slug) => {
-                setCreating(false);
-                setSelected(slug);
-              }}
-            />
-          ) : selectedNode !== null ? (
-            <DetailPane
-              key={selectedNode.slug}
-              unitName={unitName}
-              node={selectedNode}
-              blastCount={blast.size}
-              parentOptions={allSlugs}
-              forbiddenParents={highlighted}
-              refresh={refresh}
-              onClose={() => setSelected(null)}
-            />
-          ) : (
-            <p className="p-6 text-xs text-subtle-foreground">
-              Click a node to read its body and light its{" "}
-              <span className="text-foreground">blast radius</span> — the descendant subtree that
-              would become drift-possible if that aim changed. Or{" "}
-              <span className="text-foreground">＋ New node</span> to author one.
-            </p>
-          )}
-        </aside>
-      </div>
-
-      <footer className="shrink-0 border-t border-hairline px-4 py-2">
-        <GlyphLegend />
-      </footer>
-    </div>,
-    document.body,
-  );
-}
-
-// The static glyph key — open / done / dead state glyphs + the dashed
-// `depends_on` swatch. Shown in both the thin entry and the overlay footer.
-function GlyphLegend() {
-  return (
-    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-subtle-foreground">
-      <span className="flex items-center gap-1">
-        <span className="font-mono text-foreground">{AIM_GLYPH.open}</span> open
-      </span>
-      <span className="flex items-center gap-1">
-        <span className="font-mono text-foreground">{AIM_GLYPH.done}</span> done
-      </span>
-      <span className="flex items-center gap-1">
-        <span className="font-mono text-foreground">{AIM_GLYPH.dead}</span> dead
-      </span>
-      <span className="flex items-center gap-1">
-        <svg width="22" height="8" aria-hidden="true">
-          <title>depends_on</title>
-          <line
-            x1="0"
-            y1="4"
-            x2="22"
-            y2="4"
-            stroke="var(--color-info)"
-            strokeWidth="1.5"
-            strokeDasharray="4 3"
-          />
-        </svg>
-        depends_on
-      </span>
-    </div>
-  );
-}
-
-// The selection status — blast-radius count + a clear button when a node is
-// selected, or a hint to click otherwise. Lives in the overlay header.
-function SelectionStatus({
-  selectedSlug,
-  blastCount,
-  onClear,
-}: {
-  selectedSlug: string | null;
-  blastCount: number;
-  onClear: () => void;
-}) {
-  if (selectedSlug === null) {
-    return (
-      <span className="text-[11px] text-subtle-foreground">
-        click a node to light its blast radius
-      </span>
-    );
-  }
-  return (
-    <span className="flex items-center gap-2 text-[11px] text-muted-foreground">
-      <span>
-        blast radius: <span className="text-foreground">{blastCount}</span> descendant
-        {blastCount === 1 ? "" : "s"}
-      </span>
-      <button
-        type="button"
-        onClick={onClear}
-        className="rounded border border-hairline px-1.5 py-0.5 text-[10px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
-      >
-        clear
-      </button>
-    </span>
-  );
-}
-
-function Edges({
-  nodes,
-  layout,
-  highlighted,
-  hasSelection,
-}: {
-  nodes: readonly AimWire[];
-  layout: AimLayout;
-  highlighted: Set<string>;
-  hasSelection: boolean;
-}) {
-  return (
-    <svg
-      className="pointer-events-none absolute inset-0"
-      width={layout.width}
-      height={layout.height}
-      aria-hidden="true"
-    >
-      <defs>
-        <marker
-          id="aim-depends-arrow"
-          viewBox="0 0 8 8"
-          refX="7"
-          refY="4"
-          markerWidth="6"
-          markerHeight="6"
-          orient="auto-start-reverse"
-        >
-          <path d="M0 0 L8 4 L0 8 z" fill="var(--color-info)" />
-        </marker>
-      </defs>
-
-      {/* Solid parent=means edges. An edge is "in the blast radius" when both
-          endpoints are highlighted — then it shares the accent. */}
-      {nodes.map((node) => {
-        if (node.parent === null) return null;
-        const parent = layout.positions.get(node.parent);
-        const child = layout.positions.get(node.slug);
-        if (!parent || !child) return null;
-        const lit = highlighted.has(node.parent) && highlighted.has(node.slug);
-        const dimmed = hasSelection && !lit;
-        return (
-          <path
-            key={`p-${node.slug}`}
-            d={parentEdgePath(parent, child)}
-            fill="none"
-            stroke={lit ? "var(--color-primary)" : "var(--color-hairline-strong)"}
-            strokeWidth={lit ? 2 : 1.5}
-            opacity={dimmed ? 0.2 : 1}
-          />
-        );
-      })}
-
-      {/* `depends_on` cross-edges (an ARRAY per node on the wire): dashed,
-          info-hued, arrow-headed — deliberately NOT part of any blast radius
-          (kept constant). `serves` / `related` are intentionally NOT drawn
-          (listed as slug text in the detail pane instead). */}
-      {nodes.flatMap((node) => {
-        const src = layout.positions.get(node.slug);
-        if (!src) return [];
-        return node.depends_on.flatMap((targetSlug) => {
-          const tgt = layout.positions.get(targetSlug);
-          if (!tgt) return [];
-          return [
-            <path
-              key={`d-${node.slug}-${targetSlug}`}
-              d={dependsEdgePath(src, tgt)}
-              fill="none"
-              stroke="var(--color-info)"
-              strokeWidth="1.5"
-              strokeDasharray="4 3"
-              markerEnd="url(#aim-depends-arrow)"
-              opacity={hasSelection ? 0.55 : 0.9}
-            />,
-          ];
-        });
-      })}
-    </svg>
-  );
-}
-
-function NodeBox({
-  node,
-  pos,
-  isSelected,
-  lit,
-  dimmed,
-  onSelect,
-}: {
-  node: AimWire;
-  pos: NodePos;
-  isSelected: boolean;
-  lit: boolean;
-  dimmed: boolean;
-  onSelect: () => void;
-}) {
-  // Tier the styling: the selected node gets a solid primary ring; the rest of
-  // its blast radius gets a softer primary tint; everything else dims out when
-  // a selection is active so the highlighted region's size reads at a glance.
-  const tone = isSelected
-    ? "border-primary bg-primary/15 ring-1 ring-primary"
-    : lit
-      ? "border-primary/40 bg-primary/10"
-      : "border-hairline bg-surface";
-  return (
-    <button
-      type="button"
-      onClick={onSelect}
-      aria-pressed={isSelected}
-      title={`${node.slug} · ${AIM_STATE_LABEL[node.state]}`}
-      className={`absolute flex items-start gap-1.5 rounded border px-2 py-1.5 text-left transition-all ${tone} ${
-        dimmed ? "opacity-35" : "opacity-100"
-      }`}
-      style={{ left: pos.x, top: pos.cy, width: NODE_W, transform: "translateY(-50%)" }}
-    >
-      <span aria-hidden="true" className="pt-px font-mono text-sm leading-none text-foreground">
-        {AIM_GLYPH[node.state]}
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="block text-xs leading-snug text-foreground">{node.aim}</span>
-        <span className="mt-0.5 block truncate font-mono text-[10px] text-subtle-foreground">
-          {node.slug}
-        </span>
-      </span>
-    </button>
-  );
-}
-
-// Body-on-select detail pane. Stage 2-B adds an inline frontmatter EDIT
-// affordance (aim / parent / state only — cross-edges + body are preserved
-// server-side). When not editing, the frontmatter facts show as a plain
-// definition list (cross-edges as slug text) with an ✎ Edit button; the body
-// always renders raw, read-only (editing it is out of scope — the Producer
-// writes the body via normal file editing).
-function DetailPane({
-  unitName,
-  node,
-  blastCount,
-  parentOptions,
-  forbiddenParents,
-  refresh,
-  onClose,
-}: {
-  unitName: string;
-  node: AimWire;
-  blastCount: number;
-  parentOptions: readonly string[];
-  forbiddenParents: ReadonlySet<string>;
-  refresh: () => void;
-  onClose: () => void;
-}) {
-  const [editing, setEditing] = useState(false);
-
-  return (
-    <div data-testid="aim-detail" className="space-y-3 p-4">
-      <div className="flex items-start justify-between gap-2">
-        <div className="min-w-0">
-          <span className="flex items-baseline gap-1.5">
-            <span aria-hidden="true" className="font-mono text-foreground">
-              {AIM_GLYPH[node.state]}
-            </span>
-            <span className="text-foreground">{node.aim}</span>
-          </span>
-          <span className="mt-0.5 block font-mono text-[10px] text-subtle-foreground">
-            {node.slug}
+            owed-frontier
           </span>
         </div>
         <button
           type="button"
           onClick={onClose}
-          title="Close detail"
-          aria-label="Close detail"
+          title="Close the Aim panel (Esc)"
+          aria-label="Close aim panel"
+          className="rounded px-2 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+        >
+          ✕
+        </button>
+      </header>
+
+      <Ledger counts={ledger} />
+
+      <Controls
+        mode={mode}
+        onMode={setMode}
+        query={query}
+        onQuery={setQuery}
+        onNew={() => primaryRepo && openCreate(primaryRepo.repo_root, "")}
+        canCreate={primaryRepo !== null}
+      />
+
+      <div className="flex min-h-0 flex-1">
+        <div className="min-w-0 flex-1 overflow-auto">
+          {mode === "frontier" ? (
+            <FrontierList
+              repos={repos}
+              query={query}
+              selected={sel?.node.slug ?? null}
+              onSelect={select}
+            />
+          ) : (
+            <TreeNavigator
+              repos={repos}
+              query={query}
+              expanded={expanded}
+              selected={sel?.node.slug ?? null}
+              onToggleExpanded={toggleExpanded}
+              onSelect={select}
+              onAddChild={(repoRoot, parent) => openCreate(repoRoot, parent)}
+              onAddRoot={(repoRoot) => openCreate(repoRoot, "")}
+            />
+          )}
+        </div>
+        <OverviewRuler ticks={ticks} onReveal={reveal} />
+      </div>
+
+      {creating !== null ? (
+        <CreatePanel
+          unitName={unitName}
+          creating={creating}
+          repos={repos}
+          refresh={refresh}
+          onClose={() => setCreating(null)}
+          onCreated={(slug) => {
+            setCreating(null);
+            reveal(slug);
+          }}
+        />
+      ) : sel !== null ? (
+        <Inspector
+          key={sel.node.slug}
+          unitName={unitName}
+          sel={sel}
+          refresh={refresh}
+          onSelect={select}
+          onAddChild={(parent) => openCreate(sel.repo.repo_root, parent)}
+          onClose={() => setSelected(null)}
+        />
+      ) : null}
+    </div>,
+    document.body,
+  );
+}
+
+// Default branch-expansion: every repo group + every root open.
+function seedExpanded(repos: readonly RepoAimsWire[]): Set<string> {
+  const s = new Set<string>();
+  for (const r of repos) {
+    s.add(repoKey(r));
+    for (const root of findRoots(r.aims)) s.add(root.slug);
+  }
+  return s;
+}
+
+// A resolved selection: the node + the repo + the repo's index structures, so
+// the inspector / reveal can walk ancestry and forbid re-parent cycles without
+// re-deriving them.
+interface Selection {
+  node: AimWire;
+  repo: RepoAimsWire;
+  bySlug: Map<string, AimWire>;
+  childrenOf: Map<string, AimWire[]>;
+}
+
+function resolveSelection(slug: string | null, repos: readonly RepoAimsWire[]): Selection | null {
+  if (slug === null) return null;
+  for (const repo of repos) {
+    const node = repo.aims.find((n) => n.slug === slug);
+    if (node) {
+      return {
+        node,
+        repo,
+        bySlug: bySlugMap(repo.aims),
+        childrenOf: buildChildren(repo.aims),
+      };
+    }
+  }
+  return null;
+}
+
+// ── Ledger strip ──────────────────────────────────────────────────────
+
+function Ledger({ counts }: { counts: LedgerCounts }) {
+  const owed = counts.drift + counts.claimed;
+  const total = owed + counts.confirmed;
+  const owedPct = total === 0 ? 0 : Math.round((100 * owed) / total);
+  const confirmedPct = total === 0 ? 0 : 100 - owedPct;
+
+  return (
+    <div
+      data-testid="aim-ledger"
+      className="flex shrink-0 items-center gap-4 border-b border-hairline px-4 py-2"
+    >
+      <span className="flex items-center gap-1.5 font-mono text-[11px] text-warning">
+        <span aria-hidden="true" className="h-2.5 w-2.5 rounded-[2px] bg-warning" />
+        <b className="font-semibold">{counts.drift}</b> drift
+      </span>
+      <span className="flex items-center gap-1.5 font-mono text-[11px] text-warning/80">
+        <span aria-hidden="true" className="h-2.5 w-2.5 rounded-[2px] border border-warning/80" />
+        <b className="font-semibold">{counts.claimed}</b> claimed
+      </span>
+      <span className="flex items-center gap-1.5 font-mono text-[11px] text-subtle-foreground">
+        <span aria-hidden="true" className="h-2.5 w-2.5 rounded-[2px] bg-success/70" />
+        <b className="font-semibold text-muted-foreground">{counts.confirmed}</b> confirmed
+      </span>
+      <div className="flex h-1.5 flex-1 overflow-hidden rounded-full border border-hairline">
+        <div className="bg-warning" style={{ width: `${owedPct}%` }} />
+        <div className="bg-success/40" style={{ width: `${confirmedPct}%` }} />
+      </div>
+    </div>
+  );
+}
+
+// ── Controls (mode + search + new) ────────────────────────────────────
+
+function Controls({
+  mode,
+  onMode,
+  query,
+  onQuery,
+  onNew,
+  canCreate,
+}: {
+  mode: "frontier" | "tree";
+  onMode: (m: "frontier" | "tree") => void;
+  query: string;
+  onQuery: (q: string) => void;
+  onNew: () => void;
+  canCreate: boolean;
+}) {
+  return (
+    <div className="flex shrink-0 items-center gap-2 border-b border-hairline px-4 py-2">
+      <div className="flex overflow-hidden rounded border border-hairline">
+        <button
+          type="button"
+          aria-pressed={mode === "frontier"}
+          onClick={() => onMode("frontier")}
+          className={`px-3 py-1 text-[11px] transition-colors ${
+            mode === "frontier"
+              ? "bg-surface-strong text-warning"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          Frontier ⚠
+        </button>
+        <button
+          type="button"
+          aria-pressed={mode === "tree"}
+          onClick={() => onMode("tree")}
+          className={`border-l border-hairline px-3 py-1 text-[11px] transition-colors ${
+            mode === "tree"
+              ? "bg-surface-strong text-foreground"
+              : "text-muted-foreground hover:text-foreground"
+          }`}
+        >
+          Tree
+        </button>
+      </div>
+      <div className="flex flex-1 items-center gap-2 rounded border border-hairline px-2 py-1">
+        <span aria-hidden="true" className="text-subtle-foreground">
+          ⌕
+        </span>
+        <input
+          aria-label="Filter aims"
+          value={query}
+          onChange={(e) => onQuery(e.target.value)}
+          placeholder="filter by slug / ought…"
+          className="min-w-0 flex-1 bg-transparent font-mono text-[11px] text-foreground outline-none placeholder:text-subtle-foreground"
+        />
+      </div>
+      <button
+        type="button"
+        onClick={onNew}
+        disabled={!canCreate}
+        aria-label="New aim"
+        className="shrink-0 rounded border border-info/40 bg-info/10 px-2 py-1 text-[11px] text-info transition-colors hover:bg-info/20 disabled:cursor-not-allowed disabled:opacity-40"
+      >
+        ＋ aim
+      </button>
+    </div>
+  );
+}
+
+// ── Frontier mode — the owed worklist ─────────────────────────────────
+
+function FrontierList({
+  repos,
+  query,
+  selected,
+  onSelect,
+}: {
+  repos: readonly RepoAimsWire[];
+  query: string;
+  selected: string | null;
+  onSelect: (slug: string) => void;
+}) {
+  const q = query.trim().toLowerCase();
+  const matches = (n: AimWire) =>
+    q === "" || n.slug.toLowerCase().includes(q) || n.aim.toLowerCase().includes(q);
+
+  const sections = repos
+    .map((repo) => {
+      const bySlug = bySlugMap(repo.aims);
+      const owed = frontierRows(repo.aims).filter(matches);
+      const doneDrift = doneDriftedRows(repo.aims).filter(matches);
+      return { repo, bySlug, owed, doneDrift };
+    })
+    .filter((s) => s.owed.length > 0 || s.doneDrift.length > 0);
+
+  if (sections.length === 0) {
+    return (
+      <p className="px-4 py-6 text-[11px] text-subtle-foreground">
+        {q === "" ? "Nothing owed — the forest is calm." : "No owed aim matches the filter."}
+      </p>
+    );
+  }
+
+  return (
+    <div>
+      {sections.map(({ repo, bySlug, owed, doneDrift }) => {
+        const driftN = owed.filter((n) => aimTone(n) === "drift").length;
+        const claimedN = owed.length - driftN;
+        return (
+          <div key={repo.repo_root}>
+            <RepoBanner repo={repo} drift={driftN} claimed={claimedN} />
+            {owed.map((n) => (
+              <AimRow
+                key={n.slug}
+                node={n}
+                selected={selected === n.slug}
+                crumb={breadcrumbText(n.slug, bySlug) || "root"}
+                onSelect={() => onSelect(n.slug)}
+              />
+            ))}
+            {doneDrift.length > 0 && (
+              <>
+                {/* Pin #2: done-and-drifted, surfaced in its OWN cluster — a
+                    re-confirm is owed, but it is not active worklist. */}
+                <div className="px-4 py-1 font-mono text-[9px] uppercase tracking-wide text-success">
+                  done · drifted — re-confirm?
+                </div>
+                {doneDrift.map((n) => (
+                  <AimRow
+                    key={n.slug}
+                    node={n}
+                    selected={selected === n.slug}
+                    crumb={breadcrumbText(n.slug, bySlug) || "root"}
+                    onSelect={() => onSelect(n.slug)}
+                  />
+                ))}
+              </>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// A non-collapsible repo banner used in Frontier sections (the repo is context,
+// not a toggle, here). Primary repo gets the cyan/info accent.
+function RepoBanner({
+  repo,
+  drift,
+  claimed,
+}: {
+  repo: RepoAimsWire;
+  drift: number;
+  claimed: number;
+}) {
+  return (
+    <div
+      className={`flex items-center gap-2 border-y border-hairline bg-surface/40 px-3 py-1 ${
+        repo.primary ? "shadow-[inset_2px_0_0_var(--color-info)]" : ""
+      }`}
+    >
+      <span
+        className={`font-mono text-[11px] font-semibold ${
+          repo.primary ? "text-info" : "text-muted-foreground"
+        }`}
+      >
+        {repo.repo_label}
+      </span>
+      <span className="ml-auto font-mono text-[10px]">
+        {drift > 0 && <span className="text-warning">⚠{drift} </span>}
+        {claimed > 0 && <span className="text-warning/80">◌{claimed}</span>}
+      </span>
+    </div>
+  );
+}
+
+// ── Tree mode — collapsible per-repo navigator with rollups ───────────
+
+function TreeNavigator({
+  repos,
+  query,
+  expanded,
+  selected,
+  onToggleExpanded,
+  onSelect,
+  onAddChild,
+  onAddRoot,
+}: {
+  repos: readonly RepoAimsWire[];
+  query: string;
+  expanded: Set<string>;
+  selected: string | null;
+  onToggleExpanded: (key: string) => void;
+  onSelect: (slug: string) => void;
+  onAddChild: (repoRoot: string, parent: string) => void;
+  onAddRoot: (repoRoot: string) => void;
+}) {
+  const q = query.trim().toLowerCase();
+
+  // A query in Tree mode shows a FLAT, repo-tagged hit list (the tree is a
+  // navigator; a filter wants results, not a pruned tree).
+  if (q !== "") {
+    const hits = repos.flatMap((repo) =>
+      repo.aims
+        .filter((n) => n.slug.toLowerCase().includes(q) || n.aim.toLowerCase().includes(q))
+        .map((n) => ({ repo, node: n })),
+    );
+    if (hits.length === 0) {
+      return (
+        <p className="px-4 py-6 text-[11px] text-subtle-foreground">No aim matches the filter.</p>
+      );
+    }
+    return (
+      <div>
+        {hits.map(({ repo, node }) => (
+          <AimRow
+            key={`${repo.repo_root}:${node.slug}`}
+            node={node}
+            selected={selected === node.slug}
+            repoTag={repo.repo_label}
+            repoPrimary={repo.primary}
+            onSelect={() => onSelect(node.slug)}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      {repos.map((repo) => {
+        const key = repoKey(repo);
+        const open = expanded.has(key);
+        const stats = repoStats(repo.aims);
+        const childrenOf = buildChildren(repo.aims);
+        const roots = findRoots(repo.aims);
+        return (
+          <div key={repo.repo_root}>
+            <RepoHead
+              repo={repo}
+              open={open}
+              stats={stats}
+              onToggle={() => onToggleExpanded(key)}
+              onAddRoot={() => onAddRoot(repo.repo_root)}
+            />
+            {open &&
+              roots.map((root) => (
+                <TreeBranch
+                  key={root.slug}
+                  node={root}
+                  depth={0}
+                  repo={repo}
+                  childrenOf={childrenOf}
+                  expanded={expanded}
+                  selected={selected}
+                  onToggleExpanded={onToggleExpanded}
+                  onSelect={onSelect}
+                  onAddChild={onAddChild}
+                />
+              ))}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function RepoHead({
+  repo,
+  open,
+  stats,
+  onToggle,
+  onAddRoot,
+}: {
+  repo: RepoAimsWire;
+  open: boolean;
+  stats: RollupStats;
+  onToggle: () => void;
+  onAddRoot: () => void;
+}) {
+  return (
+    <div
+      data-testid="aim-repo-head"
+      data-repo={repo.repo_label}
+      className={`flex items-center gap-2 border-y border-hairline bg-surface/40 px-2 py-1 ${
+        repo.primary ? "shadow-[inset_2px_0_0_var(--color-info)]" : ""
+      }`}
+    >
+      <button
+        type="button"
+        onClick={onToggle}
+        aria-expanded={open}
+        aria-label={`${open ? "Collapse" : "Expand"} repo ${repo.repo_label}`}
+        className="flex min-w-0 flex-1 items-center gap-2 text-left"
+      >
+        <span aria-hidden="true" className="w-3 text-subtle-foreground">
+          {open ? "▾" : "▸"}
+        </span>
+        <span
+          className={`font-mono text-[11px] font-semibold ${
+            repo.primary ? "text-info" : "text-muted-foreground"
+          }`}
+        >
+          {repo.repo_label}
+        </span>
+        <span className="font-mono text-[10px] text-subtle-foreground">
+          {stats.count}
+          {stats.drift > 0 && <span className="text-warning"> ⚠{stats.drift}</span>}
+          {stats.claimed > 0 && <span className="text-warning/80"> ◌{stats.claimed}</span>}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={onAddRoot}
+        title={`New root aim in ${repo.repo_label}`}
+        aria-label={`New root aim in ${repo.repo_label}`}
+        className="shrink-0 rounded border border-hairline px-1.5 text-[11px] text-muted-foreground transition-colors hover:border-info/40 hover:text-info"
+      >
+        ＋
+      </button>
+    </div>
+  );
+}
+
+function TreeBranch({
+  node,
+  depth,
+  repo,
+  childrenOf,
+  expanded,
+  selected,
+  onToggleExpanded,
+  onSelect,
+  onAddChild,
+}: {
+  node: AimWire;
+  depth: number;
+  repo: RepoAimsWire;
+  childrenOf: Map<string, AimWire[]>;
+  expanded: Set<string>;
+  selected: string | null;
+  onToggleExpanded: (key: string) => void;
+  onSelect: (slug: string) => void;
+  onAddChild: (repoRoot: string, parent: string) => void;
+}) {
+  const kids = childrenOf.get(node.slug) ?? [];
+  const open = expanded.has(node.slug);
+  const rollup = !open && kids.length > 0 ? subtreeStats(node.slug, childrenOf) : null;
+
+  return (
+    <>
+      <AimRow
+        node={node}
+        depth={depth}
+        selected={selected === node.slug}
+        hasChildren={kids.length > 0}
+        open={open}
+        rollup={rollup}
+        onToggle={kids.length > 0 ? () => onToggleExpanded(node.slug) : undefined}
+        onSelect={() => onSelect(node.slug)}
+        onAddChild={() => onAddChild(repo.repo_root, node.slug)}
+      />
+      {open &&
+        kids.map((c) => (
+          <TreeBranch
+            key={c.slug}
+            node={c}
+            depth={depth + 1}
+            repo={repo}
+            childrenOf={childrenOf}
+            expanded={expanded}
+            selected={selected}
+            onToggleExpanded={onToggleExpanded}
+            onSelect={onSelect}
+            onAddChild={onAddChild}
+          />
+        ))}
+    </>
+  );
+}
+
+// ── The shared row ────────────────────────────────────────────────────
+
+function AimRow({
+  node,
+  depth = 0,
+  selected,
+  crumb,
+  repoTag,
+  repoPrimary,
+  hasChildren = false,
+  open = false,
+  rollup,
+  onToggle,
+  onSelect,
+  onAddChild,
+}: {
+  node: AimWire;
+  depth?: number;
+  selected: boolean;
+  crumb?: string;
+  repoTag?: string;
+  repoPrimary?: boolean;
+  hasChildren?: boolean;
+  open?: boolean;
+  rollup?: RollupStats | null;
+  onToggle?: () => void;
+  onSelect: () => void;
+  onAddChild?: () => void;
+}) {
+  const tone = aimTone(node);
+  return (
+    <div
+      data-testid="aim-row"
+      data-slug={node.slug}
+      data-tone={tone}
+      className={`group flex h-7 items-center gap-1.5 pr-2 ${
+        selected ? "bg-surface-strong" : "hover:bg-surface/60"
+      }`}
+      style={{ paddingLeft: depth > 0 ? depth * 14 : undefined }}
+    >
+      <span
+        aria-hidden="true"
+        className={`h-full w-0.5 shrink-0 rounded-full ${TONE_GUTTER[tone]}`}
+      />
+      {/* Tree toggle (only when the node has children) sits OUTSIDE the select
+          button so there is no nested-interactive markup. */}
+      {hasChildren && onToggle ? (
+        <button
+          type="button"
+          onClick={onToggle}
+          aria-label={`${open ? "Collapse" : "Expand"} ${node.slug}`}
+          className="w-3 shrink-0 text-center text-[9px] text-subtle-foreground hover:text-foreground"
+        >
+          {open ? "▾" : "▸"}
+        </button>
+      ) : depth > 0 || hasChildren ? (
+        <span
+          aria-hidden="true"
+          className="w-3 shrink-0 text-center text-[9px] text-subtle-foreground"
+        >
+          ·
+        </span>
+      ) : null}
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-pressed={selected}
+        title={`${node.slug} · ${AIM_STATE_LABEL[node.state]}`}
+        className="flex min-w-0 flex-1 items-center gap-1.5 text-left"
+      >
+        <span
+          aria-hidden="true"
+          className={`shrink-0 font-mono text-[11px] ${TONE_GLYPH_CLASS[tone]}`}
+        >
+          {TONE_GLYPH[tone]}
+        </span>
+        {/* Pin #2 distinct marker: a done node that ALSO drifted shows the done
+            ✓ glyph AND this warning drift badge — so it never reads as plain
+            done, nor as an open drift. */}
+        {tone === "done-drift" && (
+          <span
+            data-testid="aim-drift-badge"
+            aria-hidden="true"
+            title="also drifted"
+            className="shrink-0 font-mono text-[11px] text-warning"
+          >
+            ⚠
+          </span>
+        )}
+        <span className={`truncate text-[12px] ${TONE_OUGHT_CLASS[tone]}`}>{node.aim}</span>
+        {crumb !== undefined && (
+          <span className="ml-1 max-w-[34%] shrink-0 truncate font-mono text-[9px] text-subtle-foreground">
+            {crumb}
+          </span>
+        )}
+        {repoTag !== undefined && (
+          <span
+            className={`shrink-0 rounded border border-hairline px-1 font-mono text-[8px] ${
+              repoPrimary ? "text-info" : "text-subtle-foreground"
+            }`}
+          >
+            {repoTag}
+          </span>
+        )}
+        {rollup && rollup.count > 0 && (
+          <span
+            data-testid="aim-rollup"
+            className="ml-auto shrink-0 font-mono text-[9px] text-subtle-foreground"
+          >
+            {rollup.count}
+            {rollup.drift > 0 && <span className="text-warning"> ⚠{rollup.drift}</span>}
+            {rollup.claimed > 0 && <span className="text-warning/80"> ◌{rollup.claimed}</span>}
+          </span>
+        )}
+        <InteriorDots marks={node.is} />
+        <span className="shrink-0 font-mono text-[9px] text-subtle-foreground">{node.slug}</span>
+      </button>
+      {onAddChild && (
+        <button
+          type="button"
+          onClick={onAddChild}
+          title={`New child aim under ${node.slug}`}
+          aria-label={`Add child aim under ${node.slug}`}
+          className="shrink-0 rounded border border-hairline px-1 text-[11px] text-muted-foreground opacity-0 transition-opacity hover:border-info/40 hover:text-info group-hover:opacity-100"
+        >
+          ＋
+        </button>
+      )}
+    </div>
+  );
+}
+
+// Tiny per-mark dots beside a row — confirmed = filled success, claimed =
+// filled warning. Mark-only: order + kind are exactly the wire's.
+function InteriorDots({ marks }: { marks: readonly AimInteriorWire[] }) {
+  if (marks.length === 0) return null;
+  return (
+    <span className="flex shrink-0 items-center gap-0.5">
+      {marks.map((m) => (
+        // Interior lines have no id; key off the prose (mark-only — we never
+        // re-order, so position is the wire's).
+        <span
+          key={`${m.kind}:${m.text}:${m.ref ?? ""}`}
+          aria-hidden="true"
+          className={`h-1 w-1 rounded-[1px] ${m.kind === "confirmed" ? "bg-success" : "bg-warning"}`}
+        />
+      ))}
+    </span>
+  );
+}
+
+// ── Overview ruler ────────────────────────────────────────────────────
+
+function OverviewRuler({
+  ticks,
+  onReveal,
+}: {
+  ticks: readonly RulerTick[];
+  onReveal: (slug: string) => void;
+}) {
+  return (
+    <div
+      data-testid="aim-ruler"
+      className="relative w-3.5 shrink-0 overflow-hidden border-l border-hairline bg-surface/30"
+      title="Overview ruler — every node a tick, owed ones lit; click to reveal"
+    >
+      {ticks.map((t) => {
+        const top = `${(t.pos * 100).toFixed(2)}%`;
+        if (t.owed === null) {
+          return (
+            <span
+              key={t.slug}
+              data-testid="ruler-tick"
+              data-slug={t.slug}
+              data-owed="calm"
+              aria-hidden="true"
+              className="absolute right-[3px] left-[3px] h-px bg-subtle-foreground/30"
+              style={{ top }}
+            />
+          );
+        }
+        const lit = t.owed === "drift" ? "bg-warning" : "bg-warning/60";
+        return (
+          <button
+            key={t.slug}
+            type="button"
+            data-testid="ruler-tick"
+            data-slug={t.slug}
+            data-owed={t.owed}
+            onClick={() => onReveal(t.slug)}
+            title={`${t.owed === "drift" ? "⚠ drift" : "◌ claimed"} · ${t.repoLabel} · ${t.slug}`}
+            aria-label={`Reveal ${t.slug} (${t.owed})`}
+            className={`absolute right-[2px] left-[2px] rounded-[1px] ${lit} ${
+              t.owed === "drift" ? "h-[3px]" : "h-[2px]"
+            }`}
+            style={{ top }}
+          />
+        );
+      })}
+    </div>
+  );
+}
+
+// ── Inspector (replaces the old DetailPane) ───────────────────────────
+
+function Inspector({
+  unitName,
+  sel,
+  refresh,
+  onSelect,
+  onAddChild,
+  onClose,
+}: {
+  unitName: string;
+  sel: Selection;
+  refresh: () => void;
+  onSelect: (slug: string) => void;
+  onAddChild: (parent: string) => void;
+  onClose: () => void;
+}) {
+  const { node, bySlug, childrenOf } = sel;
+  const [editing, setEditing] = useState(false);
+  const chain = useMemo(() => ancestry(node.slug, bySlug), [node.slug, bySlug]);
+  const parentOptions = useMemo(() => sel.repo.aims.map((n) => n.slug), [sel.repo]);
+  // Forbid re-parenting onto self or any descendant (a trivial cycle).
+  const forbiddenParents = useMemo(() => {
+    const set = descendantsOf(node.slug, childrenOf);
+    set.add(node.slug);
+    return set;
+  }, [node.slug, childrenOf]);
+
+  return (
+    <aside
+      data-testid="aim-inspector"
+      className="flex max-h-[42vh] shrink-0 flex-col overflow-y-auto border-t border-hairline bg-surface px-4 py-3"
+    >
+      <div className="flex items-start justify-between gap-2">
+        {/* Ought-ancestry breadcrumb — every ancestor selectable; the node
+            itself is the cyan tail. */}
+        <nav className="flex min-w-0 flex-wrap items-center gap-x-1 font-mono text-[10px] text-subtle-foreground">
+          {chain.map((a, i) =>
+            i < chain.length - 1 ? (
+              <span key={a.slug} className="flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => onSelect(a.slug)}
+                  className="max-w-[14ch] truncate text-subtle-foreground hover:text-info"
+                  title={a.aim}
+                >
+                  {a.slug}
+                </button>
+                <span aria-hidden="true" className="text-hairline-strong">
+                  ›
+                </span>
+              </span>
+            ) : (
+              <span key={a.slug} className="text-info">
+                {a.slug}
+              </span>
+            ),
+          )}
+        </nav>
+        <button
+          type="button"
+          onClick={onClose}
+          title="Close inspector"
+          aria-label="Close inspector"
           className="shrink-0 rounded px-1.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
         >
           ✕
         </button>
       </div>
 
+      <p className="mt-2 text-[14px] leading-snug text-foreground">
+        <span className="font-mono text-[10px] text-info">aim:</span> {node.aim}
+      </p>
+
+      <MetaPills node={node} repoLabel={sel.repo.repo_label} repoPrimary={sel.repo.primary} />
+
       {editing ? (
-        // Remount per node (`key`) so the draft always seeds from the current
-        // node, never a stale prior selection.
         <AimEditForm
           key={node.slug}
           unitName={unitName}
@@ -623,59 +1216,158 @@ function DetailPane({
         />
       ) : (
         <>
-          <dl className="grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px]">
-            <dt className="text-subtle-foreground">state</dt>
-            <dd className="text-foreground">{AIM_STATE_LABEL[node.state]}</dd>
-            <dt className="text-subtle-foreground">parent</dt>
-            <dd className="font-mono text-muted-foreground">{node.parent ?? "(root)"}</dd>
-            {node.depends_on.length > 0 && (
-              <>
-                <dt className="text-subtle-foreground">depends_on</dt>
-                <dd className="font-mono text-muted-foreground">{node.depends_on.join(", ")}</dd>
-              </>
-            )}
-            {node.serves.length > 0 && (
-              <>
-                <dt className="text-subtle-foreground">serves</dt>
-                <dd className="font-mono text-muted-foreground">{node.serves.join(", ")}</dd>
-              </>
-            )}
-            {node.related.length > 0 && (
-              <>
-                <dt className="text-subtle-foreground">related</dt>
-                <dd className="font-mono text-muted-foreground">{node.related.join(", ")}</dd>
-              </>
-            )}
-          </dl>
-          <button
-            type="button"
-            onClick={() => setEditing(true)}
-            className="rounded border border-hairline px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
-          >
-            <span aria-hidden="true">✎</span> Edit frontmatter
-          </button>
+          <InteriorList marks={node.is} />
+          <CrossEdges node={node} />
+          <div className="mt-3 flex items-center gap-2">
+            <button
+              type="button"
+              onClick={() => setEditing(true)}
+              className="rounded border border-hairline px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:bg-surface-strong hover:text-foreground"
+            >
+              <span aria-hidden="true">✎</span> Edit frontmatter
+            </button>
+            <button
+              type="button"
+              onClick={() => onAddChild(node.slug)}
+              className="rounded border border-hairline px-2 py-0.5 text-[11px] text-muted-foreground transition-colors hover:border-info/40 hover:text-info"
+            >
+              <span aria-hidden="true">＋</span> Add child aim
+            </button>
+          </div>
         </>
       )}
+    </aside>
+  );
+}
 
-      <section className="space-y-1">
-        <h4 className="text-[10px] uppercase tracking-wide text-subtle-foreground">Body</h4>
-        <AimBody body={node.body} />
-      </section>
-
-      <p className="border-t border-hairline pt-2 text-[11px] text-subtle-foreground">
-        blast radius from here: <span className="text-foreground">{blastCount}</span> descendant
-        {blastCount === 1 ? "" : "s"} drift-possible
-      </p>
+// The meta pill row — repo / state, plus the drift←ancestor pill when the node
+// drifted (from `drift.stale_from_ancestor_slug`).
+function MetaPills({
+  node,
+  repoLabel,
+  repoPrimary,
+}: {
+  node: AimWire;
+  repoLabel: string;
+  repoPrimary: boolean;
+}) {
+  return (
+    <div className="mt-2 flex flex-wrap gap-1.5">
+      <span
+        className={`rounded border px-1.5 py-0.5 font-mono text-[9px] ${
+          repoPrimary ? "border-info/40 text-info" : "border-hairline text-subtle-foreground"
+        }`}
+      >
+        repo: {repoLabel}
+      </span>
+      <span className="rounded border border-hairline px-1.5 py-0.5 font-mono text-[9px] text-subtle-foreground">
+        state: {AIM_STATE_LABEL[node.state]}
+        {node.parent === null ? " · root" : ""}
+      </span>
+      {node.drift !== null && <DriftPill drift={node.drift} done={node.state === "done"} />}
     </div>
   );
 }
 
-// The inline frontmatter edit form (Stage 2-B): aim / parent / state ONLY. The
-// body and the cross-edges (`depends_on` / `serves` / `related`) are NOT touched
-// here — the backend preserves them byte-for-byte. Authority is operator-only,
-// soft: a plain Save, no draft/accept gate. The `parent` select excludes the
-// node itself and its descendants (`forbiddenParents`) so the operator can't
-// form a trivial cycle.
+function DriftPill({ drift, done }: { drift: AimDriftWire; done: boolean }) {
+  return (
+    <span
+      data-testid="aim-drift-pill"
+      title={`ancestor anchor moved ${drift.ancestor_change_date} (${drift.ancestor_change_sha}); this node last changed ${drift.aim_change_date}`}
+      className="rounded border border-warning/40 bg-warning/10 px-1.5 py-0.5 font-mono text-[9px] text-warning"
+    >
+      ⚠ {done ? "done · " : ""}drift ← {drift.stale_from_ancestor_slug}
+    </span>
+  );
+}
+
+// The interior `is[]` list — mark-only: confirmed / claimed exactly as authored
+// (order + kind off the wire), `ref` shown for confirmed marks.
+function InteriorList({ marks }: { marks: readonly AimInteriorWire[] }) {
+  return (
+    <section className="mt-3">
+      <h4 className="font-mono text-[9px] uppercase tracking-wide text-subtle-foreground">
+        interior — is
+      </h4>
+      {marks.length === 0 ? (
+        <p className="mt-1 text-[11px] italic text-subtle-foreground">— a pure ought —</p>
+      ) : (
+        <ul className="mt-1 space-y-1">
+          {marks.map((m) => (
+            // Interior lines have no id; key off the prose (mark-only — order is
+            // the wire's, never re-sorted).
+            <li
+              key={`${m.kind}:${m.text}:${m.ref ?? ""}`}
+              data-testid="aim-mark"
+              data-kind={m.kind}
+              className="flex items-baseline gap-2 text-[12px]"
+            >
+              <MarkTag kind={m.kind} />
+              <span className="text-muted-foreground">
+                {m.text}
+                {m.kind === "confirmed" && m.ref !== null && (
+                  <span className="ml-1 font-mono text-[9px] text-info">[{m.ref}]</span>
+                )}
+              </span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+function MarkTag({ kind }: { kind: AimInteriorKind }) {
+  if (kind === "confirmed") {
+    return (
+      <span className="shrink-0 rounded border border-success/40 px-1 py-px font-mono text-[9px] text-success">
+        ✓ confirmed
+      </span>
+    );
+  }
+  return (
+    <span className="shrink-0 rounded border border-dashed border-warning/50 px-1 py-px font-mono text-[9px] text-warning">
+      ◌ claimed
+    </span>
+  );
+}
+
+// The DAG cross-edges as slug facts (depends_on / serves / related). They are
+// not drawn as edges in the row-based panel — listed here verbatim.
+function CrossEdges({ node }: { node: AimWire }) {
+  if (node.depends_on.length === 0 && node.serves.length === 0 && node.related.length === 0) {
+    return null;
+  }
+  return (
+    <dl className="mt-3 grid grid-cols-[auto_1fr] gap-x-3 gap-y-1 text-[11px]">
+      {node.depends_on.length > 0 && (
+        <>
+          <dt className="text-subtle-foreground">depends_on</dt>
+          <dd className="font-mono text-muted-foreground">{node.depends_on.join(", ")}</dd>
+        </>
+      )}
+      {node.serves.length > 0 && (
+        <>
+          <dt className="text-subtle-foreground">serves</dt>
+          <dd className="font-mono text-muted-foreground">{node.serves.join(", ")}</dd>
+        </>
+      )}
+      {node.related.length > 0 && (
+        <>
+          <dt className="text-subtle-foreground">related</dt>
+          <dd className="font-mono text-muted-foreground">{node.related.join(", ")}</dd>
+        </>
+      )}
+    </dl>
+  );
+}
+
+// ── Write forms (carried from Stage 2-B, integrated into the inspector) ──
+
+// The inline frontmatter edit form: aim / parent / state ONLY. The body and the
+// cross-edges are preserved server-side. Pin #3: after save we `refresh()` —
+// the wire re-reports drift (the engine's parent-only verdict), and the panel
+// re-renders it. There is NO client-side drift cascade here.
 function AimEditForm({
   unitName,
   node,
@@ -720,7 +1412,7 @@ function AimEditForm({
 
   return (
     <form
-      className="space-y-2"
+      className="mt-3 space-y-2"
       onSubmit={(e) => {
         e.preventDefault();
         void onSave();
@@ -775,27 +1467,31 @@ function AimEditForm({
   );
 }
 
-// The create form (Stage 2-B): author a new node — slug / aim / parent. `state`
-// starts `open`, the body starts empty, no cross-edges (the backend default).
-// Client-side slug validation gives fast feedback; the backend stays
-// authoritative (it owns the `409` duplicate / `422` dangling-parent verdicts,
-// surfaced inline). On success the parent re-fetches and selects the new node.
-function CreateForm({
+// The create surface (root or child of an existing node), mounted in the
+// inspector slot. Author `slug` / `aim` / `parent`; `state` starts `open`, the
+// body starts empty, no cross-edges (the backend default). Client-side slug
+// validation gives fast feedback; the backend stays authoritative.
+function CreatePanel({
   unitName,
-  existingSlugs,
+  creating,
+  repos,
   refresh,
   onClose,
   onCreated,
 }: {
   unitName: string;
-  existingSlugs: readonly string[];
+  creating: Creating;
+  repos: readonly RepoAimsWire[];
   refresh: () => void;
   onClose: () => void;
   onCreated: (slug: string) => void;
 }) {
+  const repo = repos.find((r) => r.repo_root === creating.repoRoot) ?? null;
+  const existingSlugs = useMemo(() => repo?.aims.map((n) => n.slug) ?? [], [repo]);
+
   const [slug, setSlug] = useState("");
   const [aim, setAim] = useState("");
-  const [parent, setParent] = useState("");
+  const [parent, setParent] = useState(creating.initialParent);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -827,14 +1523,21 @@ function CreateForm({
   return (
     <form
       data-testid="aim-create"
-      className="space-y-2 p-4"
+      className="flex max-h-[42vh] shrink-0 flex-col gap-2 overflow-y-auto border-t border-hairline bg-surface px-4 py-3"
       onSubmit={(e) => {
         e.preventDefault();
         void onCreate();
       }}
     >
       <div className="flex items-center justify-between gap-2">
-        <h3 className="text-xs font-semibold text-foreground">＋ New aim node</h3>
+        <h3 className="text-xs font-semibold text-foreground">
+          ＋ New aim{" "}
+          <span className="font-mono text-[10px] font-normal text-subtle-foreground">
+            {creating.initialParent !== ""
+              ? `child of ${creating.initialParent}`
+              : `${repo?.repo_label ?? "?"} root`}
+          </span>
+        </h3>
         <button
           type="button"
           onClick={onClose}
@@ -846,6 +1549,16 @@ function CreateForm({
         </button>
       </div>
 
+      <AimField label="aim" htmlFor="aim-create-aim">
+        <textarea
+          id="aim-create-aim"
+          value={aim}
+          onChange={(e) => setAim(e.target.value)}
+          rows={2}
+          placeholder="the human bearing, one line."
+          className="w-full resize-y rounded border border-hairline bg-surface px-2 py-1 text-xs text-foreground"
+        />
+      </AimField>
       <AimField label="slug" htmlFor="aim-create-slug">
         <input
           id="aim-create-slug"
@@ -858,16 +1571,6 @@ function CreateForm({
         {slugError === null && duplicate && (
           <p className="mt-0.5 text-[10px] text-destructive">slug already exists</p>
         )}
-      </AimField>
-      <AimField label="aim" htmlFor="aim-create-aim">
-        <textarea
-          id="aim-create-aim"
-          value={aim}
-          onChange={(e) => setAim(e.target.value)}
-          rows={2}
-          placeholder="the human bearing, one line."
-          className="w-full resize-y rounded border border-hairline bg-surface px-2 py-1 text-xs text-foreground"
-        />
       </AimField>
       <AimField label="parent" htmlFor="aim-create-parent">
         <ParentSelect
@@ -906,9 +1609,8 @@ function CreateForm({
   );
 }
 
-// A stable empty set for the create form's parent select (no node to forbid —
-// a brand-new slug can't be its own ancestor). Module-level so it keeps a
-// constant identity across renders.
+// A stable empty set for the create form's parent select (a brand-new slug
+// can't be its own ancestor). Module-level so it keeps a constant identity.
 const EMPTY_FORBIDDEN: ReadonlySet<string> = new Set<string>();
 
 // A labelled field row shared by the edit + create forms.
@@ -935,9 +1637,7 @@ function AimField({
 }
 
 // Parent slug select: "(root)" + every existing slug except those in
-// `forbidden` (self + descendants, for the edit form). A `value` not present in
-// the options still renders (the current parent is shown even if it were, in
-// some edge case, filtered) — but normal parents are always selectable.
+// `forbidden` (self + descendants, for the edit form).
 function ParentSelect({
   id,
   value,
@@ -993,25 +1693,5 @@ function StateSelect({
         </option>
       ))}
     </select>
-  );
-}
-
-// Render the raw markdown body verbatim, read-only: `whitespace-pre-wrap`
-// preserves the authored line breaks and `font-mono` keeps refs / paths /
-// inline `[confirmed: …]` / `[claimed]` markers legible. No markdown→HTML and
-// NO honesty-tag parsing (brief): the body is free-form prose. An empty body
-// is a valid frontmatter-only node.
-function AimBody({ body }: { body: string }) {
-  if (body.trim() === "") {
-    return (
-      <p className="rounded border border-dashed border-hairline px-2 py-3 text-center text-[11px] italic text-subtle-foreground">
-        (frontmatter-only — no body)
-      </p>
-    );
-  }
-  return (
-    <pre className="max-h-[60vh] overflow-auto whitespace-pre-wrap break-words rounded bg-surface/40 px-2 py-1.5 font-mono text-[11px] leading-snug text-muted-foreground">
-      {body}
-    </pre>
   );
 }

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RAimsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RAimsSection.test.tsx
@@ -1,20 +1,22 @@
 // @vitest-environment jsdom
 //
-// RAimsSection — the aim-tree read view (Stage 1-B, #780 + #782) PLUS the
-// write affordances (graduation Stage 2-B): create a node + edit a node's
-// frontmatter (aim/parent/state only), backed by tmai-core's #501 endpoints.
-// The section is a THIN entry (summary + glyph legend + an ⤢ open affordance);
-// the actual 2D tree + the write forms live in a maximized overlay opened from
-// it. Covers the wire-backed states (render / loading / empty / error / parked),
-// the thin-entry summary, the overlay open / close (✕) / dismiss (Esc), the
-// view machinery carried from prototype #778 (body-on-select detail pane,
-// blast-radius highlight, the distinct dashed `depends_on` cross-edge, the
-// neutral `dead` glyph), and the Stage 2-B write flows (create success +
-// client/backend validation, edit save / cancel).
+// RAimsSection — the destination Aim panel (Stage B convergence, #791). The
+// section is a THIN R-panel entry (summary + owed badge + ⤢ open); the full
+// panel lives in a maximized, portalled overlay opened from it. Covers the
+// wire-backed entry states, and inside the panel: the Frontier owed worklist
+// (drift-first, breadcrumbed, calm-empty), the Tree per-repo navigator
+// (grouping + rollups + collapse), the ledger counts, the inspector (drift
+// pill + the interior `is[]` list), the overview ruler reveal, search, and the
+// carried-over create / edit write flows. Pins exercised: #1 mark-only render,
+// #2 done+drift distinct (not suppressed), #3 drift mirrors the engine (edit →
+// refetch, no client cascade).
 
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AimsResponse, AimWire } from "@/lib/api";
+import { UIPrefsProvider } from "@/lib/ui-prefs-provider";
+import type { AimDriftWire } from "@/types/generated/AimDriftWire";
+import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
 
 const aimsMock = vi.fn();
 const createAimMock = vi.fn();
@@ -35,6 +37,21 @@ vi.mock("@/lib/api", async () => {
 
 import { RAimsSection } from "../RAimsSection";
 
+function driftFrom(slug: string): AimDriftWire {
+  return {
+    stale_from_ancestor_slug: slug,
+    ancestor_change_sha: "abc1234",
+    ancestor_change_date: "2026-06-01",
+    aim_change_date: "2026-05-01",
+  };
+}
+const claimed = (text: string): AimInteriorWire => ({ kind: "claimed", text, ref: null });
+const confirmed = (text: string, ref: string): AimInteriorWire => ({
+  kind: "confirmed",
+  text,
+  ref,
+});
+
 function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
   return {
     aim: `aim ${overrides.slug}`,
@@ -50,375 +67,472 @@ function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
   };
 }
 
-function responseStub(aims: AimWire[] = []): AimsResponse {
-  return {
-    unit: "u",
-    composed_at: "2026-06-07T00:00:00Z",
-    repos: [
-      {
-        repo_label: "tmai-core",
-        repo_root: "/p/tmai-core",
-        primary: true,
-        repo_head: null,
-        aims,
-      },
-    ],
-  };
-}
-
-// The validated probe shape: two roots, a nested subtree, a depends_on
-// cross-edge, a dead node, and a body.
-const TREE: AimWire[] = [
-  aimStub({ slug: "amplify-human-judgment", aim: "人間の判断を増幅する" }),
+// Two repos:
+//   tmai-core (primary)
+//     amplify-human-judgment (root, open, claimed)            → owed (claimed)
+//       attention-per-artifact (open, drift←amplify, conf+claim) → owed (drift)
+//         attention-backend (done, confirmed)                 → plain done
+//     aim-system (root, open, confirmed)                      → calm
+//       aim-honesty (dead)                                    → abandoned
+//       review-attention-budget (done, drift←aim-system)      → PIN #2 done+drift
+//   tmai
+//     inverted-ui (root, open, claimed)                       → owed (claimed)
+const CORE: AimWire[] = [
+  aimStub({ slug: "amplify-human-judgment", aim: "amplify judgment", is: [claimed("進行中")] }),
   aimStub({
     slug: "attention-per-artifact",
-    aim: "注意を per-artifact に",
+    aim: "per-artifact attention",
     parent: "amplify-human-judgment",
-    body: "観測 → 判断 → dispatch のループ。\n[confirmed: #769] storage + wire",
+    drift: driftFrom("amplify-human-judgment"),
+    is: [confirmed("storage + wire", "PR#490"), claimed("ancestor moved — re-confirm")],
   }),
   aimStub({
     slug: "attention-backend",
-    aim: "storage + wire",
+    aim: "backend compute",
     parent: "attention-per-artifact",
     state: "done",
+    is: [confirmed("wired", "PR#500")],
   }),
-  aimStub({ slug: "aim-system", aim: "records を書く構造に" }),
   aimStub({
-    slug: "aim-authority",
-    aim: "authority = event-driven amendment",
-    parent: "aim-system",
-    depends_on: ["aim-honesty"],
-    serves: ["amplify-human-judgment"],
-    related: ["aim-shared-means"],
+    slug: "aim-system",
+    aim: "records as structure",
+    is: [confirmed("graduated", "PR#501")],
   }),
   aimStub({ slug: "aim-honesty", aim: "confirmed ⊥ claimed", parent: "aim-system", state: "dead" }),
+  aimStub({
+    slug: "review-attention-budget",
+    aim: "review budget is the limiter",
+    parent: "aim-system",
+    state: "done",
+    drift: driftFrom("aim-system"),
+  }),
+];
+const UI: AimWire[] = [
+  aimStub({ slug: "inverted-ui", aim: "root to conversation", is: [claimed("frontier")] }),
 ];
 
+function responseStub(
+  repos: { label: string; primary: boolean; aims: AimWire[] }[] = [
+    { label: "tmai-core", primary: true, aims: CORE },
+    { label: "tmai", primary: false, aims: UI },
+  ],
+): AimsResponse {
+  return {
+    unit: "u",
+    composed_at: "2026-06-07T00:00:00Z",
+    repos: repos.map((r) => ({
+      repo_label: r.label,
+      repo_root: `/p/${r.label}`,
+      primary: r.primary,
+      repo_head: null,
+      aims: r.aims,
+    })),
+  };
+}
+
+function renderPanel(unitName: string | null = "u") {
+  return render(
+    <UIPrefsProvider>
+      <RAimsSection unitName={unitName} expanded={true} onToggle={vi.fn()} />
+    </UIPrefsProvider>,
+  );
+}
+
+async function openPanel() {
+  const openBtn = await screen.findByRole("button", { name: /Open aim panel/ });
+  fireEvent.click(openBtn);
+  return screen.findByRole("dialog", { name: "Aim panel" });
+}
+
+// The row element for a slug (the panel is portalled to document.body).
+function rowEl(slug: string): HTMLElement {
+  const el = document.querySelector(`[data-testid="aim-row"][data-slug="${slug}"]`);
+  if (!el) throw new Error(`no row for ${slug}`);
+  return el as HTMLElement;
+}
+function selectRow(slug: string) {
+  // The select button is the one carrying aria-pressed (toggle / add buttons
+  // do not), so this is unambiguous within a row.
+  const btn = rowEl(slug).querySelector("button[aria-pressed]");
+  if (!btn) throw new Error(`no select button for ${slug}`);
+  fireEvent.click(btn);
+}
+
 beforeEach(() => {
+  localStorage.clear();
   aimsMock.mockReset();
   createAimMock.mockReset();
   editAimMock.mockReset();
 });
 
-// Open the maximized overlay from the thin entry, returning the dialog element.
-async function openOverlay() {
-  const openBtn = await screen.findByRole("button", { name: /Open aim-tree/ });
-  fireEvent.click(openBtn);
-  return screen.findByRole("dialog", { name: "Aim-tree" });
-}
-
 describe("RAimsSection — thin entry", () => {
-  it("shows a compact summary (aim + root count) and an open affordance, not the canvas", async () => {
-    aimsMock.mockResolvedValue(responseStub(TREE));
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+  it("shows a compact aim/repo summary + an owed badge, not the panel", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
 
-    // Summary: 6 aims across 2 roots (amplify-human-judgment + aim-system).
-    // The root count sits in its own foreground span, so assert on the full
-    // summary text rather than a single contiguous text node.
-    await waitFor(() => {
-      expect(screen.getByText(/6 aims/)).toBeTruthy();
-    });
-    expect(screen.getByText(/6 aims/).textContent).toContain("2 root");
-    // The open affordance is present…
-    expect(screen.getByRole("button", { name: /Open aim-tree/ })).toBeTruthy();
-    // …but the maximized tree is NOT mounted until it is clicked.
-    expect(screen.queryByRole("dialog", { name: "Aim-tree" })).toBeNull();
-    expect(screen.queryByText("人間の判断を増幅する")).toBeNull();
+    await waitFor(() => expect(screen.getByText(/7 aims/)).toBeTruthy());
+    expect(screen.getByText(/7 aims/).textContent).toContain("2 repo");
+    // Owed badge surfaces drift (2) without opening.
+    expect(screen.getByText(/2 drift/)).toBeTruthy();
+    // The panel is NOT mounted until opened.
+    expect(screen.queryByRole("dialog", { name: "Aim panel" })).toBeNull();
   });
 
-  it("header count is the plain total node count (no severity styling)", async () => {
-    aimsMock.mockResolvedValue(responseStub(TREE));
-    const { container } = render(<RAimsSection unitName="u" expanded={false} onToggle={vi.fn()} />);
-    await waitFor(() => {
-      expect(screen.getByText(`${TREE.length}`)).toBeTruthy();
-    });
-    expect(container.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
+  it("header count is the plain total (no severity styling)", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    const { container } = render(
+      <UIPrefsProvider>
+        <RAimsSection unitName="u" expanded={false} onToggle={vi.fn()} />
+      </UIPrefsProvider>,
+    );
+    await waitFor(() => expect(screen.getByText("7")).toBeTruthy());
+    // The Section header count carries no appraisal accent.
+    const header = container.querySelector('[data-testid="r-section-aims"] button');
+    expect(header?.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
   });
 
   it("shows a loading placeholder during the initial fetch", () => {
-    // A pending promise keeps the hook in its initial loading state.
     aimsMock.mockReturnValue(new Promise<AimsResponse>(() => {}));
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    renderPanel();
     expect(screen.getByText("Loading…")).toBeTruthy();
   });
 
-  it("stays actionable at zero aims (summary + open, so the first node can be authored)", async () => {
-    // Stage 2-B: unlike the read-only Stage 1-B's terminal "No aims."
-    // placeholder, an empty tree must still expose the create path so the
-    // operator can author the first node.
-    aimsMock.mockResolvedValue(responseStub([]));
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-    await waitFor(() => {
-      expect(screen.getByText(/0 aims/)).toBeTruthy();
-    });
-    expect(screen.getByRole("button", { name: /Open aim-tree/ })).toBeTruthy();
-    // The overlay opens and exposes the create affordance even with no nodes.
-    await openOverlay();
-    expect(screen.getByRole("button", { name: /New aim node/ })).toBeTruthy();
+  it("stays actionable at zero aims (the first node can be authored)", async () => {
+    aimsMock.mockResolvedValue(responseStub([{ label: "tmai-core", primary: true, aims: [] }]));
+    renderPanel();
+    await waitFor(() => expect(screen.getByText(/0 aims/)).toBeTruthy());
+    await openPanel();
+    expect(screen.getByRole("button", { name: "New aim" })).toBeTruthy();
   });
 
   it("surfaces a fetch error", async () => {
     aimsMock.mockRejectedValue(new Error("boom"));
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-    await waitFor(() => {
-      expect(screen.getByText(/Failed to load aims: boom/)).toBeTruthy();
-    });
+    renderPanel();
+    await waitFor(() => expect(screen.getByText(/Failed to load aims: boom/)).toBeTruthy());
   });
 
   it("parks with a placeholder when no project is selected (no fetch)", () => {
-    render(<RAimsSection unitName={null} expanded={true} onToggle={vi.fn()} />);
+    renderPanel(null);
     expect(screen.getByText(/Pick a project to see aims\./)).toBeTruthy();
     expect(aimsMock).not.toHaveBeenCalled();
   });
 });
 
-describe("RAimsSection — maximized overlay", () => {
-  it("opens the overlay on ⤢ click, rendering every aim node (anchor + slug)", async () => {
-    aimsMock.mockResolvedValue(responseStub(TREE));
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+describe("RAimsSection — panel shell", () => {
+  it("opens on ⤢, dismisses via ✕ and via Esc", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
+    await openPanel();
+    fireEvent.click(screen.getByRole("button", { name: /Close aim panel/ }));
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Aim panel" })).toBeNull());
 
-    await openOverlay();
-
-    expect(screen.getByText("人間の判断を増幅する")).toBeTruthy();
-    expect(screen.getByText("records を書く構造に")).toBeTruthy();
-    // The slug shows under the anchor inside the node box.
-    expect(screen.getByText("attention-per-artifact")).toBeTruthy();
-  });
-
-  it("dismisses via the ✕ close button", async () => {
-    aimsMock.mockResolvedValue(responseStub(TREE));
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-
-    await openOverlay();
-    fireEvent.click(screen.getByRole("button", { name: /Close aim-tree/ }));
-    await waitFor(() => {
-      expect(screen.queryByRole("dialog", { name: "Aim-tree" })).toBeNull();
-    });
-  });
-
-  it("dismisses via Esc", async () => {
-    aimsMock.mockResolvedValue(responseStub(TREE));
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-
-    await openOverlay();
+    await openPanel();
     fireEvent.keyDown(document, { key: "Escape" });
-    await waitFor(() => {
-      expect(screen.queryByRole("dialog", { name: "Aim-tree" })).toBeNull();
-    });
+    await waitFor(() => expect(screen.queryByRole("dialog", { name: "Aim panel" })).toBeNull());
   });
 
-  it("selecting a node opens its body in the detail pane and reports the blast radius", async () => {
-    aimsMock.mockResolvedValue(responseStub(TREE));
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-    await openOverlay();
-
-    const node = await screen.findByRole("button", {
-      name: /attention-per-artifact/,
-    });
-    fireEvent.click(node);
-
-    // Body-on-select: the raw markdown body renders read-only in the detail
-    // pane (scoped — the anchor/slug also appear in the tree node boxes).
-    const detail = await screen.findByTestId("aim-detail");
-    expect(within(detail).getByText(/storage \+ wire/)).toBeTruthy();
-    // Blast radius: attention-per-artifact has one descendant (attention-backend).
-    // The count is split into its own span, so assert on the pane's text.
-    expect(detail.textContent).toContain("1 descendant");
-  });
-
-  it("lists depends_on / serves / related as slug text in the detail pane", async () => {
-    aimsMock.mockResolvedValue(responseStub(TREE));
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-    await openOverlay();
-
-    const node = await screen.findByRole("button", { name: /aim-authority/ });
-    fireEvent.click(node);
-
-    const detail = await screen.findByTestId("aim-detail");
-    // Cross-edges list as slug text, scoped to the detail pane.
-    expect(within(detail).getByText("aim-honesty")).toBeTruthy(); // depends_on (drawn too)
-    expect(within(detail).getByText("amplify-human-judgment")).toBeTruthy(); // serves
-    expect(within(detail).getByText("aim-shared-means")).toBeTruthy(); // related
-  });
-
-  it("draws depends_on as a distinct dashed cross-edge path", async () => {
-    aimsMock.mockResolvedValue(responseStub(TREE));
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-    await openOverlay();
-    await screen.findByText("authority = event-driven amendment");
-    // The cross-edge is a <path> with a dasharray (the legend uses a <line>,
-    // so querying for path[stroke-dasharray] targets the edge specifically).
-    // The overlay is portalled to document.body, so query the document.
-    const dashed = document.querySelector('path[stroke-dasharray="4 3"]');
-    expect(dashed).not.toBeNull();
-  });
-
-  it("renders the dead state with a neutral glyph and no severity color", async () => {
-    aimsMock.mockResolvedValue(
-      responseStub([aimStub({ slug: "x", aim: "dead aim", state: "dead" })]),
-    );
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-    await openOverlay();
-    await screen.findByText("dead aim");
-    // Neutral shape glyph for dead — no heat / severity color anywhere.
-    expect(screen.getAllByText("⊘").length).toBeGreaterThan(0);
-    expect(document.body.innerHTML).not.toMatch(/text-warning|text-destructive|text-success/);
+  it("ledger counts drift / claimed / confirmed off the forest", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
+    await openPanel();
+    const ledger = screen.getByTestId("aim-ledger");
+    // drift=2 (attention-per-artifact open + review-attention-budget done; dead
+    // excluded), claimed marks=3, confirmed marks=3.
+    expect(ledger.textContent).toMatch(/2\s*drift/);
+    expect(ledger.textContent).toMatch(/3\s*claimed/);
+    expect(ledger.textContent).toMatch(/3\s*confirmed/);
   });
 });
 
-describe("RAimsSection — Stage 2-B create", () => {
-  it("creates a node from the form and reflects it after the refresh", async () => {
-    const created = aimStub({ slug: "new-node", aim: "the new bearing" });
-    // Initial fetch is the base tree; the post-create refresh includes the new
-    // node so it lands in the canvas.
-    aimsMock.mockResolvedValueOnce(responseStub(TREE));
-    aimsMock.mockResolvedValue(responseStub([...TREE, created]));
+describe("RAimsSection — Frontier mode (owed worklist)", () => {
+  it("defaults to Frontier and lists owed nodes drift-first, calm nodes absent", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
+    await openPanel();
+
+    // owed in core: drift (attention-per-artifact) then claimed (amplify…).
+    expect(rowEl("attention-per-artifact").dataset.tone).toBe("drift");
+    expect(rowEl("amplify-human-judgment").dataset.tone).toBe("claimed");
+    // A calm (confirmed-only) node is NOT in the worklist.
+    expect(document.querySelector('[data-testid="aim-row"][data-slug="aim-system"]')).toBeNull();
+    // owed in the non-primary repo too.
+    expect(rowEl("inverted-ui").dataset.tone).toBe("claimed");
+  });
+
+  it("breadcrumbs each owed row with its ought-ancestry", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
+    await openPanel();
+    // attention-per-artifact sits under amplify-human-judgment.
+    expect(rowEl("attention-per-artifact").textContent).toContain("amplify-human-judgment");
+  });
+
+  it("PIN #2 — a done+drift node is surfaced DISTINCTLY, not suppressed, not folded into owed", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
+    await openPanel();
+
+    // It renders (surfaced) with its own done-drift tone…
+    const r = rowEl("review-attention-budget");
+    expect(r.dataset.tone).toBe("done-drift");
+    // …carries the distinct drift badge (a done ✓ would otherwise hide it)…
+    expect(within(r).getByTestId("aim-drift-badge")).toBeTruthy();
+    // …and lives under the dedicated "done · drifted" cluster, not the worklist.
+    expect(screen.getByText(/done · drifted/)).toBeTruthy();
+  });
+
+  it("shows a calm message when nothing is owed", async () => {
+    aimsMock.mockResolvedValue(
+      responseStub([
+        {
+          label: "tmai-core",
+          primary: true,
+          aims: [aimStub({ slug: "calm", is: [confirmed("ok", "PR#1")] })],
+        },
+      ]),
+    );
+    renderPanel();
+    await openPanel();
+    expect(screen.getByText(/the forest is calm/)).toBeTruthy();
+  });
+});
+
+describe("RAimsSection — Tree mode (per-repo navigator + rollups)", () => {
+  async function openTree() {
+    await openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+  }
+
+  it("groups by repo (primary highlighted) and un-flattens the forest", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
+    await openTree();
+    const heads = screen.getAllByTestId("aim-repo-head");
+    expect(heads.map((h) => h.dataset.repo)).toEqual(["tmai-core", "tmai"]);
+    // Primary repo head carries the info accent (inset shadow var).
+    expect(heads[0].className).toContain("--color-info");
+  });
+
+  it("collapsing a branch reveals a rollup badge with the owed breakdown", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
+    await openTree();
+    // amplify is a root → open by default; collapse it.
+    const toggle = rowEl("amplify-human-judgment").querySelector('button[aria-label^="Collapse"]');
+    expect(toggle).toBeTruthy();
+    fireEvent.click(toggle as Element);
+    // Its child (attention-per-artifact) is now hidden…
+    expect(
+      document.querySelector('[data-testid="aim-row"][data-slug="attention-per-artifact"]'),
+    ).toBeNull();
+    // …and the rollup shows the subtree's drift count (⚠1: attention-per-artifact).
+    const rollup = within(rowEl("amplify-human-judgment")).getByTestId("aim-rollup");
+    expect(rollup.textContent).toContain("⚠1");
+  });
+});
+
+describe("RAimsSection — inspector", () => {
+  it("shows the drift←ancestor pill and the interior is[] list (mark-only, ref for confirmed)", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
+    await openPanel();
+    selectRow("attention-per-artifact");
+
+    const insp = await screen.findByTestId("aim-inspector");
+    // drift pill names the stale-from ancestor.
+    expect(within(insp).getByTestId("aim-drift-pill").textContent).toContain(
+      "drift ← amplify-human-judgment",
+    );
+    // is[] list: a confirmed (with ref) + a claimed, exactly as authored.
+    const marks = within(insp).getAllByTestId("aim-mark");
+    expect(marks.map((m) => m.dataset.kind)).toEqual(["confirmed", "claimed"]);
+    expect(marks[0].textContent).toContain("PR#490"); // ref shown for confirmed
+    expect(marks[1].textContent).toContain("ancestor moved");
+  });
+
+  it("breadcrumb in the inspector lets you climb to an ancestor", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
+    await openPanel();
+    selectRow("attention-per-artifact");
+
+    const insp = await screen.findByTestId("aim-inspector");
+    // The ancestor slug is a clickable crumb; clicking re-selects it.
+    fireEvent.click(within(insp).getByRole("button", { name: "amplify-human-judgment" }));
+    await waitFor(() => {
+      expect(screen.getByTestId("aim-inspector").textContent).toContain("amplify judgment");
+    });
+  });
+});
+
+describe("RAimsSection — overview ruler", () => {
+  it("clicking a lit tick reveals the node in Tree mode and selects it", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
+    await openPanel();
+
+    const tick = document.querySelector(
+      '[data-testid="ruler-tick"][data-slug="attention-per-artifact"]',
+    );
+    expect(tick?.getAttribute("data-owed")).toBe("drift");
+    fireEvent.click(tick as Element);
+
+    // Reveal switches to Tree (the Tree toggle is now pressed) and selects.
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Tree" }).getAttribute("aria-pressed")).toBe(
+        "true",
+      );
+    });
+    expect(screen.getByTestId("aim-inspector").textContent).toContain("per-artifact attention");
+  });
+});
+
+describe("RAimsSection — search", () => {
+  it("filters the owed worklist by slug / ought", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
+    await openPanel();
+
+    fireEvent.change(screen.getByLabelText("Filter aims"), { target: { value: "per-artifact" } });
+    expect(rowEl("attention-per-artifact")).toBeTruthy();
+    expect(
+      document.querySelector('[data-testid="aim-row"][data-slug="amplify-human-judgment"]'),
+    ).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Filter aims"), { target: { value: "zzz-no-match" } });
+    expect(screen.getByText(/No owed aim matches/)).toBeTruthy();
+  });
+});
+
+describe("RAimsSection — create (carried Stage 2-B, integrated)", () => {
+  it("creates from the + aim form and reflects it after the refetch", async () => {
+    const created = aimStub({ slug: "new-node", aim: "the new bearing", is: [] });
+    aimsMock.mockResolvedValueOnce(responseStub());
+    aimsMock.mockResolvedValue(
+      responseStub([{ label: "tmai-core", primary: true, aims: [...CORE, created] }]),
+    );
     createAimMock.mockResolvedValue(created);
 
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-    await openOverlay();
-
-    fireEvent.click(screen.getByRole("button", { name: /New aim node/ }));
-    fireEvent.change(screen.getByLabelText("slug"), { target: { value: "new-node" } });
+    renderPanel();
+    await openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "New aim" }));
     fireEvent.change(screen.getByLabelText("aim"), { target: { value: "the new bearing" } });
+    fireEvent.change(screen.getByLabelText("slug"), { target: { value: "new-node" } });
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
-    await waitFor(() => {
+    await waitFor(() =>
       expect(createAimMock).toHaveBeenCalledWith("u", {
         slug: "new-node",
         aim: "the new bearing",
         parent: null,
-      });
-    });
-    // The refresh re-fetch surfaces the new node (in the canvas node box, and
-    // — since create selects it — the detail pane too, hence getAllByText).
-    await waitFor(() => {
-      expect(screen.getAllByText("the new bearing").length).toBeGreaterThan(0);
-    });
+      }),
+    );
+    // The refetch + reveal surfaces the node (in a row, and the inspector).
+    await waitFor(() => expect(screen.getAllByText("the new bearing").length).toBeGreaterThan(0));
   });
 
-  it("passes the selected parent through on create", async () => {
-    aimsMock.mockResolvedValue(responseStub(TREE));
-    createAimMock.mockResolvedValue(aimStub({ slug: "child", aim: "c", parent: "aim-system" }));
+  it("offers add-child from the inspector, presetting the parent", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    createAimMock.mockResolvedValue(
+      aimStub({ slug: "child", aim: "c", parent: "amplify-human-judgment" }),
+    );
+    renderPanel();
+    await openPanel();
+    selectRow("amplify-human-judgment");
+    fireEvent.click(await screen.findByRole("button", { name: /Add child aim/ }));
 
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-    await openOverlay();
-    fireEvent.click(screen.getByRole("button", { name: /New aim node/ }));
-    fireEvent.change(screen.getByLabelText("slug"), { target: { value: "child" } });
     fireEvent.change(screen.getByLabelText("aim"), { target: { value: "c" } });
-    fireEvent.change(screen.getByLabelText("parent"), { target: { value: "aim-system" } });
+    fireEvent.change(screen.getByLabelText("slug"), { target: { value: "child" } });
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
-    await waitFor(() => {
+    await waitFor(() =>
       expect(createAimMock).toHaveBeenCalledWith("u", {
         slug: "child",
         aim: "c",
-        parent: "aim-system",
-      });
-    });
+        parent: "amplify-human-judgment",
+      }),
+    );
   });
 
-  it("blocks create on a client-invalid slug (dated) without calling the API", async () => {
-    aimsMock.mockResolvedValue(responseStub(TREE));
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-    await openOverlay();
-    fireEvent.click(screen.getByRole("button", { name: /New aim node/ }));
-    fireEvent.change(screen.getByLabelText("slug"), { target: { value: "2026-01-02-x" } });
-    fireEvent.change(screen.getByLabelText("aim"), { target: { value: "a" } });
+  it("blocks a client-invalid (dated) slug and a duplicate without calling the API", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
+    await openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "New aim" }));
 
+    fireEvent.change(screen.getByLabelText("aim"), { target: { value: "a" } });
+    fireEvent.change(screen.getByLabelText("slug"), { target: { value: "2026-01-02-x" } });
     expect(screen.getByText(/NON-dated/)).toBeTruthy();
     expect(screen.getByRole("button", { name: "Create" })).toHaveProperty("disabled", true);
-    expect(createAimMock).not.toHaveBeenCalled();
-  });
 
-  it("flags a duplicate slug client-side before the API", async () => {
-    aimsMock.mockResolvedValue(responseStub(TREE));
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-    await openOverlay();
-    fireEvent.click(screen.getByRole("button", { name: /New aim node/ }));
-    // `aim-system` already exists in TREE.
     fireEvent.change(screen.getByLabelText("slug"), { target: { value: "aim-system" } });
-    fireEvent.change(screen.getByLabelText("aim"), { target: { value: "a" } });
-
     expect(screen.getByText(/already exists/)).toBeTruthy();
-    expect(screen.getByRole("button", { name: "Create" })).toHaveProperty("disabled", true);
     expect(createAimMock).not.toHaveBeenCalled();
   });
 
-  it("surfaces a backend rejection (409/422) inline", async () => {
-    aimsMock.mockResolvedValue(responseStub(TREE));
-    // Client-valid, non-duplicate slug that the backend nonetheless rejects
-    // (e.g. a race, or a rule the client mirror does not enforce).
-    createAimMock.mockRejectedValue(new Error("aim 'racy-node' already exists"));
-
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-    await openOverlay();
-    fireEvent.click(screen.getByRole("button", { name: /New aim node/ }));
-    fireEvent.change(screen.getByLabelText("slug"), { target: { value: "racy-node" } });
+  it("surfaces a backend rejection inline", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    createAimMock.mockRejectedValue(new Error("aim 'racy' already exists"));
+    renderPanel();
+    await openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "New aim" }));
     fireEvent.change(screen.getByLabelText("aim"), { target: { value: "a" } });
+    fireEvent.change(screen.getByLabelText("slug"), { target: { value: "racy" } });
     fireEvent.click(screen.getByRole("button", { name: "Create" }));
 
-    await waitFor(() => {
-      expect(screen.getByRole("alert").textContent).toContain("already exists");
-    });
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("already exists"));
   });
 });
 
-describe("RAimsSection — Stage 2-B edit", () => {
+describe("RAimsSection — edit (pin #3: drift mirrors the engine on refetch)", () => {
   async function selectAndEdit(slug: string) {
-    aimsMock.mockResolvedValue(responseStub(TREE));
-    render(<RAimsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
-    await openOverlay();
-    fireEvent.click(await screen.findByRole("button", { name: new RegExp(slug) }));
-    const detail = await screen.findByTestId("aim-detail");
-    fireEvent.click(within(detail).getByRole("button", { name: /Edit frontmatter/ }));
-    return detail;
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
+    await openPanel();
+    // Edit from Tree mode so calm (non-owed) nodes like aim-system are reachable
+    // (Frontier only lists owed rows).
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+    selectRow(slug);
+    const insp = await screen.findByTestId("aim-inspector");
+    fireEvent.click(within(insp).getByRole("button", { name: /Edit frontmatter/ }));
+    return insp;
   }
 
-  it("saves an edited aim / parent / state and re-fetches", async () => {
+  it("saves an edited aim / parent / state and REFETCHES (no client-side cascade)", async () => {
     editAimMock.mockResolvedValue(aimStub({ slug: "aim-system", aim: "edited bearing" }));
-    const detail = await selectAndEdit("aim-system");
+    const insp = await selectAndEdit("aim-system");
 
-    fireEvent.change(within(detail).getByLabelText("aim"), {
-      target: { value: "edited bearing" },
-    });
-    fireEvent.change(within(detail).getByLabelText("state"), { target: { value: "done" } });
-    fireEvent.click(within(detail).getByRole("button", { name: "Save" }));
+    fireEvent.change(within(insp).getByLabelText("aim"), { target: { value: "edited bearing" } });
+    fireEvent.change(within(insp).getByLabelText("state"), { target: { value: "done" } });
+    fireEvent.click(within(insp).getByRole("button", { name: "Save" }));
 
-    await waitFor(() => {
+    await waitFor(() =>
       expect(editAimMock).toHaveBeenCalledWith("u", "aim-system", {
         aim: "edited bearing",
         parent: null,
         state: "done",
-      });
-    });
-    // refresh() re-invokes the aims fetch after the write.
-    await waitFor(() => {
-      expect(aimsMock.mock.calls.length).toBeGreaterThan(1);
-    });
+      }),
+    );
+    // Pin #3: the save triggers a refetch — the panel renders whatever drift the
+    // wire then reports; it does NOT fake a transitive cascade client-side.
+    await waitFor(() => expect(aimsMock.mock.calls.length).toBeGreaterThan(1));
   });
 
   it("cancel leaves the node untouched (no API call)", async () => {
-    const detail = await selectAndEdit("aim-system");
-    fireEvent.change(within(detail).getByLabelText("aim"), { target: { value: "scrapped" } });
-    fireEvent.click(within(detail).getByRole("button", { name: "Cancel" }));
-
-    // Back to the read-only facts; no edit was sent.
-    expect(within(detail).getByText(/Edit frontmatter/)).toBeTruthy();
+    const insp = await selectAndEdit("aim-system");
+    fireEvent.change(within(insp).getByLabelText("aim"), { target: { value: "scrapped" } });
+    fireEvent.click(within(insp).getByRole("button", { name: "Cancel" }));
+    expect(within(insp).getByText(/Edit frontmatter/)).toBeTruthy();
     expect(editAimMock).not.toHaveBeenCalled();
   });
 
-  it("excludes the node itself and its descendants from the parent options (no cycles)", async () => {
-    // Select amplify-human-judgment (root): its descendants are
-    // attention-per-artifact + attention-backend; none — nor itself — may
-    // become its parent.
-    const detail = await selectAndEdit("amplify-human-judgment");
-    const parentSelect = within(detail).getByLabelText("parent") as HTMLSelectElement;
+  it("excludes the node + its descendants from the parent options (no cycles)", async () => {
+    const insp = await selectAndEdit("amplify-human-judgment");
+    const parentSelect = within(insp).getByLabelText("parent") as HTMLSelectElement;
     const options = Array.from(parentSelect.options).map((o) => o.value);
     expect(options).not.toContain("amplify-human-judgment");
-    expect(options).not.toContain("attention-per-artifact");
-    expect(options).not.toContain("attention-backend");
-    // A node outside the subtree is still a valid parent.
-    expect(options).toContain("aim-system");
+    expect(options).not.toContain("attention-per-artifact"); // descendant
+    expect(options).not.toContain("attention-backend"); // deeper descendant
+    expect(options).toContain("aim-system"); // outside the subtree → allowed
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/__tests__/aim-tree.test.ts
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/aim-tree.test.ts
@@ -1,21 +1,50 @@
-// Pure aim-tree layout + traversal — no React, no DOM. Covers the tree-build
-// (parent/slug grouping + tidy layout) and the blast-radius walk graduated
-// from prototype #778 and rewired onto the live `AimWire` model.
+// Pure aim-forest model — no React, no DOM. Covers the owed/frontier ranking,
+// the per-repo + subtree rollups, the ledger counts, the ought-ancestry walk,
+// the overview-ruler order, and the pin-#2 done+drift tone. (The retired
+// tidy-tree geometry's tests retired with the canvas it served — Stage B's
+// panel is row-based, not a 2D canvas.)
 
 import { describe, expect, it } from "vitest";
 import type { AimsResponse } from "@/lib/api";
+import type { AimDriftWire } from "@/types/generated/AimDriftWire";
+import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
 import type { AimWire } from "@/types/generated/AimWire";
 import {
+  aimTone,
+  ancestry,
+  breadcrumbText,
   buildChildren,
-  computeLayout,
-  dependsEdgePath,
+  bySlugMap,
   descendantsOf,
+  doneDriftedRows,
   findRoots,
   flattenRepos,
-  NODE_W,
-  nodeHeight,
-  parentEdgePath,
+  frontierRows,
+  hasClaimed,
+  hasConfirmed,
+  isDoneDrifted,
+  isDrifted,
+  isOwed,
+  ledgerCounts,
+  repoForests,
+  repoStats,
+  rulerOrder,
+  subtreeStats,
 } from "../aim-tree";
+
+const DRIFT: AimDriftWire = {
+  stale_from_ancestor_slug: "amplify-human-judgment",
+  ancestor_change_sha: "abc1234",
+  ancestor_change_date: "2026-06-01",
+  aim_change_date: "2026-05-01",
+};
+
+function claimed(text = "owed"): AimInteriorWire {
+  return { kind: "claimed", text, ref: null };
+}
+function confirmed(text = "done", ref: string | null = "PR#1"): AimInteriorWire {
+  return { kind: "confirmed", text, ref };
+}
 
 function aim(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
   return {
@@ -51,74 +80,14 @@ describe("buildChildren", () => {
     const childrenOf = buildChildren(NODES);
     expect(childrenOf.get("root-a")?.map((n) => n.slug)).toEqual(["child-1", "child-2"]);
     expect(childrenOf.get("child-1")?.map((n) => n.slug)).toEqual(["grand-1"]);
-    // Leaves and roots have no children entry.
     expect(childrenOf.get("grand-1")).toBeUndefined();
     expect(childrenOf.get("root-b")).toBeUndefined();
   });
 
   it("does not turn a depends_on edge into a parent edge", () => {
     const childrenOf = buildChildren(NODES);
-    // child-2 depends_on child-1, but that must NOT make child-2 a child of
-    // child-1 — only `parent` builds the tree.
+    // child-2 depends_on child-1, but only `parent` builds the tree.
     expect(childrenOf.get("child-1")?.map((n) => n.slug)).toEqual(["grand-1"]);
-  });
-});
-
-describe("computeLayout", () => {
-  it("identifies the explicit roots (parent === null)", () => {
-    const layout = computeLayout(NODES);
-    expect(layout.roots.map((r) => r.slug)).toEqual(["root-a", "root-b"]);
-  });
-
-  it("positions every node and assigns depth by tree level", () => {
-    const layout = computeLayout(NODES);
-    for (const n of NODES) {
-      expect(layout.positions.has(n.slug)).toBe(true);
-    }
-    expect(layout.positions.get("root-a")?.depth).toBe(0);
-    expect(layout.positions.get("child-1")?.depth).toBe(1);
-    expect(layout.positions.get("grand-1")?.depth).toBe(2);
-    expect(layout.positions.get("child-2")?.depth).toBe(1);
-    expect(layout.positions.get("root-b")?.depth).toBe(0);
-  });
-
-  it("centers an internal node between its first and last child", () => {
-    const layout = computeLayout(NODES);
-    const rootA = layout.positions.get("root-a");
-    const child1 = layout.positions.get("child-1");
-    const child2 = layout.positions.get("child-2");
-    expect(rootA && child1 && child2).toBeTruthy();
-    if (rootA && child1 && child2) {
-      expect(rootA.cy).toBeCloseTo((child1.cy + child2.cy) / 2);
-    }
-  });
-
-  it("sizes the canvas to the deepest column", () => {
-    const layout = computeLayout(NODES);
-    // maxDepth is 2 (grand-1); width includes one node width past the last col.
-    expect(layout.width).toBeGreaterThan(NODE_W);
-    expect(layout.height).toBeGreaterThan(0);
-  });
-
-  it("treats an orphan with a missing parent as a root (renders, never vanishes)", () => {
-    const orphan = aim({ slug: "lonely", parent: "does-not-exist" });
-    const layout = computeLayout([aim({ slug: "root-a" }), orphan]);
-    expect(layout.roots.map((r) => r.slug)).toContain("lonely");
-    expect(layout.positions.has("lonely")).toBe(true);
-    expect(layout.positions.get("lonely")?.depth).toBe(0);
-  });
-
-  it("returns empty roots/positions for an empty node set", () => {
-    const layout = computeLayout([]);
-    expect(layout.roots).toEqual([]);
-    expect(layout.positions.size).toBe(0);
-  });
-
-  it("gives every node a positive estimated height", () => {
-    const layout = computeLayout(NODES);
-    for (const n of NODES) {
-      expect((layout.positions.get(n.slug)?.height ?? 0) > 0).toBe(true);
-    }
   });
 });
 
@@ -127,159 +96,251 @@ describe("findRoots", () => {
     expect(findRoots(NODES).map((r) => r.slug)).toEqual(["root-a", "root-b"]);
   });
 
-  it("treats an orphan with a missing parent as a root", () => {
+  it("treats an orphan with a missing parent as a root (renders, never vanishes)", () => {
     const orphan = aim({ slug: "lonely", parent: "ghost" });
     expect(findRoots([aim({ slug: "root-a" }), orphan]).map((r) => r.slug)).toContain("lonely");
   });
 });
 
-describe("nodeHeight (the variable-height estimate)", () => {
-  it("is taller for a longer label (more wrapped lines)", () => {
-    const short = nodeHeight("短い");
-    const long = nodeHeight("あ".repeat(130));
-    expect(long).toBeGreaterThan(short);
-  });
-
-  it("floors a 1-line label at a comfortable minimum", () => {
-    // A short label must still get a readable box, not collapse to one line of
-    // text height.
-    expect(nodeHeight("x")).toBeGreaterThanOrEqual(40);
-  });
-});
-
-// THE #782 overlap fix. Adjacent depth columns are >NODE_W apart horizontally
-// (COL_W > NODE_W), so two boxes can only share screen space when they share a
-// depth. Assert that within every depth column, the `[cy ± height/2]` vertical
-// ranges never overlap — for any node set, including long-label and tall-
-// internal-node fixtures that broke the old fixed-ROW_H layout.
-function assertNoColumnOverlap(layout: ReturnType<typeof computeLayout>) {
-  const byDepth = new Map<number, { cy: number; height: number; slug: string }[]>();
-  for (const pos of layout.positions.values()) {
-    const list = byDepth.get(pos.depth) ?? [];
-    list.push(pos);
-    byDepth.set(pos.depth, list);
-  }
-  for (const list of byDepth.values()) {
-    const sorted = [...list].sort((a, b) => a.cy - b.cy);
-    for (let i = 1; i < sorted.length; i++) {
-      const prev = sorted[i - 1];
-      const cur = sorted[i];
-      const prevBottom = prev.cy + prev.height / 2;
-      const curTop = cur.cy - cur.height / 2;
-      // curTop must sit at or below prevBottom — no vertical overlap.
-      expect(curTop).toBeGreaterThanOrEqual(prevBottom);
-    }
-  }
-}
-
-describe("computeLayout — variable-height no-overlap invariant (#782)", () => {
-  it("never overlaps nodes in a depth column for the canonical tree", () => {
-    assertNoColumnOverlap(computeLayout(NODES));
-  });
-
-  it("never overlaps leaf siblings even with a 130+ char label", () => {
-    const longLabel = "あ".repeat(135); // 135 full-width chars — wraps to many lines
-    expect(longLabel.length).toBeGreaterThanOrEqual(130);
-    const set: AimWire[] = [
-      aim({ slug: "root" }),
-      aim({ slug: "leaf-long", parent: "root", aim: longLabel }),
-      aim({ slug: "leaf-short", parent: "root", aim: "x" }),
-      aim({ slug: "leaf-mid", parent: "root", aim: "あ".repeat(40) }),
-      aim({ slug: "leaf-long2", parent: "root", aim: "drift-possible ".repeat(9) }),
-    ];
-    assertNoColumnOverlap(computeLayout(set));
-  });
-
-  it("keeps a tall internal node (long label, one short child) clear of its sibling", () => {
-    // The overhang case: an internal node whose OWN box is taller than its
-    // single child's span must not bleed into the adjacent depth-1 sibling.
-    const set: AimWire[] = [
-      aim({ slug: "root" }),
-      aim({ slug: "tall-internal", parent: "root", aim: "あ".repeat(135) }),
-      aim({ slug: "tiny-child", parent: "tall-internal", aim: "x" }),
-      aim({ slug: "sibling-leaf", parent: "root", aim: "あ".repeat(50) }),
-    ];
-    assertNoColumnOverlap(computeLayout(set));
-  });
-});
-
-describe("descendantsOf (blast radius)", () => {
+describe("descendantsOf (the re-parent cycle guard)", () => {
   it("returns the whole descendant subtree through parent edges", () => {
     const childrenOf = buildChildren(NODES);
     expect(descendantsOf("root-a", childrenOf)).toEqual(new Set(["child-1", "grand-1", "child-2"]));
   });
 
-  it("does NOT include the other root's subtree", () => {
-    const childrenOf = buildChildren(NODES);
-    expect(descendantsOf("root-a", childrenOf).has("root-b")).toBe(false);
-  });
-
-  it("is empty for a leaf", () => {
-    const childrenOf = buildChildren(NODES);
-    expect(descendantsOf("grand-1", childrenOf)).toEqual(new Set());
-  });
-
   it("does NOT follow depends_on cross-edges", () => {
     const childrenOf = buildChildren(NODES);
-    // child-2 depends_on child-1; the blast radius of child-2 is its
-    // descendant subtree only (empty), NOT child-1.
     expect(descendantsOf("child-2", childrenOf)).toEqual(new Set());
   });
 });
 
-describe("flattenRepos", () => {
-  it("returns [] for a null response", () => {
-    expect(flattenRepos(null)).toEqual([]);
+describe("owed-status predicates", () => {
+  it("isDrifted: true when the wire carries drift and the node is not dead", () => {
+    expect(isDrifted(aim({ slug: "x", drift: DRIFT }))).toBe(true);
+    expect(isDrifted(aim({ slug: "x" }))).toBe(false);
+    // A dead node's drift is noise (lineage abandoned).
+    expect(isDrifted(aim({ slug: "x", drift: DRIFT, state: "dead" }))).toBe(false);
+    // A done node's drift still counts as drift (pin #2 surfacing).
+    expect(isDrifted(aim({ slug: "x", drift: DRIFT, state: "done" }))).toBe(true);
   });
 
-  it("concatenates aims across repos", () => {
-    const res: AimsResponse = {
-      unit: "u",
-      composed_at: "2026-06-07T00:00:00Z",
-      repos: [
-        {
-          repo_label: "core",
-          repo_root: "/p/core",
-          primary: true,
-          repo_head: null,
-          aims: [aim({ slug: "a" }), aim({ slug: "b" })],
-        },
-        {
-          repo_label: "ui",
-          repo_root: "/p/ui",
-          primary: false,
-          repo_head: null,
-          aims: [aim({ slug: "c" })],
-        },
-      ],
-    };
-    expect(flattenRepos(res).map((n) => n.slug)).toEqual(["a", "b", "c"]);
+  it("hasClaimed / hasConfirmed read the author's mark kind (mark-only)", () => {
+    const n = aim({ slug: "x", is: [confirmed(), claimed()] });
+    expect(hasClaimed(n)).toBe(true);
+    expect(hasConfirmed(n)).toBe(true);
+    expect(hasClaimed(aim({ slug: "y", is: [confirmed()] }))).toBe(false);
+  });
+
+  it("isOwed: an OPEN node that drifted or carries a claimed mark", () => {
+    expect(isOwed(aim({ slug: "d", drift: DRIFT }))).toBe(true);
+    expect(isOwed(aim({ slug: "k", is: [claimed()] }))).toBe(true);
+    // A purely confirmed open node is calm, not owed.
+    expect(isOwed(aim({ slug: "c", is: [confirmed()] }))).toBe(false);
+    // done / dead are never owed, even when drifted.
+    expect(isOwed(aim({ slug: "dn", drift: DRIFT, state: "done" }))).toBe(false);
+    expect(isOwed(aim({ slug: "dd", drift: DRIFT, state: "dead" }))).toBe(false);
+  });
+
+  it("isDoneDrifted: only a done node whose wire carries drift (pin #2)", () => {
+    expect(isDoneDrifted(aim({ slug: "x", state: "done", drift: DRIFT }))).toBe(true);
+    expect(isDoneDrifted(aim({ slug: "x", state: "open", drift: DRIFT }))).toBe(false);
+    expect(isDoneDrifted(aim({ slug: "x", state: "done" }))).toBe(false);
   });
 });
 
-describe("edge-path geometry", () => {
-  it("parentEdgePath starts at the parent's right edge and ends at the child's left edge", () => {
-    const layout = computeLayout(NODES);
-    const parent = layout.positions.get("root-a");
-    const child = layout.positions.get("child-1");
-    expect(parent && child).toBeTruthy();
-    if (parent && child) {
-      const d = parentEdgePath(parent, child);
-      expect(d.startsWith(`M ${parent.x + NODE_W} ${parent.cy}`)).toBe(true);
-      expect(d).toContain(`${child.x} ${child.cy}`);
-    }
+describe("aimTone — pin #2: done+drift is distinct, not suppressed", () => {
+  it("resolves done+drift to its OWN tone, distinct from done and from drift", () => {
+    const doneDrift = aimTone(aim({ slug: "x", state: "done", drift: DRIFT }));
+    expect(doneDrift).toBe("done-drift");
+    // Distinct from the two tones it must never collapse into.
+    expect(doneDrift).not.toBe("done");
+    expect(doneDrift).not.toBe("drift");
   });
 
-  it("dependsEdgePath bows out to the right of both endpoints", () => {
-    const layout = computeLayout(NODES);
-    const src = layout.positions.get("child-2");
-    const tgt = layout.positions.get("child-1");
-    expect(src && tgt).toBeTruthy();
-    if (src && tgt) {
-      const d = dependsEdgePath(src, tgt);
-      // Both anchors are on the right edge (x + NODE_W).
-      expect(d.startsWith(`M ${src.x + NODE_W} ${src.cy}`)).toBe(true);
-      expect(d).toContain(`${tgt.x + NODE_W} ${tgt.cy}`);
-    }
+  it("plain done (no drift) is `done`; open+drift is `drift`", () => {
+    expect(aimTone(aim({ slug: "x", state: "done" }))).toBe("done");
+    expect(aimTone(aim({ slug: "x", drift: DRIFT }))).toBe("drift");
+  });
+
+  it("orders open tones drift › claimed › confirmed › root › neutral", () => {
+    expect(aimTone(aim({ slug: "x", drift: DRIFT, is: [claimed()] }))).toBe("drift");
+    expect(aimTone(aim({ slug: "x", is: [claimed(), confirmed()] }))).toBe("claimed");
+    expect(aimTone(aim({ slug: "x", is: [confirmed()] }))).toBe("confirmed");
+    expect(aimTone(aim({ slug: "x", parent: null }))).toBe("root");
+    expect(aimTone(aim({ slug: "x", parent: "root-a" }))).toBe("neutral");
+  });
+
+  it("dead always reads `dead`, even if the wire still carries drift", () => {
+    expect(aimTone(aim({ slug: "x", state: "dead", drift: DRIFT }))).toBe("dead");
+  });
+});
+
+describe("frontierRows — owed worklist, drift-first", () => {
+  const set: AimWire[] = [
+    aim({ slug: "calm", is: [confirmed()] }), // not owed
+    aim({ slug: "claim-b", is: [claimed()] }),
+    aim({ slug: "drift-z", drift: DRIFT }),
+    aim({ slug: "claim-a", is: [claimed()] }),
+    aim({ slug: "drift-a", drift: DRIFT }),
+    aim({ slug: "done-drift", state: "done", drift: DRIFT }), // pin #2 — excluded
+  ];
+
+  it("includes only owed nodes (drops calm + done+drift)", () => {
+    const slugs = frontierRows(set).map((n) => n.slug);
+    expect(slugs).not.toContain("calm");
+    expect(slugs).not.toContain("done-drift");
+  });
+
+  it("ranks drift before claimed, then stable by slug", () => {
+    expect(frontierRows(set).map((n) => n.slug)).toEqual([
+      "drift-a",
+      "drift-z",
+      "claim-a",
+      "claim-b",
+    ]);
+  });
+
+  it("doneDriftedRows surfaces the pin-#2 nodes separately", () => {
+    expect(doneDriftedRows(set).map((n) => n.slug)).toEqual(["done-drift"]);
+  });
+});
+
+describe("ancestry + breadcrumb", () => {
+  const bySlug = bySlugMap(NODES);
+
+  it("walks parent links root→node inclusive", () => {
+    expect(ancestry("grand-1", bySlug).map((n) => n.slug)).toEqual([
+      "root-a",
+      "child-1",
+      "grand-1",
+    ]);
+  });
+
+  it("breadcrumb is the ancestry ABOVE the node (empty for a root)", () => {
+    expect(breadcrumbText("grand-1", bySlug)).toBe("root-a › child-1");
+    expect(breadcrumbText("root-a", bySlug)).toBe("");
+  });
+
+  it("does not hang on a malformed parent cycle", () => {
+    const cyclic = bySlugMap([aim({ slug: "a", parent: "b" }), aim({ slug: "b", parent: "a" })]);
+    // Terminates; the exact chain is unimportant, the guard is.
+    expect(ancestry("a", cyclic).length).toBeLessThanOrEqual(2);
+  });
+});
+
+describe("rollups", () => {
+  // root with two owed descendants (one drift, one claimed) + one calm.
+  const branch: AimWire[] = [
+    aim({ slug: "root" }),
+    aim({ slug: "d", parent: "root", drift: DRIFT }),
+    aim({ slug: "k", parent: "root", is: [claimed()] }),
+    aim({ slug: "c", parent: "root", is: [confirmed()] }),
+    aim({ slug: "deep", parent: "d", drift: DRIFT }),
+  ];
+
+  it("subtreeStats counts descendants + the disjoint owed breakdown", () => {
+    const childrenOf = buildChildren(branch);
+    const st = subtreeStats("root", childrenOf);
+    expect(st.count).toBe(4); // d, k, c, deep
+    expect(st.drift).toBe(2); // d, deep
+    expect(st.claimed).toBe(1); // k
+  });
+
+  it("repoStats rolls the whole repo (drift wins over claimed per node)", () => {
+    const st = repoStats(branch);
+    expect(st.count).toBe(5);
+    expect(st.drift).toBe(2);
+    expect(st.claimed).toBe(1);
+  });
+});
+
+describe("ledgerCounts — straight off drift + is[]", () => {
+  const forest: AimWire[] = [
+    aim({ slug: "a", drift: DRIFT, is: [confirmed(), claimed()] }),
+    aim({ slug: "b", is: [claimed()] }),
+    aim({ slug: "c", is: [confirmed()] }),
+    aim({ slug: "d", state: "done", drift: DRIFT, is: [confirmed()] }), // pin #2: still drift
+    aim({ slug: "e", state: "dead", drift: DRIFT }), // dead drift = noise, excluded
+  ];
+
+  it("counts drift nodes (incl. done+drift, excl. dead) and is[] marks", () => {
+    expect(ledgerCounts(forest)).toEqual({ drift: 2, claimed: 2, confirmed: 3 });
+  });
+});
+
+describe("rulerOrder — repo-grouped DFS minimap", () => {
+  const res: AimsResponse = {
+    unit: "u",
+    composed_at: "2026-06-07T00:00:00Z",
+    repos: [
+      {
+        repo_label: "core",
+        repo_root: "/p/core",
+        primary: true,
+        repo_head: null,
+        aims: [
+          aim({ slug: "r1" }),
+          aim({ slug: "r1a", parent: "r1", drift: DRIFT }),
+          aim({ slug: "r1b", parent: "r1", is: [claimed()] }),
+        ],
+      },
+      {
+        repo_label: "ui",
+        repo_root: "/p/ui",
+        primary: false,
+        repo_head: null,
+        aims: [aim({ slug: "u1", is: [confirmed()] })],
+      },
+    ],
+  };
+
+  it("emits one tick per node in repo-grouped DFS order", () => {
+    expect(rulerOrder(res.repos).map((t) => t.slug)).toEqual(["r1", "r1a", "r1b", "u1"]);
+  });
+
+  it("lights owed ticks (drift / claimed), leaves calm ticks null", () => {
+    const ticks = rulerOrder(res.repos);
+    expect(ticks.find((t) => t.slug === "r1a")?.owed).toBe("drift");
+    expect(ticks.find((t) => t.slug === "r1b")?.owed).toBe("claimed");
+    expect(ticks.find((t) => t.slug === "u1")?.owed).toBeNull();
+  });
+
+  it("marks the first tick of a new repo as a boundary", () => {
+    const ticks = rulerOrder(res.repos);
+    expect(ticks.find((t) => t.slug === "r1")?.repoBoundary).toBe(false);
+    expect(ticks.find((t) => t.slug === "u1")?.repoBoundary).toBe(true);
+  });
+});
+
+describe("flattenRepos / repoForests", () => {
+  const res: AimsResponse = {
+    unit: "u",
+    composed_at: "2026-06-07T00:00:00Z",
+    repos: [
+      {
+        repo_label: "core",
+        repo_root: "/p/core",
+        primary: true,
+        repo_head: null,
+        aims: [aim({ slug: "a" }), aim({ slug: "b" })],
+      },
+      {
+        repo_label: "ui",
+        repo_root: "/p/ui",
+        primary: false,
+        repo_head: null,
+        aims: [aim({ slug: "c" })],
+      },
+    ],
+  };
+
+  it("flattenRepos concatenates aims across repos; [] for null", () => {
+    expect(flattenRepos(res).map((n) => n.slug)).toEqual(["a", "b", "c"]);
+    expect(flattenRepos(null)).toEqual([]);
+  });
+
+  it("repoForests keeps the per-repo grouping intact; [] for null", () => {
+    expect(repoForests(res).map((r) => r.repo_label)).toEqual(["core", "ui"]);
+    expect(repoForests(null)).toEqual([]);
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/aim-tree.ts
+++ b/clients/react/src/components/producer-console/r-panel/aim-tree.ts
@@ -1,77 +1,35 @@
-// Pure aim-tree layout + traversal — the view machinery validated in the
-// throwaway prototype #778 (`RAimTreePrototype`), graduated and rewired onto
-// the LIVE wire model (`AimWire`: `slug` / `aim` / `parent` / `state` /
-// `depends_on` / `serves` / `related` / `body`). Kept framework-free so the
-// tidy-tree layout, blast-radius traversal, and edge-path geometry are
-// unit-testable without rendering React.
+// Pure aim-forest model — the attention-economical projection the destination
+// Aim panel (Stage B convergence, #791) renders. No React, no DOM, so the
+// owed/frontier ranking, the per-repo rollups, the ledger counts, the
+// overview-ruler order, and the ought-ancestry walk are unit-testable in
+// isolation.
 //
-// Wire-vs-prototype rewire (the real work of #780): the prototype was a
-// hardcoded fixture with its OWN model (`id` / `label` / `means-done` /
-// `dependsOn` single). This module follows the wire: identity is `slug`, the
-// anchor is `aim`, the state enum is `open | done | dead` (no `means-done`;
-// `dead` exists), and `depends_on` is an ARRAY of slugs.
+// The load-bearing thesis (approach `2026-06-09-aim-console-destination-
+// convergence`): the panel does NOT render the whole tree. Default = the owed
+// FRONTIER worklist; the full tree is a collapsed navigator + branch rollups +
+// an overview ruler. So this module's center of gravity is "what is OWED" —
+// `isOwed` / `frontierRows` / `ledgerCounts` — not 2D layout (the prototype's
+// tidy-tree geometry retired with the canvas it served).
+//
+// Mark-only (design pin #1 / `doc/aims/README.md`): the interior `is[]` marks
+// (`confirmed` / `claimed`) are surfaced exactly as the author wrote them. This
+// module never re-judges, re-orders, or de-drifts them — it only counts and
+// filters on the kind the wire already carries.
 
 import type { AimState } from "@/types/generated/AimState";
 import type { AimsResponse } from "@/types/generated/AimsResponse";
 import type { AimWire } from "@/types/generated/AimWire";
+import type { RepoAimsWire } from "@/types/generated/RepoAimsWire";
 
-// ── Layout constants ──────────────────────────────────────────────────
+// ── Glyphs / labels ───────────────────────────────────────────────────
 //
-// Generous full-window values — the aim-tree now lives in a maximized overlay
-// (#782), not the narrow R-panel column, so labels get the room the prototype
-// (#778) validated (COL_W 232 / NODE_W 200) and then some. COL_W stays wider
-// than NODE_W so adjacent depth columns never overlap horizontally; that is
-// what lets the no-overlap invariant reduce to a per-depth-column vertical
-// check (only same-depth boxes share an x-range).
-export const COL_W = 248; // horizontal distance per depth level
-export const NODE_W = 216; // fixed node-box width (labels wrap within)
-const PAD_L = 24;
-const PAD_T = 24;
-const PAD_R = 40;
-const PAD_B = 24;
-const ROOT_GAP = 28; // vertical gap inserted between root subtrees
-const NODE_GAP = 16; // vertical breathing room between adjacent boxes
-
-// ── Node-height estimation ────────────────────────────────────────────
-//
-// THE overlap fix (#782): a node's box height is NOT fixed — real `aim:`
-// anchors are long sentences (up to ~132 chars) that wrap to many lines inside
-// the fixed-width box. A fixed ROW_H let tall boxes overlap their neighbours.
-// `computeLayout` instead lays nodes out with a CUMULATIVE vertical advance
-// proportional to each box's estimated rendered height (`nodeHeight`).
-//
-// We can't DOM-measure in a pure function, so estimate the wrapped line count
-// from label length against a CONSERVATIVE chars-per-line. The corpus is mostly
-// Japanese / full-width, whose glyphs are ~1em wide (≈ the font size), so we
-// assume one full-width glyph per `LABEL_FONT_PX` of inner width. That UPPER-
-// bounds the line count for any Latin-or-mixed label too (Latin glyphs are
-// narrower → fewer wrapped lines than estimated), so a box is never under-
-// allocated and the no-overlap invariant holds regardless of script.
-const LABEL_FONT_PX = 12; // text-xs label glyph advance (full-width ≈ 1em)
-const LABEL_LINE_H = 18; // text-xs × leading-snug (~1.375), rounded up
-const NODE_PAD_X = 16; // px-2 → 8px each side
-const GLYPH_COL = 22; // state glyph + gap-1.5 gutter left of the label
-const NODE_CHROME_V = 28; // py-1.5 (12) + slug line (~14) + label/slug gap (~2)
-const MIN_NODE_H = 46; // floor so a 1-line box still reads comfortably
-
-// Estimated rendered height (px) of a node box for a given `aim` label. Pure
-// and deterministic — the layout's whole no-overlap guarantee rides on it.
-export function nodeHeight(label: string): number {
-  const textW = Math.max(LABEL_FONT_PX, NODE_W - NODE_PAD_X - GLYPH_COL);
-  const charsPerLine = Math.max(1, Math.floor(textW / LABEL_FONT_PX));
-  const lines = Math.max(1, Math.ceil(label.length / charsPerLine));
-  return Math.max(MIN_NODE_H, NODE_CHROME_V + lines * LABEL_LINE_H);
-}
-
-// Per-node state glyph — SHAPE ONLY, one neutral hue, no heat / severity
-// color (the machine marks, it never appraises — `AimState` doc + brief).
-// `dead` is the wire's third state (self-death: the means failed, the lineage
-// stays, the parent is untouched); it gets a neutral struck circle, NOT a
-// warning glyph. The prototype's `◐` (`means-done`) is dropped — it was a
-// fixture invention, absent from the wire.
+// Lifecycle glyph — SHAPE, paired with one calm hue at the call site, never a
+// heat ramp (the machine marks, it never appraises — `AimState` doc). `done` =
+// reached/confirmed (✓), `dead` = self-death (neutral struck circle, NOT a
+// warning glyph — the lineage stays, the parent is untouched).
 export const AIM_GLYPH: Record<AimState, string> = {
   open: "○",
-  done: "●",
+  done: "✓",
   dead: "⊘",
 };
 
@@ -81,39 +39,87 @@ export const AIM_STATE_LABEL: Record<AimState, string> = {
   dead: "dead",
 };
 
-// Flatten the per-repo wire response into a single node set. Aims currently
-// live only in the `tmai-core` repo (one repo), but the wire is already
-// multi-repo (`RepoAimsWire[]`); concatenating keeps it correct if a second
-// repo ever carries aims. Slugs are unique within a repo and the corpus is
-// single-repo today, so no cross-repo slug-collision handling is needed yet.
+// Flatten the per-repo wire response into a single cross-repo node set — used
+// by the ledger and ruler, which span the whole forest. The per-repo grouping
+// (Frontier sections / Tree navigator) keeps `RepoAimsWire` intact instead
+// (`repoForests`); flattening is for the forest-wide aggregates only.
 export function flattenRepos(res: AimsResponse | null): AimWire[] {
   if (res === null) return [];
   return res.repos.flatMap((r) => r.aims);
 }
 
-export interface NodePos {
-  slug: string;
-  /** Left edge x of the node box. */
-  x: number;
-  /** Vertical CENTER of the node (edges anchor here; the box itself is
-   *  centered on this y via a translateY(-50%), so multi-line labels grow
-   *  symmetrically and never shift the edge anchor). */
-  cy: number;
-  /** Estimated rendered box height (`nodeHeight`). The box's vertical extent
-   *  is `[cy - height/2, cy + height/2]`; the layout spaces siblings so these
-   *  ranges never overlap within a depth column. */
-  height: number;
-  depth: number;
+// The per-repo slices, untouched — the panel groups by these (un-flatten),
+// highlighting the primary repo. `[]` for a null response.
+export function repoForests(res: AimsResponse | null): RepoAimsWire[] {
+  return res?.repos ?? [];
 }
 
-export interface AimLayout {
-  positions: Map<string, NodePos>;
-  roots: AimWire[];
-  width: number;
-  height: number;
+// ── Owed-status predicates (the attention economy) ────────────────────
+
+// Drift fact: the node carries a stale-from-ancestor verdict from the wire
+// (`drift !== null`) AND is not abandoned. A `dead` node is self-death — its
+// lineage is kept but the means failed, so a stale ancestor anchor is noise,
+// not owed work. A `done` node that drifted is NOT filtered here: that is the
+// pin-#2 case (surface it, see `isDoneDrifted` / `aimTone`).
+export function isDrifted(n: AimWire): boolean {
+  return n.drift !== null && n.state !== "dead";
 }
 
-// Index helper — children grouped by parent slug, preserving array order.
+// Has at least one `claimed` interior mark (unverified — an operator confirm is
+// owed). Mark-only: we read the kind the author wrote, never re-judge it.
+export function hasClaimed(n: AimWire): boolean {
+  return n.is.some((m) => m.kind === "claimed");
+}
+
+// Has at least one `confirmed` interior mark (external ground-truth checked —
+// real, attention-zero).
+export function hasConfirmed(n: AimWire): boolean {
+  return n.is.some((m) => m.kind === "confirmed");
+}
+
+// Owed = an OPEN node that drifted or carries a `claimed` mark — the Frontier
+// worklist eligibility. `done` / `dead` are never "owed": a `done` node's drift
+// is surfaced distinctly but NOT folded into the worklist (pin #2: "not folded
+// into plain owed").
+export function isOwed(n: AimWire): boolean {
+  return n.state === "open" && (isDrifted(n) || hasClaimed(n));
+}
+
+// Pin #2: a `done` node that is ALSO drifted — reached against an OLD ought,
+// and an ancestor's anchor has since moved, so a re-confirm is owed. Surfaced
+// distinctly (see `aimTone`), never suppressed, never treated as plain owed.
+export function isDoneDrifted(n: AimWire): boolean {
+  return n.state === "done" && n.drift !== null;
+}
+
+// The row's dominant tone — a single discriminated value the renderer maps to a
+// glyph + hue. UNLIKE a naive priority cascade, a `done` node that also drifted
+// resolves to `done-drift` (pin #2): a tone DISTINCT from plain `done` and from
+// open `drift`, so done-and-drifted is surfaced rather than swallowed by the
+// `done` check.
+export type AimTone =
+  | "done-drift" // pin #2 — reached, but an ancestor moved → re-confirm owed
+  | "done"
+  | "dead"
+  | "drift" // open + drifted
+  | "claimed" // open + a claimed mark
+  | "confirmed" // open + a confirmed mark (calm)
+  | "root"
+  | "neutral";
+
+export function aimTone(n: AimWire): AimTone {
+  if (n.state === "dead") return "dead";
+  if (n.state === "done") return n.drift !== null ? "done-drift" : "done";
+  if (isDrifted(n)) return "drift";
+  if (hasClaimed(n)) return "claimed";
+  if (hasConfirmed(n)) return "confirmed";
+  if (n.parent === null) return "root";
+  return "neutral";
+}
+
+// ── Tree skeleton ─────────────────────────────────────────────────────
+
+// Children grouped by parent slug, preserving array (slug-sorted wire) order.
 export function buildChildren(nodes: readonly AimWire[]): Map<string, AimWire[]> {
   const childrenOf = new Map<string, AimWire[]>();
   for (const n of nodes) {
@@ -126,109 +132,23 @@ export function buildChildren(nodes: readonly AimWire[]): Map<string, AimWire[]>
 }
 
 // Roots = explicit roots (`parent === null`) PLUS orphans whose `parent` slug
-// isn't a known node — so a dangling parent ref (a half-written / cross-repo
-// reference) still renders rather than silently vanishing from the canvas.
-// Shared by `computeLayout` and the R-panel thin-entry root count.
+// is unknown in this set — so a dangling / cross-repo parent ref still renders
+// rather than silently vanishing.
 export function findRoots(nodes: readonly AimWire[]): AimWire[] {
   const bySlug = new Set(nodes.map((n) => n.slug));
   return nodes.filter((n) => n.parent === null || !bySlug.has(n.parent));
 }
 
-// Variable-height tidy tree (the #782 overlap fix). Each node reserves vertical
-// room proportional to its estimated box height (`nodeHeight`) instead of a
-// fixed ROW_H, so long-label boxes never overlap their neighbours.
-//
-// The walk lays each subtree into a contiguous, non-overlapping vertical band:
-//   - a LEAF occupies exactly its own box height;
-//   - an INTERNAL node lays its children out sequentially (each child's band +
-//     a gap), centres itself on the midpoint of its first/last child as the
-//     classic tidy tree does, then — if its OWN (possibly tall) box would stick
-//     out above the band — shifts the whole subtree down so the parent's top
-//     aligns with the band's top. The subtree's reported bottom is the max of
-//     the children's bottom and the parent box's bottom.
-// Because each subtree owns a disjoint vertical band and adjacent depth columns
-// are >NODE_W apart horizontally, no two boxes that share a depth column can
-// overlap, regardless of label length.
-export function computeLayout(nodes: readonly AimWire[]): AimLayout {
-  const childrenOf = buildChildren(nodes);
-  const bySlug = new Map(nodes.map((n) => [n.slug, n] as const));
-  const positions = new Map<string, NodePos>();
-  let maxDepth = 0;
-
-  // Translate a whole subtree's `cy` by `delta` (used for the parent-overhang
-  // correction). `seen` guards against a malformed `parent` cycle.
-  function shiftSubtree(slug: string, delta: number, seen: Set<string>): void {
-    if (seen.has(slug)) return;
-    seen.add(slug);
-    const p = positions.get(slug);
-    if (p) p.cy += delta;
-    for (const c of childrenOf.get(slug) ?? []) shiftSubtree(c.slug, delta, seen);
-  }
-
-  // Lay `slug`'s subtree starting at vertical `top`; set positions and return
-  // the subtree's center y and the next free y below it.
-  function layout(slug: string, depth: number, top: number): { cy: number; bottom: number } {
-    maxDepth = Math.max(maxDepth, depth);
-    const node = bySlug.get(slug);
-    const h = nodeHeight(node?.aim ?? slug);
-    const x = PAD_L + depth * COL_W;
-    const children = childrenOf.get(slug) ?? [];
-
-    if (children.length === 0) {
-      const cy = top + h / 2;
-      positions.set(slug, { slug, x, cy, height: h, depth });
-      return { cy, bottom: top + h };
-    }
-
-    let cursor = top;
-    let firstCy = 0;
-    let lastCy = 0;
-    children.forEach((c, i) => {
-      if (i > 0) cursor += NODE_GAP;
-      const r = layout(c.slug, depth + 1, cursor);
-      if (i === 0) firstCy = r.cy;
-      lastCy = r.cy;
-      cursor = r.bottom;
-    });
-    let childrenBottom = cursor;
-    let cy = (firstCy + lastCy) / 2;
-    positions.set(slug, { slug, x, cy, height: h, depth });
-
-    // Parent-overhang correction: if this box (centred on its children) would
-    // stick out above the band top, push the whole subtree down so nothing
-    // crosses into the previous sibling's band.
-    const overhang = top - (cy - h / 2);
-    if (overhang > 0) {
-      shiftSubtree(slug, overhang, new Set<string>());
-      cy += overhang;
-      childrenBottom += overhang;
-    }
-    // The band extends to whichever is lower: the last child or this box.
-    return { cy, bottom: Math.max(childrenBottom, cy + h / 2) };
-  }
-
-  const roots = findRoots(nodes);
-  let cursor = PAD_T;
-  roots.forEach((root, i) => {
-    if (i > 0) cursor += ROOT_GAP;
-    const r = layout(root.slug, 0, cursor);
-    cursor = r.bottom;
-  });
-
-  return {
-    positions,
-    roots,
-    width: PAD_L + maxDepth * COL_W + NODE_W + PAD_R,
-    height: cursor + PAD_B,
-  };
+// Index nodes by slug — the lookup the ancestry walk + selection resolve
+// against.
+export function bySlugMap(nodes: readonly AimWire[]): Map<string, AimWire> {
+  return new Map(nodes.map((n) => [n.slug, n] as const));
 }
 
-// The blast radius: every descendant of `slug` reachable through `parent`
-// edges (NOT through `depends_on` — the cross-edge is a shared-means link,
-// drawn distinct, deliberately kept OUT of the descendant set a change would
-// cascade down). The `seen` guard makes the walk safe even against a
-// malformed `parent` cycle (the corpus is acyclic by construction, but a
-// read-only projection should never hang on bad data).
+// Every descendant of `slug` through `parent` edges (NOT `depends_on` — the
+// cross-edge is a shared-means link, deliberately out of the cascade set). The
+// `seen` guard keeps the walk safe against a malformed `parent` cycle. Used to
+// forbid an ancestor re-parenting onto its own subtree (cycle guard in edit).
 export function descendantsOf(slug: string, childrenOf: Map<string, AimWire[]>): Set<string> {
   const out = new Set<string>();
   const stack = [...(childrenOf.get(slug) ?? [])];
@@ -242,25 +162,184 @@ export function descendantsOf(slug: string, childrenOf: Map<string, AimWire[]>):
   return out;
 }
 
-// Smooth horizontal connector from a parent's right edge to a child's left
-// edge (S-curve via a cubic with control points at the x-midpoint).
-export function parentEdgePath(parent: NodePos, child: NodePos): string {
-  const x1 = parent.x + NODE_W;
-  const y1 = parent.cy;
-  const x2 = child.x;
-  const y2 = child.cy;
-  const mx = (x1 + x2) / 2;
-  return `M ${x1} ${y1} C ${mx} ${y1}, ${mx} ${y2}, ${x2} ${y2}`;
+// The ought-ancestry chain root→node (inclusive of `slug` at the tail), via
+// `parent` links. The Inspector breadcrumb and the Frontier row crumb read
+// this. `seen` guards a malformed parent cycle; an unknown parent ends the
+// walk (the node renders as its own root).
+export function ancestry(slug: string, bySlug: ReadonlyMap<string, AimWire>): AimWire[] {
+  const chain: AimWire[] = [];
+  const seen = new Set<string>();
+  let cur: string | null = slug;
+  while (cur !== null && !seen.has(cur)) {
+    seen.add(cur);
+    const n = bySlug.get(cur);
+    if (!n) break;
+    chain.unshift(n);
+    cur = n.parent;
+  }
+  return chain;
 }
 
-// A `depends_on` cross-edge bows out to the RIGHT of both endpoints (where
-// the node's right side is whitespace), so the dashed cross-edge never reads
-// as one of the leftward solid parent connectors.
-export function dependsEdgePath(src: NodePos, tgt: NodePos): string {
-  const x1 = src.x + NODE_W;
-  const y1 = src.cy;
-  const x2 = tgt.x + NODE_W;
-  const y2 = tgt.cy;
-  const bow = Math.max(x1, x2) + 48;
-  return `M ${x1} ${y1} C ${bow} ${y1}, ${bow} ${y2}, ${x2} ${y2}`;
+// The breadcrumb text for a Frontier row = the ought-ancestry ABOVE the node
+// (root → parent), each rendered by slug, joined with `›`. Empty string for a
+// root (it has no ancestry to crumb).
+export function breadcrumbText(slug: string, bySlug: ReadonlyMap<string, AimWire>): string {
+  return ancestry(slug, bySlug)
+    .slice(0, -1)
+    .map((n) => n.slug)
+    .join(" › ");
+}
+
+// ── Frontier worklist ─────────────────────────────────────────────────
+
+// Rank for the owed worklist: drift before claimed (the ancestor-moved verdict
+// outranks an unverified self-claim), then stable by slug.
+function owedRank(n: AimWire): number {
+  return isDrifted(n) ? 0 : 1;
+}
+
+// The owed worklist for a node set — drift-first, then claimed, stable by slug.
+// done+drift is NOT here (it is surfaced separately by `doneDriftedRows`).
+export function frontierRows(nodes: readonly AimWire[]): AimWire[] {
+  return nodes
+    .filter(isOwed)
+    .sort((a, b) => owedRank(a) - owedRank(b) || a.slug.localeCompare(b.slug));
+}
+
+// Pin #2 surfacing: the done-and-drifted nodes for a set, stable by slug.
+// Listed in a distinct Frontier cluster (re-confirm owed) and rendered with the
+// `done-drift` tone — surfaced, not suppressed, not folded into the worklist.
+export function doneDriftedRows(nodes: readonly AimWire[]): AimWire[] {
+  return nodes.filter(isDoneDrifted).sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+// ── Rollups + ledger ──────────────────────────────────────────────────
+
+export interface RollupStats {
+  /** Total descendant (or repo-member) count. */
+  count: number;
+  /** Of those, how many are drifted-and-owed (open + drifted). */
+  drift: number;
+  /** Of those, how many are claimed-and-owed (open + claimed, not drifted). */
+  claimed: number;
+}
+
+// Descendant rollup for a collapsed branch — total descendants + the owed
+// breakdown, so a folded branch can show `⚠N ◌M` without expanding. drift and
+// claimed are disjoint (drift wins) to mirror the row glyph.
+export function subtreeStats(slug: string, childrenOf: Map<string, AimWire[]>): RollupStats {
+  let count = 0;
+  let drift = 0;
+  let claimed = 0;
+  const seen = new Set<string>();
+  const stack = [...(childrenOf.get(slug) ?? [])];
+  while (stack.length > 0) {
+    const n = stack.pop();
+    if (!n || seen.has(n.slug)) continue;
+    seen.add(n.slug);
+    count++;
+    if (n.state === "open") {
+      if (isDrifted(n)) drift++;
+      else if (hasClaimed(n)) claimed++;
+    }
+    for (const c of childrenOf.get(n.slug) ?? []) stack.push(c);
+  }
+  return { count, drift, claimed };
+}
+
+// Repo-wide rollup (every node in the repo) — drives the Tree repo-header
+// badge and the Frontier repo-section badge.
+export function repoStats(aims: readonly AimWire[]): RollupStats {
+  let drift = 0;
+  let claimed = 0;
+  for (const n of aims) {
+    if (n.state !== "open") continue;
+    if (isDrifted(n)) drift++;
+    else if (hasClaimed(n)) claimed++;
+  }
+  return { count: aims.length, drift, claimed };
+}
+
+export interface LedgerCounts {
+  /** Drifted nodes across the forest (engine-honest: includes done+drift,
+   *  excludes abandoned `dead` — see `isDrifted`). */
+  drift: number;
+  /** Total `claimed` interior marks across the forest. */
+  claimed: number;
+  /** Total `confirmed` interior marks across the forest. */
+  confirmed: number;
+}
+
+// The ledger strip's three counts, straight off the forest's `drift` + `is[]`.
+// drift counts NODES (a node drifts); claimed/confirmed count MARKS (a node can
+// carry several). Engine-honest per pin #2: a done-and-drifted node still
+// counts as drift — it is surfaced, not suppressed.
+export function ledgerCounts(nodes: readonly AimWire[]): LedgerCounts {
+  let drift = 0;
+  let claimed = 0;
+  let confirmed = 0;
+  for (const n of nodes) {
+    if (n.drift !== null && n.state !== "dead") drift++;
+    for (const m of n.is) {
+      if (m.kind === "confirmed") confirmed++;
+      else if (m.kind === "claimed") claimed++;
+    }
+  }
+  return { drift, claimed, confirmed };
+}
+
+// ── Overview ruler ────────────────────────────────────────────────────
+
+export interface RulerTick {
+  slug: string;
+  repoLabel: string;
+  /** `drift` / `claimed` light the tick (owed); `null` is calm forest texture. */
+  owed: "drift" | "claimed" | null;
+  /** Fractional position 0..1 down the whole-forest DFS order. */
+  pos: number;
+  /** True at the first tick of a repo after the first — a repo boundary line. */
+  repoBoundary: boolean;
+}
+
+// The overview-ruler ticks: a repo-grouped DFS over every forest, each node a
+// tick, owed ones (drift / claimed) lit. The minimap proves "you are not
+// looking at the whole tree" while keeping the whole forest's owed density in
+// peripheral view; clicking a lit tick reveals the node in Tree mode.
+export function rulerOrder(repos: readonly RepoAimsWire[]): RulerTick[] {
+  const flat: { slug: string; repoLabel: string; owed: "drift" | "claimed" | null }[] = [];
+  for (const repo of repos) {
+    const childrenOf = buildChildren(repo.aims);
+    const bySlug = bySlugMap(repo.aims);
+    const seen = new Set<string>();
+    const visit = (slug: string): void => {
+      if (seen.has(slug)) return;
+      seen.add(slug);
+      const n = bySlug.get(slug);
+      if (!n) return;
+      const owed: "drift" | "claimed" | null = isDrifted(n)
+        ? "drift"
+        : isOwed(n)
+          ? "claimed"
+          : null;
+      flat.push({ slug, repoLabel: repo.repo_label, owed });
+      for (const c of childrenOf.get(slug) ?? []) visit(c.slug);
+    };
+    for (const root of findRoots(repo.aims)) visit(root.slug);
+  }
+
+  const n = flat.length;
+  let prevLabel: string | null = null;
+  return flat.map((t, i) => {
+    const repoBoundary = prevLabel !== null && t.repoLabel !== prevLabel;
+    prevLabel = t.repoLabel;
+    return {
+      slug: t.slug,
+      repoLabel: t.repoLabel,
+      owed: t.owed,
+      // Position by index over the count (clientHeight-independent), so the
+      // ruler re-scales with the panel without re-measuring.
+      pos: n <= 1 ? 0 : i / n,
+      repoBoundary,
+    };
+  });
 }

--- a/clients/react/src/lib/__tests__/ui-prefs.test.ts
+++ b/clients/react/src/lib/__tests__/ui-prefs.test.ts
@@ -81,6 +81,22 @@ describe("ui-prefs", () => {
     expect(loadUIPrefs().attentionStripWidth).toBe(DEFAULT_UI_PREFS.attentionStripWidth);
   });
 
+  it("defaults the aim panel to frontier mode and round-trips a switch to tree", () => {
+    // The owed-worklist default is load-bearing (the panel is a write surface,
+    // not a passive full-tree dump).
+    expect(loadUIPrefs().aimMode).toBe("frontier");
+    saveUIPrefs({ ...DEFAULT_UI_PREFS, aimMode: "tree" });
+    expect(loadUIPrefs().aimMode).toBe("tree");
+  });
+
+  it("falls back to the default aim mode for an unknown value", () => {
+    localStorage.setItem(
+      UI_PREFS_STORAGE_KEY,
+      JSON.stringify({ ...DEFAULT_UI_PREFS, aimMode: "galaxy" }),
+    );
+    expect(loadUIPrefs().aimMode).toBe(DEFAULT_UI_PREFS.aimMode);
+  });
+
   it("round-trips a saved blob", () => {
     const next: UIPrefs = {
       ...DEFAULT_UI_PREFS,

--- a/clients/react/src/lib/ui-prefs.ts
+++ b/clients/react/src/lib/ui-prefs.ts
@@ -10,6 +10,15 @@
 
 import { DEFAULT_THEME_NAME, THEME_NAMES, type ThemeName } from "@/lib/theme";
 
+// Which mode the Aim panel (◎ Aims, Stage B convergence) opens in. `frontier`
+// = the owed worklist (default — the load-bearing thesis: the panel is a WRITE
+// surface, not a passive full-tree dump); `tree` = the collapsed per-repo
+// navigator. Durable across sessions, browser-side; the volatile bits (the
+// expanded-branch set, the search filter) stay component-local and are NOT
+// persisted (a stale persisted filter would silently hide rows on next open).
+export type AimMode = "frontier" | "tree";
+export const AIM_MODES: readonly AimMode[] = ["frontier", "tree"];
+
 export interface UIPrefs {
   // WebUI colour theme. Presentation-only; lives here (not in tmai-core
   // config / api-spec) by the same convention as every other field.
@@ -31,6 +40,9 @@ export interface UIPrefs {
   // pick a default to expand (approach 2026-05-29 §"tmai は何を絶対しない"
   // rule 6: no tmai-selected default expand).
   rPanelExpandedSections: string[];
+  // Aim panel mode. Default `frontier` — the owed worklist is the panel's
+  // load-bearing thesis (NOT a passive full-tree dump). See AimMode.
+  aimMode: AimMode;
 }
 
 // Attention-strip width bounds (px). Floor keeps the section content
@@ -47,6 +59,7 @@ export const DEFAULT_UI_PREFS: UIPrefs = {
   attentionStripCollapsed: false,
   attentionStripWidth: ATTENTION_STRIP_WIDTH_DEFAULT,
   rPanelExpandedSections: [],
+  aimMode: "frontier",
 };
 
 export const UI_PREFS_STORAGE_KEY = "tmai:ui:prefs";
@@ -99,6 +112,9 @@ function coercePrefs(raw: unknown): UIPrefs {
       DEFAULT_UI_PREFS.attentionStripWidth,
     ),
     rPanelExpandedSections: coerceExpandedSections(r.rPanelExpandedSections),
+    aimMode: AIM_MODES.includes(r.aimMode as AimMode)
+      ? (r.aimMode as AimMode)
+      : DEFAULT_UI_PREFS.aimMode,
   };
 }
 


### PR DESCRIPTION
Resolves #791. Stage B of the **aim-console destination convergence** (tmai-core `doc/approaches/2026-06-09-aim-console-destination-convergence.md`) — the Aim panel core, consuming the now-merged Stage-A wire (`AimWire.drift`, `AimWire.is`).

## Load-bearing thesis (kept)
The panel does **not** render the whole tree. Default = the owed **Frontier** worklist (nodes drifted OR carrying a `claimed` mark, drift-first, breadcrumbed); the full tree is a collapsed per-repo **Tree** navigator + branch rollups + an overview ruler. It stays an attention-economical write surface, never a passive full-tree dump (the approach's named failure-signal).

## What changed
- **`aim-tree.ts`** rewritten as the pure owed/frontier/ledger/ruler/ancestry model (`isOwed` / `frontierRows` / `aimTone` / `ledgerCounts` / `rulerOrder` / `subtreeStats` / `ancestry` …). The 2D tidy-tree geometry retired with the canvas it served.
- **Frontier⊥Tree** segmented modes. Tree un-flattens `RepoAimsWire` (primary repo highlighted), collapsible, with `⚠N ◌N` rollup badges on folded branches.
- **Ledger** strip (drift / claimed / confirmed) + bar, straight off the forest's `drift` + `is[]`.
- **Inspector** replaces the DetailPane: ought-ancestry breadcrumb + a **drift←ancestor** pill (from `drift.stale_from_ancestor_slug`) + the interior **`is[]`** list (confirmed/claimed as authored, `ref` shown for confirmed) + the existing edit / add-child affordances.
- **Overview ruler** — forest minimap, owed ticks lit, click → reveal in Tree.
- **Search/filter** by slug / ought. The Stage 2-B create + edit forms are carried and integrated into the inspector (edit) + add-child / `+ aim` flow.

## Pins honoured
- **#1 mark-only** — only the wire's `kind` drives `is[]` styling; never re-judged / re-ordered / appraised.
- **#2 done+drift distinct** — a `state: done` node that is *also* drifted gets the `done-drift` tone (a done ✓ **and** a drift ⚠ badge), surfaced in its own Frontier `done · drifted` cluster + the Tree — never suppressed, never folded into plain owed.
- **#3 drift mirrors the engine** — an ought edit **refetches** the forest and renders whatever drift the wire reports; **no** client-side transitive cascade.

## Guards
- Generated types imported from `@/types/generated/…` (`AimWire`, `AimDriftWire`, `AimInteriorWire`, `AimInteriorKind`) — no hand-mirror.
- UI-only **mode** persisted in `ui-prefs` (browser-side, not tmai-core config); filter + branch-expansion stay component-local.
- Theme: app design tokens only (drift = `warning`, claimed = `warning` hollow, confirmed/done = `success`, root/selection = `info`/`primary`) — the mock is the structure/behaviour reference, not its raw CSS.

## Scope
B-core **and** B-rest landed together (ledger, modes, grouping, inspector, drift badges, overview ruler, search, drift-cycle) — they were cohesive enough not to split.

Out of scope (unchanged): tmai-core / Stage A backend, unit tabs / PR pills / worker headers (Stage C), bash footer (Stage D). One wire gap noted in the friction file (the #501 create endpoint carries no `repo`, so per-repo create can't target a non-primary repo yet) — **not** patched here.

## Gate
- `pnpm lint` (biome) ✅
- `pnpm build` (tsc -b && vite build) ✅
- `pnpm test` (vitest) ✅ — 743 passed / 2 skipped, incl. **+45** pure aim-model tests and **+25** component tests covering Frontier ranking + owed filter, Tree grouping + rollups, inspector drift pill + `is[]`, ledger counts, the ruler reveal, search, create/edit, and **done+drift distinct rendering (pin #2)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)