### PR TITLE
S2: aim-ui console — Aim pane (Frontier⊥Tree, ledger, ruler, inspector, create-aim modal) in dev-tool tokens (#795)

### DIFF
--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -12,10 +12,12 @@
 // dev-tool tokens are scoped to `.aim-console` in `styles/aim-console.css`
 // so they never bleed into the existing console.
 //
-// S1 SCOPE = the TOKEN LAYER + the SHELL: the top bar (real, data-driven
-// unit tabs) and the 3-pane grid incl. the PR-rail expand/collapse
-// transition. The three pane BODIES are placeholders / stubs here:
-//   - S2 fills the Aim worklist (Frontier⊥Tree, ledger, ruler, inspector);
+// SCOPE so far: the TOKEN LAYER + the SHELL (S1) and the Aim pane (S2). The
+// top bar (real, data-driven unit tabs) and the 3-pane grid incl. the PR-rail
+// expand/collapse transition are S1; the Aim (left) pane is now the real
+// worklist (Frontier⊥Tree, ledger, overview ruler, inspector, create-aim
+// modal — `AimPane`, reusing the Stage B logic layer). The remaining two
+// bodies are still stubs:
 //   - S3 fills the Session conversation (tabs + bash footer);
 //   - S4 fills the PR-rail PR/Issue lists.
 
@@ -23,6 +25,7 @@ import { useState } from "react";
 import { useUnitAttention } from "@/hooks/useUnitAttention";
 import type { UnitResponse } from "@/lib/api";
 import { cn } from "@/lib/utils";
+import { AimPane } from "./AimPane";
 // Bundled dev-tool typography (offline-robust @fontsource, NOT a Google Fonts
 // <link>) — loads the exact families `aim-console.css` references via --sans /
 // --mono so the dev-tool look matches the mock instead of falling back to
@@ -114,19 +117,9 @@ export function AimConsole({
 
       {/* ── 3-pane grid ── */}
       <div className="ac-main">
-        {/* AIM — S2 worklist */}
+        {/* AIM — S2 worklist (Frontier⊥Tree, ledger, ruler, inspector, modal) */}
         <section className="ac-col ac-aim" aria-label="Aim">
-          <div className="ac-ahead">
-            <div className="ac-arow1">
-              <h1>Aim</h1>
-              <span className="ac-scale">Frontier ⊥ Tree</span>
-              <span className="ac-premise">AIM-PREMISE</span>
-            </div>
-          </div>
-          <PaneStub
-            stage="S2"
-            note="Aim worklist (Frontier⊥Tree), ledger + bar, overview ruler, and inspector land here."
-          />
+          <AimPane unitName={activeUnitName} />
         </section>
 
         {/* SESSION — S3 conversation */}

--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -114,10 +114,27 @@ export function AimPane({ unitName }: { unitName: string | null }) {
   const [modal, setModal] = useState<ModalDescriptor | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
   const seededRef = useRef(false);
+  const prevUnitRef = useRef(unitName);
+
+  // A unit change invalidates the per-unit view state: the previous unit's
+  // selection / open modal / filter are meaningless against the NEW forest, and
+  // the expand set must re-seed to the new unit's roots. Reset them and re-arm
+  // the seed gate, so the seed effect below re-seeds once the new forest lands.
+  // (`useUnitAims` clears + refetches the forest on the same `unitName` change.)
+  // Runs only on an actual change — mount keeps the lazy-init / first-fetch path.
+  useEffect(() => {
+    if (prevUnitRef.current === unitName) return;
+    prevUnitRef.current = unitName;
+    seededRef.current = false;
+    setSelected(null);
+    setModal(null);
+    setQuery("");
+  }, [unitName]);
 
   // Seed the branch-expansion set once the forest first arrives — the lazy
   // init above ran against an empty forest while the first fetch was in flight.
-  // Guarded so an operator's later collapse/expand survives the 60s poll.
+  // Guarded so an operator's later collapse/expand survives the 60s poll; the
+  // gate is re-armed on a unit change (effect above).
   useEffect(() => {
     if (!seededRef.current && repos.length > 0) {
       seededRef.current = true;

--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -1,0 +1,1273 @@
+// AimPane — the aim-console's Aim (left) pane (S2). A FAITHFUL reproduction of
+// the destination mock (`origin/mock/aim-ui-sample` → `assets/ui-sample.html`,
+// the `.aim` section + the create-aim modal) in the aim-console's scoped
+// dev-tool tokens (`.ac-*` family, `styles/aim-console.css`). Serves aim node
+// `aim-ui` (`tmai-core:doc/aims/aim-ui.md`).
+//
+// THE KEY MOVE — REUSE the logic, REPRODUCE the presentation. The entire aim
+// data + owed/frontier/rollup/ledger/ruler model already exists, built against
+// the REAL wire in Stage B (`r-panel/aim-tree.ts`); this pane imports it
+// wholesale and only ports the mock's markup/classes. The write path is the
+// same too (`api.createAim` / `api.editAim`, `hooks/useUnitAims`). So this file
+// is NOT a re-implementation of the worklist algorithms — it is the
+// presentation port. `RAimsSection.tsx` is the behavioural reference (refetch
+// on edit, the done-drift tone, the three design pins); we do NOT import its
+// markup — that speaks the existing console's Tailwind tokens, this speaks the
+// dev-tool tokens.
+//
+// Design pins honoured (same as RAimsSection):
+//   #1 mark-only — the `is[]` marks render exactly as authored; only the wire's
+//      `kind` drives styling, never a re-judgement.
+//   #2 done+drift distinct — a `done` node that is ALSO drifted gets the
+//      `done-drift` tone (a ✓ glyph AND a ⚠ badge), surfaced in its own
+//      Frontier cluster, never folded into plain owed.
+//   #3 drift mirrors the engine — after a create / edit we `refresh()` and
+//      render whatever drift the wire reports; there is NO client-side cascade.
+//
+// UI state: the Frontier/Tree mode persists in `ui-prefs` (browser-side, same
+// `aimMode` key RAimsSection uses); the expanded-branch set + the search filter
+// stay component-local (a persisted filter would silently hide rows next open).
+
+import {
+  type FormEvent,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  AIM_STATE_LABEL,
+  type AimTone,
+  aimTone,
+  ancestry,
+  breadcrumbText,
+  buildChildren,
+  bySlugMap,
+  descendantsOf,
+  doneDriftedRows,
+  findRoots,
+  flattenRepos,
+  frontierRows,
+  type LedgerCounts,
+  ledgerCounts,
+  type RollupStats,
+  type RulerTick,
+  repoForests,
+  repoStats,
+  rulerOrder,
+  subtreeStats,
+} from "@/components/producer-console/r-panel/aim-tree";
+import { useUnitAims } from "@/hooks/useUnitAims";
+import { api } from "@/lib/api";
+import { useUIPref } from "@/lib/ui-prefs-provider";
+import { cn } from "@/lib/utils";
+import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
+import type { AimState } from "@/types/generated/AimState";
+import type { AimWire } from "@/types/generated/AimWire";
+import type { RepoAimsWire } from "@/types/generated/RepoAimsWire";
+import { suggestSlug, validateAimSlug } from "./slug";
+
+// ── tone → presentation (mark-only: only the wire-derived tone drives this) ──
+//
+// Maps the aim-tree `AimTone` onto the mock's row class (`dr`/`cl`/`cf`/`ne`/
+// `rt`/`done`/`dead`). `done-drift` reuses the `done` row tint but carries an
+// extra `dd` modifier so the warning gutter + ⚠ badge surface the owed drift
+// (pin #2 — it must not read as plain done).
+const TONE_ROW_CLASS: Record<AimTone, string> = {
+  "done-drift": "done dd",
+  done: "done",
+  dead: "dead",
+  drift: "dr",
+  claimed: "cl",
+  confirmed: "cf",
+  root: "rt",
+  neutral: "ne",
+};
+
+// Normalize a thrown API error into a short, operator-readable message — the
+// HTTP client throws `Error` whose message carries the backend's text.
+function writeErrorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+// Stable identity key for a repo group in the expanded set (root is unique per
+// unit). Mirrors RAimsSection's `repoKey`.
+const repoKey = (r: RepoAimsWire): string => `repo:${r.repo_root}`;
+
+const EMPTY_FORBIDDEN: ReadonlySet<string> = new Set<string>();
+
+// ── orchestrator ──────────────────────────────────────────────────────
+
+export function AimPane({ unitName }: { unitName: string | null }) {
+  const { data, loading, error, refresh } = useUnitAims(unitName);
+  const repos = useMemo(() => repoForests(data), [data]);
+  const allNodes = useMemo(() => flattenRepos(data), [data]);
+  const ledger = useMemo(() => ledgerCounts(allNodes), [allNodes]);
+  const ticks = useMemo(() => rulerOrder(repos), [repos]);
+
+  const [mode, setMode] = useUIPref("aimMode");
+  const [query, setQuery] = useState("");
+  const [selected, setSelected] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(() => seedExpanded(repos));
+  const [modal, setModal] = useState<ModalDescriptor | null>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const seededRef = useRef(false);
+
+  // Seed the branch-expansion set once the forest first arrives — the lazy
+  // init above ran against an empty forest while the first fetch was in flight.
+  // Guarded so an operator's later collapse/expand survives the 60s poll.
+  useEffect(() => {
+    if (!seededRef.current && repos.length > 0) {
+      seededRef.current = true;
+      setExpanded(seedExpanded(repos));
+    }
+  }, [repos]);
+
+  const sel = useMemo(() => resolveSelection(selected, repos), [selected, repos]);
+  const primaryRepo = repos.find((r) => r.primary) ?? repos[0] ?? null;
+
+  const toggleExpanded = useCallback((key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  }, []);
+
+  const select = useCallback((slug: string) => {
+    setModal(null);
+    setSelected(slug);
+  }, []);
+
+  // Reveal a node in Tree mode: open its repo group + every ancestor, switch to
+  // Tree, select it. When the slug is not yet in the loaded forest (a just-
+  // created node, before the refetch lands) we still switch + select; the
+  // selection resolves once the refreshed wire arrives.
+  const reveal = useCallback(
+    (slug: string) => {
+      const found = resolveSelection(slug, repos);
+      if (found) {
+        setExpanded((prev) => {
+          const next = new Set(prev);
+          next.add(repoKey(found.repo));
+          for (const a of ancestry(slug, found.bySlug)) next.add(a.slug);
+          return next;
+        });
+      }
+      setMode("tree");
+      setSelected(slug);
+    },
+    [repos, setMode],
+  );
+
+  const openCreate = useCallback((repoRoot: string, parent: string) => {
+    setSelected(null);
+    setModal({ mode: "create", repoRoot, parent });
+  }, []);
+
+  const openEdit = useCallback((slug: string) => {
+    setModal({ mode: "edit", slug });
+  }, []);
+
+  // Scroll the freshly-selected row into view (centered) — reproduces the
+  // mock's reveal scroll. The slug is a validated kebab identity (`[a-z0-9-]`),
+  // so it needs no attribute-selector escaping. Guarded for jsdom, where
+  // scrollIntoView is absent.
+  useEffect(() => {
+    if (selected === null) return;
+    const el = listRef.current?.querySelector(`[data-slug="${selected}"]`);
+    if (el instanceof HTMLElement && typeof el.scrollIntoView === "function") {
+      el.scrollIntoView({ block: "center" });
+    }
+  }, [selected]);
+
+  let listContent: ReactNode;
+  if (unitName === null) {
+    listContent = <div className="ac-hint">プロジェクトを選択すると aim が表示されます。</div>;
+  } else if (error !== null) {
+    listContent = <div className="ac-hint">aims の読み込みに失敗: {error.message}</div>;
+  } else if (loading && allNodes.length === 0) {
+    listContent = <div className="ac-hint">Loading…</div>;
+  } else if (mode === "tree") {
+    listContent = (
+      <TreeNavigator
+        repos={repos}
+        query={query}
+        expanded={expanded}
+        selected={sel?.node.slug ?? null}
+        onToggleExpanded={toggleExpanded}
+        onSelect={select}
+        onAddChild={(repoRoot, parent) => openCreate(repoRoot, parent)}
+        onAddRoot={(repoRoot) => openCreate(repoRoot, "")}
+      />
+    );
+  } else {
+    listContent = (
+      <FrontierList
+        repos={repos}
+        query={query}
+        selected={sel?.node.slug ?? null}
+        onSelect={select}
+      />
+    );
+  }
+
+  return (
+    <>
+      <div className="ac-ahead">
+        <div className="ac-arow1">
+          <h1>Aim</h1>
+          <span className="ac-scale">
+            {allNodes.length} aims · {repos.length} repo{repos.length === 1 ? "" : "s"} (per-repo)
+          </span>
+          <span
+            className="ac-premise"
+            title="The owed frontier is the panel's premise — not a full-tree dump"
+          >
+            AIM-PREMISE
+          </span>
+        </div>
+
+        <Ledger counts={ledger} onOwedClick={() => setMode("frontier")} />
+
+        <div className="ac-actl">
+          <div className="ac-seg">
+            <button
+              type="button"
+              className={cn("ac-seg-btn", mode === "frontier" && "on owed")}
+              aria-pressed={mode === "frontier"}
+              onClick={() => setMode("frontier")}
+            >
+              Frontier ⚠
+            </button>
+            <button
+              type="button"
+              className={cn("ac-seg-btn", mode === "tree" && "on")}
+              aria-pressed={mode === "tree"}
+              onClick={() => setMode("tree")}
+            >
+              Tree
+            </button>
+          </div>
+          <div className="ac-search">
+            <span aria-hidden="true" className="ac-search-i">
+              ⌕
+            </span>
+            <input
+              aria-label="Filter aims"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="slug / ought を filter…"
+            />
+            <span className="k" aria-hidden="true">
+              /
+            </span>
+          </div>
+          <button
+            type="button"
+            className="ac-newbtn"
+            disabled={primaryRepo === null}
+            onClick={() => primaryRepo && openCreate(primaryRepo.repo_root, "")}
+            title="新規 aim（root / 既存の子）"
+            aria-label="New aim"
+          >
+            ＋ aim
+          </button>
+        </div>
+      </div>
+
+      <div className="ac-alist-wrap">
+        <div className="ac-alist" ref={listRef}>
+          {listContent}
+        </div>
+        <OverviewRuler ticks={ticks} onReveal={reveal} />
+      </div>
+
+      <div className={cn("ac-insp", sel !== null && "on")}>
+        {sel !== null && (
+          <Inspector
+            key={sel.node.slug}
+            sel={sel}
+            onSelectAncestor={select}
+            onEdit={() => openEdit(sel.node.slug)}
+            onAddChild={(parent) => openCreate(sel.repo.repo_root, parent)}
+            onClose={() => setSelected(null)}
+          />
+        )}
+      </div>
+
+      {modal !== null && unitName !== null && (
+        <CreateEditModal
+          descriptor={modal}
+          repos={repos}
+          unitName={unitName}
+          refresh={refresh}
+          onClose={() => setModal(null)}
+          onDone={(slug) => {
+            setModal(null);
+            reveal(slug);
+          }}
+        />
+      )}
+    </>
+  );
+}
+
+// ── selection / expansion helpers (local; aim-tree does the real work) ──
+
+// A resolved selection: the node + its repo + the repo's index structures, so
+// the inspector / reveal / modal walk ancestry + forbid cycles without
+// re-deriving them. Mirrors RAimsSection's `Selection`.
+interface Selection {
+  node: AimWire;
+  repo: RepoAimsWire;
+  bySlug: Map<string, AimWire>;
+  childrenOf: Map<string, AimWire[]>;
+}
+
+function resolveSelection(slug: string | null, repos: readonly RepoAimsWire[]): Selection | null {
+  if (slug === null) return null;
+  for (const repo of repos) {
+    const node = repo.aims.find((n) => n.slug === slug);
+    if (node) {
+      return { node, repo, bySlug: bySlugMap(repo.aims), childrenOf: buildChildren(repo.aims) };
+    }
+  }
+  return null;
+}
+
+// Default branch-expansion: every repo group + every root open (the mock's
+// default — deeper branches collapse behind a rollup).
+function seedExpanded(repos: readonly RepoAimsWire[]): Set<string> {
+  const s = new Set<string>();
+  for (const r of repos) {
+    s.add(repoKey(r));
+    for (const root of findRoots(r.aims)) s.add(root.slug);
+  }
+  return s;
+}
+
+// Depth of a node (root = 0), for the modal's parent-select indentation.
+function depthOf(slug: string, bySlug: ReadonlyMap<string, AimWire>): number {
+  return Math.max(0, ancestry(slug, bySlug).length - 1);
+}
+
+// ── ledger strip ──────────────────────────────────────────────────────
+
+function Ledger({ counts, onOwedClick }: { counts: LedgerCounts; onOwedClick: () => void }) {
+  const owed = counts.drift + counts.claimed;
+  const total = owed + counts.confirmed || 1;
+  return (
+    <div className="ac-ledger" data-testid="aim-ledger">
+      <button type="button" className="ac-lg dr" onClick={onOwedClick}>
+        <span className="sw" aria-hidden="true" />
+        <b>{counts.drift}</b> drift
+      </button>
+      <button type="button" className="ac-lg cl" onClick={onOwedClick}>
+        <span className="sw" aria-hidden="true" />
+        <b>{counts.claimed}</b> claimed
+      </button>
+      <span className="ac-lg cf">
+        <span className="sw" aria-hidden="true" />
+        <b>{counts.confirmed}</b> confirmed
+      </span>
+      <span className="ac-lbar" aria-hidden="true">
+        <span className="o" style={{ width: `${(100 * owed) / total}%` }} />
+        <span className="c" style={{ width: `${(100 * counts.confirmed) / total}%` }} />
+      </span>
+    </div>
+  );
+}
+
+// ── Frontier mode — the owed worklist ─────────────────────────────────
+
+function FrontierList({
+  repos,
+  query,
+  selected,
+  onSelect,
+}: {
+  repos: readonly RepoAimsWire[];
+  query: string;
+  selected: string | null;
+  onSelect: (slug: string) => void;
+}) {
+  const q = query.trim().toLowerCase();
+  const matches = (n: AimWire) =>
+    q === "" || n.slug.toLowerCase().includes(q) || n.aim.toLowerCase().includes(q);
+
+  const sections = repos
+    .map((repo) => {
+      const bySlug = bySlugMap(repo.aims);
+      const owed = frontierRows(repo.aims).filter(matches);
+      const doneDrift = doneDriftedRows(repo.aims).filter(matches);
+      return { repo, bySlug, owed, doneDrift };
+    })
+    .filter((s) => s.owed.length > 0 || s.doneDrift.length > 0);
+
+  if (sections.length === 0) {
+    return (
+      <div className="ac-hint">
+        {q === "" ? "owed なし — 盤面は calm。" : "owed に filter 一致なし。"}
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {sections.map(({ repo, bySlug, owed, doneDrift }) => {
+        const driftN = owed.filter((n) => aimTone(n) === "drift").length;
+        const claimedN = owed.length - driftN;
+        return (
+          <div key={repo.repo_root}>
+            <RepoBanner repo={repo} drift={driftN} claimed={claimedN} />
+            {owed.map((n) => (
+              <AimRow
+                key={n.slug}
+                node={n}
+                selected={selected === n.slug}
+                crumb={breadcrumbText(n.slug, bySlug) || "root"}
+                onSelect={() => onSelect(n.slug)}
+              />
+            ))}
+            {doneDrift.length > 0 && (
+              <>
+                {/* Pin #2: done-and-drifted, surfaced in its OWN cluster — a
+                    re-confirm is owed, but it is not active worklist. */}
+                <div className="ac-ghead calm">
+                  <span className="c">done · drifted — 再確認?</span>
+                </div>
+                {doneDrift.map((n) => (
+                  <AimRow
+                    key={n.slug}
+                    node={n}
+                    selected={selected === n.slug}
+                    crumb={breadcrumbText(n.slug, bySlug) || "root"}
+                    onSelect={() => onSelect(n.slug)}
+                  />
+                ))}
+              </>
+            )}
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+// A non-collapsible repo banner used in Frontier sections (the repo is context,
+// not a toggle, here). Primary repo gets the cyan accent.
+function RepoBanner({
+  repo,
+  drift,
+  claimed,
+}: {
+  repo: RepoAimsWire;
+  drift: number;
+  claimed: number;
+}) {
+  return (
+    <div className={cn("ac-repohead", "frontier", repo.primary && "pri")}>
+      <span className="ac-rh-name">{repo.repo_label}</span>
+      <span className="ac-rh-stat">
+        {drift > 0 && <span className="w">⚠{drift} </span>}
+        {claimed > 0 && <span className="k">◌{claimed}</span>}
+      </span>
+    </div>
+  );
+}
+
+// ── Tree mode — collapsible per-repo navigator with rollups ───────────
+
+function TreeNavigator({
+  repos,
+  query,
+  expanded,
+  selected,
+  onToggleExpanded,
+  onSelect,
+  onAddChild,
+  onAddRoot,
+}: {
+  repos: readonly RepoAimsWire[];
+  query: string;
+  expanded: Set<string>;
+  selected: string | null;
+  onToggleExpanded: (key: string) => void;
+  onSelect: (slug: string) => void;
+  onAddChild: (repoRoot: string, parent: string) => void;
+  onAddRoot: (repoRoot: string) => void;
+}) {
+  const q = query.trim().toLowerCase();
+
+  // A query in Tree mode shows a FLAT, repo-tagged hit list (the tree is a
+  // navigator; a filter wants results, not a pruned tree).
+  if (q !== "") {
+    const hits = repos.flatMap((repo) =>
+      repo.aims
+        .filter((n) => n.slug.toLowerCase().includes(q) || n.aim.toLowerCase().includes(q))
+        .map((n) => ({ repo, node: n })),
+    );
+    if (hits.length === 0) return <div className="ac-hint">一致なし</div>;
+    return (
+      <>
+        {hits.map(({ repo, node }) => (
+          <AimRow
+            key={`${repo.repo_root}:${node.slug}`}
+            node={node}
+            selected={selected === node.slug}
+            repoTag={repo.repo_label}
+            repoPrimary={repo.primary}
+            onSelect={() => onSelect(node.slug)}
+          />
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <>
+      {repos.map((repo) => {
+        const key = repoKey(repo);
+        const open = expanded.has(key);
+        const stats = repoStats(repo.aims);
+        const childrenOf = buildChildren(repo.aims);
+        const roots = findRoots(repo.aims);
+        return (
+          <div key={repo.repo_root}>
+            <RepoHead
+              repo={repo}
+              open={open}
+              stats={stats}
+              onToggle={() => onToggleExpanded(key)}
+              onAddRoot={() => onAddRoot(repo.repo_root)}
+            />
+            {open &&
+              roots.map((root) => (
+                <TreeBranch
+                  key={root.slug}
+                  node={root}
+                  depth={0}
+                  repo={repo}
+                  childrenOf={childrenOf}
+                  expanded={expanded}
+                  selected={selected}
+                  onToggleExpanded={onToggleExpanded}
+                  onSelect={onSelect}
+                  onAddChild={onAddChild}
+                />
+              ))}
+          </div>
+        );
+      })}
+    </>
+  );
+}
+
+function RepoHead({
+  repo,
+  open,
+  stats,
+  onToggle,
+  onAddRoot,
+}: {
+  repo: RepoAimsWire;
+  open: boolean;
+  stats: RollupStats;
+  onToggle: () => void;
+  onAddRoot: () => void;
+}) {
+  return (
+    <div
+      data-testid="aim-repo-head"
+      data-repo={repo.repo_label}
+      className={cn("ac-repohead", repo.primary && "pri")}
+    >
+      <button
+        type="button"
+        className="ac-repohead-main"
+        onClick={onToggle}
+        aria-expanded={open}
+        aria-label={`${open ? "Collapse" : "Expand"} repo ${repo.repo_label}`}
+      >
+        <span className="ac-rh-tw" aria-hidden="true">
+          {open ? "▾" : "▸"}
+        </span>
+        <span className="ac-rh-name">{repo.repo_label}</span>
+        <span className="ac-rh-stat">
+          {stats.count}
+          {stats.drift > 0 && <span className="w"> ⚠{stats.drift}</span>}
+          {stats.claimed > 0 && <span className="k"> ◌{stats.claimed}</span>}
+        </span>
+      </button>
+      <button
+        type="button"
+        className="ac-addbtn"
+        onClick={onAddRoot}
+        title={`${repo.repo_label} に root aim を作成`}
+        aria-label={`New root aim in ${repo.repo_label}`}
+      >
+        ＋
+      </button>
+    </div>
+  );
+}
+
+function TreeBranch({
+  node,
+  depth,
+  repo,
+  childrenOf,
+  expanded,
+  selected,
+  onToggleExpanded,
+  onSelect,
+  onAddChild,
+}: {
+  node: AimWire;
+  depth: number;
+  repo: RepoAimsWire;
+  childrenOf: Map<string, AimWire[]>;
+  expanded: Set<string>;
+  selected: string | null;
+  onToggleExpanded: (key: string) => void;
+  onSelect: (slug: string) => void;
+  onAddChild: (repoRoot: string, parent: string) => void;
+}) {
+  const kids = childrenOf.get(node.slug) ?? [];
+  const open = expanded.has(node.slug);
+  const rollup = !open && kids.length > 0 ? subtreeStats(node.slug, childrenOf) : null;
+
+  return (
+    <>
+      <AimRow
+        node={node}
+        depth={depth}
+        treeRow
+        selected={selected === node.slug}
+        hasChildren={kids.length > 0}
+        open={open}
+        rollup={rollup}
+        onToggle={kids.length > 0 ? () => onToggleExpanded(node.slug) : undefined}
+        onSelect={() => onSelect(node.slug)}
+        onAddChild={() => onAddChild(repo.repo_root, node.slug)}
+      />
+      {open &&
+        kids.map((c) => (
+          <TreeBranch
+            key={c.slug}
+            node={c}
+            depth={depth + 1}
+            repo={repo}
+            childrenOf={childrenOf}
+            expanded={expanded}
+            selected={selected}
+            onToggleExpanded={onToggleExpanded}
+            onSelect={onSelect}
+            onAddChild={onAddChild}
+          />
+        ))}
+    </>
+  );
+}
+
+// ── the shared row ────────────────────────────────────────────────────
+
+function AimRow({
+  node,
+  depth = 0,
+  treeRow = false,
+  selected,
+  crumb,
+  repoTag,
+  repoPrimary,
+  hasChildren = false,
+  open = false,
+  rollup,
+  onToggle,
+  onSelect,
+  onAddChild,
+}: {
+  node: AimWire;
+  depth?: number;
+  treeRow?: boolean;
+  selected: boolean;
+  crumb?: string;
+  repoTag?: string;
+  repoPrimary?: boolean;
+  hasChildren?: boolean;
+  open?: boolean;
+  rollup?: RollupStats | null;
+  onToggle?: () => void;
+  onSelect: () => void;
+  onAddChild?: () => void;
+}) {
+  const tone = aimTone(node);
+  return (
+    <div
+      data-testid="aim-row"
+      data-slug={node.slug}
+      data-tone={tone}
+      className={cn("ac-r", TONE_ROW_CLASS[tone], selected && "sel")}
+      style={depth > 0 ? { paddingLeft: 12 + depth * 15 } : undefined}
+    >
+      <span className="ac-gut" aria-hidden="true" />
+      {/* Tree toggle (children) / spacer (leaf), OUTSIDE the select button so
+          there is no nested-interactive markup. Frontier rows omit it. */}
+      {treeRow ? (
+        hasChildren && onToggle ? (
+          <button
+            type="button"
+            className="ac-tx has"
+            onClick={onToggle}
+            aria-label={`${open ? "Collapse" : "Expand"} ${node.slug}`}
+          >
+            {open ? "▾" : "▸"}
+          </button>
+        ) : (
+          <span className="ac-tx" aria-hidden="true">
+            ·
+          </span>
+        )
+      ) : null}
+      <button
+        type="button"
+        className="ac-r-main"
+        onClick={onSelect}
+        aria-pressed={selected}
+        title={`${node.slug} · ${AIM_STATE_LABEL[node.state]}`}
+      >
+        <ToneGlyph tone={tone} />
+        <span className="ac-ought">{node.aim}</span>
+        {crumb !== undefined && <span className="ac-crumb-i">{crumb}</span>}
+        {repoTag !== undefined && (
+          <span className={cn("ac-repo", repoPrimary && "pri")}>{repoTag}</span>
+        )}
+        {rollup && rollup.count > 0 && (
+          <span className="ac-roll" data-testid="aim-rollup">
+            {rollup.count}
+            {rollup.drift > 0 && <span className="w"> ⚠{rollup.drift}</span>}
+            {rollup.claimed > 0 && <span className="k"> ◌{rollup.claimed}</span>}
+          </span>
+        )}
+        <InteriorDots marks={node.is} />
+        <span className="ac-slug">{node.slug}</span>
+      </button>
+      {onAddChild && (
+        <button
+          type="button"
+          className="ac-addbtn row"
+          onClick={onAddChild}
+          title={`${node.slug} に子 aim を作成`}
+          aria-label={`Add child aim under ${node.slug}`}
+        >
+          ＋
+        </button>
+      )}
+    </div>
+  );
+}
+
+// Glyph + (for done-drift) the distinct drift badge. Mirrors the mock's `gly()`
+// plus pin #2's done+drift surfacing.
+function ToneGlyph({ tone }: { tone: AimTone }) {
+  switch (tone) {
+    case "done-drift":
+      return (
+        <>
+          <span className="ac-gly dn" aria-hidden="true">
+            ✓
+          </span>
+          <span
+            className="ac-gly dr"
+            data-testid="aim-drift-badge"
+            title="also drifted"
+            aria-hidden="true"
+          >
+            ⚠
+          </span>
+        </>
+      );
+    case "done":
+      return (
+        <span className="ac-gly dn" aria-hidden="true">
+          ✓
+        </span>
+      );
+    case "dead":
+      return (
+        <span className="ac-gly dd" aria-hidden="true">
+          ✕
+        </span>
+      );
+    case "drift":
+      return (
+        <span className="ac-gly dr" aria-hidden="true">
+          ⚠
+        </span>
+      );
+    case "claimed":
+      return (
+        <span className="ac-gly cl" aria-hidden="true">
+          ◌
+        </span>
+      );
+    default:
+      return <span className="ac-gly" aria-hidden="true" />;
+  }
+}
+
+// Tiny per-mark dots beside a row — confirmed = green, claimed = ochre.
+// Mark-only: order + kind are exactly the wire's.
+function InteriorDots({ marks }: { marks: readonly AimInteriorWire[] }) {
+  if (marks.length === 0) return null;
+  return (
+    <span className="ac-ism">
+      {marks.map((m) => (
+        // Interior lines have no id; key off the prose (mark-only — never re-ordered).
+        <i
+          key={`${m.kind}:${m.text}:${m.ref ?? ""}`}
+          className={m.kind === "confirmed" ? "c" : "k"}
+          aria-hidden="true"
+        />
+      ))}
+    </span>
+  );
+}
+
+// ── overview ruler ────────────────────────────────────────────────────
+
+function OverviewRuler({
+  ticks,
+  onReveal,
+}: {
+  ticks: readonly RulerTick[];
+  onReveal: (slug: string) => void;
+}) {
+  return (
+    <div
+      className="ac-ruler"
+      data-testid="aim-ruler"
+      title="overview ruler — every node a tick, owed ones lit; click to reveal"
+    >
+      {ticks.map((t) => {
+        const top = `${(t.pos * 100).toFixed(2)}%`;
+        if (t.owed === null) {
+          return (
+            <span
+              key={t.slug}
+              data-testid="ruler-tick"
+              data-slug={t.slug}
+              data-owed="calm"
+              aria-hidden="true"
+              className="ac-tick"
+              style={{ top }}
+            />
+          );
+        }
+        return (
+          <button
+            key={t.slug}
+            type="button"
+            data-testid="ruler-tick"
+            data-slug={t.slug}
+            data-owed={t.owed}
+            onClick={() => onReveal(t.slug)}
+            title={`${t.owed === "drift" ? "⚠ drift" : "◌ claimed"} · ${t.repoLabel} · ${t.slug}`}
+            aria-label={`Reveal ${t.slug} (${t.owed})`}
+            className={cn("ac-tick", t.owed === "drift" ? "dr" : "cl")}
+            style={{ top }}
+          />
+        );
+      })}
+      {/* repo-boundary dividers (a separate pass — same visual as inline) */}
+      {ticks
+        .filter((t) => t.repoBoundary)
+        .map((t) => (
+          <span
+            key={`rdiv-${t.slug}`}
+            className="ac-rdiv"
+            aria-hidden="true"
+            style={{ top: `${(t.pos * 100).toFixed(2)}%` }}
+          />
+        ))}
+    </div>
+  );
+}
+
+// ── inspector ─────────────────────────────────────────────────────────
+
+function Inspector({
+  sel,
+  onSelectAncestor,
+  onEdit,
+  onAddChild,
+  onClose,
+}: {
+  sel: Selection;
+  onSelectAncestor: (slug: string) => void;
+  onEdit: () => void;
+  onAddChild: (parent: string) => void;
+  onClose: () => void;
+}) {
+  const { node, repo, bySlug } = sel;
+  const chain = useMemo(() => ancestry(node.slug, bySlug), [node.slug, bySlug]);
+
+  return (
+    <div className="ac-insp-in" data-testid="aim-inspector">
+      <button
+        type="button"
+        className="ac-insp-x"
+        onClick={onClose}
+        aria-label="Close inspector"
+        title="閉じる"
+      >
+        ✕
+      </button>
+
+      {/* Ought-ancestry breadcrumb — every ancestor selectable; the node itself
+          is the cyan tail. */}
+      <nav className="ac-icrumb">
+        {chain.map((a, i) =>
+          i < chain.length - 1 ? (
+            <span key={a.slug} className="ac-icrumb-item">
+              <button
+                type="button"
+                className="ac-icrumb-link"
+                onClick={() => onSelectAncestor(a.slug)}
+                title={a.aim}
+              >
+                {a.aim.slice(0, 18)}…
+              </button>
+              <span className="s" aria-hidden="true">
+                ›
+              </span>
+            </span>
+          ) : (
+            <span key={a.slug} className="ac-icrumb-cur">
+              {a.slug}
+            </span>
+          ),
+        )}
+      </nav>
+
+      <div className="ac-iought">
+        <b>aim:</b> {node.aim}
+      </div>
+
+      <div className="ac-imeta">
+        <span className={cn("ac-pill", repo.primary && "op")}>repo: {repo.repo_label}</span>
+        <span className="ac-pill op">
+          state: {AIM_STATE_LABEL[node.state]}
+          {node.parent === null ? " · root" : ""}
+        </span>
+        {node.drift !== null && (
+          <span
+            className="ac-pill dr"
+            data-testid="aim-drift-pill"
+            title={`ancestor anchor moved ${node.drift.ancestor_change_date} (${node.drift.ancestor_change_sha}); this node last changed ${node.drift.aim_change_date}`}
+          >
+            ⚠ {node.state === "done" ? "done · " : ""}drift ← 祖先{" "}
+            {node.drift.stale_from_ancestor_slug}
+          </span>
+        )}
+      </div>
+
+      <div className="ac-iis">
+        <div className="ac-isec">interior — is</div>
+        {node.is.length === 0 ? (
+          <div className="ac-il dim">— 純粋な ought —</div>
+        ) : (
+          node.is.map((m) => (
+            <div
+              className="ac-il"
+              key={`${m.kind}:${m.text}:${m.ref ?? ""}`}
+              data-testid="aim-mark"
+              data-kind={m.kind}
+            >
+              <span className={cn("ac-tg", m.kind === "confirmed" ? "c" : "k")}>
+                {m.kind === "confirmed" ? "✓ confirmed" : "◌ claimed"}
+              </span>
+              <span>
+                {m.text}
+                {m.kind === "confirmed" && m.ref !== null && (
+                  <span className="ac-ref"> [{m.ref}]</span>
+                )}
+              </span>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="ac-insp-actions">
+        <button type="button" className="ac-btn small" onClick={onEdit}>
+          ✎ 編集
+        </button>{" "}
+        <button type="button" className="ac-btn small" onClick={() => onAddChild(node.slug)}>
+          ＋ 子 aim を作成
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// ── create / edit modal ───────────────────────────────────────────────
+
+// What the modal is doing: a CREATE (root in `repoRoot`, optionally under
+// `parent`) or an EDIT of an existing node by `slug`. The mock's single modal
+// doubles for both (edit shows the `state` select, freezes repo + slug).
+type ModalDescriptor =
+  | { mode: "create"; repoRoot: string; parent: string }
+  | { mode: "edit"; slug: string };
+
+function CreateEditModal({
+  descriptor,
+  repos,
+  unitName,
+  refresh,
+  onClose,
+  onDone,
+}: {
+  descriptor: ModalDescriptor;
+  repos: readonly RepoAimsWire[];
+  unitName: string;
+  refresh: () => void;
+  onClose: () => void;
+  onDone: (slug: string) => void;
+}) {
+  const isEdit = descriptor.mode === "edit";
+  const editSel = isEdit ? resolveSelection(descriptor.slug, repos) : null;
+
+  const [repoRoot, setRepoRoot] = useState(
+    isEdit ? (editSel?.repo.repo_root ?? "") : descriptor.repoRoot,
+  );
+  const repo = repos.find((r) => r.repo_root === repoRoot) ?? null;
+  const existingSlugs = useMemo(() => new Set(repo?.aims.map((n) => n.slug) ?? []), [repo]);
+  const bySlug = useMemo(() => bySlugMap(repo?.aims ?? []), [repo]);
+  const childrenOf = useMemo(() => buildChildren(repo?.aims ?? []), [repo]);
+
+  const [aim, setAim] = useState(isEdit ? (editSel?.node.aim ?? "") : "");
+  const [slug, setSlug] = useState(isEdit ? descriptor.slug : "");
+  // Edit: slug is frozen, so the auto-suggest never fires.
+  const [slugTouched, setSlugTouched] = useState(isEdit);
+  const [parent, setParent] = useState(isEdit ? (editSel?.node.parent ?? "") : descriptor.parent);
+  const [state, setState] = useState<AimState>(isEdit ? (editSel?.node.state ?? "open") : "open");
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Edit: forbid re-parenting onto self or any descendant (a trivial cycle).
+  const forbidden = useMemo(() => {
+    if (!isEdit || editSel === null) return EMPTY_FORBIDDEN;
+    const set = descendantsOf(editSel.node.slug, childrenOf);
+    set.add(editSel.node.slug);
+    return set;
+  }, [isEdit, editSel, childrenOf]);
+
+  // Esc dismisses the modal (document-level so it fires regardless of focus).
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === "Escape") onClose();
+    }
+    document.addEventListener("keydown", onKeyDown);
+    return () => document.removeEventListener("keydown", onKeyDown);
+  }, [onClose]);
+
+  const trimmedAim = aim.trim();
+  const trimmedSlug = slug.trim();
+  const slugShapeError = validateAimSlug(trimmedSlug);
+  const duplicate = !isEdit && existingSlugs.has(trimmedSlug);
+
+  const slugMsg = isEdit
+    ? "(slug は不変)"
+    : (slugShapeError ?? (duplicate ? "slug 重複" : trimmedSlug !== "" ? "✓ ok" : ""));
+  const slugMsgKind = isEdit
+    ? ""
+    : slugShapeError !== null || duplicate
+      ? "err"
+      : trimmedSlug !== ""
+        ? "ok"
+        : "";
+
+  const canSubmit = isEdit
+    ? trimmedAim !== "" && !submitting
+    : trimmedAim !== "" &&
+      trimmedSlug !== "" &&
+      slugShapeError === null &&
+      !duplicate &&
+      !submitting;
+
+  function onAimChange(next: string) {
+    setAim(next);
+    // Auto-derive the slug from the aim until the operator types one (create).
+    if (!isEdit && !slugTouched) setSlug(suggestSlug(next, existingSlugs));
+  }
+
+  function onRepoChange(nextRoot: string) {
+    setRepoRoot(nextRoot);
+    setParent("");
+  }
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      if (isEdit) {
+        await api.editAim(unitName, descriptor.slug, {
+          aim: trimmedAim,
+          parent: parent === "" ? null : parent,
+          state,
+        });
+        refresh();
+        onDone(descriptor.slug);
+      } else {
+        const created = await api.createAim(unitName, {
+          slug: trimmedSlug,
+          aim: trimmedAim,
+          parent: parent === "" ? null : parent,
+        });
+        refresh();
+        onDone(created.slug);
+      }
+    } catch (err) {
+      setError(writeErrorMessage(err));
+      setSubmitting(false);
+    }
+  }
+
+  const title = isEdit ? "aim を編集" : "新規 aim";
+  const ctx = parent
+    ? `— child of ${parent}（${repo?.repo_label ?? "?"}）`
+    : `— ${repo?.repo_label ?? "?"} の root`;
+  const submitLabel = submitting ? (isEdit ? "保存中…" : "作成中…") : isEdit ? "保存" : "作成";
+
+  return (
+    // biome-ignore lint/a11y/useKeyWithClickEvents: backdrop tap-to-close; Esc handles the keyboard path.
+    // biome-ignore lint/a11y/noStaticElementInteractions: the backdrop is a dismiss target, not a control.
+    <div
+      className="ac-modal-bg"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div
+        className="ac-modal"
+        role="dialog"
+        aria-modal="true"
+        aria-label={title}
+        data-testid="aim-create-modal"
+      >
+        <form onSubmit={onSubmit}>
+          <h3>
+            {title} <span className="ctx">{ctx}</span>
+          </h3>
+          <div className="ac-modal-body">
+            <div className="ac-fld">
+              <label htmlFor="ac-m-aim">
+                aim — 人間が書く1文の ought <span className="req">*</span>
+              </label>
+              <textarea
+                id="ac-m-aim"
+                value={aim}
+                onChange={(e) => onAimChange(e.target.value)}
+                placeholder="その高度の不可分な選択(bearing)を1文で…"
+              />
+              <div className="ac-hint2">
+                body(is)は Producer が後で filing。ここは operator の bearing のみ。
+              </div>
+            </div>
+
+            <div className="ac-frow">
+              <div className="ac-fld ac-fld-repo">
+                <label htmlFor="ac-m-repo">repo</label>
+                <select
+                  id="ac-m-repo"
+                  value={repoRoot}
+                  disabled={isEdit}
+                  onChange={(e) => onRepoChange(e.target.value)}
+                >
+                  {isEdit ? (
+                    <option value={repoRoot}>{repo?.repo_label ?? repoRoot}</option>
+                  ) : (
+                    repos.map((r) => (
+                      <option key={r.repo_root} value={r.repo_root}>
+                        {r.repo_label}
+                      </option>
+                    ))
+                  )}
+                </select>
+              </div>
+              <div className="ac-fld ac-fld-parent">
+                <label htmlFor="ac-m-parent">parent</label>
+                <select id="ac-m-parent" value={parent} onChange={(e) => setParent(e.target.value)}>
+                  <option value="">（root — {repo?.repo_label ?? "?"} の最上位）</option>
+                  {(repo?.aims ?? [])
+                    .filter((n) => !forbidden.has(n.slug))
+                    .map((n) => (
+                      <option key={n.slug} value={n.slug}>
+                        {`${"· ".repeat(depthOf(n.slug, bySlug))}${n.aim.slice(0, 32)}`}
+                      </option>
+                    ))}
+                </select>
+              </div>
+            </div>
+
+            <div className="ac-fld">
+              <label htmlFor="ac-m-slug">slug — 安定 identity（日付なし kebab）</label>
+              <div className="ac-slugrow">
+                <input
+                  id="ac-m-slug"
+                  value={slug}
+                  disabled={isEdit}
+                  onChange={(e) => {
+                    setSlug(e.target.value);
+                    setSlugTouched(true);
+                  }}
+                  placeholder="例: attention-icon-row"
+                />
+                <span className={cn("ac-hint2", slugMsgKind)}>{slugMsg}</span>
+              </div>
+              <div className="ac-hint2">
+                Producer が aim から派生 → operator が確認/訂正。rename=identity
+                死なので誕生時のみ。
+              </div>
+            </div>
+
+            {isEdit && (
+              <div className="ac-fld">
+                <label htmlFor="ac-m-state">state</label>
+                <select
+                  id="ac-m-state"
+                  value={state}
+                  onChange={(e) => setState(e.target.value as AimState)}
+                >
+                  <option value="open">open</option>
+                  <option value="done">done — aim 到達 / confirmed</option>
+                  <option value="dead">dead — self-death（系譜は残す・親無傷）</option>
+                </select>
+              </div>
+            )}
+
+            {error !== null && (
+              <p role="alert" className="ac-hint2 err">
+                {error}
+              </p>
+            )}
+          </div>
+          <div className="ac-modal-foot">
+            <button type="button" className="ac-btn" onClick={onClose}>
+              cancel
+            </button>
+            <button type="submit" className="ac-btn primary" disabled={!canSubmit}>
+              {submitLabel}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
@@ -1,24 +1,39 @@
 // @vitest-environment jsdom
 //
-// AimConsole S1 shell test. The aim console is a faithful reproduction of
-// the destination mock (`origin/mock/aim-ui-sample`): a full-window 3-pane
-// console under a sober top bar. S1 reproduces the SHELL — top bar (real
-// unit tabs), the 3-pane grid, and the PR-rail expand/collapse transition.
-// The pane BODIES are stubs (S2–S4), so this test asserts STRUCTURE +
-// the one live interaction (the rail toggle) + the callbacks, not pane
-// content.
+// AimConsole shell test. The aim console is a faithful reproduction of the
+// destination mock (`origin/mock/aim-ui-sample`): a full-window 3-pane console
+// under a sober top bar. This test covers the SHELL — top bar (real unit
+// tabs), the 3-pane grid, the PR-rail expand/collapse transition, and the
+// callbacks. The Aim (left) pane is now the real S2 worklist (its behaviour is
+// covered in AimPane.test.tsx); the Session / PR-rail bodies remain S3 / S4
+// stubs.
 //
-// `useUnitAttention` is mocked so the per-tab attention rollup never hits
-// the network (mirrors how UnitTabs tabs poll for the ⚠N badge).
+// `useUnitAttention` is mocked so the per-tab attention rollup never hits the
+// network; `api.aims` is mocked to a pending promise so the embedded AimPane
+// parks in its loading state (no network, no act-warning churn) — the shell
+// assertions don't depend on aim data.
 
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { UnitResponse } from "@/lib/api";
+import type { AimsResponse, UnitResponse } from "@/lib/api";
+import { UIPrefsProvider } from "@/lib/ui-prefs-provider";
 import { AimConsole } from "../AimConsole";
 
 vi.mock("@/hooks/useUnitAttention", () => ({
   useUnitAttention: () => ({ data: null, loading: false, error: null }),
 }));
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      // Park the AimPane fetch in flight — the shell tests are data-agnostic.
+      aims: () => new Promise<AimsResponse>(() => {}),
+    },
+  };
+});
 
 const UNITS: UnitResponse[] = [
   {
@@ -39,7 +54,11 @@ function renderConsole(overrides: Partial<Parameters<typeof AimConsole>[0]> = {}
     onExit: vi.fn(),
     ...overrides,
   };
-  render(<AimConsole {...props} />);
+  render(
+    <UIPrefsProvider>
+      <AimConsole {...props} />
+    </UIPrefsProvider>,
+  );
   return props;
 }
 
@@ -55,9 +74,13 @@ describe("AimConsole — S1 shell", () => {
     expect(screen.getByLabelText("PR / Issue rail")).toBeTruthy();
   });
 
-  it("marks the panes as S2–S4 stubs (no worklist/session/PR logic in S1)", () => {
+  it("fills the Aim pane (S2) and leaves Session / PR-rail as S3 / S4 stubs", () => {
     renderConsole();
-    expect(screen.getByTestId("aim-pane-stub-s2")).toBeTruthy();
+    // The Aim pane is now the real worklist: no S2 stub, real chrome present.
+    expect(screen.queryByTestId("aim-pane-stub-s2")).toBeNull();
+    expect(screen.getByTestId("aim-ledger")).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Frontier ⚠" })).toBeTruthy();
+    // Session + PR-rail bodies remain stubs.
     expect(screen.getByTestId("aim-pane-stub-s3")).toBeTruthy();
     expect(screen.getByTestId("aim-pane-stub-s4")).toBeTruthy();
   });

--- a/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
@@ -152,6 +152,19 @@ function selectRow(slug: string) {
   fireEvent.click(btn);
 }
 
+// "Forest is in" signal. The ledger renders DURING loading, so it is NOT a
+// load gate; the "＋ aim" button, by contrast, enables only once the forest
+// (with a primary repo) has loaded (`primaryRepo !== null`). Any test that
+// interacts with loaded data must await this first — otherwise the interaction
+// can land on the loading-state render and silently no-op (e.g. a disabled
+// "＋ aim" click never opens the modal).
+async function awaitLoaded() {
+  await waitFor(() => {
+    const btn = screen.getByRole("button", { name: "New aim" }) as HTMLButtonElement;
+    if (btn.disabled) throw new Error("forest not loaded yet");
+  });
+}
+
 beforeEach(() => {
   localStorage.clear();
   aimsMock.mockReset();
@@ -229,7 +242,7 @@ describe("AimPane — Tree mode (per-repo navigator + rollups)", () => {
   it("groups by repo (primary highlighted) and rolls up a collapsed branch", async () => {
     aimsMock.mockResolvedValue(responseStub());
     renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
     fireEvent.click(screen.getByRole("button", { name: "Tree" }));
 
     const heads = await screen.findAllByTestId("aim-repo-head");
@@ -251,7 +264,7 @@ describe("AimPane — Tree mode (per-repo navigator + rollups)", () => {
   it("a search in Tree mode shows a flat, repo-tagged hit list", async () => {
     aimsMock.mockResolvedValue(responseStub());
     renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
     fireEvent.click(screen.getByRole("button", { name: "Tree" }));
     fireEvent.change(screen.getByLabelText("Filter aims"), { target: { value: "aim-system" } });
     expect(rowEl("aim-system")).toBeTruthy();
@@ -289,7 +302,7 @@ describe("AimPane — inspector", () => {
   it("shows the drift←ancestor pill and the interior is[] (mark-only, ref for confirmed)", async () => {
     aimsMock.mockResolvedValue(responseStub());
     renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
     selectRow("attention-per-artifact");
 
     const insp = await screen.findByTestId("aim-inspector");
@@ -305,7 +318,7 @@ describe("AimPane — inspector", () => {
   it("breadcrumb climbs to an ancestor", async () => {
     aimsMock.mockResolvedValue(responseStub());
     renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
     selectRow("attention-per-artifact");
     const insp = await screen.findByTestId("aim-inspector");
     fireEvent.click(within(insp).getByRole("button", { name: /amplify judgment/ }));
@@ -319,7 +332,7 @@ describe("AimPane — search", () => {
   it("filters the owed worklist by slug / ought", async () => {
     aimsMock.mockResolvedValue(responseStub());
     renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
 
     fireEvent.change(screen.getByLabelText("Filter aims"), { target: { value: "per-artifact" } });
     expect(rowEl("attention-per-artifact")).toBeTruthy();
@@ -345,7 +358,7 @@ describe("AimPane — create modal", () => {
     createAimMock.mockResolvedValue(created);
 
     renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
     fireEvent.click(screen.getByRole("button", { name: "New aim" }));
 
     const modal = await screen.findByTestId("aim-create-modal");
@@ -370,7 +383,7 @@ describe("AimPane — create modal", () => {
   it("auto-derives the slug from the aim until the operator types one", async () => {
     aimsMock.mockResolvedValue(responseStub());
     renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
     fireEvent.click(screen.getByRole("button", { name: "New aim" }));
     const modal = await screen.findByTestId("aim-create-modal");
     fireEvent.change(within(modal).getByLabelText(/aim — /), {
@@ -384,7 +397,7 @@ describe("AimPane — create modal", () => {
   it("blocks a dated slug and a duplicate without calling the API", async () => {
     aimsMock.mockResolvedValue(responseStub());
     renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
     fireEvent.click(screen.getByRole("button", { name: "New aim" }));
     const modal = await screen.findByTestId("aim-create-modal");
 
@@ -404,7 +417,7 @@ describe("AimPane — create modal", () => {
     aimsMock.mockResolvedValue(responseStub());
     createAimMock.mockRejectedValue(new Error("aim 'racy' already exists"));
     renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
     fireEvent.click(screen.getByRole("button", { name: "New aim" }));
     const modal = await screen.findByTestId("aim-create-modal");
     fireEvent.change(within(modal).getByLabelText(/aim — /), { target: { value: "a" } });
@@ -416,7 +429,7 @@ describe("AimPane — create modal", () => {
   it("Esc closes the modal", async () => {
     aimsMock.mockResolvedValue(responseStub());
     renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
     fireEvent.click(screen.getByRole("button", { name: "New aim" }));
     await screen.findByTestId("aim-create-modal");
     fireEvent.keyDown(document, { key: "Escape" });
@@ -429,7 +442,7 @@ describe("AimPane — create modal", () => {
       aimStub({ slug: "child", aim: "c", parent: "amplify-human-judgment" }),
     );
     renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
     selectRow("amplify-human-judgment");
     fireEvent.click(await screen.findByRole("button", { name: /子 aim/ }));
 
@@ -458,7 +471,7 @@ describe("AimPane — edit modal (pin #3: drift mirrors the engine on refetch)",
       aimStub({ slug: "aim-system", aim: "edited bearing", state: "done" }),
     );
     renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
     // Edit from Tree mode so the calm (non-owed) aim-system is reachable.
     fireEvent.click(screen.getByRole("button", { name: "Tree" }));
     selectRow("aim-system");
@@ -488,7 +501,7 @@ describe("AimPane — edit modal (pin #3: drift mirrors the engine on refetch)",
   it("excludes the node + its descendants from the edit parent options (no cycles)", async () => {
     aimsMock.mockResolvedValue(responseStub());
     renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
     fireEvent.click(screen.getByRole("button", { name: "Tree" }));
     selectRow("amplify-human-judgment");
     const insp = await screen.findByTestId("aim-inspector");
@@ -508,13 +521,13 @@ describe("AimPane — mode persistence", () => {
   it("persists the Frontier/Tree mode across remounts (ui-prefs)", async () => {
     aimsMock.mockResolvedValue(responseStub());
     const { unmount } = renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
     fireEvent.click(screen.getByRole("button", { name: "Tree" }));
     expect(screen.getByRole("button", { name: "Tree" }).getAttribute("aria-pressed")).toBe("true");
 
     unmount();
     renderPane();
-    await screen.findByTestId("aim-ledger");
+    await awaitLoaded();
     await waitFor(() =>
       expect(screen.getByRole("button", { name: "Tree" }).getAttribute("aria-pressed")).toBe(
         "true",

--- a/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
@@ -1,0 +1,524 @@
+// @vitest-environment jsdom
+//
+// AimPane — the aim-console's Aim (left) pane (S2). A faithful reproduction of
+// the destination mock's `.aim` section + create-aim modal in the dev-tool
+// tokens, wired to the REUSED Stage B logic layer (`r-panel/aim-tree.ts`,
+// `useUnitAims`, `api.createAim` / `api.editAim`). This test covers the
+// presentation port against the real wire shape: the ledger, the Frontier owed
+// worklist (drift-first, breadcrumbed, done-drift distinct — pin #2), the Tree
+// navigator (grouping + rollups + collapse), the overview ruler reveal, the
+// inspector (drift pill + interior is[] — pin #1 mark-only), the search filter,
+// and the create / edit modal (kebab validation + refetch — pin #3).
+//
+// Mirrors RAimsSection.test.tsx's fixtures (same forest) so the two surfaces
+// stay behaviourally comparable; only the markup/queries differ.
+
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AimsResponse, AimWire } from "@/lib/api";
+import { UIPrefsProvider } from "@/lib/ui-prefs-provider";
+import type { AimDriftWire } from "@/types/generated/AimDriftWire";
+import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
+
+const aimsMock = vi.fn();
+const createAimMock = vi.fn();
+const editAimMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      aims: (...args: unknown[]) => aimsMock(...args),
+      createAim: (...args: unknown[]) => createAimMock(...args),
+      editAim: (...args: unknown[]) => editAimMock(...args),
+    },
+  };
+});
+
+import { AimPane } from "../AimPane";
+
+function driftFrom(slug: string): AimDriftWire {
+  return {
+    stale_from_ancestor_slug: slug,
+    ancestor_change_sha: "abc1234",
+    ancestor_change_date: "2026-06-01",
+    aim_change_date: "2026-05-01",
+  };
+}
+const claimed = (text: string): AimInteriorWire => ({ kind: "claimed", text, ref: null });
+const confirmed = (text: string, ref: string): AimInteriorWire => ({
+  kind: "confirmed",
+  text,
+  ref,
+});
+
+function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
+  return {
+    aim: `aim ${overrides.slug}`,
+    parent: null,
+    state: "open",
+    depends_on: [],
+    serves: [],
+    related: [],
+    body: "",
+    drift: null,
+    is: [],
+    ...overrides,
+  };
+}
+
+// Two repos (same shape as RAimsSection's fixture):
+//   tmai-core (primary)
+//     amplify-human-judgment (root, open, claimed)               → owed (claimed)
+//       attention-per-artifact (open, drift←amplify, conf+claim)  → owed (drift)
+//         attention-backend (done, confirmed)                     → plain done
+//     aim-system (root, open, confirmed)                          → calm
+//       aim-honesty (dead)                                        → abandoned
+//       review-attention-budget (done, drift←aim-system)          → PIN #2
+//   tmai
+//     inverted-ui (root, open, claimed)                           → owed (claimed)
+const CORE: AimWire[] = [
+  aimStub({ slug: "amplify-human-judgment", aim: "amplify judgment", is: [claimed("進行中")] }),
+  aimStub({
+    slug: "attention-per-artifact",
+    aim: "per-artifact attention",
+    parent: "amplify-human-judgment",
+    drift: driftFrom("amplify-human-judgment"),
+    is: [confirmed("storage + wire", "PR#490"), claimed("ancestor moved — re-confirm")],
+  }),
+  aimStub({
+    slug: "attention-backend",
+    aim: "backend compute",
+    parent: "attention-per-artifact",
+    state: "done",
+    is: [confirmed("wired", "PR#500")],
+  }),
+  aimStub({
+    slug: "aim-system",
+    aim: "records as structure",
+    is: [confirmed("graduated", "PR#501")],
+  }),
+  aimStub({ slug: "aim-honesty", aim: "confirmed ⊥ claimed", parent: "aim-system", state: "dead" }),
+  aimStub({
+    slug: "review-attention-budget",
+    aim: "review budget is the limiter",
+    parent: "aim-system",
+    state: "done",
+    drift: driftFrom("aim-system"),
+  }),
+];
+const UI: AimWire[] = [
+  aimStub({ slug: "inverted-ui", aim: "root to conversation", is: [claimed("frontier")] }),
+];
+
+function responseStub(
+  repos: { label: string; primary: boolean; aims: AimWire[] }[] = [
+    { label: "tmai-core", primary: true, aims: CORE },
+    { label: "tmai", primary: false, aims: UI },
+  ],
+): AimsResponse {
+  return {
+    unit: "u",
+    composed_at: "2026-06-08T00:00:00Z",
+    repos: repos.map((r) => ({
+      repo_label: r.label,
+      repo_root: `/p/${r.label}`,
+      primary: r.primary,
+      repo_head: null,
+      aims: r.aims,
+    })),
+  };
+}
+
+function renderPane(unitName: string | null = "u") {
+  return render(
+    <UIPrefsProvider>
+      <AimPane unitName={unitName} />
+    </UIPrefsProvider>,
+  );
+}
+
+function rowEl(slug: string): HTMLElement {
+  const el = document.querySelector(`[data-testid="aim-row"][data-slug="${slug}"]`);
+  if (!el) throw new Error(`no row for ${slug}`);
+  return el as HTMLElement;
+}
+function selectRow(slug: string) {
+  // The select button is the one carrying aria-pressed (toggle / add buttons do not).
+  const btn = rowEl(slug).querySelector("button[aria-pressed]");
+  if (!btn) throw new Error(`no select button for ${slug}`);
+  fireEvent.click(btn);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  aimsMock.mockReset();
+  createAimMock.mockReset();
+  editAimMock.mockReset();
+});
+
+describe("AimPane — load + ledger", () => {
+  it("parks with a placeholder + no fetch when no unit is focused", () => {
+    renderPane(null);
+    expect(screen.getByText(/プロジェクトを選択/)).toBeTruthy();
+    expect(aimsMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a fetch error", async () => {
+    aimsMock.mockRejectedValue(new Error("boom"));
+    renderPane();
+    await waitFor(() => expect(screen.getByText(/読み込みに失敗: boom/)).toBeTruthy());
+  });
+
+  it("ledger counts drift / claimed / confirmed off the forest", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    const ledger = await screen.findByTestId("aim-ledger");
+    // drift=2 (attention-per-artifact open + review-attention-budget done; dead
+    // excluded), claimed marks=3, confirmed marks=3.
+    await waitFor(() => expect(ledger.textContent).toMatch(/2\s*drift/));
+    expect(ledger.textContent).toMatch(/3\s*claimed/);
+    expect(ledger.textContent).toMatch(/3\s*confirmed/);
+  });
+});
+
+describe("AimPane — Frontier mode (owed worklist)", () => {
+  it("defaults to Frontier, lists owed drift-first, calm absent, done-drift distinct", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await waitFor(() => expect(rowEl("attention-per-artifact").dataset.tone).toBe("drift"));
+    expect(rowEl("amplify-human-judgment").dataset.tone).toBe("claimed");
+    // A calm (confirmed-only) node is NOT in the worklist.
+    expect(document.querySelector('[data-testid="aim-row"][data-slug="aim-system"]')).toBeNull();
+    // Owed in the non-primary repo too.
+    expect(rowEl("inverted-ui").dataset.tone).toBe("claimed");
+
+    // Pin #2: done+drift surfaced distinctly, with its badge, in its own cluster.
+    const r = rowEl("review-attention-budget");
+    expect(r.dataset.tone).toBe("done-drift");
+    expect(within(r).getByTestId("aim-drift-badge")).toBeTruthy();
+    expect(screen.getByText(/done · drifted/)).toBeTruthy();
+  });
+
+  it("breadcrumbs each owed row with its ought-ancestry", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await waitFor(() =>
+      expect(rowEl("attention-per-artifact").textContent).toContain("amplify-human-judgment"),
+    );
+  });
+
+  it("shows a calm message when nothing is owed", async () => {
+    aimsMock.mockResolvedValue(
+      responseStub([
+        {
+          label: "tmai-core",
+          primary: true,
+          aims: [aimStub({ slug: "calm", is: [confirmed("ok", "PR#1")] })],
+        },
+      ]),
+    );
+    renderPane();
+    await waitFor(() => expect(screen.getByText(/盤面は calm/)).toBeTruthy());
+  });
+});
+
+describe("AimPane — Tree mode (per-repo navigator + rollups)", () => {
+  it("groups by repo (primary highlighted) and rolls up a collapsed branch", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await screen.findByTestId("aim-ledger");
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+
+    const heads = await screen.findAllByTestId("aim-repo-head");
+    expect(heads.map((h) => h.dataset.repo)).toEqual(["tmai-core", "tmai"]);
+    expect(heads[0].className).toContain("pri");
+
+    // amplify is a root → open by default; collapse it.
+    const toggle = rowEl("amplify-human-judgment").querySelector('button[aria-label^="Collapse"]');
+    fireEvent.click(toggle as Element);
+    // Its child is now hidden, and the rollup shows the subtree drift (⚠1).
+    expect(
+      document.querySelector('[data-testid="aim-row"][data-slug="attention-per-artifact"]'),
+    ).toBeNull();
+    expect(within(rowEl("amplify-human-judgment")).getByTestId("aim-rollup").textContent).toContain(
+      "⚠1",
+    );
+  });
+
+  it("a search in Tree mode shows a flat, repo-tagged hit list", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await screen.findByTestId("aim-ledger");
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+    fireEvent.change(screen.getByLabelText("Filter aims"), { target: { value: "aim-system" } });
+    expect(rowEl("aim-system")).toBeTruthy();
+    // The flat hit carries the repo tag.
+    expect(rowEl("aim-system").textContent).toContain("tmai-core");
+  });
+});
+
+describe("AimPane — overview ruler", () => {
+  it("clicking a lit tick reveals the node in Tree mode and selects it", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await screen.findByTestId("aim-ruler");
+
+    const tick = await waitFor(() => {
+      const t = document.querySelector(
+        '[data-testid="ruler-tick"][data-slug="attention-per-artifact"]',
+      );
+      if (!t) throw new Error("no tick yet");
+      return t;
+    });
+    expect(tick.getAttribute("data-owed")).toBe("drift");
+    fireEvent.click(tick);
+
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Tree" }).getAttribute("aria-pressed")).toBe(
+        "true",
+      ),
+    );
+    expect(screen.getByTestId("aim-inspector").textContent).toContain("per-artifact attention");
+  });
+});
+
+describe("AimPane — inspector", () => {
+  it("shows the drift←ancestor pill and the interior is[] (mark-only, ref for confirmed)", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await screen.findByTestId("aim-ledger");
+    selectRow("attention-per-artifact");
+
+    const insp = await screen.findByTestId("aim-inspector");
+    expect(within(insp).getByTestId("aim-drift-pill").textContent).toContain(
+      "drift ← 祖先 amplify-human-judgment",
+    );
+    const marks = within(insp).getAllByTestId("aim-mark");
+    expect(marks.map((m) => m.dataset.kind)).toEqual(["confirmed", "claimed"]);
+    expect(marks[0].textContent).toContain("PR#490");
+    expect(marks[1].textContent).toContain("ancestor moved");
+  });
+
+  it("breadcrumb climbs to an ancestor", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await screen.findByTestId("aim-ledger");
+    selectRow("attention-per-artifact");
+    const insp = await screen.findByTestId("aim-inspector");
+    fireEvent.click(within(insp).getByRole("button", { name: /amplify judgment/ }));
+    await waitFor(() =>
+      expect(screen.getByTestId("aim-inspector").textContent).toContain("amplify judgment"),
+    );
+  });
+});
+
+describe("AimPane — search", () => {
+  it("filters the owed worklist by slug / ought", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await screen.findByTestId("aim-ledger");
+
+    fireEvent.change(screen.getByLabelText("Filter aims"), { target: { value: "per-artifact" } });
+    expect(rowEl("attention-per-artifact")).toBeTruthy();
+    expect(
+      document.querySelector('[data-testid="aim-row"][data-slug="amplify-human-judgment"]'),
+    ).toBeNull();
+
+    fireEvent.change(screen.getByLabelText("Filter aims"), { target: { value: "zzz-no-match" } });
+    expect(screen.getByText(/filter 一致なし/)).toBeTruthy();
+  });
+});
+
+describe("AimPane — create modal", () => {
+  it("creates via the modal and reflects it after the refetch", async () => {
+    const created = aimStub({ slug: "new-node", aim: "the new bearing" });
+    aimsMock.mockResolvedValueOnce(responseStub());
+    aimsMock.mockResolvedValue(
+      responseStub([
+        { label: "tmai-core", primary: true, aims: [...CORE, created] },
+        { label: "tmai", primary: false, aims: UI },
+      ]),
+    );
+    createAimMock.mockResolvedValue(created);
+
+    renderPane();
+    await screen.findByTestId("aim-ledger");
+    fireEvent.click(screen.getByRole("button", { name: "New aim" }));
+
+    const modal = await screen.findByTestId("aim-create-modal");
+    fireEvent.change(within(modal).getByLabelText(/aim — /), {
+      target: { value: "the new bearing" },
+    });
+    fireEvent.change(within(modal).getByLabelText(/slug — /), { target: { value: "new-node" } });
+    fireEvent.click(within(modal).getByRole("button", { name: "作成" }));
+
+    await waitFor(() =>
+      expect(createAimMock).toHaveBeenCalledWith("u", {
+        slug: "new-node",
+        aim: "the new bearing",
+        parent: null,
+      }),
+    );
+    // Pin #3: a create triggers a refetch.
+    await waitFor(() => expect(aimsMock.mock.calls.length).toBeGreaterThan(1));
+    await waitFor(() => expect(screen.getAllByText("the new bearing").length).toBeGreaterThan(0));
+  });
+
+  it("auto-derives the slug from the aim until the operator types one", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await screen.findByTestId("aim-ledger");
+    fireEvent.click(screen.getByRole("button", { name: "New aim" }));
+    const modal = await screen.findByTestId("aim-create-modal");
+    fireEvent.change(within(modal).getByLabelText(/aim — /), {
+      target: { value: "Attention icon row" },
+    });
+    expect((within(modal).getByLabelText(/slug — /) as HTMLInputElement).value).toBe(
+      "attention-icon-row",
+    );
+  });
+
+  it("blocks a dated slug and a duplicate without calling the API", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await screen.findByTestId("aim-ledger");
+    fireEvent.click(screen.getByRole("button", { name: "New aim" }));
+    const modal = await screen.findByTestId("aim-create-modal");
+
+    fireEvent.change(within(modal).getByLabelText(/aim — /), { target: { value: "a" } });
+    fireEvent.change(within(modal).getByLabelText(/slug — /), {
+      target: { value: "2026-01-02-x" },
+    });
+    expect(within(modal).getByText("日付 prefix 不可")).toBeTruthy();
+    expect(within(modal).getByRole("button", { name: "作成" })).toHaveProperty("disabled", true);
+
+    fireEvent.change(within(modal).getByLabelText(/slug — /), { target: { value: "aim-system" } });
+    expect(within(modal).getByText("slug 重複")).toBeTruthy();
+    expect(createAimMock).not.toHaveBeenCalled();
+  });
+
+  it("surfaces a backend rejection inline", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    createAimMock.mockRejectedValue(new Error("aim 'racy' already exists"));
+    renderPane();
+    await screen.findByTestId("aim-ledger");
+    fireEvent.click(screen.getByRole("button", { name: "New aim" }));
+    const modal = await screen.findByTestId("aim-create-modal");
+    fireEvent.change(within(modal).getByLabelText(/aim — /), { target: { value: "a" } });
+    fireEvent.change(within(modal).getByLabelText(/slug — /), { target: { value: "racy" } });
+    fireEvent.click(within(modal).getByRole("button", { name: "作成" }));
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("already exists"));
+  });
+
+  it("Esc closes the modal", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await screen.findByTestId("aim-ledger");
+    fireEvent.click(screen.getByRole("button", { name: "New aim" }));
+    await screen.findByTestId("aim-create-modal");
+    fireEvent.keyDown(document, { key: "Escape" });
+    await waitFor(() => expect(screen.queryByTestId("aim-create-modal")).toBeNull());
+  });
+
+  it("add-child from the inspector presets the parent", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    createAimMock.mockResolvedValue(
+      aimStub({ slug: "child", aim: "c", parent: "amplify-human-judgment" }),
+    );
+    renderPane();
+    await screen.findByTestId("aim-ledger");
+    selectRow("amplify-human-judgment");
+    fireEvent.click(await screen.findByRole("button", { name: /子 aim/ }));
+
+    const modal = await screen.findByTestId("aim-create-modal");
+    expect((within(modal).getByLabelText("parent") as HTMLSelectElement).value).toBe(
+      "amplify-human-judgment",
+    );
+    fireEvent.change(within(modal).getByLabelText(/aim — /), { target: { value: "c" } });
+    fireEvent.change(within(modal).getByLabelText(/slug — /), { target: { value: "child" } });
+    fireEvent.click(within(modal).getByRole("button", { name: "作成" }));
+
+    await waitFor(() =>
+      expect(createAimMock).toHaveBeenCalledWith("u", {
+        slug: "child",
+        aim: "c",
+        parent: "amplify-human-judgment",
+      }),
+    );
+  });
+});
+
+describe("AimPane — edit modal (pin #3: drift mirrors the engine on refetch)", () => {
+  it("edits aim / state via the modal and refetches (no client cascade)", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    editAimMock.mockResolvedValue(
+      aimStub({ slug: "aim-system", aim: "edited bearing", state: "done" }),
+    );
+    renderPane();
+    await screen.findByTestId("aim-ledger");
+    // Edit from Tree mode so the calm (non-owed) aim-system is reachable.
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+    selectRow("aim-system");
+
+    const insp = await screen.findByTestId("aim-inspector");
+    fireEvent.click(within(insp).getByRole("button", { name: /編集/ }));
+
+    const modal = await screen.findByTestId("aim-create-modal");
+    // Edit mode: slug frozen.
+    expect((within(modal).getByLabelText(/slug — /) as HTMLInputElement).disabled).toBe(true);
+    fireEvent.change(within(modal).getByLabelText(/aim — /), {
+      target: { value: "edited bearing" },
+    });
+    fireEvent.change(within(modal).getByLabelText("state"), { target: { value: "done" } });
+    fireEvent.click(within(modal).getByRole("button", { name: "保存" }));
+
+    await waitFor(() =>
+      expect(editAimMock).toHaveBeenCalledWith("u", "aim-system", {
+        aim: "edited bearing",
+        parent: null,
+        state: "done",
+      }),
+    );
+    await waitFor(() => expect(aimsMock.mock.calls.length).toBeGreaterThan(1));
+  });
+
+  it("excludes the node + its descendants from the edit parent options (no cycles)", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await screen.findByTestId("aim-ledger");
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+    selectRow("amplify-human-judgment");
+    const insp = await screen.findByTestId("aim-inspector");
+    fireEvent.click(within(insp).getByRole("button", { name: /編集/ }));
+
+    const modal = await screen.findByTestId("aim-create-modal");
+    const parentSelect = within(modal).getByLabelText("parent") as HTMLSelectElement;
+    const values = Array.from(parentSelect.options).map((o) => o.value);
+    expect(values).not.toContain("amplify-human-judgment"); // self
+    expect(values).not.toContain("attention-per-artifact"); // descendant
+    expect(values).not.toContain("attention-backend"); // deeper descendant
+    expect(values).toContain("aim-system"); // outside subtree → allowed
+  });
+});
+
+describe("AimPane — mode persistence", () => {
+  it("persists the Frontier/Tree mode across remounts (ui-prefs)", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    const { unmount } = renderPane();
+    await screen.findByTestId("aim-ledger");
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+    expect(screen.getByRole("button", { name: "Tree" }).getAttribute("aria-pressed")).toBe("true");
+
+    unmount();
+    renderPane();
+    await screen.findByTestId("aim-ledger");
+    await waitFor(() =>
+      expect(screen.getByRole("button", { name: "Tree" }).getAttribute("aria-pressed")).toBe(
+        "true",
+      ),
+    );
+  });
+});

--- a/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
@@ -535,3 +535,49 @@ describe("AimPane — mode persistence", () => {
     );
   });
 });
+
+describe("AimPane — unit change", () => {
+  it("resets per-unit view state (selection + forest) when the focused unit changes", async () => {
+    aimsMock.mockImplementation((unit: string) =>
+      Promise.resolve(
+        unit === "a"
+          ? responseStub([
+              {
+                label: "repo-a",
+                primary: true,
+                aims: [aimStub({ slug: "a-root", aim: "A root", is: [claimed("x")] })],
+              },
+            ])
+          : responseStub([
+              {
+                label: "repo-b",
+                primary: true,
+                aims: [aimStub({ slug: "b-root", aim: "B root", is: [claimed("y")] })],
+              },
+            ]),
+      ),
+    );
+
+    const { rerender } = render(
+      <UIPrefsProvider>
+        <AimPane unitName="a" />
+      </UIPrefsProvider>,
+    );
+    await awaitLoaded();
+    selectRow("a-root");
+    await screen.findByTestId("aim-inspector");
+
+    // Switch to unit "b" (a different forest) — same AimPane instance (no key
+    // remount), so the in-component reset must clear the stale state.
+    rerender(
+      <UIPrefsProvider>
+        <AimPane unitName="b" />
+      </UIPrefsProvider>,
+    );
+
+    await waitFor(() => expect(rowEl("b-root")).toBeTruthy());
+    // The previous unit's node is gone and its inspector selection cleared.
+    expect(document.querySelector('[data-testid="aim-row"][data-slug="a-root"]')).toBeNull();
+    expect(screen.queryByTestId("aim-inspector")).toBeNull();
+  });
+});

--- a/clients/react/src/components/aim-console/__tests__/slug.test.ts
+++ b/clients/react/src/components/aim-console/__tests__/slug.test.ts
@@ -52,4 +52,24 @@ describe("suggestSlug", () => {
     const long = "a".repeat(60);
     expect(suggestSlug(long, new Set())).toHaveLength(40);
   });
+
+  it("never leaves a trailing hyphen when the 40-char cut lands on a separator", () => {
+    // Three 19-char words join to "...(19)-...(19)-...(19)"; slice(0, 40) lands
+    // exactly on the second separator → a naive cut would end in '-'.
+    const aim = `${"a".repeat(19)} ${"b".repeat(19)} ${"c".repeat(19)}`;
+    const s = suggestSlug(aim, new Set());
+    expect(s.endsWith("-")).toBe(false);
+    expect(s.length).toBeLessThanOrEqual(40);
+    // The suggestion itself must pass the slug validator.
+    expect(validateAimSlug(s)).toBeNull();
+  });
+
+  it("keeps the slug ≤40 and valid even after a dedup suffix", () => {
+    const base = "a".repeat(40);
+    const existing = new Set([base]); // forces a -N suffix on the capped base
+    const s = suggestSlug("a".repeat(60), existing);
+    expect(s.length).toBeLessThanOrEqual(40);
+    expect(existing.has(s)).toBe(false);
+    expect(validateAimSlug(s)).toBeNull();
+  });
 });

--- a/clients/react/src/components/aim-console/__tests__/slug.test.ts
+++ b/clients/react/src/components/aim-console/__tests__/slug.test.ts
@@ -1,0 +1,55 @@
+// Aim-console create-modal slug helpers — the client-side mirror of the
+// backend's slug rules (tmai-core #501) and the mock's suggest/validate.
+
+import { describe, expect, it } from "vitest";
+import { suggestSlug, validateAimSlug } from "../slug";
+
+describe("validateAimSlug", () => {
+  it("accepts a lowercase kebab slug (returns null)", () => {
+    expect(validateAimSlug("attention-icon-row")).toBeNull();
+    expect(validateAimSlug("a")).toBeNull();
+    expect(validateAimSlug("aim123")).toBeNull();
+  });
+
+  it("treats an empty slug as 'not yet', not an error", () => {
+    expect(validateAimSlug("")).toBeNull();
+  });
+
+  it("rejects uppercase / spaces / illegal punctuation", () => {
+    expect(validateAimSlug("Attention")).not.toBeNull();
+    expect(validateAimSlug("two words")).not.toBeNull();
+    expect(validateAimSlug("under_score")).not.toBeNull();
+  });
+
+  it("rejects leading / trailing / doubled dashes", () => {
+    expect(validateAimSlug("-lead")).not.toBeNull();
+    expect(validateAimSlug("trail-")).not.toBeNull();
+    expect(validateAimSlug("double--dash")).not.toBeNull();
+  });
+
+  it("rejects a YYYY-MM-DD dated prefix (aim slugs are dateless)", () => {
+    expect(validateAimSlug("2026-06-08-thing")).toBe("日付 prefix 不可");
+  });
+});
+
+describe("suggestSlug", () => {
+  it("derives a kebab slug from the aim prose", () => {
+    expect(suggestSlug("Attention level を surface する", new Set())).toBe(
+      "attention-level-surface",
+    );
+  });
+
+  it("falls back to new-aim when the aim has no usable characters", () => {
+    expect(suggestSlug("　…！", new Set())).toBe("new-aim");
+  });
+
+  it("de-duplicates against existing slugs by appending -2, -3…", () => {
+    const existing = new Set(["drift", "drift-2"]);
+    expect(suggestSlug("drift", existing)).toBe("drift-3");
+  });
+
+  it("caps the base at 40 characters", () => {
+    const long = "a".repeat(60);
+    expect(suggestSlug(long, new Set())).toHaveLength(40);
+  });
+});

--- a/clients/react/src/components/aim-console/slug.ts
+++ b/clients/react/src/components/aim-console/slug.ts
@@ -1,0 +1,37 @@
+// Client-side slug helpers for the aim-console create-aim modal — a fast-feedback
+// MIRROR of the backend's `validate_new_aim_slug` (tmai-core #501) and the
+// destination mock's `validateSlug` / `suggestSlug`. The backend stays
+// authoritative (it owns the `409` / `422`); these only spare the operator a
+// round-trip on the obvious cases. Pure + framework-free so they unit-test in
+// isolation.
+
+// Validate a candidate slug shape. Returns a short Japanese message (the
+// console UI is `lang=ja`, mirroring the mock's copy), or `null` when the shape
+// is valid. An EMPTY slug is "not yet" — not a shape error — so it returns
+// `null`; the caller gates the submit on non-emptiness. Duplicate detection is
+// the caller's job (it owns the repo's existing-slug set).
+export function validateAimSlug(slug: string): string | null {
+  if (slug === "") return null;
+  // lowercase kebab only — alnum runs joined by single `-`, no leading /
+  // trailing / doubled `-`.
+  if (!/^[a-z0-9]+(-[a-z0-9]+)*$/.test(slug)) return "lowercase kebab のみ（[a-z0-9-]）";
+  // A `YYYY-MM-DD-` prefix is the decision / approach convention; aim slugs are
+  // dateless stable identities.
+  if (/^\d{4}-\d{2}-\d{2}/.test(slug)) return "日付 prefix 不可";
+  return null;
+}
+
+// Derive a kebab slug suggestion from the aim text, de-duplicated against the
+// repo's existing slugs (append `-2`, `-3`, …). Mirrors the mock's
+// `suggestSlug`: lowercase, alnum runs joined by `-`, capped at 40 chars,
+// falling back to `new-aim` when the aim has no usable characters.
+export function suggestSlug(aim: string, existing: ReadonlySet<string>): string {
+  const base = (aim.toLowerCase().match(/[a-z0-9]+/g) ?? []).join("-").slice(0, 40) || "new-aim";
+  let candidate = base;
+  let i = 2;
+  while (existing.has(candidate)) {
+    candidate = `${base}-${i}`;
+    i++;
+  }
+  return candidate;
+}

--- a/clients/react/src/components/aim-console/slug.ts
+++ b/clients/react/src/components/aim-console/slug.ts
@@ -21,17 +21,29 @@ export function validateAimSlug(slug: string): string | null {
   return null;
 }
 
+// Max slug length (mirrors the mock's 40-char cap).
+const SLUG_MAX = 40;
+
+// Strip any trailing `-` — a 40-char cut can land mid-separator, and a trailing
+// hyphen fails `validateAimSlug`.
+const trimTrailingDash = (s: string): string => s.replace(/-+$/, "");
+
 // Derive a kebab slug suggestion from the aim text, de-duplicated against the
 // repo's existing slugs (append `-2`, `-3`, …). Mirrors the mock's
-// `suggestSlug`: lowercase, alnum runs joined by `-`, capped at 40 chars,
-// falling back to `new-aim` when the aim has no usable characters.
+// `suggestSlug`: lowercase, alnum runs joined by `-`, falling back to `new-aim`
+// when the aim has no usable characters. ALWAYS returns a value that passes
+// `validateAimSlug`: the 40-char cap is enforced WITH no trailing hyphen, and
+// the dedup suffix shrinks the base so the whole slug stays ≤ 40.
 export function suggestSlug(aim: string, existing: ReadonlySet<string>): string {
-  const base = (aim.toLowerCase().match(/[a-z0-9]+/g) ?? []).join("-").slice(0, 40) || "new-aim";
-  let candidate = base;
-  let i = 2;
-  while (existing.has(candidate)) {
-    candidate = `${base}-${i}`;
-    i++;
+  const base =
+    trimTrailingDash((aim.toLowerCase().match(/[a-z0-9]+/g) ?? []).join("-").slice(0, SLUG_MAX)) ||
+    "new-aim";
+  if (!existing.has(base)) return base;
+  // Collision — append `-N`, trimming the base so base+suffix stays within cap
+  // and never ends on a dangling hyphen.
+  for (let i = 2; ; i++) {
+    const suffix = `-${i}`;
+    const candidate = trimTrailingDash(base.slice(0, SLUG_MAX - suffix.length)) + suffix;
+    if (!existing.has(candidate)) return candidate;
   }
-  return candidate;
 }

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -646,7 +646,7 @@
   right: 1px;
   height: 5px;
   opacity: 1;
-  box-shadow: 0 0 6px currentColor;
+  box-shadow: 0 0 6px currentcolor;
 }
 .aim-console .ac-rdiv {
   position: absolute;

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -417,6 +417,859 @@
   max-width: 36ch;
 }
 
+/* ════════════════════════════════════════════════════════════════════════
+   S2 — AIM PANE (Frontier⊥Tree worklist, ledger, ruler, inspector, modal).
+
+   A faithful port of the mock's `.aim` section + the create-aim modal into the
+   `.ac-*` family (so it stays scoped + namespaced with the S1 shell). Wired to
+   the reused Stage B logic layer (`r-panel/aim-tree.ts`); this is the
+   PRESENTATION only — drift→--amber, claimed→--ochre, confirmed→--green,
+   structure/root/select→--cyan.
+   ════════════════════════════════════════════════════════════════════════ */
+
+/* ── ledger (quiet) ───────────────────────────────────────────────────── */
+.aim-console .ac-ledger {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 12px 9px;
+}
+.aim-console .ac-lg {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 11px;
+  border: none;
+  background: transparent;
+  padding: 0;
+  cursor: default;
+  color: var(--dim);
+}
+.aim-console button.ac-lg {
+  cursor: pointer;
+}
+.aim-console .ac-lg .sw {
+  width: 9px;
+  height: 9px;
+  border-radius: 2px;
+}
+.aim-console .ac-lg.dr {
+  color: var(--amber);
+}
+.aim-console .ac-lg.dr .sw {
+  background: var(--amber);
+}
+.aim-console .ac-lg.cl {
+  color: var(--ochre);
+}
+.aim-console .ac-lg.cl .sw {
+  background: var(--ochre);
+}
+.aim-console .ac-lg.cf {
+  color: var(--dim);
+}
+.aim-console .ac-lg.cf .sw {
+  background: var(--green);
+}
+.aim-console .ac-lg b {
+  font-weight: 600;
+}
+.aim-console .ac-lbar {
+  flex: 1;
+  height: 4px;
+  background: #0c1110;
+  border: 1px solid var(--line-2);
+  display: flex;
+  overflow: hidden;
+}
+.aim-console .ac-lbar .o {
+  background: var(--amber);
+}
+.aim-console .ac-lbar .c {
+  background: var(--green-d);
+}
+
+/* ── controls (segmented mode + search + new) ─────────────────────────── */
+.aim-console .ac-actl {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  border-top: 1px solid var(--line-2);
+  background: var(--panel);
+}
+.aim-console .ac-seg {
+  display: flex;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  overflow: hidden;
+}
+.aim-console .ac-seg-btn {
+  background: transparent;
+  color: var(--dim);
+  border: none;
+  border-right: 1px solid var(--line);
+  padding: 5px 11px;
+  font: 500 11px var(--sans);
+  cursor: pointer;
+}
+.aim-console .ac-seg-btn:last-child {
+  border-right: none;
+}
+.aim-console .ac-seg-btn.on {
+  background: var(--elev);
+  color: var(--txt);
+}
+.aim-console .ac-seg-btn.on.owed {
+  color: var(--amber);
+}
+.aim-console .ac-search {
+  flex: 1;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  border: 1px solid var(--line);
+  border-radius: 4px;
+  padding: 4px 9px;
+}
+.aim-console .ac-search-i {
+  color: var(--faint);
+}
+.aim-console .ac-search input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  outline: none;
+  color: var(--txt);
+  font-family: var(--mono);
+  font-size: 11.5px;
+}
+.aim-console .ac-search input::placeholder {
+  color: var(--faint);
+}
+.aim-console .ac-search .k {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--faint);
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  padding: 1px 4px;
+}
+.aim-console .ac-newbtn {
+  background: var(--cyan-d);
+  color: var(--cyan);
+  border: 1px solid #1f4541;
+  border-radius: 4px;
+  padding: 5px 10px;
+  font: 500 11px var(--sans);
+  cursor: pointer;
+  flex: none;
+}
+.aim-console .ac-newbtn:hover {
+  background: #163a38;
+}
+.aim-console .ac-newbtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* ── list + ruler ─────────────────────────────────────────────────────── */
+.aim-console .ac-alist-wrap {
+  position: relative;
+  flex: 1;
+  min-height: 0;
+  display: flex;
+}
+.aim-console .ac-alist {
+  flex: 1;
+  overflow: auto;
+}
+.aim-console .ac-hint {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--faint);
+  padding: 20px 14px;
+}
+
+/* overview ruler = whole-forest minimap: every node a faint mark, owed lit */
+.aim-console .ac-ruler {
+  width: 14px;
+  flex: none;
+  position: relative;
+  background: #090d0e;
+  border-left: 1px solid var(--line);
+  overflow: hidden;
+}
+.aim-console .ac-ruler::before {
+  content: "OWED";
+  position: absolute;
+  bottom: 6px;
+  left: 0;
+  right: 0;
+  text-align: center;
+  writing-mode: vertical-rl;
+  transform: rotate(180deg);
+  font: 8px var(--mono);
+  letter-spacing: 1px;
+  color: #313c3b;
+}
+.aim-console .ac-tick {
+  position: absolute;
+  left: 3px;
+  right: 3px;
+  height: 1px;
+  background: var(--faint);
+  opacity: 0.18;
+  border: none;
+  padding: 0;
+} /* calm = forest texture */
+.aim-console button.ac-tick {
+  cursor: pointer;
+}
+.aim-console .ac-tick.dr {
+  height: 3px;
+  border-radius: 1px;
+  background: var(--amber);
+  opacity: 0.8;
+}
+.aim-console .ac-tick.cl {
+  height: 2px;
+  border-radius: 1px;
+  background: var(--ochre);
+  opacity: 0.55;
+}
+.aim-console .ac-tick.dr:hover,
+.aim-console .ac-tick.cl:hover {
+  left: 1px;
+  right: 1px;
+  height: 5px;
+  opacity: 1;
+  box-shadow: 0 0 6px currentColor;
+}
+.aim-console .ac-rdiv {
+  position: absolute;
+  left: 0;
+  right: 0;
+  height: 1px;
+  background: var(--cyan);
+  opacity: 0.4;
+}
+
+/* ── shared row ───────────────────────────────────────────────────────── */
+.aim-console .ac-r {
+  display: flex;
+  align-items: center;
+  height: var(--rh);
+  padding-right: 8px;
+  border-left: 2px solid transparent;
+  position: relative;
+}
+.aim-console .ac-r:hover {
+  background: var(--line-2);
+}
+.aim-console .ac-r.sel {
+  background: #0f1818;
+  border-left-color: var(--cyan);
+}
+.aim-console .ac-gut {
+  width: 2px;
+  align-self: stretch;
+  margin-right: 7px;
+  background: transparent;
+  flex: none;
+}
+.aim-console .ac-r.dr .ac-gut {
+  background: var(--amber);
+}
+.aim-console .ac-r.cl .ac-gut {
+  background: var(--ochre);
+}
+.aim-console .ac-r.cf .ac-gut {
+  background: var(--green);
+  opacity: 0.5;
+}
+.aim-console .ac-r.ne .ac-gut {
+  background: #283635;
+}
+.aim-console .ac-r.rt .ac-gut {
+  background: var(--cyan);
+}
+.aim-console .ac-r.done .ac-gut {
+  background: var(--green);
+  opacity: 0.4;
+}
+.aim-console .ac-r.done.dd .ac-gut {
+  background: var(--amber);
+  opacity: 0.7;
+} /* pin #2: done+drift gutter surfaces the owed drift */
+.aim-console .ac-r.dead .ac-gut {
+  background: #3a2a30;
+}
+/* the inner select button — fills the row, no chrome of its own */
+.aim-console .ac-r-main {
+  display: flex;
+  align-items: center;
+  gap: 0;
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+.aim-console .ac-tx {
+  width: 16px;
+  text-align: center;
+  color: var(--faint);
+  font-size: 9px;
+  flex: none;
+  background: transparent;
+  border: none;
+  padding: 0;
+}
+.aim-console button.ac-tx.has {
+  cursor: pointer;
+}
+.aim-console button.ac-tx.has:hover {
+  color: var(--txt);
+}
+.aim-console .ac-gly {
+  width: 14px;
+  text-align: center;
+  flex: none;
+  font-size: 10px;
+}
+.aim-console .ac-gly.dr {
+  color: var(--amber);
+  animation: ac-pulse 2.8s ease-in-out infinite;
+}
+.aim-console .ac-gly.cl {
+  color: var(--ochre);
+}
+.aim-console .ac-gly.dn {
+  color: var(--green);
+}
+.aim-console .ac-gly.dd {
+  color: var(--faint);
+}
+.aim-console .ac-ought {
+  flex: 1;
+  min-width: 0;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  font-size: 12px;
+  margin-left: 2px;
+}
+.aim-console .ac-r.cf .ac-ought {
+  color: var(--dim);
+}
+.aim-console .ac-r.dr .ac-ought {
+  color: #e9d3a4;
+}
+.aim-console .ac-r.done .ac-ought {
+  color: var(--faint);
+}
+.aim-console .ac-r.dead .ac-ought {
+  text-decoration: line-through;
+  color: var(--faint);
+}
+.aim-console .ac-r.dead {
+  opacity: 0.5;
+}
+.aim-console .ac-crumb-i {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--faint);
+  margin-left: 10px;
+  white-space: nowrap;
+  max-width: 34%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  flex: none;
+}
+.aim-console .ac-roll {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--faint);
+  margin-left: auto;
+  padding-left: 9px;
+  flex: none;
+}
+.aim-console .ac-roll .w {
+  color: var(--amber);
+}
+.aim-console .ac-roll .k {
+  color: var(--ochre);
+}
+.aim-console .ac-ism {
+  display: flex;
+  gap: 2px;
+  flex: none;
+  margin-left: 9px;
+}
+.aim-console .ac-ism i {
+  width: 5px;
+  height: 5px;
+  border-radius: 1px;
+}
+.aim-console .ac-ism i.c {
+  background: var(--green);
+}
+.aim-console .ac-ism i.k {
+  background: var(--ochre);
+}
+.aim-console .ac-slug {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--faint);
+  flex: none;
+  white-space: nowrap;
+  margin-left: 9px;
+}
+.aim-console .ac-repo {
+  font-family: var(--mono);
+  font-size: 8px;
+  padding: 1px 4px;
+  border: 1px solid var(--line);
+  border-radius: 2px;
+  color: var(--faint);
+  flex: none;
+  margin-left: 9px;
+}
+.aim-console .ac-repo.pri {
+  color: var(--cyan);
+  border-color: var(--cyan-d);
+}
+
+/* done · drifted cluster header (frontier) */
+.aim-console .ac-ghead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 9px 12px 5px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--faint);
+}
+.aim-console .ac-ghead.calm .c {
+  color: var(--green);
+}
+
+/* per-repo group header */
+.aim-console .ac-repohead {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  height: 26px;
+  padding: 0 9px;
+  background: #0c1314;
+  border-top: 1px solid var(--line);
+  border-bottom: 1px solid var(--line-2);
+  position: sticky;
+  top: 0;
+  z-index: 3;
+}
+.aim-console .ac-repohead.pri {
+  box-shadow: inset 2px 0 0 var(--cyan);
+}
+.aim-console .ac-repohead-main {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+  text-align: left;
+  height: 100%;
+}
+.aim-console .ac-rh-tw {
+  width: 12px;
+  text-align: center;
+  color: var(--faint);
+  font-size: 9px;
+}
+.aim-console .ac-rh-name {
+  font-family: var(--mono);
+  font-size: 11px;
+  font-weight: 600;
+  color: var(--dim);
+  letter-spacing: 0.5px;
+}
+.aim-console .ac-repohead.pri .ac-rh-name {
+  color: var(--cyan);
+}
+.aim-console .ac-rh-stat {
+  margin-left: auto;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--faint);
+}
+.aim-console .ac-rh-stat .w {
+  color: var(--amber);
+}
+.aim-console .ac-rh-stat .k {
+  color: var(--ochre);
+}
+.aim-console .ac-repohead.frontier .ac-rh-stat {
+  margin-left: auto;
+}
+
+/* add-aim affordances */
+.aim-console .ac-addbtn {
+  width: 16px;
+  height: 16px;
+  line-height: 13px;
+  text-align: center;
+  border: 1px solid var(--line);
+  border-radius: 3px;
+  background: transparent;
+  color: var(--dim);
+  font-size: 12px;
+  cursor: pointer;
+  flex: none;
+}
+.aim-console .ac-addbtn:hover {
+  color: var(--cyan);
+  border-color: var(--cyan-d);
+  background: var(--cyan-d);
+}
+.aim-console .ac-repohead .ac-addbtn {
+  margin-left: 8px;
+}
+.aim-console .ac-r .ac-addbtn.row {
+  opacity: 0;
+  margin-left: 6px;
+}
+.aim-console .ac-r:hover .ac-addbtn.row {
+  opacity: 0.8;
+}
+.aim-console .ac-r .ac-addbtn.row:hover {
+  opacity: 1;
+}
+
+/* ── inspector ────────────────────────────────────────────────────────── */
+.aim-console .ac-insp {
+  flex: none;
+  max-height: 0;
+  overflow: hidden;
+  border-top: 1px solid var(--line);
+  background: var(--panel);
+  transition: max-height 0.22s ease;
+}
+.aim-console .ac-insp.on {
+  max-height: 400px;
+}
+.aim-console .ac-insp-in {
+  padding: 12px 14px 14px;
+  overflow: auto;
+  max-height: 400px;
+  position: relative;
+}
+.aim-console .ac-insp-x {
+  position: absolute;
+  top: 9px;
+  right: 12px;
+  color: var(--faint);
+  cursor: pointer;
+  background: transparent;
+  border: none;
+  font-size: inherit;
+}
+.aim-console .ac-insp-x:hover {
+  color: var(--txt);
+}
+.aim-console .ac-icrumb {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 5px;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--faint);
+  margin-bottom: 8px;
+}
+.aim-console .ac-icrumb-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+}
+.aim-console .ac-icrumb-link {
+  background: transparent;
+  border: none;
+  padding: 0;
+  color: var(--faint);
+  font: inherit;
+  cursor: pointer;
+  max-width: 18ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.aim-console .ac-icrumb-link:hover {
+  color: var(--cyan);
+}
+.aim-console .ac-icrumb .s {
+  color: #2c3a39;
+}
+.aim-console .ac-icrumb-cur {
+  color: var(--cyan);
+}
+.aim-console .ac-iought {
+  font-size: 14px;
+  color: #dfe9e6;
+  line-height: 1.45;
+}
+.aim-console .ac-iought b {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--cyan);
+}
+.aim-console .ac-imeta {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  margin: 9px 0 11px;
+}
+.aim-console .ac-pill {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  padding: 2px 7px;
+  border-radius: 3px;
+  border: 1px solid var(--line);
+  color: var(--dim);
+}
+.aim-console .ac-pill.dr {
+  color: var(--amber);
+  border-color: #3a2e14;
+  background: var(--amber-d);
+}
+.aim-console .ac-pill.op {
+  color: var(--cyan);
+  border-color: var(--cyan-d);
+}
+.aim-console .ac-isec {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--faint);
+  margin: 10px 0 5px;
+}
+.aim-console .ac-il {
+  display: flex;
+  gap: 8px;
+  padding: 3px 0;
+  align-items: baseline;
+  font-size: 12px;
+  color: var(--dim);
+}
+.aim-console .ac-il.dim {
+  color: var(--faint);
+}
+.aim-console .ac-tg {
+  font-family: var(--mono);
+  font-size: 9px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  flex: none;
+}
+.aim-console .ac-tg.c {
+  color: var(--green);
+  border: 1px solid var(--green-d);
+}
+.aim-console .ac-tg.k {
+  color: var(--ochre);
+  border: 1px dashed #3a2e1a;
+}
+.aim-console .ac-ref {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--cyan);
+}
+.aim-console .ac-insp-actions {
+  margin-top: 12px;
+}
+
+/* ── buttons (inspector + modal) ──────────────────────────────────────── */
+.aim-console .ac-btn {
+  padding: 6px 12px;
+  border-radius: 6px;
+  font: 500 11.5px var(--sans);
+  cursor: pointer;
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--dim);
+}
+.aim-console .ac-btn:hover {
+  color: var(--txt);
+  border-color: #2c3a39;
+}
+.aim-console .ac-btn.small {
+  padding: 5px 10px;
+  font-size: 11px;
+}
+.aim-console .ac-btn.primary {
+  background: var(--cyan-d);
+  color: var(--cyan);
+  border-color: #1f4541;
+}
+.aim-console .ac-btn.primary:hover {
+  background: #163a38;
+  color: var(--cyan);
+}
+.aim-console .ac-btn.primary:disabled {
+  opacity: 0.38;
+  cursor: not-allowed;
+}
+
+/* ── create / edit modal ──────────────────────────────────────────────── */
+.aim-console .ac-modal-bg {
+  position: fixed;
+  inset: 0;
+  background: rgba(4, 7, 8, 0.62);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100;
+}
+.aim-console .ac-modal {
+  width: 460px;
+  max-width: 92vw;
+  background: var(--panel);
+  border: 1px solid var(--line);
+  border-radius: 9px;
+  box-shadow: 0 24px 70px -22px #000;
+  overflow: hidden;
+}
+.aim-console .ac-modal h3 {
+  margin: 0;
+  padding: 13px 16px;
+  font-size: 13px;
+  font-weight: 600;
+  border-bottom: 1px solid var(--line-2);
+  color: var(--txt);
+}
+.aim-console .ac-modal h3 .ctx {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--faint);
+  font-weight: 400;
+  margin-left: 6px;
+}
+.aim-console .ac-modal-body {
+  padding: 15px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.aim-console .ac-frow {
+  display: flex;
+  gap: 12px;
+}
+.aim-console .ac-fld {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.aim-console .ac-fld-repo {
+  flex: 1;
+}
+.aim-console .ac-fld-parent {
+  flex: 2;
+  min-width: 0;
+}
+.aim-console .ac-fld label {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 0.5px;
+  color: var(--dim);
+  text-transform: uppercase;
+}
+.aim-console .ac-fld label .req {
+  color: var(--amber);
+}
+.aim-console .ac-fld input,
+.aim-console .ac-fld textarea,
+.aim-console .ac-fld select {
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 8px 10px;
+  color: var(--txt);
+  font-family: var(--sans);
+  font-size: 13px;
+  outline: none;
+}
+.aim-console .ac-fld textarea {
+  resize: vertical;
+  min-height: 40px;
+  line-height: 1.5;
+}
+.aim-console .ac-fld select {
+  font-family: var(--mono);
+  font-size: 12px;
+  max-width: 100%;
+}
+.aim-console .ac-fld input:focus,
+.aim-console .ac-fld textarea:focus,
+.aim-console .ac-fld select:focus {
+  border-color: var(--cyan);
+}
+.aim-console .ac-fld input:disabled,
+.aim-console .ac-fld select:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+.aim-console .ac-slugrow {
+  display: flex;
+  gap: 9px;
+  align-items: center;
+}
+.aim-console .ac-slugrow input {
+  flex: 1;
+  font-family: var(--mono);
+  font-size: 12px;
+}
+.aim-console .ac-hint2 {
+  font-size: 10.5px;
+  color: var(--faint);
+}
+.aim-console .ac-hint2.err {
+  color: var(--danger);
+}
+.aim-console .ac-hint2.ok {
+  color: var(--green);
+}
+.aim-console .ac-modal-foot {
+  display: flex;
+  justify-content: flex-end;
+  gap: 9px;
+  padding: 12px 16px;
+  border-top: 1px solid var(--line-2);
+}
+
+@keyframes ac-pulse {
+  0%,
+  100% {
+    opacity: 0.55;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
 @media (prefers-reduced-motion: reduce) {
   .aim-console *,
   .aim-console {


### PR DESCRIPTION
Resolves #795. Stage 2 of 4 reproducing the destination aim-console mock in `clients/react`. S1 (#794) landed the shell; **S2 fills the Aim (left) pane** — previously an S2 `PaneStub` — with the real owed worklist, faithful to the mock's `.aim` section + create-aim modal (`origin/mock/aim-ui-sample`). Serves aim node `aim-ui`.

## The key move: reuse the logic, reproduce the presentation

Stage B already built the entire aim data + logic layer against the **real wire**. S2 imports it wholesale and only ports the mock's markup/classes — it is the *presentation port*, not a re-implementation of the worklist algorithms.

- **REUSE** `r-panel/aim-tree.ts` (`frontierRows` / `doneDriftedRows` / `ledgerCounts` / `rulerOrder` / `aimTone` / `subtreeStats` / `repoStats` / `ancestry` / `breadcrumbText`, all of it as-is), `hooks/useUnitAims` (real forest for the **focused unit**), and `api.createAim` / `api.editAim` (write).
- **REPRODUCE** only the presentation: the mock's classes ported into the scoped `.ac-*` dev-tool tokens in `styles/aim-console.css` (drift→`--amber`, claimed→`--ochre`, confirmed→`--green`, structure/root→`--cyan`).

## What's in the Aim pane (`AimPane.tsx`)

1. **Ledger** — drift / claimed / confirmed counts + the owed/confirmed bar (from `ledgerCounts`).
2. **Controls** — the `Frontier ⚠ | Tree` segmented toggle (mode persisted in `ui-prefs`, same `aimMode` key as RAimsSection) + search/filter + `＋ aim`.
3. **Frontier mode** — the owed worklist (`frontierRows`, drift-first), per-repo grouped, breadcrumbed (`breadcrumbText`), with the `is[]` mini-marks, plus the done-drift cluster (`doneDriftedRows`, pin #2).
4. **Tree mode** — the per-repo collapsible navigator with branch rollups (`subtreeStats` / `repoStats`), tone glyphs/gutters (`aimTone`), expand/collapse.
5. **Overview ruler** — the right-edge minimap (`rulerOrder`), owed ticks lit, repo dividers, click-to-reveal.
6. **Inspector** — collapsible bottom panel: ancestry crumb, the `aim:` ought, meta pills (repo / state / drift←ancestor), the interior `is[]` (mark-only — pin #1), and `✎ 編集` / `＋ 子 aim` actions.
7. **Create-aim modal** — the mock's modal (aim textarea, repo + parent selects, slug field with client-side kebab validation in new `slug.ts`, state select on edit) wired to `api.createAim` / `api.editAim`; refetch-on-write (pin #3). NOTE: `AimCreateRequest` carries no `repo` for root-create (#501 wire gap, deferred to Stage D) — the modal UI is reproduced faithfully but does not fix that wire here.

## Coexist, do not rip

`RAimsSection.tsx` / the existing R-panel / `ProducerConsole` are **untouched** and stay the default. `aim-tree.ts` logic is reused **as-is** (the known `ledgerCounts` done-state edge case is left as a separate follow-up). Session pane (S3) + PR rail (S4) stay S1 stubs. Real data, no mock seed.

## Gates — all green

- `pnpm -C clients/react lint` ✅ (one pre-existing warning in `ProducerFeedChip.tsx`, untouched)
- `pnpm -C clients/react build` ✅
- `pnpm -C clients/react test` ✅ (781 passed; new `AimPane.test.tsx` covers Frontier/Tree/ledger/ruler/inspector/create+edit modal, `slug.test.ts` the validation helpers)

No `any`; wire types imported from `@/types/generated/`, not hand-mirrored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Aim パネルを実装。Frontier/Tree ビューの切り替え、作成・編集機能、インスペクタによる詳細表示に対応しました。
  * Aim 名から slug を自動提案し、入力時に形式と重複をリアルタイム検証します。

* **Style**
  * Aim コンソール用スタイルを追加しました。

* **Tests**
  * Aim パネルおよび関連機能の統合テストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->