### PR TITLE
S1: aim-ui console — design tokens + 3-pane shell + top-bar toggle (coexist) (#793)

### DIFF
--- a/clients/react/package.json
+++ b/clients/react/package.json
@@ -16,6 +16,9 @@
     "version": "npm run changelog && git add CHANGELOG.md"
   },
   "dependencies": {
+    "@fontsource/ibm-plex-mono": "^5.2.7",
+    "@fontsource/inter-tight": "^5.2.7",
+    "@fontsource/noto-sans-jp": "^5.2.9",
     "@tailwindcss/typography": "^0.5.20",
     "@tauri-apps/api": "^2.11.0",
     "@xterm/addon-fit": "^0.11.0",

--- a/clients/react/pnpm-lock.yaml
+++ b/clients/react/pnpm-lock.yaml
@@ -12,6 +12,15 @@ importers:
 
   .:
     dependencies:
+      '@fontsource/ibm-plex-mono':
+        specifier: ^5.2.7
+        version: 5.2.7
+      '@fontsource/inter-tight':
+        specifier: ^5.2.7
+        version: 5.2.7
+      '@fontsource/noto-sans-jp':
+        specifier: ^5.2.9
+        version: 5.2.9
       '@tailwindcss/typography':
         specifier: ^0.5.20
         version: 0.5.20(tailwindcss@4.3.0)
@@ -147,24 +156,28 @@ packages:
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-arm64@2.4.16':
     resolution: {integrity: sha512-2kFb4//jxfZaP6D+Rj5VkHkxgyD9EoRAVBEQb8PKRv+s4NO2zYNJKXFaJmK1CmhufJOWEfpHKaRbOja7qjmdhQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-linux-x64-musl@2.4.16':
     resolution: {integrity: sha512-iHDS+MCM65DPqWGu+ECC3uoALyj2H7F4nVUPxIPjz/PIl94EUu+EDfGZDzFP+NY1EOPVt9NQvwFqq7HdMmowdg==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@biomejs/cli-linux-x64@2.4.16':
     resolution: {integrity: sha512-NbcBbi/nJqn5baae6wqRXdS7Gadf2uRpehSh6vMSYpG8OhkXl/Xg8aorWrJ+9VWqAT5ml90alLvorkpMW0nBwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@biomejs/cli-win32-arm64@2.4.16':
     resolution: {integrity: sha512-0rgImMsNb5v/chhkIFe3wu7PEFClS6RBAYUijGL9UsYN3PanSaoK24HSSuSJb1pYbYYVjzAyZTl3gtjJ84BM8A==}
@@ -242,6 +255,15 @@ packages:
       '@noble/hashes':
         optional: true
 
+  '@fontsource/ibm-plex-mono@5.2.7':
+    resolution: {integrity: sha512-MKAb8qV+CaiMQn2B0dIi1OV3565NYzp3WN5b4oT6LTkk+F0jR6j0ZN+5BKJiIhffDC3rtBULsYZE65+0018z9w==}
+
+  '@fontsource/inter-tight@5.2.7':
+    resolution: {integrity: sha512-44TmSfHdNQus/3MWOMIonUEnbxwQhiaFo2sfBJEGIE4c7TN+GO6kfLzsTH4Nu52BC9HDZFl9fPQ6Cwzp9vYTtQ==}
+
+  '@fontsource/noto-sans-jp@5.2.9':
+    resolution: {integrity: sha512-6yVGiofnrnbiJjU8ch4JGSs2HqyozxMvsVyVmFwOnDH3u//qQKLqmKM4n0lqN0637uaJNzUW9nIJqbbMgHVQzw==}
+
   '@iconify/types@2.0.0':
     resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
 
@@ -311,36 +333,42 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-arm64-musl@1.0.3':
     resolution: {integrity: sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-linux-ppc64-gnu@1.0.3':
     resolution: {integrity: sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-s390x-gnu@1.0.3':
     resolution: {integrity: sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-gnu@1.0.3':
     resolution: {integrity: sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rolldown/binding-linux-x64-musl@1.0.3':
     resolution: {integrity: sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==}
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rolldown/binding-openharmony-arm64@1.0.3':
     resolution: {integrity: sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==}
@@ -409,24 +437,28 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.0':
     resolution: {integrity: sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.0':
     resolution: {integrity: sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.0':
     resolution: {integrity: sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.0':
     resolution: {integrity: sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==}
@@ -1163,24 +1195,28 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -1880,6 +1916,12 @@ snapshots:
     optional: true
 
   '@exodus/bytes@1.15.0': {}
+
+  '@fontsource/ibm-plex-mono@5.2.7': {}
+
+  '@fontsource/inter-tight@5.2.7': {}
+
+  '@fontsource/noto-sans-jp@5.2.9': {}
 
   '@iconify/types@2.0.0': {}
 

--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -2,6 +2,8 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { AgentActions } from "@/components/agent/AgentActions";
 import { AgentList } from "@/components/agent/AgentList";
 import { PreviewPanel } from "@/components/agent/PreviewPanel";
+import { AimConsole } from "@/components/aim-console/AimConsole";
+import { type ConsoleMode, DEFAULT_CONSOLE_MODE } from "@/components/aim-console/console-mode";
 import { CalibrationChip } from "@/components/calibration/CalibrationChip";
 import { CalibrationPanel } from "@/components/calibration/CalibrationPanel";
 import { TripwireBanner } from "@/components/calibration/TripwireBanner";
@@ -119,6 +121,20 @@ export function App() {
   // more error-prone; this enum makes the constraint explicit.
   const [mainPanel, setMainPanel] = useState<"agents" | "settings" | "security" | "calibration">(
     "agents",
+  );
+  // Coexist console-mode toggle (aim node `tmai-core:doc/aims/aim-ui.md`).
+  // A sibling of `mainPanel`: which TOP-LEVEL console is shown. `producer`
+  // (default) keeps the entire existing shell (sidebar + digest/conversation
+  // + R panel); `aim` swaps the whole window for the new full-screen
+  // <AimConsole>. Aim-ui is opt-in via the StatusBar button and stays opt-in
+  // until the aim mechanism matures — the existing console is never ripped
+  // out. Deliberately NOT persisted to ui-prefs in S1: the aim panes are
+  // stubs, so a reload should land back on the working Producer console
+  // rather than a stub-only screen.
+  const [consoleMode, setConsoleMode] = useState<ConsoleMode>(DEFAULT_CONSOLE_MODE);
+  const toggleConsoleMode = useCallback(
+    () => setConsoleMode((m) => (m === "aim" ? "producer" : "aim")),
+    [],
   );
   const [showHelp, setShowHelp] = useState(false);
   // Persistent right R panel (project artifact inventory — approach
@@ -660,6 +676,24 @@ export function App() {
     <RIssueViewer selected={selectedIssue} onClose={clearIssue} />
   ) : null;
 
+  // Coexist: when the operator opts into aim-ui, the new full-window aim
+  // console takes over the whole shell (its own top bar + 3-pane grid),
+  // replacing the existing sidebar / digest / R panel. Returned AFTER every
+  // hook above so the rules of hooks hold; the matching EXIT toggle lives in
+  // the aim console's own top bar (the StatusBar that hosts the ENTER toggle
+  // is not rendered in this mode).
+  if (consoleMode === "aim") {
+    return (
+      <AimConsole
+        units={unitsData?.units ?? []}
+        activeUnitName={unitName}
+        onSelectUnit={handleSelectUnit}
+        onAddUnit={handleAddUnit}
+        onExit={toggleConsoleMode}
+      />
+    );
+  }
+
   return (
     <div ref={rPanelSplit.containerRef} className="flex h-screen text-foreground">
       {/* Mobile: overlay backdrop when drawer is open */}
@@ -725,6 +759,8 @@ export function App() {
             onSecurityClick={() => {
               toggleSecurity();
             }}
+            consoleMode={consoleMode}
+            onToggleConsoleMode={toggleConsoleMode}
             indicatorSlot={
               <>
                 <ProducerFeedChip data={producerFeedData} onClick={handleTriggerProducerFeed} />
@@ -784,6 +820,8 @@ export function App() {
             onSecurityClick={() => {
               toggleSecurity();
             }}
+            consoleMode={consoleMode}
+            onToggleConsoleMode={toggleConsoleMode}
             onReturnToConsole={
               selection !== null || mainPanel !== "agents" ? returnToConsole : undefined
             }

--- a/clients/react/src/__tests__/App.console-mode.test.tsx
+++ b/clients/react/src/__tests__/App.console-mode.test.tsx
@@ -1,0 +1,203 @@
+// @vitest-environment jsdom
+//
+// App-level coexist-toggle wiring test (aim node
+// `tmai-core:doc/aims/aim-ui.md`, S1). The StatusBar hosts a console-mode
+// toggle; App holds the `consoleMode` sibling state. The contract:
+//
+//   1. DEFAULT is the existing ProducerConsole — aim-ui is opt-in;
+//   2. the StatusBar toggle switches the WHOLE shell to the full-window
+//      <AimConsole> (the sidebar / digest / R panel are replaced);
+//   3. the aim console's own EXIT toggle returns to the Producer console.
+//
+// The real <AimConsole> is covered by its own test; here it's stubbed so we
+// observe WHICH top-level view App renders, plus the exit seam.
+
+import { fireEvent, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentSnapshot } from "@/lib/api";
+import { renderWithProviders } from "@/test/render";
+
+// ── hook mocks ──
+const useAgentsMock = vi.fn();
+const useResponsiveLayoutMock = vi.fn();
+const useSplitPaneMock = vi.fn();
+
+vi.mock("@/lib/sse-provider", () => ({
+  useSSE: () => undefined,
+  useSSEContext: () => ({
+    cache: { agents: [], worktrees: [], queueEntries: [], loading: false },
+    refreshCache: vi.fn(),
+    subscribe: vi.fn(),
+  }),
+}));
+vi.mock("@/hooks/useActiveTheme", () => ({ useApplyTheme: () => undefined }));
+vi.mock("@/hooks/useAgents", () => ({ useAgents: () => useAgentsMock() }));
+vi.mock("@/hooks/useWorktrees", () => ({
+  useWorktrees: () => ({ worktrees: [], loading: false, refresh: vi.fn() }),
+}));
+vi.mock("@/hooks/useUnits", () => ({
+  useUnits: () => ({ data: { units: [] }, loading: false, error: null }),
+}));
+vi.mock("@/hooks/useCalibration", () => ({
+  useCalibration: () => ({ data: null, loading: false, error: null }),
+}));
+vi.mock("@/hooks/useNotificationConfig", () => ({ useNotificationConfig: () => ({}) }));
+vi.mock("@/hooks/useIdleNotification", () => ({
+  useIdleNotification: () => ({ handleAgentStopped: vi.fn() }),
+}));
+vi.mock("@/hooks/useResponsiveLayout", () => ({
+  useResponsiveLayout: () => useResponsiveLayoutMock(),
+}));
+vi.mock("@/hooks/useSplitPane", () => ({
+  useSplitPane: () => useSplitPaneMock(),
+  makeSplitKeyHandler: () => () => undefined,
+  RATIO_STEP: 0.025,
+}));
+vi.mock("@/hooks/useAgentSelectionFallback", () => ({
+  useAgentSelectionFallback: () => undefined,
+}));
+vi.mock("@/hooks/useKeyboardShortcuts", () => ({ useKeyboardShortcuts: () => undefined }));
+vi.mock("@/hooks/useProducerFeed", () => ({
+  useProducerFeed: () => ({ data: null, loading: false, error: null }),
+}));
+
+// ── component stubs (everything heavy / networked) ──
+vi.mock("@/components/producer-console/r-panel/RPanel", () => ({
+  RPanel: () => <div data-testid="r-panel-stub">r-panel</div>,
+}));
+vi.mock("@/components/producer-console/r-panel/r-viewer/RPrViewer", () => ({
+  RPrViewer: () => null,
+  selectedPrKey: () => "pr-key",
+}));
+vi.mock("@/components/producer-console/r-panel/r-viewer/RRecordViewer", () => ({
+  RRecordViewer: () => null,
+  selectedRecordKey: () => "rec-key",
+}));
+vi.mock("@/components/producer-console/r-panel/r-viewer/RIssueViewer", () => ({
+  RIssueViewer: () => null,
+  selectedIssueKey: () => "iss-key",
+}));
+vi.mock("@/components/producer-console/ProducerConsole", () => ({
+  ProducerConsole: () => <div data-testid="producer-console-stub">digest</div>,
+}));
+vi.mock("@/components/producer-console/ProducerConversationHeader", () => ({
+  ProducerConversationHeader: () => null,
+}));
+vi.mock("@/components/agent/PreviewPanel", () => ({ PreviewPanel: () => null }));
+vi.mock("@/components/agent/AgentActions", () => ({ AgentActions: () => null }));
+vi.mock("@/components/terminal/TerminalPanel", () => ({ TerminalPanel: () => null }));
+vi.mock("@/components/agent/AgentList", () => ({ AgentList: () => null }));
+vi.mock("@/components/terminal/TerminalList", () => ({ TerminalList: () => null }));
+vi.mock("@/components/usage/UsagePanel", () => ({ UsagePanel: () => null }));
+vi.mock("@/components/settings/SettingsPanel", () => ({ SettingsPanel: () => null }));
+vi.mock("@/components/settings/SecurityPanel", () => ({ SecurityPanel: () => null }));
+vi.mock("@/components/calibration/CalibrationPanel", () => ({ CalibrationPanel: () => null }));
+
+// The aim console is stubbed to a marker + an exit button wired to `onExit`,
+// so we can observe the switch and the return path without rendering the
+// real 3-pane shell.
+vi.mock("@/components/aim-console/AimConsole", () => ({
+  AimConsole: ({ onExit }: { onExit: () => void }) => (
+    <div data-testid="aim-console-stub">
+      <button type="button" onClick={onExit}>
+        exit-aim
+      </button>
+    </div>
+  ),
+}));
+
+import { App } from "@/App";
+
+function agent(target: string, cwd: string): AgentSnapshot {
+  return {
+    id: target,
+    target,
+    agent_type: "ClaudeCode",
+    title: target,
+    cwd,
+    display_cwd: cwd,
+    display_name: target,
+    detection_source: "HttpHook",
+    git_branch: null,
+    git_dirty: null,
+    is_worktree: null,
+    git_common_dir: null,
+    worktree_name: null,
+    worktree_base_branch: null,
+    effort_level: null,
+    active_subagents: 0,
+    compaction_count: 0,
+    pty_session_id: null,
+    send_capability: "None",
+    is_virtual: false,
+    team_info: null,
+    is_orchestrator: false,
+    attention: null,
+  } as AgentSnapshot;
+}
+
+function responsive(overrides: Record<string, unknown> = {}) {
+  return {
+    // Expanded sidebar so the StatusBar settings/toggle cluster renders.
+    sidebarCollapsed: false,
+    toggleSidebar: vi.fn(),
+    actionPanelCollapsed: true,
+    toggleActionPanel: vi.fn(),
+    isNarrowScreen: false,
+    isMobileScreen: false,
+    mobileDrawerOpen: false,
+    toggleMobileDrawer: vi.fn(),
+    closeMobileDrawer: vi.fn(),
+    ...overrides,
+  };
+}
+
+function splitPane(isNarrowScreen = false) {
+  return {
+    splitRatio: 0.5,
+    isDragging: false,
+    containerRef: { current: null },
+    onDividerMouseDown: vi.fn(),
+    onDividerDoubleClick: vi.fn(),
+    adjustRatio: vi.fn(),
+    isNarrowScreen,
+  };
+}
+
+beforeEach(() => {
+  useAgentsMock.mockReset();
+  useResponsiveLayoutMock.mockReset();
+  useSplitPaneMock.mockReset();
+  useAgentsMock.mockReturnValue({
+    agents: [agent("claude:abc", "/p/alpha")],
+    attentionCount: 0,
+    loading: false,
+    refresh: vi.fn(),
+  });
+  useResponsiveLayoutMock.mockReturnValue(responsive());
+  useSplitPaneMock.mockReturnValue(splitPane(false));
+});
+
+describe("App — console-mode coexist toggle", () => {
+  it("defaults to the Producer console (aim-ui is opt-in)", () => {
+    renderWithProviders(<App />);
+    expect(screen.getByTestId("producer-console-stub")).toBeTruthy();
+    expect(screen.queryByTestId("aim-console-stub")).toBeNull();
+  });
+
+  it("switches the whole shell to the aim console and back", () => {
+    renderWithProviders(<App />);
+
+    // Enter aim-ui via the StatusBar toggle.
+    fireEvent.click(screen.getByLabelText("Switch to the aim console"));
+    expect(screen.getByTestId("aim-console-stub")).toBeTruthy();
+    // The existing shell is replaced — digest AND R panel are gone.
+    expect(screen.queryByTestId("producer-console-stub")).toBeNull();
+    expect(screen.queryByTestId("r-panel-stub")).toBeNull();
+
+    // Exit via the aim console's own toggle → back to the Producer console.
+    fireEvent.click(screen.getByText("exit-aim"));
+    expect(screen.getByTestId("producer-console-stub")).toBeTruthy();
+    expect(screen.queryByTestId("aim-console-stub")).toBeNull();
+  });
+});

--- a/clients/react/src/__tests__/App.console-mode.test.tsx
+++ b/clients/react/src/__tests__/App.console-mode.test.tsx
@@ -189,7 +189,7 @@ describe("App — console-mode coexist toggle", () => {
     renderWithProviders(<App />);
 
     // Enter aim-ui via the StatusBar toggle.
-    fireEvent.click(screen.getByLabelText("Switch to the aim console"));
+    fireEvent.click(screen.getByLabelText("Switch to the aim console (preview)"));
     expect(screen.getByTestId("aim-console-stub")).toBeTruthy();
     // The existing shell is replaced — digest AND R panel are gone.
     expect(screen.queryByTestId("producer-console-stub")).toBeNull();

--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -23,6 +23,21 @@ import { useState } from "react";
 import { useUnitAttention } from "@/hooks/useUnitAttention";
 import type { UnitResponse } from "@/lib/api";
 import { cn } from "@/lib/utils";
+// Bundled dev-tool typography (offline-robust @fontsource, NOT a Google Fonts
+// <link>) — loads the exact families `aim-console.css` references via --sans /
+// --mono so the dev-tool look matches the mock instead of falling back to
+// system fonts. Loading is document-global, but ONLY `.aim-console` references
+// these families, so the existing console is unaffected. Weights mirror the
+// mock: IBM Plex Mono 400/500/600, Inter Tight 400/500/600, Noto Sans JP
+// 400/500.
+import "@fontsource/ibm-plex-mono/400.css";
+import "@fontsource/ibm-plex-mono/500.css";
+import "@fontsource/ibm-plex-mono/600.css";
+import "@fontsource/inter-tight/400.css";
+import "@fontsource/inter-tight/500.css";
+import "@fontsource/inter-tight/600.css";
+import "@fontsource/noto-sans-jp/400.css";
+import "@fontsource/noto-sans-jp/500.css";
 import "@/styles/aim-console.css";
 
 function repoBasename(path: string): string {

--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -1,0 +1,224 @@
+// AimConsole — the destination aim-console shell (S1).
+//
+// A faithful reproduction of the destination mock
+// (`origin/mock/aim-ui-sample` → `assets/ui-sample.html`, dev-tool / scale
+// variant): a full-window 3-pane console — Aim (worklist) ⟂ Session (raw CC)
+// ⟂ PR-rail — under a sober top bar (brand + unit tabs + meta). Serves aim
+// node `aim-ui` (`tmai-core:doc/aims/aim-ui.md`), part of the aim-model
+// dogfood.
+//
+// COEXIST, DO NOT RIP: this is opt-in behind a StatusBar toggle; the
+// existing ProducerConsole stays the default (see `console-mode.ts`). The
+// dev-tool tokens are scoped to `.aim-console` in `styles/aim-console.css`
+// so they never bleed into the existing console.
+//
+// S1 SCOPE = the TOKEN LAYER + the SHELL: the top bar (real, data-driven
+// unit tabs) and the 3-pane grid incl. the PR-rail expand/collapse
+// transition. The three pane BODIES are placeholders / stubs here:
+//   - S2 fills the Aim worklist (Frontier⊥Tree, ledger, ruler, inspector);
+//   - S3 fills the Session conversation (tabs + bash footer);
+//   - S4 fills the PR-rail PR/Issue lists.
+
+import { useState } from "react";
+import { useUnitAttention } from "@/hooks/useUnitAttention";
+import type { UnitResponse } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import "@/styles/aim-console.css";
+
+function repoBasename(path: string): string {
+  return path.split("/").filter(Boolean).pop() ?? path;
+}
+
+interface AimConsoleProps {
+  /** Configured `[[unit]]` membership (App's `useUnits`), rendered as the
+   *  top-bar unit tabs. Empty = no tabs (cwd-synthesized units aren't
+   *  enumerated; same convention as the existing UnitTabs). */
+  units: UnitResponse[];
+  /** Name of the currently focused unit, so the matching tab highlights. */
+  activeUnitName: string | null;
+  /** Re-scope the focused unit to the clicked tab. */
+  onSelectUnit: (unit: UnitResponse) => void;
+  /** "Add unit = launch Producer" affordance (App's clipboard placeholder). */
+  onAddUnit: () => void;
+  /** Switch back to the existing ProducerConsole (the default view). The
+   *  ENTER toggle lives in StatusBar; this is its EXIT pair, since the
+   *  full-window aim console replaces the existing chrome incl. StatusBar. */
+  onExit: () => void;
+}
+
+export function AimConsole({
+  units,
+  activeUnitName,
+  onSelectUnit,
+  onAddUnit,
+  onExit,
+}: AimConsoleProps) {
+  // PR-rail expand state — the only live interaction in the S1 shell. The
+  // collapsed 46px rail expands to a 320px panel via the `.pr-open` modifier
+  // on the root (mock `body.pr-open { --pr: 320px }`). The panel CONTENT is
+  // an S4 stub.
+  const [prOpen, setPrOpen] = useState(false);
+  const metaUnit = activeUnitName ?? units[0]?.name ?? "—";
+
+  return (
+    <div className={cn("aim-console", prOpen && "pr-open")} data-testid="aim-console">
+      {/* ── top bar ── */}
+      <div className="ac-top">
+        <div className="ac-brand">
+          <b>tmai</b> console
+        </div>
+        {units.map((unit) => (
+          <AimUnitTab
+            key={unit.name}
+            unit={unit}
+            active={unit.name === activeUnitName}
+            onSelect={() => onSelectUnit(unit)}
+          />
+        ))}
+        <button
+          type="button"
+          className="ac-uadd"
+          onClick={onAddUnit}
+          title="Add unit = launch a Producer in a unit's primary repo"
+          aria-label="Add unit — launch Producer"
+        >
+          +
+        </button>
+        <div className="ac-sp" />
+        <div className="ac-meta">unit {metaUnit} · opus-4.8 · max</div>
+        <button
+          type="button"
+          className="ac-exit"
+          onClick={onExit}
+          title="Return to the Producer console"
+          aria-label="Return to the Producer console"
+        >
+          ‹ console
+        </button>
+      </div>
+
+      {/* ── 3-pane grid ── */}
+      <div className="ac-main">
+        {/* AIM — S2 worklist */}
+        <section className="ac-col ac-aim" aria-label="Aim">
+          <div className="ac-ahead">
+            <div className="ac-arow1">
+              <h1>Aim</h1>
+              <span className="ac-scale">Frontier ⊥ Tree</span>
+              <span className="ac-premise">AIM-PREMISE</span>
+            </div>
+          </div>
+          <PaneStub
+            stage="S2"
+            note="Aim worklist (Frontier⊥Tree), ledger + bar, overview ruler, and inspector land here."
+          />
+        </section>
+
+        {/* SESSION — S3 conversation */}
+        <section className="ac-col ac-session" aria-label="Session">
+          <div className="ac-stabs" aria-hidden="true">
+            <span className="ac-stab on">
+              <span className="ac-ro p">PROD</span> Producer
+            </span>
+          </div>
+          <PaneStub
+            stage="S3"
+            note="Session conversation (raw CC), session tabs, and the bash footer land here."
+          />
+        </section>
+
+        {/* PR RAIL — collapsed rail ⇄ expanded panel (S1); lists are S4 */}
+        <section className="ac-col ac-pr" aria-label="PR / Issue rail">
+          <button
+            type="button"
+            className="ac-prrail"
+            onClick={() => setPrOpen(true)}
+            title="Expand PR / Issue rail"
+            aria-label="Expand PR / Issue rail"
+            aria-expanded={prOpen}
+          >
+            <span className="ac-v w">PR</span>
+            <span className="ac-v">Issue</span>
+            <span className="ac-g">‹ EXTERNAL</span>
+          </button>
+          <div className="ac-prfull">
+            <div className="ac-prh">
+              PR / ISSUE — unit {metaUnit}
+              <button
+                type="button"
+                className="ac-x"
+                onClick={() => setPrOpen(false)}
+                title="Collapse PR / Issue rail"
+                aria-label="Collapse PR / Issue rail"
+              >
+                ✕
+              </button>
+            </div>
+            <div className="ac-prb">
+              <PaneStub
+                stage="S4"
+                note="PR / Issue lists (the rail's expand/collapse content) land here."
+              />
+            </div>
+          </div>
+        </section>
+      </div>
+    </div>
+  );
+}
+
+// Top-bar unit tab — repo pills (primary highlighted) + an attention rollup
+// badge (⚠N). Mirrors the existing `UnitTabs`/`UnitTab` data wiring (reuses
+// `useUnitAttention`, no new wire) but styled with the aim-console tokens.
+// Per-unit so each tab calls the hook on its own without a rules-of-hooks
+// violation as the tab list grows.
+function AimUnitTab({
+  unit,
+  active,
+  onSelect,
+}: {
+  unit: UnitResponse;
+  active: boolean;
+  onSelect: () => void;
+}) {
+  const { data } = useUnitAttention(unit.name);
+  const highCount = data?.entries.filter((e) => e.level === "high").length ?? 0;
+
+  return (
+    <button
+      type="button"
+      className={cn("ac-utab", active && "on")}
+      onClick={onSelect}
+      aria-current={active ? "true" : undefined}
+      aria-label={`unit: ${unit.name}`}
+      title={`unit: ${unit.name}`}
+    >
+      <span className="ac-d" />
+      {unit.repos.map((repo) => (
+        <span
+          key={repo.path}
+          className={cn("ac-rp", repo.primary && "pri")}
+          data-testid="aim-repo-pill"
+          data-primary={repo.primary ? "true" : "false"}
+        >
+          {repoBasename(repo.path)}
+        </span>
+      ))}
+      {highCount > 0 && (
+        <span className="ac-um" title={`${highCount} owed attention`}>
+          ⚠{highCount}
+        </span>
+      )}
+    </button>
+  );
+}
+
+// Placeholder body for a pane whose real content arrives in a later stage.
+function PaneStub({ stage, note }: { stage: string; note: string }) {
+  return (
+    <div className="ac-stub" data-testid={`aim-pane-stub-${stage.toLowerCase()}`}>
+      <span className="ac-stub-stage">{stage}</span>
+      <p className="ac-stub-note">{note}</p>
+    </div>
+  );
+}

--- a/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
@@ -1,0 +1,107 @@
+// @vitest-environment jsdom
+//
+// AimConsole S1 shell test. The aim console is a faithful reproduction of
+// the destination mock (`origin/mock/aim-ui-sample`): a full-window 3-pane
+// console under a sober top bar. S1 reproduces the SHELL — top bar (real
+// unit tabs), the 3-pane grid, and the PR-rail expand/collapse transition.
+// The pane BODIES are stubs (S2–S4), so this test asserts STRUCTURE +
+// the one live interaction (the rail toggle) + the callbacks, not pane
+// content.
+//
+// `useUnitAttention` is mocked so the per-tab attention rollup never hits
+// the network (mirrors how UnitTabs tabs poll for the ⚠N badge).
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { UnitResponse } from "@/lib/api";
+import { AimConsole } from "../AimConsole";
+
+vi.mock("@/hooks/useUnitAttention", () => ({
+  useUnitAttention: () => ({ data: null, loading: false, error: null }),
+}));
+
+const UNITS: UnitResponse[] = [
+  {
+    name: "tmai",
+    repos: [
+      { path: "/home/u/tmai", primary: true },
+      { path: "/home/u/tmai-core", primary: false },
+    ],
+  },
+];
+
+function renderConsole(overrides: Partial<Parameters<typeof AimConsole>[0]> = {}) {
+  const props = {
+    units: UNITS,
+    activeUnitName: "tmai" as string | null,
+    onSelectUnit: vi.fn(),
+    onAddUnit: vi.fn(),
+    onExit: vi.fn(),
+    ...overrides,
+  };
+  render(<AimConsole {...props} />);
+  return props;
+}
+
+describe("AimConsole — S1 shell", () => {
+  it("renders the top bar brand and the 3 panes", () => {
+    renderConsole();
+    // The brand reads "tmai console"; "tmai" alone also appears as a repo
+    // pill, so assert the brand via its container's full text.
+    const brand = screen.getByText("console").closest(".ac-brand");
+    expect(brand?.textContent).toContain("tmai");
+    expect(screen.getByLabelText("Aim")).toBeTruthy();
+    expect(screen.getByLabelText("Session")).toBeTruthy();
+    expect(screen.getByLabelText("PR / Issue rail")).toBeTruthy();
+  });
+
+  it("marks the panes as S2–S4 stubs (no worklist/session/PR logic in S1)", () => {
+    renderConsole();
+    expect(screen.getByTestId("aim-pane-stub-s2")).toBeTruthy();
+    expect(screen.getByTestId("aim-pane-stub-s3")).toBeTruthy();
+    expect(screen.getByTestId("aim-pane-stub-s4")).toBeTruthy();
+  });
+
+  it("renders a top-bar unit tab with primary + secondary repo pills", () => {
+    renderConsole();
+    const tab = screen.getByRole("button", { name: "unit: tmai" });
+    const pills = within(tab).getAllByTestId("aim-repo-pill");
+    expect(pills.map((p) => p.textContent)).toEqual(["tmai", "tmai-core"]);
+    expect(pills[0].getAttribute("data-primary")).toBe("true");
+    expect(pills[1].getAttribute("data-primary")).toBe("false");
+  });
+
+  it("expands and collapses the PR rail (the S1 transition, via .pr-open)", () => {
+    renderConsole();
+    const root = screen.getByTestId("aim-console");
+    // Collapsed by default.
+    expect(root.className).not.toContain("pr-open");
+
+    // Click the collapsed rail → expands.
+    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
+    expect(root.className).toContain("pr-open");
+
+    // The expanded panel's close (✕) → collapses again.
+    fireEvent.click(screen.getByRole("button", { name: "Collapse PR / Issue rail" }));
+    expect(root.className).not.toContain("pr-open");
+  });
+
+  it("calls onSelectUnit / onAddUnit / onExit from the top bar", () => {
+    const props = renderConsole();
+
+    fireEvent.click(screen.getByRole("button", { name: "unit: tmai" }));
+    expect(props.onSelectUnit).toHaveBeenCalledWith(UNITS[0]);
+
+    fireEvent.click(screen.getByRole("button", { name: "Add unit — launch Producer" }));
+    expect(props.onAddUnit).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByRole("button", { name: "Return to the Producer console" }));
+    expect(props.onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back the meta readout to the first unit when none is focused", () => {
+    renderConsole({ activeUnitName: null });
+    // metaUnit = units[0].name when activeUnitName is null.
+    expect(screen.getByText(/unit tmai · opus-4\.8 · max/)).toBeTruthy();
+  });
+});

--- a/clients/react/src/components/aim-console/console-mode.ts
+++ b/clients/react/src/components/aim-console/console-mode.ts
@@ -1,0 +1,14 @@
+// The two top-level console views the operator can switch between.
+//
+// COEXIST, DO NOT RIP (aim node `tmai-core:doc/aims/aim-ui.md`): `producer`
+// is the existing hand-over digest console — the DEFAULT, and it stays the
+// default until the aim mechanism matures. `aim` is the new full-window
+// 3-pane aim console (S1 shell + S2–S4 fill).
+//
+// The toggle to ENTER aim-ui lives in StatusBar (the existing top chrome);
+// the toggle to EXIT lives in the aim console's own top bar, because the
+// aim console is a full-screen takeover that replaces the existing shell —
+// StatusBar included — while it is shown.
+export type ConsoleMode = "producer" | "aim";
+
+export const DEFAULT_CONSOLE_MODE: ConsoleMode = "producer";

--- a/clients/react/src/components/layout/StatusBar.tsx
+++ b/clients/react/src/components/layout/StatusBar.tsx
@@ -1,4 +1,5 @@
 import type { ReactNode } from "react";
+import type { ConsoleMode } from "@/components/aim-console/console-mode";
 
 interface StatusBarProps {
   agentCount: number;
@@ -7,6 +8,15 @@ interface StatusBarProps {
   onToggleCollapse?: () => void;
   onSettingsClick: () => void;
   onSecurityClick: () => void;
+  /** Coexist toggle (aim node `tmai-core:doc/aims/aim-ui.md`): which
+   *  top-level console is shown. `producer` (default) = the existing
+   *  hand-over digest console; `aim` = the new full-window 3-pane aim
+   *  console. The toggle button below ENTERS aim-ui (its EXIT pair lives
+   *  in the aim console's own top bar, since that console replaces this
+   *  StatusBar while shown). Omitting `onToggleConsoleMode` hides the
+   *  button (e.g. the collapsed sidebar, which has no settings cluster). */
+  consoleMode?: ConsoleMode;
+  onToggleConsoleMode?: () => void;
   /** Optional pre-rendered indicator slot — currently used for the
    *  calibration / tier-1 tripwire chip (DR §B.3/§B.4). Sits between
    *  the attention count and the settings / security buttons. */
@@ -38,12 +48,38 @@ export function StatusBar({
   onToggleCollapse,
   onSettingsClick,
   onSecurityClick,
+  consoleMode = "producer",
+  onToggleConsoleMode,
   indicatorSlot,
   onReturnToConsole,
   isMobile,
   onMobileMenuClick,
   unitTabs,
 }: StatusBarProps) {
+  // Coexist console-mode toggle. Rendered next to the Settings/Security
+  // cluster (the desktop-expanded + mobile chrome where those buttons live).
+  // In practice this StatusBar only renders while `producer` is active — the
+  // aim console takes over the whole shell once entered — so the label is
+  // derived from `consoleMode` purely for correctness.
+  const consoleModeButton = onToggleConsoleMode ? (
+    <button
+      type="button"
+      onClick={onToggleConsoleMode}
+      aria-pressed={consoleMode === "aim"}
+      className="rounded px-1.5 py-0.5 text-muted-foreground transition-colors hover:bg-surface-strong hover:text-primary"
+      title={
+        consoleMode === "aim"
+          ? "Switch to the Producer console"
+          : "Switch to the aim console (preview)"
+      }
+      aria-label={
+        consoleMode === "aim" ? "Switch to the Producer console" : "Switch to the aim console"
+      }
+    >
+      ◎
+    </button>
+  ) : null;
+
   if (isMobile) {
     return (
       <div className="border-b border-hairline">
@@ -90,6 +126,7 @@ export function StatusBar({
                 🏠
               </button>
             )}
+            {consoleModeButton}
             <button
               type="button"
               onClick={onSecurityClick}
@@ -204,6 +241,7 @@ export function StatusBar({
               🏠
             </button>
           )}
+          {consoleModeButton}
           <button
             type="button"
             onClick={onSecurityClick}

--- a/clients/react/src/components/layout/StatusBar.tsx
+++ b/clients/react/src/components/layout/StatusBar.tsx
@@ -73,7 +73,9 @@ export function StatusBar({
           : "Switch to the aim console (preview)"
       }
       aria-label={
-        consoleMode === "aim" ? "Switch to the Producer console" : "Switch to the aim console"
+        consoleMode === "aim"
+          ? "Switch to the Producer console"
+          : "Switch to the aim console (preview)"
       }
     >
       ◎

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -1,0 +1,426 @@
+/* ════════════════════════════════════════════════════════════════════════
+   tmai aim console — DEDICATED, SCOPED design-token + shell stylesheet.
+
+   Faithful port of the destination mock (`origin/mock/aim-ui-sample` →
+   `assets/ui-sample.html`, dev-tool / scale variant). Serves aim node
+   `aim-ui` (`tmai-core:doc/aims/aim-ui.md`).
+
+   COEXIST, DO NOT RIP: the existing console keeps its own
+   tokens/themes (globals.css + lib/theme.ts). EVERYTHING here is scoped
+   under `.aim-console` so the dev-tool palette (low-chroma, k9s/lazygit
+   tone) and the 12.5px/27px density NEVER bleed into the existing
+   console. Custom properties declared on `.aim-console` only inherit
+   DOWN into the aim-console subtree, so the existing UI — which is never
+   a descendant of `.aim-console` — cannot see them.
+
+   This file is NOT processed by Tailwind (it has no `@import "tailwindcss"`)
+   and is NOT linted/formatted by biome (CSS is disabled in biome.json), so
+   the literal hex token values live here the way `lib/theme.ts` legitimately
+   holds colour values — and the repo-wide raw-palette lock only scans
+   `*.tsx?`, never `*.css`.
+
+   S1 reproduces the TOKEN LAYER + the SHELL: top bar, 3-pane grid, and the
+   PR-rail expand/collapse transition. The three panes are placeholders /
+   stubs here — the worklist (S2), session (S3), and PR/Issue lists (S4)
+   fill them in later stages.
+   ════════════════════════════════════════════════════════════════════════ */
+
+.aim-console {
+  /* ── design tokens (mock `:root`, dev-tool / scale) ─────────────────── */
+  --bg: #0b0e0f;
+  --panel: #0d1112;
+  --panel-2: #11171800;
+  --elev: #121819;
+  --line: #1b2122;
+  --line-2: #161b1c;
+  --txt: #c2cbc8;
+  --dim: #7b8784;
+  --faint: #4d5856;
+  --amber: #cf9b46;
+  --amber-d: #241c0e; /* drift / owed-strong */
+  --ochre: #b1894f;
+  --ochre-d: #1f1810; /* claimed */
+  --green: #4a9476;
+  --green-d: #10211a; /* confirmed / calm */
+  --cyan: #4aa39d;
+  --cyan-d: #102423; /* structure / select / root */
+  --violet: #8f7ad6;
+  --violet-d: #171428; /* worker */
+  --danger: #d96a6a;
+  --sans: "Inter Tight", "Noto Sans JP", system-ui, sans-serif;
+  --mono: "IBM Plex Mono", ui-monospace, Menlo, monospace;
+  --rh: 27px;
+
+  /* 3-pane column track (mock `.main`). The PR-rail collapses to a 46px
+     rail and expands to 320px via the `.pr-open` modifier below. */
+  --aim: 1.18fr;
+  --sess: 1fr;
+  --pr: 46px;
+
+  /* full-window shell (mock `body`) — the aim console is a full-screen
+     takeover, so it owns the viewport while it is shown. */
+  height: 100vh;
+  width: 100%;
+  background: var(--bg);
+  color: var(--txt);
+  font-family: var(--sans);
+  font-size: 12.5px;
+  line-height: 1.5;
+  display: grid;
+  grid-template-rows: auto 1fr;
+  overflow: hidden;
+  -webkit-font-smoothing: antialiased;
+}
+
+.aim-console ::selection {
+  background: rgba(74, 163, 157, 0.22);
+}
+.aim-console ::-webkit-scrollbar {
+  width: 10px;
+  height: 10px;
+}
+.aim-console ::-webkit-scrollbar-thumb {
+  background: #19201f;
+  border: 2px solid var(--bg);
+}
+.aim-console ::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+/* ── top bar (sober) ──────────────────────────────────────────────────── */
+.aim-console .ac-top {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  height: 40px;
+  padding: 0 10px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--line);
+}
+.aim-console .ac-brand {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 1.5px;
+  color: var(--dim);
+  margin-right: 14px;
+}
+.aim-console .ac-brand b {
+  color: var(--txt);
+  font-weight: 600;
+}
+.aim-console .ac-utab {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  height: 40px;
+  padding: 0 13px;
+  cursor: pointer;
+  color: var(--dim);
+  font-size: 12px;
+  border: none;
+  border-bottom: 2px solid transparent;
+  background: transparent;
+  user-select: none;
+}
+.aim-console .ac-utab:hover {
+  color: var(--txt);
+  background: var(--line-2);
+}
+.aim-console .ac-utab.on {
+  color: var(--txt);
+  border-bottom-color: var(--cyan);
+}
+.aim-console .ac-utab .ac-d {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--faint);
+}
+.aim-console .ac-utab.on .ac-d {
+  background: var(--cyan);
+}
+.aim-console .ac-um {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  color: var(--amber);
+  background: var(--amber-d);
+  border: 1px solid #3a2e14;
+}
+.aim-console .ac-um.call {
+  color: var(--danger);
+  background: #221111;
+  border-color: #3a1d1d;
+}
+.aim-console .ac-rp {
+  font-family: var(--mono);
+  font-size: 9px;
+  padding: 1px 5px;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  color: var(--dim);
+  letter-spacing: 0.3px;
+}
+.aim-console .ac-rp.pri {
+  color: var(--cyan);
+  border-color: var(--cyan-d);
+  background: var(--cyan-d);
+} /* primary repo of the unit */
+.aim-console .ac-uadd {
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 5px;
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--dim);
+  cursor: pointer;
+  font-size: 14px;
+  border-radius: 4px;
+}
+.aim-console .ac-uadd:hover {
+  color: var(--cyan);
+}
+.aim-console .ac-sp {
+  flex: 1;
+}
+.aim-console .ac-meta {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--faint);
+  letter-spacing: 0.5px;
+}
+/* exit back to the existing ProducerConsole (the default view). The
+   ENTER toggle lives in StatusBar; this is its EXIT pair, since the
+   full-window aim console replaces the existing chrome incl. StatusBar. */
+.aim-console .ac-exit {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--dim);
+  background: transparent;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 4px 10px;
+  margin-left: 12px;
+  cursor: pointer;
+  letter-spacing: 0.5px;
+}
+.aim-console .ac-exit:hover {
+  color: var(--cyan);
+  border-color: var(--cyan-d);
+}
+
+/* ── 3-pane grid (mock `.main`) ───────────────────────────────────────── */
+.aim-console .ac-main {
+  display: grid;
+  grid-template-columns: var(--aim, 1.18fr) var(--sess, 1fr) var(--pr, 46px);
+  min-height: 0;
+  transition: grid-template-columns 0.2s ease;
+}
+.aim-console.pr-open {
+  --pr: 320px;
+}
+.aim-console .ac-col {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  border-right: 1px solid var(--line);
+}
+.aim-console .ac-col:last-child {
+  border-right: none;
+}
+
+/* ── AIM pane (header chrome + S2 stub) ───────────────────────────────── */
+.aim-console .ac-aim {
+  background: var(--panel);
+}
+.aim-console .ac-ahead {
+  flex: none;
+  border-bottom: 1px solid var(--line);
+}
+.aim-console .ac-arow1 {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 12px 7px;
+}
+.aim-console .ac-arow1 h1 {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.3px;
+  color: var(--txt);
+}
+.aim-console .ac-scale {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--faint);
+}
+.aim-console .ac-premise {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--cyan);
+  border: 1px solid var(--cyan-d);
+  border-radius: 3px;
+  padding: 2px 7px;
+  letter-spacing: 0.5px;
+}
+
+/* ── SESSION pane (faux tabs row + S3 stub) ───────────────────────────── */
+.aim-console .ac-session {
+  background: var(--bg);
+}
+.aim-console .ac-stabs {
+  display: flex;
+  gap: 2px;
+  height: 35px;
+  padding: 6px 8px 0;
+  background: var(--panel);
+  border-bottom: 1px solid var(--line-2);
+}
+.aim-console .ac-stab {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 11px;
+  height: 29px;
+  color: var(--dim);
+  font-size: 11.5px;
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: 3px 3px 0 0;
+  position: relative;
+  top: 1px;
+}
+.aim-console .ac-stab.on {
+  background: var(--bg);
+  color: var(--txt);
+  border-color: var(--line-2);
+}
+.aim-console .ac-ro {
+  font-family: var(--mono);
+  font-size: 8px;
+  padding: 1px 4px;
+  border-radius: 3px;
+}
+.aim-console .ac-ro.p {
+  color: var(--cyan);
+  border: 1px solid var(--cyan-d);
+}
+
+/* ── PR rail (collapsed rail ⇄ expanded panel — the S1 transition) ─────── */
+.aim-console .ac-pr {
+  background: var(--panel);
+}
+.aim-console .ac-prrail {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 9px;
+  width: 100%;
+  height: 100%;
+  padding-top: 12px;
+  border: none;
+  background: transparent;
+  cursor: pointer;
+}
+.aim-console.pr-open .ac-prrail {
+  display: none;
+}
+.aim-console .ac-prrail .ac-v {
+  writing-mode: vertical-rl;
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--dim);
+  border: 1px solid var(--line-2);
+  padding: 8px 3px;
+  letter-spacing: 1px;
+}
+.aim-console .ac-prrail .ac-v.w {
+  color: var(--amber);
+  border-color: #3a2e14;
+  background: var(--amber-d);
+}
+.aim-console .ac-prrail .ac-g {
+  writing-mode: vertical-rl;
+  color: var(--faint);
+  font-size: 9px;
+  margin-top: auto;
+  padding-bottom: 12px;
+  letter-spacing: 2px;
+}
+.aim-console .ac-prfull {
+  display: none;
+  flex-direction: column;
+  height: 100%;
+}
+.aim-console.pr-open .ac-prfull {
+  display: flex;
+}
+.aim-console .ac-prh {
+  display: flex;
+  align-items: center;
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--line-2);
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--dim);
+}
+.aim-console .ac-prh .ac-x {
+  margin-left: auto;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: inherit;
+  cursor: pointer;
+}
+.aim-console .ac-prh .ac-x:hover {
+  color: var(--txt);
+}
+.aim-console .ac-prb {
+  flex: 1;
+  overflow: auto;
+  padding: 5px 7px;
+}
+
+/* ── pane stub (placeholder content — replaced in S2–S4) ──────────────── */
+.aim-console .ac-stub {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 24px;
+  text-align: center;
+  color: var(--faint);
+}
+.aim-console .ac-stub-stage {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 1px;
+  color: var(--cyan);
+  border: 1px solid var(--cyan-d);
+  border-radius: 3px;
+  padding: 2px 9px;
+}
+.aim-console .ac-stub-note {
+  margin: 0;
+  font-size: 11.5px;
+  line-height: 1.5;
+  max-width: 36ch;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .aim-console *,
+  .aim-console {
+    transition-duration: 0.01ms !important;
+    animation-duration: 0.01ms !important;
+  }
+}


### PR DESCRIPTION
Resolves #793. First of 4 sequential stages reproducing the destination **aim-console mock** (`origin/mock/aim-ui-sample`, dev-tool/scale variant) in `clients/react`. Serves aim node `aim-ui` (`tmai-core` `doc/aims/aim-ui.md`).

**Coexist, do not rip:** the existing `ProducerConsole` stays the default; the new aim-ui is opt-in behind a toggle until the aim mechanism matures.

## S1 scope (this PR)

1. **Design tokens.** Ported the mock's token layer — color palette (`--amber`=drift, `--ochre`=claimed, `--green`=confirmed, `--cyan`=structure/root, `--violet`=worker, plus `--bg`/`--panel`/`--line`/`--dim`/`--faint`), fonts (IBM Plex Mono / Inter Tight / Noto Sans JP), density (12.5px base, 27px row height) — into a dedicated `src/styles/aim-console.css`. Everything is **scoped under `.aim-console`** so the tokens do NOT bleed into the existing console (custom properties only cascade down into the aim-console subtree; the two modes are mutually exclusive in the DOM). CSS is not scanned by the repo-wide raw-palette lock (it only scans `*.tsx?`) and is not linted/formatted by biome, so the literal hex values live there the way `lib/theme.ts` legitimately holds colour values.

2. **`AimConsole` shell.** A new full-window component reproducing the mock's **top bar** (brand `tmai console` + data-driven unit tabs with repo pills + ⚠N attention rollup + meta + an exit toggle) and the **3-pane grid** (`grid-template-columns: 1.18fr 1fr 46px` → Aim / Session / PR-rail), including the **PR-rail expand transition** (`--pr: 46px ↔ 320px` via `.pr-open`). The three panes are **placeholders / stubs** in S1 — filled in S2–S4.

3. **Toggle (coexist).** A button in `StatusBar` (next to Settings) **enters** aim-ui; `App.tsx` holds a sibling `consoleMode` state (default `producer`); the aim console's own top bar **exits** back. Because the aim console is a full-window takeover that replaces the existing shell (StatusBar included), the enter/exit controls live on the two surfaces respectively. Not persisted to ui-prefs in S1 — the panes are stubs, so a reload lands back on the working Producer console.

## Out of scope (later stages — stubs only here)

- **S2**: Aim worklist (Frontier⊥Tree), ledger + bar, overview ruler, inspector, per-repo grouping, create-aim modal.
- **S3**: Session conversation + session tabs + bash footer.
- **S4**: PR-rail PR/Issue lists.

## Gate — all green

- `pnpm -C clients/react lint` ✅ (exit 0; the 1 warning is pre-existing in `ProducerFeedChip`)
- `pnpm -C clients/react build` ✅ (tsc -b && vite build)
- `pnpm -C clients/react test` ✅ (751 passed, 2 skipped)

No `any`. Generated types imported from `@/lib/api` (which re-exports `@/types/generated/`), not hand-mirrored.

## Tests added

- `AimConsole.test.tsx` — top-bar brand + 3 panes, S2–S4 stub markers, repo pills (primary/secondary), the PR-rail expand/collapse transition, and the top-bar callbacks.
- `App.console-mode.test.tsx` — default is the Producer console (aim-ui opt-in); the StatusBar toggle swaps the whole shell to `AimConsole` and the aim console's exit returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Aim Consoleが新たに追加されました。トップバーのユニットタブからユニットを管理でき、Aim作業、Session会話、PR/Issueレールを一つの画面から利用できます。
  * Producer ConsoleとAim Consoleを切り替える機能が追加されました。

* **Tests**
  * Aim Consoleとコンソール切替機能の包括的なテストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->