### PR TITLE
S3: aim-ui console — Session conversation pane (tabs + term + shead/Handoff, reuse existing infra) (#797)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -690,6 +690,10 @@ export function App() {
         onSelectUnit={handleSelectUnit}
         onAddUnit={handleAddUnit}
         onExit={toggleConsoleMode}
+        agents={agents}
+        currentProjectPath={currentProject}
+        trigger={triggerHandoff}
+        onOpenSettings={openSettingsFromOverride}
       />
     );
   }

--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -12,20 +12,23 @@
 // dev-tool tokens are scoped to `.aim-console` in `styles/aim-console.css`
 // so they never bleed into the existing console.
 //
-// SCOPE so far: the TOKEN LAYER + the SHELL (S1) and the Aim pane (S2). The
-// top bar (real, data-driven unit tabs) and the 3-pane grid incl. the PR-rail
-// expand/collapse transition are S1; the Aim (left) pane is now the real
-// worklist (Frontier⊥Tree, ledger, overview ruler, inspector, create-aim
-// modal — `AimPane`, reusing the Stage B logic layer). The remaining two
-// bodies are still stubs:
-//   - S3 fills the Session conversation (tabs + bash footer);
-//   - S4 fills the PR-rail PR/Issue lists.
+// SCOPE so far: the TOKEN LAYER + the SHELL (S1), the Aim pane (S2), and the
+// Session pane (S3). The top bar (real, data-driven unit tabs) and the 3-pane
+// grid incl. the PR-rail expand/collapse transition are S1; the Aim (left)
+// pane is the real worklist (Frontier⊥Tree, ledger, overview ruler, inspector,
+// create-aim modal — `AimPane`, reusing the Stage B logic layer); the Session
+// (centre) pane is the real conversation surface (tabs + shead + term —
+// `SessionPane`, reusing the existing console infra). The remaining body is
+// still a stub:
+//   - the Session pane LEAVES ROOM for the S4 bash footer (built later);
+//   - the PR-rail PR/Issue lists are still an S4 stub.
 
 import { useState } from "react";
 import { useUnitAttention } from "@/hooks/useUnitAttention";
-import type { UnitResponse } from "@/lib/api";
+import type { AgentSnapshot, TriggerHandoffRitualRequest, UnitResponse } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { AimPane } from "./AimPane";
+import { SessionPane } from "./SessionPane";
 // Bundled dev-tool typography (offline-robust @fontsource, NOT a Google Fonts
 // <link>) — loads the exact families `aim-console.css` references via --sans /
 // --mono so the dev-tool look matches the mock instead of falling back to
@@ -62,6 +65,19 @@ interface AimConsoleProps {
    *  ENTER toggle lives in StatusBar; this is its EXIT pair, since the
    *  full-window aim console replaces the existing chrome incl. StatusBar. */
   onExit: () => void;
+  /** Live agent list (App's `useAgents`) — drives the Session pane's tabs
+   *  (Producer + workers). Threaded in rather than read here so the existing
+   *  console keeps the single `useAgents` call. */
+  agents: AgentSnapshot[];
+  /** Primary repo path for the focused unit (App's `currentProject`) — the
+   *  Session pane resolves the single Producer and scopes workers from it. */
+  currentProjectPath: string | null;
+  /** App-level lifted handoff ritual trigger (one `useHandoffRitual`
+   *  instance, in App), forwarded to the Producer's shead. */
+  trigger: (unit: string, body: TriggerHandoffRitualRequest) => Promise<void>;
+  /** ⚙ deep-link into Settings (auto-handoff threshold), forwarded to the
+   *  Producer's shead. */
+  onOpenSettings: () => void;
 }
 
 export function AimConsole({
@@ -70,6 +86,10 @@ export function AimConsole({
   onSelectUnit,
   onAddUnit,
   onExit,
+  agents,
+  currentProjectPath,
+  trigger,
+  onOpenSettings,
 }: AimConsoleProps) {
   // PR-rail expand state — the only live interaction in the S1 shell. The
   // collapsed 46px rail expands to a 320px panel via the `.pr-open` modifier
@@ -122,16 +142,14 @@ export function AimConsole({
           <AimPane unitName={activeUnitName} />
         </section>
 
-        {/* SESSION — S3 conversation */}
+        {/* SESSION — S3 conversation (tabs + shead + term; bash footer is S4) */}
         <section className="ac-col ac-session" aria-label="Session">
-          <div className="ac-stabs" aria-hidden="true">
-            <span className="ac-stab on">
-              <span className="ac-ro p">PROD</span> Producer
-            </span>
-          </div>
-          <PaneStub
-            stage="S3"
-            note="Session conversation (raw CC), session tabs, and the bash footer land here."
+          <SessionPane
+            agents={agents}
+            unitName={activeUnitName}
+            currentProjectPath={currentProjectPath}
+            trigger={trigger}
+            onOpenSettings={onOpenSettings}
           />
         </section>
 

--- a/clients/react/src/components/aim-console/SessionPane.tsx
+++ b/clients/react/src/components/aim-console/SessionPane.tsx
@@ -1,0 +1,211 @@
+// SessionPane — the centre Session conversation pane of the aim-console (S3).
+//
+// A faithful reproduction of the mock's `.session` section
+// (`origin/mock/aim-ui-sample` → `assets/ui-sample.html`): session tabs
+// (`.stabs`), the `.shead` (model / cwd / Handoff), and the `.term`
+// conversation view — in the aim-console dev-tool tokens (`.ac-stabs` /
+// `.ac-stab` / `.ac-ro`, extended from S1's stub). The mock's docked
+// `.footer` (tabbed bash terminals) is SKIPPED here — that is S4; this pane
+// only RESERVES the strip at the bottom for it (`.ac-sfoot`).
+//
+// REUSE, DON'T REBUILD (issue #797): the existing console already renders
+// agent conversations. This pane wires the SAME infra into the aim-console:
+//   - session tabs ← the live agent list (Producer via `findProducerForUnit`
+//     + the unit's workers);
+//   - shead ← `ProducerConversationHeader` for the Producer (model / cwd /
+//     ctx% + the App-lifted Handoff & restart ritual), a plain model / cwd
+//     bar for a worker;
+//   - term ← `TerminalPanel` (live PTY) / `PreviewPanel` (between selections),
+//     UNCHANGED.
+//
+// The aim console is a full-screen TAKEOVER (App renders ONLY `<AimConsole>`
+// in aim mode), so the selected SESSION is LOCAL state here — NOT App's
+// main-pane selection. `agents` / `trigger` / `unitName` / `currentProjectPath`
+// / `onOpenSettings` are threaded in from App (the aim-console's own wiring);
+// the existing console still consumes them exactly as before.
+
+import { useMemo, useState } from "react";
+import { PreviewPanel } from "@/components/agent/PreviewPanel";
+import { ProducerConversationHeader } from "@/components/producer-console/ProducerConversationHeader";
+import { TerminalPanel } from "@/components/terminal/TerminalPanel";
+import {
+  type AgentSnapshot,
+  isAiAgentLoose,
+  normalizeGitDir,
+  type TriggerHandoffRitualRequest,
+} from "@/lib/api";
+import { findProducerForUnit } from "@/lib/producer";
+import { cn } from "@/lib/utils";
+
+interface SessionPaneProps {
+  /** Live agent list (App's `useAgents`). The Producer is resolved via
+   *  `findProducerForUnit`; the rest of this unit's AI agents are workers. */
+  agents: AgentSnapshot[];
+  /** Unit name (basename of `currentProjectPath`) — scopes the worker tabs
+   *  and keys the handoff ritual endpoint. */
+  unitName: string | null;
+  /** Primary repo path for the focused unit — resolves the single Producer
+   *  and the back-compat (no-`unit`-field) worker scope. */
+  currentProjectPath: string | null;
+  /** App-level lifted handoff ritual trigger (one `useHandoffRitual`
+   *  instance, in App). Threaded straight into `ProducerConversationHeader`. */
+  trigger: (unit: string, body: TriggerHandoffRitualRequest) => Promise<void>;
+  /** ⚙ deep-link into Settings (auto-handoff threshold). */
+  onOpenSettings: () => void;
+}
+
+function repoBasename(path: string): string {
+  return path.split("/").filter(Boolean).pop() ?? path;
+}
+
+// Does this agent belong to the focused unit? Prefer the wire `unit` field
+// (a `[[unit]]` can span several repos, so a worker at a SECONDARY repo still
+// carries the unit's name — #439); fall back to a primary-repo-dir match for
+// an engine not yet rebuilt to serve `unit` (the same transition window
+// `groupByProject` handles).
+function agentInUnit(
+  agent: AgentSnapshot,
+  unitName: string | null,
+  primaryPath: string | null,
+): boolean {
+  if (agent.unit && agent.unit.length > 0) {
+    return unitName !== null && agent.unit === unitName;
+  }
+  if (primaryPath === null) return false;
+  return normalizeGitDir(agent.git_common_dir ?? agent.cwd) === normalizeGitDir(primaryPath);
+}
+
+// Tab status dot colour — reuse ProducerConversationHeader's flat `attention`
+// mapping (tmai-core@2026-05-09 Phase 4): `halted` → at a permission prompt,
+// `started` / `completed` → waiting on the operator, `null` → running.
+function statusClass(attention: AgentSnapshot["attention"]): string {
+  if (attention === "halted") return "halt";
+  if (attention === "started" || attention === "completed") return "wait";
+  return "run";
+}
+
+function statusWord(attention: AgentSnapshot["attention"]): string {
+  if (attention === "halted") return "Halted";
+  if (attention === "completed") return "Done";
+  if (attention === "started") return "Started";
+  return "Active";
+}
+
+export function SessionPane({
+  agents,
+  unitName,
+  currentProjectPath,
+  trigger,
+  onOpenSettings,
+}: SessionPaneProps) {
+  // Producer + workers for the focused unit. The Producer (if any) leads;
+  // workers follow, sorted by name for a stable tab order. Resolution mirrors
+  // the existing console exactly (same `findProducerForUnit`), so both
+  // surfaces agree on who the Producer is.
+  const { producer, sessionAgents } = useMemo(() => {
+    const prod = findProducerForUnit(agents, currentProjectPath);
+    const unitAgents = agents
+      .filter(isAiAgentLoose)
+      .filter((a) => agentInUnit(a, unitName, currentProjectPath));
+    const workers = unitAgents
+      .filter((a) => a.target !== prod?.target)
+      .sort((a, b) => a.display_name.localeCompare(b.display_name));
+    return { producer: prod, sessionAgents: prod ? [prod, ...workers] : workers };
+  }, [agents, unitName, currentProjectPath]);
+
+  // Local selected SESSION — independent of App's main-pane selection, since
+  // the aim console is a full-screen takeover. `null` falls through to the
+  // first tab; a stale target (the session went away) does the same.
+  const [selectedTarget, setSelectedTarget] = useState<string | null>(null);
+  const effectiveTarget = useMemo(() => {
+    if (selectedTarget && sessionAgents.some((a) => a.target === selectedTarget)) {
+      return selectedTarget;
+    }
+    return sessionAgents[0]?.target ?? null;
+  }, [selectedTarget, sessionAgents]);
+  const selectedAgent = sessionAgents.find((a) => a.target === effectiveTarget) ?? null;
+  const isProducerSelected = selectedAgent !== null && selectedAgent.target === producer?.target;
+
+  return (
+    <>
+      {/* ── session tabs (mock `.stabs`) ── */}
+      <div className="ac-stabs" role="tablist" aria-label="Sessions">
+        {sessionAgents.map((a) => {
+          const isProd = a.target === producer?.target;
+          const selected = a.target === effectiveTarget;
+          return (
+            <button
+              key={a.target}
+              type="button"
+              role="tab"
+              aria-selected={selected}
+              className={cn("ac-stab", selected && "on")}
+              onClick={() => setSelectedTarget(a.target)}
+              title={`${isProd ? "Producer" : "worker"}: ${a.display_name} — ${statusWord(a.attention)}`}
+            >
+              <span className={cn("ac-ro", isProd ? "p" : "w")}>{isProd ? "PROD" : "WRK"}</span>
+              <span className="ac-stab-name">{a.display_name}</span>
+              <span
+                className={cn("ac-sdot", statusClass(a.attention))}
+                aria-hidden="true"
+                title={statusWord(a.attention)}
+              />
+            </button>
+          );
+        })}
+        {/* Worker dispatch affordance. Dispatch is an existing capability, not
+            S3 work — rendered faithfully (mock `.sadd`) but inert here. */}
+        <span className="ac-sadd" title="worker dispatch (existing capability)" aria-hidden="true">
+          +
+        </span>
+      </div>
+
+      {/* ── shead (mock `.shead`) ── Producer gets the full
+          ProducerConversationHeader (ctx% + the Handoff & restart ritual);
+          a worker gets a plain model / cwd bar. */}
+      {selectedAgent &&
+        (isProducerSelected ? (
+          <ProducerConversationHeader
+            agents={agents}
+            currentProjectPath={currentProjectPath}
+            unitName={unitName}
+            trigger={trigger}
+            onOpenSettings={onOpenSettings}
+          />
+        ) : (
+          <div className="ac-shead">
+            <span className="m">
+              {selectedAgent.model_display_name ?? selectedAgent.model_id ?? "—"}
+            </span>
+            <span className="w">
+              repo {repoBasename(selectedAgent.git_common_dir ?? selectedAgent.cwd)}
+              {selectedAgent.git_branch ? ` · ${selectedAgent.git_branch}` : ""} ·{" "}
+              {selectedAgent.display_cwd}
+            </span>
+          </div>
+        ))}
+
+      {/* ── term (mock `.term`) ── the raw-CC conversation. Live PTY →
+          TerminalPanel; between selections (no live PTY) → PreviewPanel. */}
+      <div className="ac-term">
+        {selectedAgent ? (
+          selectedAgent.pty_session_id ? (
+            <TerminalPanel key={selectedAgent.target} agentId={selectedAgent.target} />
+          ) : (
+            <PreviewPanel key={selectedAgent.target} agentId={selectedAgent.target} />
+          )
+        ) : (
+          <div className="ac-term-empty">
+            No active session for this unit — launch a Producer or dispatch a worker.
+          </div>
+        )}
+      </div>
+
+      {/* ── footer reservation ── the docked bash footer is S4; this pane only
+          LEAVES ROOM for it (mock `.footer` collapsed height). Not built. */}
+      <div className="ac-sfoot" aria-hidden="true" data-testid="aim-session-footer-reserve">
+        <span className="ac-sfoot-hint">bash · S4</span>
+      </div>
+    </>
+  );
+}

--- a/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
@@ -52,6 +52,14 @@ function renderConsole(overrides: Partial<Parameters<typeof AimConsole>[0]> = {}
     onSelectUnit: vi.fn(),
     onAddUnit: vi.fn(),
     onExit: vi.fn(),
+    // S3 Session-pane wiring — empty here so the shell tests stay
+    // data-agnostic (no live sessions → the pane parks in its empty state,
+    // no TerminalPanel / PreviewPanel mount, no SSE). The pane's own
+    // behaviour is covered in SessionPane.test.tsx.
+    agents: [],
+    currentProjectPath: "/home/u/tmai" as string | null,
+    trigger: vi.fn(),
+    onOpenSettings: vi.fn(),
     ...overrides,
   };
   render(
@@ -74,14 +82,18 @@ describe("AimConsole — S1 shell", () => {
     expect(screen.getByLabelText("PR / Issue rail")).toBeTruthy();
   });
 
-  it("fills the Aim pane (S2) and leaves Session / PR-rail as S3 / S4 stubs", () => {
+  it("fills the Aim (S2) and Session (S3) panes, leaves the PR-rail as an S4 stub", () => {
     renderConsole();
     // The Aim pane is now the real worklist: no S2 stub, real chrome present.
     expect(screen.queryByTestId("aim-pane-stub-s2")).toBeNull();
     expect(screen.getByTestId("aim-ledger")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Frontier ⚠" })).toBeTruthy();
-    // Session + PR-rail bodies remain stubs.
-    expect(screen.getByTestId("aim-pane-stub-s3")).toBeTruthy();
+    // The Session pane is real now (no S3 stub): the session tablist + the
+    // S4-footer reservation render even with no live sessions.
+    expect(screen.queryByTestId("aim-pane-stub-s3")).toBeNull();
+    expect(screen.getByRole("tablist", { name: "Sessions" })).toBeTruthy();
+    expect(screen.getByTestId("aim-session-footer-reserve")).toBeTruthy();
+    // The PR-rail body remains an S4 stub.
     expect(screen.getByTestId("aim-pane-stub-s4")).toBeTruthy();
   });
 

--- a/clients/react/src/components/aim-console/__tests__/SessionPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/SessionPane.test.tsx
@@ -1,0 +1,194 @@
+// @vitest-environment jsdom
+//
+// SessionPane (S3) test. The Session pane is a faithful reproduction of the
+// mock's `.session` section (session tabs + shead + term), wiring the EXISTING
+// console infra into the aim-console:
+//   - tabs ← the live agent list (Producer via `findProducerForUnit` + the
+//     unit's workers);
+//   - shead ← ProducerConversationHeader for the Producer (the Handoff &
+//     restart ritual), a plain model/cwd bar for a worker;
+//   - term ← TerminalPanel (live PTY) / PreviewPanel (no live PTY).
+//
+// TerminalPanel / PreviewPanel are heavy (xterm + the PTY plane), so they are
+// stubbed to the agentId they receive — the pane logic under test is the tab
+// list, the LOCAL session selection, and the shead split. `api` is mocked so
+// ProducerConversationHeader's settings fetch never hits the network.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { AgentSnapshot } from "@/lib/api";
+import { SessionPane } from "../SessionPane";
+
+vi.mock("@/components/terminal/TerminalPanel", () => ({
+  TerminalPanel: ({ agentId }: { agentId: string }) => (
+    <div data-testid="ac-term-terminal">{agentId}</div>
+  ),
+}));
+vi.mock("@/components/agent/PreviewPanel", () => ({
+  PreviewPanel: ({ agentId }: { agentId: string }) => (
+    <div data-testid="ac-term-preview">{agentId}</div>
+  ),
+}));
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      // Park the threshold fetch in flight — the pane tests don't assert on
+      // the ctx readout, and this keeps the network out of jsdom.
+      getOrchestratorSettings: () => new Promise<never>(() => {}),
+    },
+  };
+});
+
+function stubAgent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot {
+  return {
+    id: partial.id,
+    target: partial.target ?? partial.id,
+    agent_type: partial.agent_type ?? "ClaudeCode",
+    title: partial.title ?? partial.id,
+    cwd: partial.cwd ?? "/home/u/tmai",
+    display_cwd: partial.display_cwd ?? "~/tmai",
+    display_name: partial.display_name ?? partial.id,
+    detection_source: partial.detection_source ?? "IpcSocket",
+    git_branch: partial.git_branch ?? "main",
+    git_dirty: partial.git_dirty ?? false,
+    is_worktree: partial.is_worktree ?? false,
+    git_common_dir: partial.git_common_dir ?? "/home/u/tmai/.git",
+    unit: partial.unit,
+    worktree_name: partial.worktree_name ?? null,
+    worktree_base_branch: partial.worktree_base_branch ?? null,
+    effort_level: partial.effort_level ?? null,
+    active_subagents: partial.active_subagents ?? 0,
+    compaction_count: partial.compaction_count ?? 0,
+    pty_session_id: partial.pty_session_id ?? null,
+    send_capability: partial.send_capability ?? "Ipc",
+    is_virtual: partial.is_virtual ?? false,
+    team_info: partial.team_info ?? null,
+    attention: partial.attention ?? null,
+    model_id: partial.model_id,
+    model_display_name: partial.model_display_name,
+  };
+}
+
+// A `[[unit]]` spanning tmai + tmai-core: the Producer at the primary repo, a
+// worker in each repo (the secondary-repo worker carries `unit` so it still
+// scopes in), plus two agents that must NOT appear — a bash terminal (not an
+// AI agent) and a worker from a different unit.
+const PRODUCER = stubAgent({
+  id: "claude:prod",
+  display_name: "Producer",
+  is_worktree: false,
+  git_common_dir: "/home/u/tmai/.git",
+  unit: "tmai",
+  model_display_name: "opus-4.8",
+  pty_session_id: "pty-prod",
+});
+const WORKER_UI = stubAgent({
+  id: "claude:w1",
+  display_name: "attention-ui",
+  is_worktree: true,
+  git_common_dir: "/home/u/tmai/.git",
+  unit: "tmai",
+  model_display_name: "sonnet-4.6",
+  pty_session_id: "pty-w1",
+});
+const WORKER_DRIFT = stubAgent({
+  id: "claude:w2",
+  display_name: "drift-cycle",
+  is_worktree: true,
+  git_common_dir: "/home/u/tmai-core/.git",
+  unit: "tmai",
+  model_id: "opus-4.8",
+  pty_session_id: null, // no live PTY → PreviewPanel
+  attention: "started",
+});
+const BASH_TERM = stubAgent({
+  id: "bash:term1",
+  agent_type: { Custom: "bash" },
+  display_name: "sh-1",
+  unit: "tmai",
+});
+const OTHER_UNIT = stubAgent({
+  id: "claude:other",
+  display_name: "infra-worker",
+  is_worktree: true,
+  git_common_dir: "/home/u/infra/.git",
+  unit: "infra",
+});
+
+const ALL_AGENTS = [PRODUCER, WORKER_UI, WORKER_DRIFT, BASH_TERM, OTHER_UNIT];
+
+function renderPane(overrides: Partial<Parameters<typeof SessionPane>[0]> = {}) {
+  const props = {
+    agents: ALL_AGENTS,
+    unitName: "tmai" as string | null,
+    currentProjectPath: "/home/u/tmai" as string | null,
+    trigger: vi.fn(),
+    onOpenSettings: vi.fn(),
+    ...overrides,
+  };
+  render(<SessionPane {...props} />);
+  return props;
+}
+
+describe("SessionPane — S3 Session conversation", () => {
+  it("renders one tab per session agent — Producer (PROD) + this unit's workers (WRK)", () => {
+    renderPane();
+    const tabs = screen.getAllByRole("tab");
+    // Producer first, then workers sorted by name (attention-ui, drift-cycle).
+    expect(tabs.map((t) => t.textContent)).toEqual([
+      expect.stringContaining("Producer"),
+      expect.stringContaining("attention-ui"),
+      expect.stringContaining("drift-cycle"),
+    ]);
+    // Role badges: PROD on the Producer, WRK on a worker.
+    expect(screen.getByRole("tab", { name: /Producer/ }).textContent).toContain("PROD");
+    expect(screen.getByRole("tab", { name: /attention-ui/ }).textContent).toContain("WRK");
+  });
+
+  it("excludes non-AI terminals and agents from other units", () => {
+    renderPane();
+    expect(screen.queryByRole("tab", { name: /sh-1/ })).toBeNull();
+    expect(screen.queryByRole("tab", { name: /infra-worker/ })).toBeNull();
+  });
+
+  it("defaults to the Producer and switches the term when another tab is selected", () => {
+    renderPane();
+    // Default selection = Producer (a live PTY → TerminalPanel).
+    expect(screen.getByTestId("ac-term-terminal").textContent).toBe("claude:prod");
+
+    // A worker with no live PTY → PreviewPanel.
+    fireEvent.click(screen.getByRole("tab", { name: /drift-cycle/ }));
+    expect(screen.queryByTestId("ac-term-terminal")).toBeNull();
+    expect(screen.getByTestId("ac-term-preview").textContent).toBe("claude:w2");
+
+    // A worker with a live PTY → TerminalPanel again.
+    fireEvent.click(screen.getByRole("tab", { name: /attention-ui/ }));
+    expect(screen.getByTestId("ac-term-terminal").textContent).toBe("claude:w1");
+  });
+
+  it("renders the Handoff & restart shead for the Producer, a plain bar for a worker", () => {
+    renderPane();
+    // Producer selected by default → the ProducerConversationHeader shead
+    // carries the Handoff & restart ritual.
+    expect(screen.getByRole("button", { name: /Handoff & restart/ })).toBeTruthy();
+
+    // Switch to a worker → no Handoff ritual; plain model/cwd bar instead.
+    fireEvent.click(screen.getByRole("tab", { name: /attention-ui/ }));
+    expect(screen.queryByRole("button", { name: /Handoff & restart/ })).toBeNull();
+    expect(screen.getByText("sonnet-4.6")).toBeTruthy();
+  });
+
+  it("reserves the bottom strip for the S4 bash footer (does not fill the whole pane)", () => {
+    renderPane();
+    expect(screen.getByTestId("aim-session-footer-reserve")).toBeTruthy();
+  });
+
+  it("renders an empty state when the unit has no live sessions", () => {
+    renderPane({ agents: [] });
+    expect(screen.queryAllByRole("tab")).toHaveLength(0);
+    expect(screen.getByText(/No active session for this unit/)).toBeTruthy();
+  });
+});

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -291,27 +291,136 @@
   padding: 0 11px;
   height: 29px;
   color: var(--dim);
+  font-family: var(--sans);
   font-size: 11.5px;
+  background: transparent;
   border: 1px solid transparent;
   border-bottom: none;
   border-radius: 3px 3px 0 0;
   position: relative;
   top: 1px;
+  cursor: pointer;
+}
+.aim-console .ac-stab:hover {
+  background: var(--line-2);
+  color: var(--txt);
 }
 .aim-console .ac-stab.on {
   background: var(--bg);
   color: var(--txt);
   border-color: var(--line-2);
 }
+.aim-console .ac-stab-name {
+  max-width: 13ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .aim-console .ac-ro {
   font-family: var(--mono);
   font-size: 8px;
   padding: 1px 4px;
   border-radius: 3px;
+  flex: none;
 }
 .aim-console .ac-ro.p {
   color: var(--cyan);
   border: 1px solid var(--cyan-d);
+}
+.aim-console .ac-ro.w {
+  color: var(--violet);
+  border: 1px solid var(--violet-d);
+}
+/* per-tab status dot — colour reflects the agent's `attention` axis. */
+.aim-console .ac-sdot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  flex: none;
+  background: var(--faint);
+}
+.aim-console .ac-sdot.run {
+  background: var(--green);
+}
+.aim-console .ac-sdot.wait {
+  background: var(--amber);
+}
+.aim-console .ac-sdot.halt {
+  background: var(--danger);
+}
+/* worker-dispatch affordance (mock `.sadd`) — inert in S3 (dispatch is an
+   existing capability, not new work here). */
+.aim-console .ac-sadd {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  height: 29px;
+  color: var(--faint);
+  font-size: 14px;
+}
+
+/* ── shead (mock `.shead`) — the WORKER plain model/cwd bar. The Producer
+   reuses ProducerConversationHeader (its own tokens), not this. ─────────── */
+.aim-console .ac-shead {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  flex: none;
+  padding: 7px 12px;
+  border-bottom: 1px solid var(--line-2);
+  background: var(--panel);
+  font-size: 11px;
+  color: var(--dim);
+}
+.aim-console .ac-shead .m {
+  font-family: var(--mono);
+  color: var(--txt);
+}
+.aim-console .ac-shead .w {
+  font-family: var(--mono);
+  color: var(--faint);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* ── term (mock `.term`) — the conversation surface. TerminalPanel /
+   PreviewPanel fill it; this is just the flex container. ────────────────── */
+.aim-console .ac-term {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+  background: #070a0b;
+}
+.aim-console .ac-term-empty {
+  margin: auto;
+  padding: 24px;
+  text-align: center;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--faint);
+}
+
+/* ── footer reservation ── the docked bash footer is S4; S3 only RESERVES
+   this strip (mock `.footer` collapsed height) so the term doesn't fill the
+   whole pane. Not the footer itself. ────────────────────────────────────── */
+.aim-console .ac-sfoot {
+  flex: none;
+  height: 33px;
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  background: var(--panel);
+  border-top: 1px solid var(--line);
+}
+.aim-console .ac-sfoot-hint {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--faint);
+  letter-spacing: 0.5px;
 }
 
 /* ── PR rail (collapsed rail ⇄ expanded panel — the S1 transition) ─────── */


### PR DESCRIPTION
Resolves #797. Stage 3 of the aim-console rebuild in `clients/react`: fills the **centre Session pane** (was the S1 `PaneStub`) with the real conversation surface, faithful to the mock's `.session` section (`origin/mock/aim-ui-sample` → `assets/ui-sample.html`) **minus** the docked bash footer (that is S4 — this pane only reserves room for it). Serves aim node `aim-ui`. **Coexist, do not rip**: the existing `ProducerConsole` + App's main-pane conversation rendering stay the default and are untouched.

## What this does — REUSE, don't rebuild

New `SessionPane` wires the **existing console infra** into the aim-console dev-tool tokens (extends S1's `.ac-stabs`/`.ac-stab`/`.ac-ro`):

- **Session tabs** — one tab per agent from the live list: the **Producer** (`PROD` badge, resolved via the shared `findProducerForUnit` — same resolver the existing console uses) + **this unit's workers** (`WRK` badge), each with the name + an attention status dot. Workers are scoped to the focused unit via the wire `unit` field (so a worker at a *secondary* repo of a multi-repo unit still scopes in), with a primary-repo-dir fallback for a not-yet-rebuilt engine. The `+` worker-dispatch affordance is rendered faithfully but **inert** (dispatch is an existing capability, not S3 work).
- **shead** — `ProducerConversationHeader` for the Producer (model / cwd / ctx% + the **Handoff & restart** ritual fired via the App-lifted `trigger`); a plain `.ac-shead` model/cwd bar for a worker.
- **term** — `TerminalPanel` (live PTY) / `PreviewPanel` (no live PTY), unchanged.

The aim console is a **full-screen takeover**, so the selected session is **local state** in `SessionPane`, not App's main-pane selection.

## Wiring

`AimConsole` gains four props threaded from `App.tsx` — `agents`, `currentProjectPath`, `trigger` (handoff), `onOpenSettings`. The existing console keeps its single `useAgents` call and consumes those values exactly as before. `ProducerConsole` / App's main-pane rendering / `TerminalPanel` internals are **not touched**.

## Out of scope (later stages)

- **S4**: the docked bash footer — the pane leaves a 33px reserved strip (`.ac-sfoot`) at the bottom so the term doesn't fill the whole height; not built.
- **S5**: the PR rail — its stub stays.

## Gate — all green locally

- `pnpm -C clients/react lint` ✓ (exit 0)
- `pnpm -C clients/react build` ✓ (exit 0)
- `pnpm -C clients/react test` ✓ (97 files, 790 passed / 2 skipped)

New `SessionPane.test.tsx`: tabs from agents (incl. unit-scoping + non-AI/other-unit filtering), selection switches the term across the PTY/preview branch, Producer Handoff shead vs worker plain bar, footer reservation, empty state. `AimConsole.test.tsx` updated for the now-filled S3 pane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * セッション管理ペインが追加され、セッションタブの表示と選択機能が実装されました。
  * エージェント選択に応じた表示パネル（ターミナル/プレビュー）の切り替え機能が追加されました。
  * ハンドオフ & リスタート操作のUI機能が実装されました。

* **スタイル**
  * セッションペインのタブ、ヘッダー、ターミナル領域のスタイリングが追加されました。

* **テスト**
  * セッションペインの動作検証テストが追加されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->