### PR TITLE
S4: aim-ui console — docked bash footer (per-repo + ad-hoc shell terminals, split, collapse; reuse spawnPty + TerminalPanel) (#799)

### DIFF
--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -12,16 +12,17 @@
 // dev-tool tokens are scoped to `.aim-console` in `styles/aim-console.css`
 // so they never bleed into the existing console.
 //
-// SCOPE so far: the TOKEN LAYER + the SHELL (S1), the Aim pane (S2), and the
-// Session pane (S3). The top bar (real, data-driven unit tabs) and the 3-pane
-// grid incl. the PR-rail expand/collapse transition are S1; the Aim (left)
-// pane is the real worklist (Frontier⊥Tree, ledger, overview ruler, inspector,
-// create-aim modal — `AimPane`, reusing the Stage B logic layer); the Session
-// (centre) pane is the real conversation surface (tabs + shead + term —
-// `SessionPane`, reusing the existing console infra). The remaining body is
-// still a stub:
-//   - the Session pane LEAVES ROOM for the S4 bash footer (built later);
-//   - the PR-rail PR/Issue lists are still an S4 stub.
+// SCOPE so far: the TOKEN LAYER + the SHELL (S1), the Aim pane (S2), the
+// Session pane (S3), and its docked bash footer (S4). The top bar (real,
+// data-driven unit tabs) and the 3-pane grid incl. the PR-rail expand/collapse
+// transition are S1; the Aim (left) pane is the real worklist (Frontier⊥Tree,
+// ledger, overview ruler, inspector, create-aim modal — `AimPane`, reusing the
+// Stage B logic layer); the Session (centre) pane is the real conversation
+// surface (tabs + shead + term — `SessionPane`, reusing the existing console
+// infra) with the real docked bash footer (per-repo + ad-hoc shell terminals,
+// reusing `api.spawnPty` + `TerminalPanel`). The remaining body is still a
+// stub:
+//   - the PR-rail PR/Issue lists are still an S5 stub.
 
 import { useState } from "react";
 import { useUnitAttention } from "@/hooks/useUnitAttention";
@@ -94,9 +95,13 @@ export function AimConsole({
   // PR-rail expand state — the only live interaction in the S1 shell. The
   // collapsed 46px rail expands to a 320px panel via the `.pr-open` modifier
   // on the root (mock `body.pr-open { --pr: 320px }`). The panel CONTENT is
-  // an S4 stub.
+  // an S5 stub.
   const [prOpen, setPrOpen] = useState(false);
   const metaUnit = activeUnitName ?? units[0]?.name ?? "—";
+  // The focused unit's repos drive the Session pane's per-repo bash footer
+  // tabs (S4). A cwd-synthesized unit isn't in the configured membership, so
+  // `repos` is empty there — the footer falls back to `currentProjectPath`.
+  const activeUnit = units.find((u) => u.name === activeUnitName) ?? null;
 
   return (
     <div className={cn("aim-console", prOpen && "pr-open")} data-testid="aim-console">
@@ -142,7 +147,7 @@ export function AimConsole({
           <AimPane unitName={activeUnitName} />
         </section>
 
-        {/* SESSION — S3 conversation (tabs + shead + term; bash footer is S4) */}
+        {/* SESSION — S3 conversation (tabs + shead + term) + S4 bash footer */}
         <section className="ac-col ac-session" aria-label="Session">
           <SessionPane
             agents={agents}
@@ -150,10 +155,11 @@ export function AimConsole({
             currentProjectPath={currentProjectPath}
             trigger={trigger}
             onOpenSettings={onOpenSettings}
+            repos={activeUnit?.repos ?? []}
           />
         </section>
 
-        {/* PR RAIL — collapsed rail ⇄ expanded panel (S1); lists are S4 */}
+        {/* PR RAIL — collapsed rail ⇄ expanded panel (S1); lists are S5 */}
         <section className="ac-col ac-pr" aria-label="PR / Issue rail">
           <button
             type="button"
@@ -182,7 +188,7 @@ export function AimConsole({
             </div>
             <div className="ac-prb">
               <PaneStub
-                stage="S4"
+                stage="S5"
                 note="PR / Issue lists (the rail's expand/collapse content) land here."
               />
             </div>

--- a/clients/react/src/components/aim-console/BashFooter.tsx
+++ b/clients/react/src/components/aim-console/BashFooter.tsx
@@ -134,6 +134,10 @@ export function BashFooter({ repos, primaryPath, agents }: BashFooterProps) {
     }));
     return [...repoTabs, ...adhoc];
   }, [footerRepos, adhoc]);
+  // Current tabs for the click handlers (which are []-dep callbacks) — lets a
+  // tab click re-attempt activation by key without re-binding on every render.
+  const tabsRef = useRef(tabs);
+  tabsRef.current = tabs;
 
   // Highlighted tab — the explicit selection if still present, else the first
   // tab (for the chrome; spawning still waits for an actual activation).
@@ -145,12 +149,32 @@ export function BashFooter({ repos, primaryPath, agents }: BashFooterProps) {
   const partnerTab =
     splitOn && tabs.length >= 2 ? (tabs.find((t) => t.key !== activeTab?.key) ?? null) : null;
 
-  // Lazily spawn (or re-attach) a tab's PTY. Idempotent: a tab that already
-  // has a session, or one mid-spawn, is a no-op. The guard is set
-  // synchronously BEFORE any await so a re-entrant call (StrictMode's
-  // double-invoked effect) can't race a second spawn.
+  // Lazily spawn (or re-attach) a tab's PTY. Idempotent for a tab that is
+  // mid-spawn or already attached to a LIVE shell; but a stored session whose
+  // bash has DIED (its agent is gone from the list) is treated as stale —
+  // cleared and re-spawned — so a non-closeable repo tab can't get stranded on
+  // a dead terminal until the whole console remounts.
   const activate = useCallback((tab: FooterTab) => {
-    if (spawningRef.current.has(tab.key) || sessionsRef.current[tab.key]) return;
+    // A spawn in flight, OR a spawned session not yet confirmed live on the
+    // wire: `spawningRef` holds the key across that whole window, so this guard
+    // also blocks StrictMode's double-invoked effect AND the brief spawn→wire
+    // gap from racing a second spawn. The key is released only once the session
+    // is observed live (the liveness effect below) or the spawn fails / closes.
+    if (spawningRef.current.has(tab.key)) return;
+    // Already attached to a live shell — nothing to do.
+    const stored = sessionsRef.current[tab.key];
+    if (stored && resolveAgent(stored, agentsRef.current)) return;
+    // A settled-then-DEAD session: drop the stale id and fall through to
+    // re-attach / spawn (the still-in-flight case was caught by the guard
+    // above, so this only fires for a session that was live and has since
+    // exited — e.g. the user ran `exit` in the footer bash).
+    if (stored) {
+      setSessions((cur) => {
+        const next = { ...cur };
+        delete next[tab.key];
+        return next;
+      });
+    }
     spawningRef.current.add(tab.key);
 
     // Re-attach BEFORE spawning — re-use an already-running shell at this
@@ -188,11 +212,33 @@ export function BashFooter({ repos, primaryPath, agents }: BashFooterProps) {
     if (partnerTab) activate(partnerTab);
   }, [open, activeTab, partnerTab, activate]);
 
+  // Release the in-flight guard once the wire confirms a stored session as a
+  // live agent. Until then `spawningRef` holds the key (covering the spawn→wire
+  // window); releasing it on confirmation is what lets a LATER death of that
+  // shell re-trigger a spawn on the next activation (the `activate` liveness
+  // check). Driven by `agents` / `sessions` so it tracks the live roster.
+  useEffect(() => {
+    for (const [key, id] of Object.entries(sessions)) {
+      if (resolveAgent(id, agents)) {
+        spawningRef.current.delete(key);
+      }
+    }
+  }, [agents, sessions]);
+
   // ── tab-bar actions ──────────────────────────────────────────────────────
-  const openOnto = useCallback((key: string) => {
-    setActiveKey(key);
-    setOpen(true);
-  }, []);
+  const openOnto = useCallback(
+    (key: string) => {
+      setActiveKey(key);
+      setOpen(true);
+      // Re-attempt activation on every click — covers re-clicking the ALREADY-
+      // active tab to revive a dead shell, where no state change would re-run
+      // the spawn effect on its own. `activate` is guarded, so a click on a
+      // live tab is a no-op.
+      const tab = tabsRef.current.find((t) => t.key === key);
+      if (tab) activate(tab);
+    },
+    [activate],
+  );
 
   const toggleOpen = useCallback(() => {
     setOpen((v) => !v);

--- a/clients/react/src/components/aim-console/BashFooter.tsx
+++ b/clients/react/src/components/aim-console/BashFooter.tsx
@@ -1,0 +1,367 @@
+// BashFooter — the docked bash footer of the aim-console Session pane (S4).
+//
+// A faithful reproduction of the mock's `.footer` (`origin/mock/aim-ui-sample`
+// → `assets/ui-sample.html`, the `.footer`/`.fbar`/`.ftab`/`.ftwrap` chrome +
+// the `terms[]` / renderFt / switchTerm / addTerm / split / collapse JS), in
+// the aim-console dev-tool tokens (`.ac-footer` / `.ac-fbar` / `.ac-ftab` /
+// `.ac-ftwrap`). It docks at the bottom of the Session pane, replacing S3's
+// `.ac-sfoot` reservation strip.
+//
+// REUSE, DON'T REBUILD (issue #799): the shell-terminal primitives already
+// exist — this footer does NOT add a new PTY layer.
+//   - `api.spawnPty({ command: "bash", cwd })` opens a shell PTY in a repo's
+//     cwd (`bash` is an existing spawn-allow-list runtime);
+//   - `TerminalPanel` renders the live PTY by the resolved agent target
+//     (reused AS-IS — its internals are untouched);
+//   - the live agent list (App's `useAgents`, threaded in as `agents`) lets
+//     the footer DISCOVER an already-running bash for a repo's cwd and
+//     RE-ATTACH to it rather than spawn a duplicate.
+//
+// LAZY SPAWN (load-bearing resource hygiene): these are real OS processes.
+// NOTHING is spawned on mount — the footer mounts COLLAPSED with no live
+// terminal. A repo's PTY is spawned (or re-attached) only when its tab is
+// first surfaced (the footer opened onto it, the tab clicked, or split made it
+// the partner pane). Ad-hoc shells spawn on the explicit `+`. Closing an
+// ad-hoc tab kills its PTY (`api.killAgent`) so we never strand orphan shells.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { TerminalPanel } from "@/components/terminal/TerminalPanel";
+import { type AgentSnapshot, api, isAiAgentLoose, normalizeGitDir } from "@/lib/api";
+import { cn } from "@/lib/utils";
+import type { UnitRepoWire } from "@/types/generated/UnitRepoWire";
+
+interface BashFooterProps {
+  /** The focused unit's repos (primary first; the same `repos[]` order the
+   *  top-bar tab uses). One per-repo bash tab each. Empty for a
+   *  cwd-synthesized unit not in the configured membership — then the footer
+   *  falls back to a single tab at `primaryPath`. */
+  repos: UnitRepoWire[];
+  /** The unit's primary repo cwd — ad-hoc shells (`sh-N`) spawn here, and it
+   *  is the fallback single repo when `repos` is empty. `null` when no unit /
+   *  project is focused (the footer then shows only the `+` affordance). */
+  primaryPath: string | null;
+  /** Live agent list (App's `useAgents`). Read to discover already-running
+   *  bash sessions (re-attach over duplicate) and to resolve a spawned
+   *  `session_id` → the canonical agent target `TerminalPanel` subscribes on
+   *  (the same id mapping the existing console uses). */
+  agents: AgentSnapshot[];
+}
+
+type TabKind = "repo" | "adhoc";
+
+interface FooterTab {
+  /** Stable key — `repo:<path>` for a per-repo tab, `adhoc:<seq>` for an
+   *  ad-hoc shell. Keys the React list, the active-tab tracking, and the
+   *  lazy-spawn session map. */
+  key: string;
+  kind: TabKind;
+  /** Tab caption — a repo basename, or `sh-N` for an ad-hoc shell. */
+  label: string;
+  /** Spawn cwd for this tab's bash. */
+  cwd: string;
+  /** Only ad-hoc shells carry the `×` close affordance (mock `closeable`). */
+  closeable: boolean;
+}
+
+function repoBasename(path: string): string {
+  return path.split("/").filter(Boolean).pop() ?? path;
+}
+
+// An already-running plain shell (NOT an AI agent — `isAiAgentLoose` excludes
+// the bash-wrapped Producer and the workers) whose cwd is this repo. Found by
+// normalized-cwd equality so a footer-spawned `bash` at the repo root
+// re-attaches on the next activation instead of leaking a second shell.
+function findExistingBash(cwd: string, agents: AgentSnapshot[]): AgentSnapshot | undefined {
+  const target = normalizeGitDir(cwd);
+  return agents.find((a) => !isAiAgentLoose(a) && normalizeGitDir(a.cwd) === target);
+}
+
+// Resolve a stored PTY id (a `spawnPty` `session_id`, or an agent `target`
+// from a re-attach) to its live snapshot. `target` is the stable key across
+// the provisional→canonical re-key; fall back to `id`, exactly as the
+// existing console's `selectedAgent` lookup does.
+function resolveAgent(
+  storedId: string | undefined,
+  agents: AgentSnapshot[],
+): AgentSnapshot | undefined {
+  if (!storedId) return undefined;
+  return agents.find((a) => a.target === storedId || a.id === storedId);
+}
+
+export function BashFooter({ repos, primaryPath, agents }: BashFooterProps) {
+  // Collapsed (33px tab bar) ↔ expanded (210px) — the mock's `body.bash-on`,
+  // local here. Starts COLLAPSED so mount spawns nothing.
+  const [open, setOpen] = useState(false);
+  const [splitOn, setSplitOn] = useState(false);
+  // Per-repo + ad-hoc tab → its live PTY id (a `spawnPty` session_id or a
+  // re-attached agent target). A key is absent until its tab is first
+  // surfaced — that absence is the lazy-spawn gate.
+  const [sessions, setSessions] = useState<Record<string, string>>({});
+  const [adhoc, setAdhoc] = useState<FooterTab[]>([]);
+  const [activeKey, setActiveKey] = useState<string | null>(null);
+  const seqRef = useRef(0);
+
+  // Read `agents` / `sessions` inside the activation + close callbacks without
+  // making them (and the spawn effect) re-run on every SSE tick — only the
+  // snapshot at the moment of the action matters.
+  const agentsRef = useRef(agents);
+  agentsRef.current = agents;
+  const sessionsRef = useRef(sessions);
+  sessionsRef.current = sessions;
+  // In-flight / settled spawn guard, keyed by tab key. Prevents a concurrent
+  // double-spawn (StrictMode's double-invoked effect, an agents-driven effect
+  // re-run) for the same tab; the key stays once spawned so a resolved tab is
+  // never re-spawned. Cleared only on a failed spawn (to allow a retry) or on
+  // close. The spawn/kill side effects run OUTSIDE the state updaters (which
+  // StrictMode double-invokes) so they fire exactly once.
+  const spawningRef = useRef<Set<string>>(new Set());
+
+  // Per-repo tabs (lazy) — derived from the unit's repos, falling back to the
+  // primary path for a unit absent from the configured membership.
+  const footerRepos: UnitRepoWire[] = useMemo(() => {
+    if (repos.length > 0) return repos;
+    if (primaryPath) return [{ path: primaryPath, primary: true }];
+    return [];
+  }, [repos, primaryPath]);
+
+  const tabs: FooterTab[] = useMemo(() => {
+    const repoTabs: FooterTab[] = footerRepos.map((r) => ({
+      key: `repo:${r.path}`,
+      kind: "repo",
+      label: repoBasename(r.path),
+      cwd: r.path,
+      closeable: false,
+    }));
+    return [...repoTabs, ...adhoc];
+  }, [footerRepos, adhoc]);
+
+  // Highlighted tab — the explicit selection if still present, else the first
+  // tab (for the chrome; spawning still waits for an actual activation).
+  const effectiveActiveKey =
+    activeKey && tabs.some((t) => t.key === activeKey) ? activeKey : (tabs[0]?.key ?? null);
+  const activeTab = tabs.find((t) => t.key === effectiveActiveKey) ?? null;
+  // Split partner — the first OTHER tab (mock `terms.find(t => t.id !== a.id)`).
+  // Split needs two tabs to mean anything.
+  const partnerTab =
+    splitOn && tabs.length >= 2 ? (tabs.find((t) => t.key !== activeTab?.key) ?? null) : null;
+
+  // Lazily spawn (or re-attach) a tab's PTY. Idempotent: a tab that already
+  // has a session, or one mid-spawn, is a no-op. The guard is set
+  // synchronously BEFORE any await so a re-entrant call (StrictMode's
+  // double-invoked effect) can't race a second spawn.
+  const activate = useCallback((tab: FooterTab) => {
+    if (spawningRef.current.has(tab.key) || sessionsRef.current[tab.key]) return;
+    spawningRef.current.add(tab.key);
+
+    // Re-attach BEFORE spawning — re-use an already-running shell at this
+    // repo's cwd over leaking a duplicate (per-repo tabs only; ad-hoc shells
+    // are always fresh).
+    if (tab.kind === "repo") {
+      const existing = findExistingBash(tab.cwd, agentsRef.current);
+      if (existing) {
+        setSessions((cur) => ({ ...cur, [tab.key]: existing.target }));
+        return;
+      }
+    }
+
+    // No live shell to re-use — spawn one. The `session_id` is stored as the
+    // tab's PTY id; it resolves to a live agent snapshot once the wire
+    // delivers it (the same id the existing console selects on after spawn).
+    api
+      .spawnPty({ command: "bash", cwd: tab.cwd })
+      .then((res) => {
+        setSessions((cur) => ({ ...cur, [tab.key]: res.session_id }));
+      })
+      .catch(() => {
+        // Failed — drop the guard so a later activation can retry.
+        spawningRef.current.delete(tab.key);
+      });
+  }, []);
+
+  // The lazy-spawn driver: whenever the footer is OPEN, ensure the surfaced
+  // tab(s) have a live PTY. Collapsed → nothing surfaced → nothing spawned
+  // (so mount, which starts collapsed, never spawns). Reads `agents` via the
+  // ref so this fires on visibility/selection changes, not on every SSE tick.
+  useEffect(() => {
+    if (!open) return;
+    if (activeTab) activate(activeTab);
+    if (partnerTab) activate(partnerTab);
+  }, [open, activeTab, partnerTab, activate]);
+
+  // ── tab-bar actions ──────────────────────────────────────────────────────
+  const openOnto = useCallback((key: string) => {
+    setActiveKey(key);
+    setOpen(true);
+  }, []);
+
+  const toggleOpen = useCallback(() => {
+    setOpen((v) => !v);
+  }, []);
+
+  const addAdhoc = useCallback(() => {
+    if (!primaryPath) return; // no cwd to spawn into
+    seqRef.current += 1;
+    const key = `adhoc:${seqRef.current}`;
+    setAdhoc((prev) => [
+      ...prev,
+      { key, kind: "adhoc", label: `sh-${seqRef.current}`, cwd: primaryPath, closeable: true },
+    ]);
+    setActiveKey(key);
+    setOpen(true);
+  }, [primaryPath]);
+
+  const closeTab = useCallback((key: string) => {
+    // Stop the PTY so we don't strand an orphan shell (`api.killAgent` — the
+    // same path the existing console's Kill button uses). Resolve to the
+    // canonical target if the wire has delivered it; else kill by the stored
+    // session id (a valid agent id immediately after spawn). The kill runs
+    // OUTSIDE the state updater so it fires exactly once.
+    const storedId = sessionsRef.current[key];
+    if (storedId) {
+      const agent = resolveAgent(storedId, agentsRef.current);
+      api.killAgent(agent?.target ?? storedId).catch(() => {});
+    }
+    spawningRef.current.delete(key);
+    setSessions((prev) => {
+      const next = { ...prev };
+      delete next[key];
+      return next;
+    });
+    setAdhoc((prev) => prev.filter((t) => t.key !== key));
+    setActiveKey((cur) => (cur === key ? null : cur));
+  }, []);
+
+  const toggleSplit = useCallback(() => {
+    setSplitOn((v) => !v);
+    setOpen(true);
+  }, []);
+
+  // ── render ─────────────────────────────────────────────────────────────
+  const renderPane = (tab: FooterTab, withHeader: boolean) => {
+    const agent = resolveAgent(sessions[tab.key], agents);
+    return (
+      <div className="ac-ftpane" key={tab.key}>
+        {withHeader && (
+          <div className="ac-ftpane-h">
+            {tab.label} · {tab.cwd}
+          </div>
+        )}
+        <div className="ac-ftbody">
+          {agent ? (
+            // Reuse TerminalPanel AS-IS, keyed on the resolved target so a
+            // tab switch tears down and re-attaches cleanly (PTY-server
+            // replays scrollback — tmai-core #227).
+            <TerminalPanel key={agent.target} agentId={agent.target} />
+          ) : (
+            <div className="ac-fthint">starting bash in {tab.cwd}…</div>
+          )}
+        </div>
+      </div>
+    );
+  };
+
+  return (
+    <div
+      className={cn("ac-footer", open && "open")}
+      data-testid="aim-bash-footer"
+      data-open={open ? "true" : "false"}
+    >
+      <div className="ac-fbar">
+        <div className="ac-ftabs" role="tablist" aria-label="Bash terminals">
+          {tabs.map((tab) => {
+            const selected = tab.key === effectiveActiveKey;
+            const running = tab.closeable
+              ? resolveAgent(sessions[tab.key], agents) !== undefined
+              : resolveAgent(sessions[tab.key], agents) !== undefined ||
+                findExistingBash(tab.cwd, agents) !== undefined;
+            return (
+              <div
+                key={tab.key}
+                className={cn("ac-ftab", selected && "on")}
+                data-testid={`aim-bash-tab-${tab.label}`}
+              >
+                <button
+                  type="button"
+                  role="tab"
+                  aria-selected={selected}
+                  className="ac-ftab-btn"
+                  onClick={() => openOnto(tab.key)}
+                  title={`${tab.label} — ${tab.cwd}`}
+                >
+                  {running && (
+                    <span
+                      className="ac-rdot"
+                      aria-hidden="true"
+                      title="bash running in this repo"
+                    />
+                  )}
+                  <span>{tab.label}</span>
+                </button>
+                {tab.closeable && (
+                  <button
+                    type="button"
+                    className="ac-fclose"
+                    onClick={() => closeTab(tab.key)}
+                    title={`Close ${tab.label}`}
+                    aria-label={`Close ${tab.label}`}
+                  >
+                    ×
+                  </button>
+                )}
+              </div>
+            );
+          })}
+        </div>
+        <button
+          type="button"
+          className="ac-fadd"
+          onClick={addAdhoc}
+          disabled={!primaryPath}
+          title="New ad-hoc terminal in the primary repo"
+          aria-label="New ad-hoc terminal"
+        >
+          +
+        </button>
+        <span className="ac-fsp" />
+        <button
+          type="button"
+          className={cn("ac-fsplit", splitOn && "on")}
+          onClick={toggleSplit}
+          disabled={tabs.length < 2}
+          aria-pressed={splitOn}
+          title="Split view (two terminals side by side)"
+          aria-label="Toggle split view"
+        >
+          ⊟
+        </button>
+        <button
+          type="button"
+          className="ac-fcar"
+          onClick={toggleOpen}
+          aria-expanded={open}
+          title="Open / close bash"
+          aria-label={open ? "Collapse bash footer" : "Expand bash footer"}
+        >
+          {open ? "▾" : "▴"}
+        </button>
+      </div>
+
+      {open && (
+        <div className={cn("ac-ftwrap", partnerTab && "split")}>
+          {activeTab ? (
+            partnerTab ? (
+              <>
+                {renderPane(activeTab, true)}
+                {renderPane(partnerTab, true)}
+              </>
+            ) : (
+              renderPane(activeTab, false)
+            )
+          ) : (
+            <div className="ac-fthint">No repo to open a shell in — focus a unit first.</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/clients/react/src/components/aim-console/SessionPane.tsx
+++ b/clients/react/src/components/aim-console/SessionPane.tsx
@@ -5,8 +5,8 @@
 // (`.stabs`), the `.shead` (model / cwd / Handoff), and the `.term`
 // conversation view — in the aim-console dev-tool tokens (`.ac-stabs` /
 // `.ac-stab` / `.ac-ro`, extended from S1's stub). The mock's docked
-// `.footer` (tabbed bash terminals) is SKIPPED here — that is S4; this pane
-// only RESERVES the strip at the bottom for it (`.ac-sfoot`).
+// `.footer` (tabbed bash terminals) lands at the bottom as `<BashFooter>`
+// (S4) — the strip S3 reserved is now the real docked bash footer.
 //
 // REUSE, DON'T REBUILD (issue #797): the existing console already renders
 // agent conversations. This pane wires the SAME infra into the aim-console:
@@ -36,6 +36,8 @@ import {
 } from "@/lib/api";
 import { findProducerForUnit } from "@/lib/producer";
 import { cn } from "@/lib/utils";
+import type { UnitRepoWire } from "@/types/generated/UnitRepoWire";
+import { BashFooter } from "./BashFooter";
 
 interface SessionPaneProps {
   /** Live agent list (App's `useAgents`). The Producer is resolved via
@@ -52,6 +54,11 @@ interface SessionPaneProps {
   trigger: (unit: string, body: TriggerHandoffRitualRequest) => Promise<void>;
   /** ⚙ deep-link into Settings (auto-handoff threshold). */
   onOpenSettings: () => void;
+  /** The focused unit's repos (primary first), threaded from AimConsole's
+   *  membership list — one per-repo bash tab each in the docked footer (S4).
+   *  Empty for a cwd-synthesized unit not in the configured membership; the
+   *  footer then falls back to `currentProjectPath`. */
+  repos: UnitRepoWire[];
 }
 
 function repoBasename(path: string): string {
@@ -97,6 +104,7 @@ export function SessionPane({
   currentProjectPath,
   trigger,
   onOpenSettings,
+  repos,
 }: SessionPaneProps) {
   // Producer + workers for the focused unit. The Producer (if any) leads;
   // workers follow, sorted by name for a stable tab order. Resolution mirrors
@@ -201,11 +209,11 @@ export function SessionPane({
         )}
       </div>
 
-      {/* ── footer reservation ── the docked bash footer is S4; this pane only
-          LEAVES ROOM for it (mock `.footer` collapsed height). Not built. */}
-      <div className="ac-sfoot" aria-hidden="true" data-testid="aim-session-footer-reserve">
-        <span className="ac-sfoot-hint">bash · S4</span>
-      </div>
+      {/* ── docked bash footer (mock `.footer`) ── per-repo + ad-hoc shell
+          terminals, lazy-spawned on first activation and rendered via the
+          reused TerminalPanel. Collapsed by default (S3 reserved this strip;
+          S4 fills it). */}
+      <BashFooter repos={repos} primaryPath={currentProjectPath} agents={agents} />
     </>
   );
 }

--- a/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
@@ -5,8 +5,8 @@
 // under a sober top bar. This test covers the SHELL — top bar (real unit
 // tabs), the 3-pane grid, the PR-rail expand/collapse transition, and the
 // callbacks. The Aim (left) pane is now the real S2 worklist (its behaviour is
-// covered in AimPane.test.tsx); the Session / PR-rail bodies remain S3 / S4
-// stubs.
+// covered in AimPane.test.tsx); the Session pane is real (tabs + shead + term +
+// the docked S4 bash footer); the PR-rail body remains an S5 stub.
 //
 // `useUnitAttention` is mocked so the per-tab attention rollup never hits the
 // network; `api.aims` is mocked to a pending promise so the embedded AimPane
@@ -82,19 +82,19 @@ describe("AimConsole — S1 shell", () => {
     expect(screen.getByLabelText("PR / Issue rail")).toBeTruthy();
   });
 
-  it("fills the Aim (S2) and Session (S3) panes, leaves the PR-rail as an S4 stub", () => {
+  it("fills the Aim (S2) and Session (S3+S4) panes, leaves the PR-rail as an S5 stub", () => {
     renderConsole();
     // The Aim pane is now the real worklist: no S2 stub, real chrome present.
     expect(screen.queryByTestId("aim-pane-stub-s2")).toBeNull();
     expect(screen.getByTestId("aim-ledger")).toBeTruthy();
     expect(screen.getByRole("button", { name: "Frontier ⚠" })).toBeTruthy();
     // The Session pane is real now (no S3 stub): the session tablist + the
-    // S4-footer reservation render even with no live sessions.
+    // real docked S4 bash footer render even with no live sessions.
     expect(screen.queryByTestId("aim-pane-stub-s3")).toBeNull();
     expect(screen.getByRole("tablist", { name: "Sessions" })).toBeTruthy();
-    expect(screen.getByTestId("aim-session-footer-reserve")).toBeTruthy();
-    // The PR-rail body remains an S4 stub.
-    expect(screen.getByTestId("aim-pane-stub-s4")).toBeTruthy();
+    expect(screen.getByTestId("aim-bash-footer")).toBeTruthy();
+    // The PR-rail body remains an S5 stub.
+    expect(screen.getByTestId("aim-pane-stub-s5")).toBeTruthy();
   });
 
   it("renders a top-bar unit tab with primary + secondary repo pills", () => {

--- a/clients/react/src/components/aim-console/__tests__/BashFooter.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/BashFooter.test.tsx
@@ -1,0 +1,231 @@
+// @vitest-environment jsdom
+//
+// BashFooter (S4) test — the docked bash footer of the aim-console Session
+// pane. The footer reuses the existing shell-terminal primitives (issue
+// #799): `api.spawnPty({ command: "bash", cwd })` to open a PTY, the live
+// agent list to DISCOVER + re-attach an already-running bash, and
+// `TerminalPanel` to render it. So the unit under test is the footer's own
+// logic — collapse/expand, LAZY spawn on first activation (NOT on mount),
+// re-attach over duplicate, ad-hoc add/close (kill on close), and split — with
+// `spawnPty` / `killAgent` / `TerminalPanel` stubbed.
+
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { type AgentSnapshot, api } from "@/lib/api";
+import { BashFooter } from "../BashFooter";
+
+// TerminalPanel is heavy (xterm + the PTY plane); stub it to the agentId it
+// receives so we can assert WHICH session a pane attaches to.
+vi.mock("@/components/terminal/TerminalPanel", () => ({
+  TerminalPanel: ({ agentId }: { agentId: string }) => (
+    <div data-testid="ac-footer-terminal">{agentId}</div>
+  ),
+}));
+
+// Mock only the two spawn/kill side effects; keep `isAiAgentLoose` /
+// `normalizeGitDir` real (the footer's re-attach discovery depends on them).
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      spawnPty: vi.fn(),
+      killAgent: vi.fn(),
+    },
+  };
+});
+
+const spawnPty = vi.mocked(api.spawnPty);
+const killAgent = vi.mocked(api.killAgent);
+
+function bashAgent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot {
+  return {
+    id: partial.id,
+    target: partial.target ?? partial.id,
+    // A plain shell — `isAiAgentLoose` must return false so the footer treats
+    // it as re-attachable (the bash-wrapped Producer / workers are excluded).
+    agent_type: partial.agent_type ?? { Custom: "bash" },
+    title: partial.title ?? partial.id,
+    cwd: partial.cwd ?? "/home/u/tmai",
+    display_cwd: partial.display_cwd ?? "~/tmai",
+    display_name: partial.display_name ?? partial.id,
+    detection_source: partial.detection_source ?? "IpcSocket",
+    git_branch: partial.git_branch ?? "main",
+    git_dirty: partial.git_dirty ?? false,
+    is_worktree: partial.is_worktree ?? false,
+    git_common_dir: partial.git_common_dir ?? "/home/u/tmai/.git",
+    unit: partial.unit,
+    worktree_name: partial.worktree_name ?? null,
+    worktree_base_branch: partial.worktree_base_branch ?? null,
+    effort_level: partial.effort_level ?? null,
+    active_subagents: partial.active_subagents ?? 0,
+    compaction_count: partial.compaction_count ?? 0,
+    pty_session_id: partial.pty_session_id ?? partial.target ?? partial.id,
+    send_capability: partial.send_capability ?? "Ipc",
+    is_virtual: partial.is_virtual ?? false,
+    team_info: partial.team_info ?? null,
+    attention: partial.attention ?? null,
+    model_id: partial.model_id,
+    model_display_name: partial.model_display_name,
+  };
+}
+
+const REPOS = [
+  { path: "/home/u/tmai", primary: true },
+  { path: "/home/u/tmai-core", primary: false },
+];
+
+function renderFooter(overrides: Partial<Parameters<typeof BashFooter>[0]> = {}) {
+  const props = {
+    repos: REPOS,
+    primaryPath: "/home/u/tmai" as string | null,
+    agents: [] as AgentSnapshot[],
+    ...overrides,
+  };
+  render(<BashFooter {...props} />);
+  return props;
+}
+
+beforeEach(() => {
+  spawnPty.mockReset();
+  killAgent.mockReset();
+  spawnPty.mockResolvedValue({ session_id: "sess-new", pid: 1, command: "bash" });
+  killAgent.mockResolvedValue(undefined);
+});
+
+describe("BashFooter — S4 docked bash footer", () => {
+  it("mounts COLLAPSED with one tab per repo and spawns NOTHING (lazy hygiene)", () => {
+    renderFooter();
+    const footer = screen.getByTestId("aim-bash-footer");
+    expect(footer.getAttribute("data-open")).toBe("false");
+    // One tab per repo (primary first), no terminal mounted, no PTY spawned.
+    expect(screen.getByTestId("aim-bash-tab-tmai")).toBeTruthy();
+    expect(screen.getByTestId("aim-bash-tab-tmai-core")).toBeTruthy();
+    expect(screen.queryByTestId("ac-footer-terminal")).toBeNull();
+    expect(spawnPty).not.toHaveBeenCalled();
+  });
+
+  it("expands on the carat and lazy-spawns ONLY the active repo's bash", async () => {
+    renderFooter();
+    fireEvent.click(screen.getByRole("button", { name: "Expand bash footer" }));
+    expect(screen.getByTestId("aim-bash-footer").getAttribute("data-open")).toBe("true");
+    await waitFor(() =>
+      expect(spawnPty).toHaveBeenCalledWith({ command: "bash", cwd: "/home/u/tmai" }),
+    );
+    // The secondary repo is NOT surfaced, so its shell is not spawned.
+    expect(spawnPty).toHaveBeenCalledTimes(1);
+  });
+
+  it("lazy-spawns a repo's bash on its FIRST tab activation (cwd = that repo)", async () => {
+    renderFooter();
+    fireEvent.click(within(screen.getByTestId("aim-bash-tab-tmai-core")).getByRole("tab"));
+    await waitFor(() =>
+      expect(spawnPty).toHaveBeenCalledWith({ command: "bash", cwd: "/home/u/tmai-core" }),
+    );
+    expect(spawnPty).toHaveBeenCalledTimes(1);
+  });
+
+  it("RE-ATTACHES to an already-running bash for the repo's cwd (no duplicate spawn)", async () => {
+    const existing = bashAgent({
+      id: "bash:existing",
+      target: "term-core",
+      cwd: "/home/u/tmai-core",
+      git_common_dir: "/home/u/tmai-core/.git",
+    });
+    renderFooter({ agents: [existing] });
+    fireEvent.click(within(screen.getByTestId("aim-bash-tab-tmai-core")).getByRole("tab"));
+    // The pane attaches to the existing session — and no new shell is spawned.
+    expect((await screen.findByTestId("ac-footer-terminal")).textContent).toBe("term-core");
+    expect(spawnPty).not.toHaveBeenCalled();
+  });
+
+  it("shows a running dot for a repo that already has a live bash", () => {
+    const existing = bashAgent({
+      id: "bash:existing",
+      target: "term-core",
+      cwd: "/home/u/tmai-core",
+      git_common_dir: "/home/u/tmai-core/.git",
+    });
+    renderFooter({ agents: [existing] });
+    // tmai-core has a live shell → running dot; tmai does not.
+    expect(
+      within(screen.getByTestId("aim-bash-tab-tmai-core")).queryByTitle(
+        "bash running in this repo",
+      ),
+    ).toBeTruthy();
+    expect(
+      within(screen.getByTestId("aim-bash-tab-tmai")).queryByTitle("bash running in this repo"),
+    ).toBeNull();
+  });
+
+  it("adds an ad-hoc sh-N tab on `+` and spawns it in the primary repo", async () => {
+    renderFooter();
+    fireEvent.click(screen.getByRole("button", { name: "New ad-hoc terminal" }));
+    expect(screen.getByTestId("aim-bash-tab-sh-1")).toBeTruthy();
+    await waitFor(() =>
+      expect(spawnPty).toHaveBeenCalledWith({ command: "bash", cwd: "/home/u/tmai" }),
+    );
+    // A second `+` → sh-2.
+    fireEvent.click(screen.getByRole("button", { name: "New ad-hoc terminal" }));
+    expect(screen.getByTestId("aim-bash-tab-sh-2")).toBeTruthy();
+  });
+
+  it("closes an ad-hoc tab and KILLS its PTY (no stranded orphan)", async () => {
+    const spawned = bashAgent({ id: "bash:s1", target: "sess-1", cwd: "/home/u/tmai" });
+    spawnPty.mockResolvedValue({ session_id: "sess-1", pid: 2, command: "bash" });
+    renderFooter({ agents: [spawned] });
+    fireEvent.click(screen.getByRole("button", { name: "New ad-hoc terminal" }));
+    // The ad-hoc spawn resolves and the pane attaches to it.
+    expect((await screen.findByTestId("ac-footer-terminal")).textContent).toBe("sess-1");
+    fireEvent.click(screen.getByRole("button", { name: "Close sh-1" }));
+    expect(screen.queryByTestId("aim-bash-tab-sh-1")).toBeNull();
+    expect(killAgent).toHaveBeenCalledWith("sess-1");
+  });
+
+  it("split view renders two terminals side by side (active + partner)", async () => {
+    const a = bashAgent({
+      id: "bash:a",
+      target: "term-a",
+      cwd: "/home/u/tmai",
+      git_common_dir: "/home/u/tmai/.git",
+    });
+    const b = bashAgent({
+      id: "bash:b",
+      target: "term-b",
+      cwd: "/home/u/tmai-core",
+      git_common_dir: "/home/u/tmai-core/.git",
+    });
+    renderFooter({ agents: [a, b] });
+    fireEvent.click(screen.getByRole("button", { name: "Toggle split view" }));
+    const terminals = await screen.findAllByTestId("ac-footer-terminal");
+    expect(terminals).toHaveLength(2);
+    expect(terminals.map((t) => t.textContent).sort()).toEqual(["term-a", "term-b"]);
+    // The wrap carries the `.split` modifier; both panes get a header.
+    const footer = screen.getByTestId("aim-bash-footer");
+    expect(footer.querySelector(".ac-ftwrap.split")).toBeTruthy();
+  });
+
+  it("disables split with fewer than two tabs", () => {
+    renderFooter({ repos: [], primaryPath: "/home/u/solo" });
+    expect(
+      (screen.getByRole("button", { name: "Toggle split view" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+
+  it("falls back to a single primary-path tab when the unit has no repos", () => {
+    renderFooter({ repos: [], primaryPath: "/home/u/solo" });
+    expect(screen.getByTestId("aim-bash-tab-solo")).toBeTruthy();
+    // And `+` still works off the primary path.
+    expect(
+      (screen.getByRole("button", { name: "New ad-hoc terminal" }) as HTMLButtonElement).disabled,
+    ).toBe(false);
+  });
+
+  it("disables `+` when there is no primary repo to spawn into", () => {
+    renderFooter({ repos: [], primaryPath: null });
+    expect(
+      (screen.getByRole("button", { name: "New ad-hoc terminal" }) as HTMLButtonElement).disabled,
+    ).toBe(true);
+  });
+});

--- a/clients/react/src/components/aim-console/__tests__/BashFooter.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/BashFooter.test.tsx
@@ -140,6 +140,32 @@ describe("BashFooter — S4 docked bash footer", () => {
     expect(spawnPty).not.toHaveBeenCalled();
   });
 
+  it("re-spawns a repo tab whose stored session has DIED (stale id gone from agents)", async () => {
+    const live = bashAgent({
+      id: "bash:core",
+      target: "term-core",
+      cwd: "/home/u/tmai-core",
+      git_common_dir: "/home/u/tmai-core/.git",
+    });
+    const { rerender } = render(
+      <BashFooter repos={REPOS} primaryPath="/home/u/tmai" agents={[live]} />,
+    );
+    // First activation re-attaches to the live shell (no spawn).
+    fireEvent.click(within(screen.getByTestId("aim-bash-tab-tmai-core")).getByRole("tab"));
+    expect((await screen.findByTestId("ac-footer-terminal")).textContent).toBe("term-core");
+    expect(spawnPty).not.toHaveBeenCalled();
+
+    // The bash exits → its agent drops off the live roster.
+    rerender(<BashFooter repos={REPOS} primaryPath="/home/u/tmai" agents={[]} />);
+
+    // Re-activating the (non-closeable) repo tab must NOT stay stuck on the dead
+    // session — it clears the stale id and spawns a fresh bash for that cwd.
+    fireEvent.click(within(screen.getByTestId("aim-bash-tab-tmai-core")).getByRole("tab"));
+    await waitFor(() =>
+      expect(spawnPty).toHaveBeenCalledWith({ command: "bash", cwd: "/home/u/tmai-core" }),
+    );
+  });
+
   it("shows a running dot for a repo that already has a live bash", () => {
     const existing = bashAgent({
       id: "bash:existing",

--- a/clients/react/src/components/aim-console/__tests__/SessionPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/SessionPane.test.tsx
@@ -24,6 +24,12 @@ vi.mock("@/components/terminal/TerminalPanel", () => ({
     <div data-testid="ac-term-terminal">{agentId}</div>
   ),
 }));
+// BashFooter (S4) is covered in BashFooter.test.tsx; stub it here so the
+// Session-pane tests stay focused on the tab/shead/term wiring and the docked
+// footer's own spawn/PTY machinery stays out of these assertions.
+vi.mock("../BashFooter", () => ({
+  BashFooter: () => <div data-testid="aim-bash-footer" />,
+}));
 vi.mock("@/components/agent/PreviewPanel", () => ({
   PreviewPanel: ({ agentId }: { agentId: string }) => (
     <div data-testid="ac-term-preview">{agentId}</div>
@@ -127,6 +133,10 @@ function renderPane(overrides: Partial<Parameters<typeof SessionPane>[0]> = {}) 
     currentProjectPath: "/home/u/tmai" as string | null,
     trigger: vi.fn(),
     onOpenSettings: vi.fn(),
+    repos: [
+      { path: "/home/u/tmai", primary: true },
+      { path: "/home/u/tmai-core", primary: false },
+    ],
     ...overrides,
   };
   render(<SessionPane {...props} />);
@@ -181,9 +191,9 @@ describe("SessionPane — S3 Session conversation", () => {
     expect(screen.getByText("sonnet-4.6")).toBeTruthy();
   });
 
-  it("reserves the bottom strip for the S4 bash footer (does not fill the whole pane)", () => {
+  it("docks the S4 bash footer at the bottom of the pane", () => {
     renderPane();
-    expect(screen.getByTestId("aim-session-footer-reserve")).toBeTruthy();
+    expect(screen.getByTestId("aim-bash-footer")).toBeTruthy();
   });
 
   it("renders an empty state when the unit has no live sessions", () => {

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -20,9 +20,9 @@
    `*.tsx?`, never `*.css`.
 
    S1 reproduces the TOKEN LAYER + the SHELL: top bar, 3-pane grid, and the
-   PR-rail expand/collapse transition. The three panes are placeholders /
-   stubs here — the worklist (S2), session (S3), and PR/Issue lists (S4)
-   fill them in later stages.
+   PR-rail expand/collapse transition. The panes fill in over later stages —
+   the worklist (S2), session (S3) + its docked bash footer (S4), and the
+   PR/Issue lists (S5).
    ════════════════════════════════════════════════════════════════════════ */
 
 .aim-console {
@@ -404,23 +404,180 @@
   color: var(--faint);
 }
 
-/* ── footer reservation ── the docked bash footer is S4; S3 only RESERVES
-   this strip (mock `.footer` collapsed height) so the term doesn't fill the
-   whole pane. Not the footer itself. ────────────────────────────────────── */
-.aim-console .ac-sfoot {
+/* ── docked bash footer (mock `.footer`/`.fbar`/`.ftab`/`.ftwrap`) ────────
+   The Session pane's docked bash terminals (S4): a collapsed 33px tab bar
+   that expands to 210px (mock `body.bash-on .footer`), a tab strip (one per
+   repo + ad-hoc shells), `+` add, split toggle, and the open/close carat.
+   Each surfaced terminal is the reused TerminalPanel filling `.ac-ftbody`. */
+.aim-console .ac-footer {
   flex: none;
   height: 33px;
-  display: flex;
-  align-items: center;
-  padding: 0 12px;
+  overflow: hidden;
   background: var(--panel);
   border-top: 1px solid var(--line);
+  transition: height 0.2s ease;
+  display: flex;
+  flex-direction: column;
 }
-.aim-console .ac-sfoot-hint {
+.aim-console .ac-footer.open {
+  height: 210px;
+}
+.aim-console .ac-fbar {
+  display: flex;
+  align-items: stretch;
+  height: 33px;
+  flex: none;
+  padding: 0 4px;
+}
+.aim-console .ac-ftabs {
+  display: flex;
+  align-items: stretch;
+}
+/* The tab is a flex shell carrying the visual state; the caption is a bare
+   button inside it (so the ad-hoc `×` is a SIBLING button, never nested). */
+.aim-console .ac-ftab {
+  display: flex;
+  align-items: center;
+  height: 33px;
+  border-bottom: 2px solid transparent;
+  user-select: none;
+}
+.aim-console .ac-ftab:hover {
+  background: var(--line-2);
+}
+.aim-console .ac-ftab.on {
+  border-bottom-color: var(--cyan);
+}
+.aim-console .ac-ftab-btn {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  height: 100%;
+  padding: 0 6px 0 11px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--dim);
   font-family: var(--mono);
-  font-size: 10px;
+  font-size: 11px;
+}
+.aim-console .ac-ftab:hover .ac-ftab-btn,
+.aim-console .ac-ftab.on .ac-ftab-btn {
+  color: var(--txt);
+}
+.aim-console .ac-rdot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: var(--green);
+  box-shadow: 0 0 6px var(--green);
+  flex: none;
+}
+.aim-console .ac-fclose {
+  padding: 0 9px 0 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
   color: var(--faint);
-  letter-spacing: 0.5px;
+  font-size: 13px;
+  line-height: 1;
+}
+.aim-console .ac-fclose:hover {
+  color: var(--danger);
+}
+.aim-console .ac-fadd {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 26px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--faint);
+  font-size: 14px;
+}
+.aim-console .ac-fadd:hover {
+  color: var(--cyan);
+}
+.aim-console .ac-fadd:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.aim-console .ac-fsp {
+  flex: 1;
+}
+.aim-console .ac-fsplit {
+  display: flex;
+  align-items: center;
+  padding: 0 9px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--faint);
+  font-size: 13px;
+}
+.aim-console .ac-fsplit:hover {
+  color: var(--cyan);
+}
+.aim-console .ac-fsplit.on {
+  color: var(--cyan);
+}
+.aim-console .ac-fsplit:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.aim-console .ac-fcar {
+  display: flex;
+  align-items: center;
+  padding: 0 9px;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  color: var(--faint);
+  font-size: 10px;
+}
+.aim-console .ac-fcar:hover {
+  color: var(--txt);
+}
+.aim-console .ac-ftwrap {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+  display: flex;
+}
+.aim-console .ac-ftpane {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.aim-console .ac-ftwrap.split .ac-ftpane {
+  border-right: 1px solid var(--line-2);
+}
+.aim-console .ac-ftwrap.split .ac-ftpane:last-child {
+  border-right: none;
+}
+.aim-console .ac-ftpane-h {
+  flex: none;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--faint);
+  padding: 5px 12px 3px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.aim-console .ac-ftbody {
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+.aim-console .ac-fthint {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--faint);
+  padding: 8px 14px;
 }
 
 /* ── PR rail (collapsed rail ⇄ expanded panel — the S1 transition) ─────── */


### PR DESCRIPTION
Resolves #799. Stage 4 of the aim-console rebuild in `clients/react`: fills the strip S3 reserved at the bottom of the Session pane (`.ac-sfoot`) with the real **docked bash footer**, faithful to the mock's `.footer` (`origin/mock/aim-ui-sample`), in the aim-console dev-tool tokens.

**Coexist, do not rip** — the existing console's terminal/agent handling, `TerminalPanel` internals, and the sidebar are untouched; the footer is aim-console-only.

## The big win: reuse the primitives (no new PTY layer)
- `api.spawnPty({ command: "bash", cwd })` opens a shell PTY per repo cwd (`bash` is an existing spawn-allow-list runtime).
- `components/terminal/TerminalPanel` renders each live PTY by the resolved agent target — **reused as-is**.
- The live agent list (`useAgents`, threaded through `SessionPane`) discovers an already-running bash for a repo's cwd so the footer **re-attaches** instead of spawning a duplicate.

## Behaviour (faithful to the mock)
- **Footer chrome** (`.ac-footer`/`.ac-fbar`): collapsed (~33px tab bar) ↔ expanded (~210px) via the carat (▴/▾); tab strip + `+` (add ad-hoc) + split toggle.
- **Per-repo terminals**: one tab per the unit's repos (primary first), each a bash in that repo's cwd, with a running-indicator dot for live ones. **Lazy-spawn** — the PTY is spawned on a tab's **first activation**, never on mount (load-bearing: auto-spawning a shell per repo on every console open would leak real processes), and re-attaches to an existing bash for that cwd if one is running.
- **Ad-hoc terminals**: `+` spawns `sh-N` in the unit's primary repo; closeable (the `×` kills the PTY via `api.killAgent` so no orphan shell is stranded).
- **Split view**: the split toggle renders the active tab + its partner side by side (`.ac-ftwrap.split`).
- **Render**: each active terminal via `TerminalPanel` (the session id from `spawnPty` / the discovered agent); switching tabs swaps the rendered terminal.

Spawn/kill side effects run **outside** the React state updaters and behind a per-tab guard, so StrictMode's double-invoke can't double-spawn.

## Wiring
`AimConsole` passes the focused unit's `repos` (fallback to `currentProjectPath` for a cwd-synthesized unit absent from the configured membership) through `SessionPane` into the new `BashFooter`. The PR-rail stub is relabelled S4 → S5.

## Out of scope
- **S5**: the PR rail — its S1 stub stays (now labelled S5).
- No changes to the existing console's terminal/agent handling, `TerminalPanel` internals, or the sidebar. No auto-spawn on mount.

## Tests / gate (all green locally)
- `pnpm -C clients/react lint` ✓
- `pnpm -C clients/react build` ✓
- `pnpm -C clients/react test` ✓ (801 passed)

`BashFooter.test.tsx` covers: collapse/expand, no-spawn-on-mount, lazy-spawn on activate (per-repo + carat-open), re-attach over duplicate, running dot, ad-hoc add + close-kills-PTY, split view, and the `repos`-empty / no-primary-path fallbacks (`spawnPty`/`killAgent`/`TerminalPanel` mocked). `SessionPane`/`AimConsole` tests updated for the real footer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * セッション下部にドッキング可能なBashフッター機能を追加しました。リポジトリごとのターミナルタブ管理、アドホックタブの追加、分割表示に対応しています。

* **Style**
  * BashフッターのUI要素に関するスタイルを追加しました。

* **Tests**
  * Bashフッター機能のテストを新規追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->