### PR TITLE
S5: aim-ui console — PR rail (per-repo PR/Issue lists, reuse useUnitPrs/useUnitIssues + status-pills) (#801)

### DIFF
--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -13,22 +13,25 @@
 // so they never bleed into the existing console.
 //
 // SCOPE so far: the TOKEN LAYER + the SHELL (S1), the Aim pane (S2), the
-// Session pane (S3), and its docked bash footer (S4). The top bar (real,
-// data-driven unit tabs) and the 3-pane grid incl. the PR-rail expand/collapse
-// transition are S1; the Aim (left) pane is the real worklist (Frontier⊥Tree,
-// ledger, overview ruler, inspector, create-aim modal — `AimPane`, reusing the
-// Stage B logic layer); the Session (centre) pane is the real conversation
-// surface (tabs + shead + term — `SessionPane`, reusing the existing console
-// infra) with the real docked bash footer (per-repo + ad-hoc shell terminals,
-// reusing `api.spawnPty` + `TerminalPanel`). The remaining body is still a
-// stub:
-//   - the PR-rail PR/Issue lists are still an S5 stub.
+// Session pane (S3), its docked bash footer (S4), and the PR-rail lists (S5).
+// The top bar (real, data-driven unit tabs) and the 3-pane grid incl. the
+// PR-rail expand/collapse transition are S1; the Aim (left) pane is the real
+// worklist (Frontier⊥Tree, ledger, overview ruler, inspector, create-aim
+// modal — `AimPane`, reusing the Stage B logic layer); the Session (centre)
+// pane is the real conversation surface (tabs + shead + term — `SessionPane`,
+// reusing the existing console infra) with the real docked bash footer
+// (per-repo + ad-hoc shell terminals, reusing `api.spawnPty` +
+// `TerminalPanel`); the PR-rail (right) is the real per-repo PR + Issue
+// inventory (`PrRail`, reusing `useUnitPrs` / `useUnitIssues` + the
+// `prStatusPills` / `issueStatusPills` derivation). The shell is now fully
+// filled in.
 
 import { useState } from "react";
 import { useUnitAttention } from "@/hooks/useUnitAttention";
 import type { AgentSnapshot, TriggerHandoffRitualRequest, UnitResponse } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import { AimPane } from "./AimPane";
+import { PrRail } from "./PrRail";
 import { SessionPane } from "./SessionPane";
 // Bundled dev-tool typography (offline-robust @fontsource, NOT a Google Fonts
 // <link>) — loads the exact families `aim-console.css` references via --sans /
@@ -92,10 +95,10 @@ export function AimConsole({
   trigger,
   onOpenSettings,
 }: AimConsoleProps) {
-  // PR-rail expand state — the only live interaction in the S1 shell. The
-  // collapsed 46px rail expands to a 320px panel via the `.pr-open` modifier
-  // on the root (mock `body.pr-open { --pr: 320px }`). The panel CONTENT is
-  // an S5 stub.
+  // PR-rail expand state — the S1 shell's mechanism. The collapsed 46px rail
+  // expands to a 320px panel via the `.pr-open` modifier on the root (mock
+  // `body.pr-open { --pr: 320px }`). The state stays HERE; `PrRail` only
+  // renders the rail/panel CONTENT (S5) and calls back to toggle it.
   const [prOpen, setPrOpen] = useState(false);
   const metaUnit = activeUnitName ?? units[0]?.name ?? "—";
   // The focused unit's repos drive the Session pane's per-repo bash footer
@@ -159,40 +162,17 @@ export function AimConsole({
           />
         </section>
 
-        {/* PR RAIL — collapsed rail ⇄ expanded panel (S1); lists are S5 */}
+        {/* PR RAIL — collapsed rail ⇄ expanded panel (S1 mechanism); the
+            per-repo PR + Issue lists + live counts are the real S5 content */}
         <section className="ac-col ac-pr" aria-label="PR / Issue rail">
-          <button
-            type="button"
-            className="ac-prrail"
-            onClick={() => setPrOpen(true)}
-            title="Expand PR / Issue rail"
-            aria-label="Expand PR / Issue rail"
-            aria-expanded={prOpen}
-          >
-            <span className="ac-v w">PR</span>
-            <span className="ac-v">Issue</span>
-            <span className="ac-g">‹ EXTERNAL</span>
-          </button>
-          <div className="ac-prfull">
-            <div className="ac-prh">
-              PR / ISSUE — unit {metaUnit}
-              <button
-                type="button"
-                className="ac-x"
-                onClick={() => setPrOpen(false)}
-                title="Collapse PR / Issue rail"
-                aria-label="Collapse PR / Issue rail"
-              >
-                ✕
-              </button>
-            </div>
-            <div className="ac-prb">
-              <PaneStub
-                stage="S5"
-                note="PR / Issue lists (the rail's expand/collapse content) land here."
-              />
-            </div>
-          </div>
+          <PrRail
+            unitName={activeUnitName}
+            unitLabel={metaUnit}
+            repos={activeUnit?.repos ?? []}
+            open={prOpen}
+            onExpand={() => setPrOpen(true)}
+            onCollapse={() => setPrOpen(false)}
+          />
         </section>
       </div>
     </div>
@@ -242,15 +222,5 @@ function AimUnitTab({
         </span>
       )}
     </button>
-  );
-}
-
-// Placeholder body for a pane whose real content arrives in a later stage.
-function PaneStub({ stage, note }: { stage: string; note: string }) {
-  return (
-    <div className="ac-stub" data-testid={`aim-pane-stub-${stage.toLowerCase()}`}>
-      <span className="ac-stub-stage">{stage}</span>
-      <p className="ac-stub-note">{note}</p>
-    </div>
   );
 }

--- a/clients/react/src/components/aim-console/PrRail.tsx
+++ b/clients/react/src/components/aim-console/PrRail.tsx
@@ -1,0 +1,238 @@
+// PrRail — the aim-console's PR / Issue rail (S5). A faithful reproduction of
+// the destination mock's PR rail (`origin/mock/aim-ui-sample` → the `.col.pr`
+// section) in the dev-tool tokens: a collapsed vertical rail (live PR / Issue
+// open-counts + a static `‹ EXTERNAL` framing) that expands to a per-repo
+// PR + Issue inventory grouped across the whole unit.
+//
+// REUSE, DON'T REBUILD: the data comes from `useUnitPrs` / `useUnitIssues`
+// (the same unit-scoped, multi-repo hooks the Producer console's R panel
+// uses), and each row's categorical status pill is derived by the SAME
+// `prStatusPills` / `issueStatusPills` functions (import-only) so the
+// lifecycle/CI colour story stays consistent with `RPrsSection` /
+// `RIssuesSection`. WHY the pills are rendered here as local `.ac-pst` spans
+// instead of the shared `StatusPills` component: `StatusPills` carries the
+// producer-console theme classes; the aim-console reproduces the mock's
+// dev-tool `.pst` look in its own scoped tokens (issue #801 bounding —
+// touch ONLY `aim-console/**` + `aim-console.css`). The colour is still
+// CATEGORICAL, never appraisal (`2026-05-26-tmai-states-facts-not-appraisals`):
+// it names which lifecycle/CI state a PR/Issue is in, it never ranks urgency.
+//
+// COEXIST: display-only. The aim-console has no R₂ viewer and the mock rows
+// have no detail target, so rows are inert (no click-to-viewer, no
+// github.com link-out — the dev-loop stays in-tmai). Attention is a separate
+// axis (`useUnitAttention`), deliberately NOT wired here (S5 scope).
+//
+// The expand/collapse MECHANISM is the S1 shell's (the root's `.pr-open`
+// modifier + the grid transition + the `prOpen` state in `AimConsole`); this
+// component only renders the rail/panel CONTENT and calls back the threaded
+// `onExpand` / `onCollapse` — it never owns the open state.
+
+import {
+  issueStatusPills,
+  type PillTone,
+  prStatusPills,
+  type StatusPill,
+} from "@/components/producer-console/r-panel/status-pills";
+import { useUnitIssues } from "@/hooks/useUnitIssues";
+import { useUnitPrs } from "@/hooks/useUnitPrs";
+import type {
+  IssueSummaryWire,
+  PrSummaryWire,
+  RepoIssuesWire,
+  RepoPrsWire,
+  UnitRepoWire,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+interface PrRailProps {
+  /** Focused unit — scopes both the PR and Issue hooks. `null` parks them
+   *  (no fetch), mirroring the rest of the aim console. */
+  unitName: string | null;
+  /** Display label for the panel header (App's `metaUnit` — the focused
+   *  unit, or the first configured unit when none is focused). */
+  unitLabel: string;
+  /** The focused unit's configured repos — drives the header's `· {N} repos`
+   *  count. Empty for a cwd-synthesized unit (same convention as the S4
+   *  bash footer's fallback). */
+  repos: UnitRepoWire[];
+  /** Whether the rail is expanded — drives `aria-expanded` on the collapsed
+   *  rail button. The actual show/hide is the root's `.pr-open` display
+   *  toggle (S1), untouched here. */
+  open: boolean;
+  /** The S1 mechanism's `setPrOpen(true)` (collapsed rail click) /
+   *  `setPrOpen(false)` (✕), threaded in so the open state stays in
+   *  `AimConsole`. */
+  onExpand: () => void;
+  onCollapse: () => void;
+}
+
+// Map a categorical pill tone to the mock's `.pst` colour modifier
+// (green / amber / dim / violet, + a red fail variant for CI failure that
+// the mock's open-only sample never showed). The tone→colour intent is the
+// SAME categorical mapping `StatusPills` uses; only the token layer differs.
+const PST_TONE_CLASS: Record<PillTone, string> = {
+  ok: "o", // open / approved / CI pass → --green
+  warn: "r", // review / changes requested / CI pending → --amber
+  danger: "f", // CI fail → --danger
+  info: "m", // merged → --violet
+  muted: "d", // draft / closed → --dim
+};
+
+export function PrRail({ unitName, unitLabel, repos, open, onExpand, onCollapse }: PrRailProps) {
+  // One poll each, feeding BOTH the collapsed counts and the expanded lists
+  // (so the rail never double-polls). The endpoints are open-only + already
+  // unit-scoped across every repo, so the totals are the live open counts.
+  const { data: prData } = useUnitPrs(unitName);
+  const { data: issueData } = useUnitIssues(unitName);
+
+  const prRepos = prData?.repos ?? [];
+  const issueRepos = issueData?.repos ?? [];
+  const openPrCount = prRepos.reduce((n, r) => n + r.prs.length, 0);
+  const openIssueCount = issueRepos.reduce((n, r) => n + r.issues.length, 0);
+
+  return (
+    <>
+      {/* ── collapsed rail (live open-counts + static EXTERNAL framing) ── */}
+      <button
+        type="button"
+        className="ac-prrail"
+        onClick={onExpand}
+        title="Expand PR / Issue rail"
+        aria-label="Expand PR / Issue rail"
+        aria-expanded={open}
+      >
+        {/* `.ac-v.w` keeps the amber dev-tool accent as a STATIC accent — it
+            is NOT an attention signal (attention is a separate axis, out of
+            S5 scope); it just shows the live open PR count. */}
+        <span className="ac-v w">PR {openPrCount}</span>
+        <span className="ac-v">Issue {openIssueCount}</span>
+        <span className="ac-g">‹ EXTERNAL</span>
+      </button>
+
+      {/* ── expanded panel (per-repo PR + Issue inventory) ── */}
+      <div className="ac-prfull">
+        <div className="ac-prh">
+          PR / ISSUE — unit {unitLabel} · {repos.length} repos
+          <button
+            type="button"
+            className="ac-x"
+            onClick={onCollapse}
+            title="Collapse PR / Issue rail"
+            aria-label="Collapse PR / Issue rail"
+          >
+            ✕
+          </button>
+        </div>
+        <div className="ac-prb">
+          <PrGroup repos={prRepos} count={openPrCount} />
+          <IssueGroup repos={issueRepos} count={openIssueCount} />
+        </div>
+      </div>
+    </>
+  );
+}
+
+// "Pull Requests · N" — the unit's open PRs, gathered flat across every repo
+// (primary first, then declaration order, as the endpoint returns them), each
+// row tagged with its owning repo pill.
+function PrGroup({ repos, count }: { repos: RepoPrsWire[]; count: number }) {
+  return (
+    <div className="ac-prg" data-testid="ac-pr-group">
+      <h4>Pull Requests · {count}</h4>
+      {count === 0 ? (
+        <p className="ac-prempty">No open PRs.</p>
+      ) : (
+        repos.flatMap((repo) =>
+          repo.prs.map((pr) => (
+            <PrRow key={`${repo.repo_path}#${pr.number}`} pr={pr} repo={repo} />
+          )),
+        )
+      )}
+    </div>
+  );
+}
+
+// "Issues · N" — same shape, the unit's open issues across every repo.
+function IssueGroup({ repos, count }: { repos: RepoIssuesWire[]; count: number }) {
+  return (
+    <div className="ac-prg" data-testid="ac-issue-group">
+      <h4>Issues · {count}</h4>
+      {count === 0 ? (
+        <p className="ac-prempty">No open issues.</p>
+      ) : (
+        repos.flatMap((repo) =>
+          repo.issues.map((issue) => (
+            <IssueRow key={`${repo.repo_path}#${issue.number}`} issue={issue} repo={repo} />
+          )),
+        )
+      )}
+    </div>
+  );
+}
+
+function PrRow({ pr, repo }: { pr: PrSummaryWire; repo: RepoPrsWire }) {
+  return (
+    <Row
+      repoLabel={repo.repo_label}
+      primary={repo.primary}
+      number={pr.number}
+      title={pr.title}
+      pills={prStatusPills(pr)}
+    />
+  );
+}
+
+function IssueRow({ issue, repo }: { issue: IssueSummaryWire; repo: RepoIssuesWire }) {
+  return (
+    <Row
+      repoLabel={repo.repo_label}
+      primary={repo.primary}
+      number={issue.number}
+      title={issue.title}
+      pills={issueStatusPills(issue)}
+    />
+  );
+}
+
+// One inventory row (mock `.pi`): repo pill (primary highlighted) + `#number`
+// (mono) + single-line ellipsised title + categorical status pill(s).
+// Display-only — no click target (see file header).
+function Row({
+  repoLabel,
+  primary,
+  number,
+  title,
+  pills,
+}: {
+  repoLabel: string;
+  primary: boolean;
+  number: bigint;
+  title: string;
+  pills: StatusPill[];
+}) {
+  return (
+    <div className="ac-pi" data-testid="ac-pi">
+      <span
+        className={cn("ac-repo", primary && "pri")}
+        data-testid="ac-pi-repo"
+        data-primary={primary ? "true" : "false"}
+      >
+        {repoLabel}
+      </span>
+      <span className="ac-pn">#{Number(number)}</span>
+      <span className="ac-pt">{title}</span>
+      <span className="ac-psts">
+        {pills.map((p) => (
+          <span
+            key={p.key}
+            className={cn("ac-pst", PST_TONE_CLASS[p.tone])}
+            data-testid="ac-status-pill"
+            data-tone={p.tone}
+          >
+            {p.label}
+          </span>
+        ))}
+      </span>
+    </div>
+  );
+}

--- a/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
@@ -6,16 +6,18 @@
 // tabs), the 3-pane grid, the PR-rail expand/collapse transition, and the
 // callbacks. The Aim (left) pane is now the real S2 worklist (its behaviour is
 // covered in AimPane.test.tsx); the Session pane is real (tabs + shead + term +
-// the docked S4 bash footer); the PR-rail body remains an S5 stub.
+// the docked S4 bash footer); the PR-rail is now the real S5 PR/Issue rail
+// (its behaviour is covered in PrRail.test.tsx).
 //
 // `useUnitAttention` is mocked so the per-tab attention rollup never hits the
-// network; `api.aims` is mocked to a pending promise so the embedded AimPane
-// parks in its loading state (no network, no act-warning churn) — the shell
-// assertions don't depend on aim data.
+// network; `api.aims` / `api.unitPrs` / `api.unitIssues` are mocked to pending
+// promises so the embedded AimPane + PrRail park in their loading states (no
+// network, no act-warning churn) — the shell assertions don't depend on the
+// data.
 
 import { fireEvent, render, screen, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { AimsResponse, UnitResponse } from "@/lib/api";
+import type { AimsResponse, UnitIssuesResponse, UnitPrsResponse, UnitResponse } from "@/lib/api";
 import { UIPrefsProvider } from "@/lib/ui-prefs-provider";
 import { AimConsole } from "../AimConsole";
 
@@ -29,8 +31,11 @@ vi.mock("@/lib/api", async () => {
     ...actual,
     api: {
       ...actual.api,
-      // Park the AimPane fetch in flight — the shell tests are data-agnostic.
+      // Park the AimPane + PrRail fetches in flight — the shell tests are
+      // data-agnostic.
       aims: () => new Promise<AimsResponse>(() => {}),
+      unitPrs: () => new Promise<UnitPrsResponse>(() => {}),
+      unitIssues: () => new Promise<UnitIssuesResponse>(() => {}),
     },
   };
 });
@@ -82,7 +87,7 @@ describe("AimConsole — S1 shell", () => {
     expect(screen.getByLabelText("PR / Issue rail")).toBeTruthy();
   });
 
-  it("fills the Aim (S2) and Session (S3+S4) panes, leaves the PR-rail as an S5 stub", () => {
+  it("fills all three panes — Aim (S2), Session (S3+S4), PR-rail (S5) — no stubs", () => {
     renderConsole();
     // The Aim pane is now the real worklist: no S2 stub, real chrome present.
     expect(screen.queryByTestId("aim-pane-stub-s2")).toBeNull();
@@ -93,8 +98,12 @@ describe("AimConsole — S1 shell", () => {
     expect(screen.queryByTestId("aim-pane-stub-s3")).toBeNull();
     expect(screen.getByRole("tablist", { name: "Sessions" })).toBeTruthy();
     expect(screen.getByTestId("aim-bash-footer")).toBeTruthy();
-    // The PR-rail body remains an S5 stub.
-    expect(screen.getByTestId("aim-pane-stub-s5")).toBeTruthy();
+    // The PR-rail is now real (no S5 stub): the collapsed rail + both groups
+    // of the expanded panel render even while the lists are still loading.
+    expect(screen.queryByTestId("aim-pane-stub-s5")).toBeNull();
+    expect(screen.getByText("‹ EXTERNAL")).toBeTruthy();
+    expect(screen.getByTestId("ac-pr-group")).toBeTruthy();
+    expect(screen.getByTestId("ac-issue-group")).toBeTruthy();
   });
 
   it("renders a top-bar unit tab with primary + secondary repo pills", () => {

--- a/clients/react/src/components/aim-console/__tests__/PrRail.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/PrRail.test.tsx
@@ -1,0 +1,267 @@
+// @vitest-environment jsdom
+//
+// PrRail — the aim-console's PR / Issue rail (S5). A faithful reproduction of
+// the destination mock's PR rail in the dev-tool tokens, wired to the REUSED
+// unit-scoped, multi-repo hooks (`useUnitPrs` / `useUnitIssues`) and the
+// REUSED categorical pill derivation (`prStatusPills` / `issueStatusPills`).
+//
+// This test mocks the two hooks (so nothing hits the network) and covers the
+// contract: per-repo grouping across the whole unit (primary highlighted),
+// the group counts, the categorical status pills, the live collapsed-rail
+// open-counts, the header repo-count, and the expand/collapse callbacks.
+
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { UseUnitIssuesResult } from "@/hooks/useUnitIssues";
+import type { UseUnitPrsResult } from "@/hooks/useUnitPrs";
+import type {
+  IssueSummaryWire,
+  PrSummaryWire,
+  UnitIssuesResponse,
+  UnitPrsResponse,
+  UnitRepoWire,
+} from "@/lib/api";
+
+const useUnitPrsMock = vi.fn();
+const useUnitIssuesMock = vi.fn();
+
+vi.mock("@/hooks/useUnitPrs", () => ({
+  useUnitPrs: (unit: string | null) => useUnitPrsMock(unit),
+}));
+vi.mock("@/hooks/useUnitIssues", () => ({
+  useUnitIssues: (unit: string | null) => useUnitIssuesMock(unit),
+}));
+
+import { PrRail } from "../PrRail";
+
+function pr(overrides: Partial<PrSummaryWire> = {}): PrSummaryWire {
+  return {
+    number: 100n,
+    title: "PR title",
+    state: "OPEN",
+    head_branch: "feat/x",
+    head_sha: "abc1234",
+    base_branch: "main",
+    url: "https://github.com/o/r/pull/100",
+    review_decision: null,
+    check_status: null,
+    is_draft: false,
+    additions: 10n,
+    deletions: 1n,
+    comments: 0n,
+    reviews: 0n,
+    author: "me",
+    merge_commit_sha: null,
+    ...overrides,
+  };
+}
+
+function issue(overrides: Partial<IssueSummaryWire> = {}): IssueSummaryWire {
+  return {
+    number: 500n,
+    title: "issue title",
+    state: "open",
+    url: "https://github.com/o/r/issues/500",
+    labels: [],
+    assignees: [],
+    ...overrides,
+  };
+}
+
+// unit `tmai` spans 2 repos: tmai (primary) + tmai-core. PRs interleave across
+// both repos; issues likewise. Counts: 3 PRs, 2 issues.
+function prsResponse(): UnitPrsResponse {
+  return {
+    unit: "tmai",
+    repos: [
+      {
+        repo_path: "/home/u/tmai",
+        repo_label: "tmai",
+        primary: true,
+        prs: [
+          pr({ number: 790n, title: "aim inline surfacing", review_decision: "REVIEW_REQUIRED" }),
+          pr({ number: 788n, title: "gen: sync spec ← core", is_draft: true }),
+        ],
+      },
+      {
+        repo_path: "/home/u/tmai-core",
+        repo_label: "tmai-core",
+        primary: false,
+        prs: [pr({ number: 502n, title: "aim write endpoints", state: "MERGED" })],
+      },
+    ],
+  };
+}
+
+function issuesResponse(): UnitIssuesResponse {
+  return {
+    unit: "tmai",
+    repos: [
+      {
+        repo_path: "/home/u/tmai",
+        repo_label: "tmai",
+        primary: true,
+        issues: [issue({ number: 509n, title: "destination layout" })],
+      },
+      {
+        repo_path: "/home/u/tmai-core",
+        repo_label: "tmai-core",
+        primary: false,
+        issues: [issue({ number: 512n, title: "cross-edge propagation" })],
+      },
+    ],
+  };
+}
+
+const REPOS: UnitRepoWire[] = [
+  { path: "/home/u/tmai", primary: true },
+  { path: "/home/u/tmai-core", primary: false },
+];
+
+function prsResult(data: UnitPrsResponse | null): UseUnitPrsResult {
+  return { data, loading: false, error: null };
+}
+function issuesResult(data: UnitIssuesResponse | null): UseUnitIssuesResult {
+  return { data, loading: false, error: null };
+}
+
+function renderRail(overrides: Partial<Parameters<typeof PrRail>[0]> = {}) {
+  const props = {
+    unitName: "tmai" as string | null,
+    unitLabel: "tmai",
+    repos: REPOS,
+    open: false,
+    onExpand: vi.fn(),
+    onCollapse: vi.fn(),
+    ...overrides,
+  };
+  render(<PrRail {...props} />);
+  return props;
+}
+
+beforeEach(() => {
+  useUnitPrsMock.mockReset();
+  useUnitIssuesMock.mockReset();
+  useUnitPrsMock.mockReturnValue(prsResult(prsResponse()));
+  useUnitIssuesMock.mockReturnValue(issuesResult(issuesResponse()));
+});
+
+describe("PrRail — collapsed rail (live open-counts)", () => {
+  it("scopes both hooks to the focused unit", () => {
+    renderRail({ unitName: "tmai" });
+    expect(useUnitPrsMock).toHaveBeenCalledWith("tmai");
+    expect(useUnitIssuesMock).toHaveBeenCalledWith("tmai");
+  });
+
+  it("wires the vertical PR / Issue labels to the real totals", () => {
+    renderRail();
+    const rail = screen.getByRole("button", { name: "Expand PR / Issue rail" });
+    // 3 open PRs across both repos, 2 open issues.
+    expect(within(rail).getByText("PR 3")).toBeTruthy();
+    expect(within(rail).getByText("Issue 2")).toBeTruthy();
+    expect(within(rail).getByText("‹ EXTERNAL")).toBeTruthy();
+    // The amber `.w` accent is a STATIC dev-tool accent on the PR label, not
+    // an attention signal.
+    expect(within(rail).getByText("PR 3").className).toContain("w");
+  });
+
+  it("shows zero counts when the unit has no open PRs / issues", () => {
+    useUnitPrsMock.mockReturnValue(prsResult({ unit: "tmai", repos: [] }));
+    useUnitIssuesMock.mockReturnValue(issuesResult({ unit: "tmai", repos: [] }));
+    renderRail();
+    const rail = screen.getByRole("button", { name: "Expand PR / Issue rail" });
+    expect(within(rail).getByText("PR 0")).toBeTruthy();
+    expect(within(rail).getByText("Issue 0")).toBeTruthy();
+  });
+});
+
+describe("PrRail — expanded panel header", () => {
+  it("shows `unit {label} · {N} repos` from the unit's repos", () => {
+    renderRail({ unitLabel: "tmai", repos: REPOS });
+    expect(screen.getByText(/unit tmai · 2 repos/)).toBeTruthy();
+  });
+});
+
+describe("PrRail — expanded panel groups", () => {
+  it("groups Pull Requests · N across the whole unit, each row tagged with its repo pill", () => {
+    renderRail();
+    const group = screen.getByTestId("ac-pr-group");
+    expect(within(group).getByText("Pull Requests · 3")).toBeTruthy();
+
+    // All three PRs render, in primary-first repo order.
+    const rows = within(group).getAllByTestId("ac-pi");
+    expect(rows).toHaveLength(3);
+    const repoOf = (i: number) => within(rows[i]).getByTestId("ac-pi-repo").textContent;
+    expect(rows.map((_, i) => repoOf(i))).toEqual(["tmai", "tmai", "tmai-core"]);
+
+    // The primary repo's pill is highlighted; the secondary's is not.
+    expect(within(rows[0]).getByTestId("ac-pi-repo").dataset.primary).toBe("true");
+    expect(within(rows[2]).getByTestId("ac-pi-repo").dataset.primary).toBe("false");
+
+    // The number is mono `#{n}`; the title is present.
+    expect(within(rows[0]).getByText("#790")).toBeTruthy();
+    expect(within(rows[0]).getByText("aim inline surfacing")).toBeTruthy();
+  });
+
+  it("groups Issues · N the same way", () => {
+    renderRail();
+    const group = screen.getByTestId("ac-issue-group");
+    expect(within(group).getByText("Issues · 2")).toBeTruthy();
+    const rows = within(group).getAllByTestId("ac-pi");
+    expect(rows).toHaveLength(2);
+    expect(within(rows[0]).getByText("#509")).toBeTruthy();
+    expect(within(rows[0]).getByTestId("ac-pi-repo").dataset.primary).toBe("true");
+    expect(within(rows[1]).getByTestId("ac-pi-repo").textContent).toBe("tmai-core");
+  });
+
+  it("renders categorical status pills (reused prStatusPills / issueStatusPills)", () => {
+    renderRail();
+    // #790 OPEN + REVIEW_REQUIRED → open (ok) + review (warn).
+    const reviewPill = screen.getByText("review");
+    expect(reviewPill.dataset.tone).toBe("warn");
+    expect(reviewPill.className).toContain("r");
+    // #788 draft → muted.
+    const draftPill = screen.getByText("draft");
+    expect(draftPill.dataset.tone).toBe("muted");
+    expect(draftPill.className).toContain("d");
+    // #502 merged → info (violet).
+    const mergedPill = screen.getByText("merged");
+    expect(mergedPill.dataset.tone).toBe("info");
+    expect(mergedPill.className).toContain("m");
+    // Issues are open → ok (green).
+    const openPills = screen
+      .getAllByTestId("ac-status-pill")
+      .filter((p) => p.textContent === "open");
+    expect(openPills.length).toBeGreaterThan(0);
+    for (const p of openPills) expect(p.dataset.tone).toBe("ok");
+  });
+
+  it("shows an empty message per group when the unit has none", () => {
+    useUnitPrsMock.mockReturnValue(prsResult({ unit: "tmai", repos: [] }));
+    useUnitIssuesMock.mockReturnValue(issuesResult({ unit: "tmai", repos: [] }));
+    renderRail();
+    expect(within(screen.getByTestId("ac-pr-group")).getByText("No open PRs.")).toBeTruthy();
+    expect(within(screen.getByTestId("ac-issue-group")).getByText("No open issues.")).toBeTruthy();
+  });
+});
+
+describe("PrRail — expand / collapse (S1 mechanism, threaded callbacks)", () => {
+  it("clicking the collapsed rail calls onExpand", () => {
+    const props = renderRail({ open: false });
+    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
+    expect(props.onExpand).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking the ✕ calls onCollapse", () => {
+    const props = renderRail({ open: true });
+    fireEvent.click(screen.getByRole("button", { name: "Collapse PR / Issue rail" }));
+    expect(props.onCollapse).toHaveBeenCalledTimes(1);
+  });
+
+  it("reflects the open state on the rail's aria-expanded", () => {
+    renderRail({ open: true });
+    expect(
+      screen.getByRole("button", { name: "Expand PR / Issue rail" }).getAttribute("aria-expanded"),
+    ).toBe("true");
+  });
+});

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -655,32 +655,85 @@
   padding: 5px 7px;
 }
 
-/* ── pane stub (placeholder content — replaced in S2–S4) ──────────────── */
-.aim-console .ac-stub {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  padding: 24px;
-  text-align: center;
+/* ── S5 PR-rail lists (per-repo PR + Issue inventory inside `.ac-prb`) ────
+   A faithful port of the mock's `.prg` / `.pi` / `.pst` into the `.ac-*`
+   family. The `.pst` pill colour is CATEGORICAL (lifecycle / CI state),
+   never appraisal — see `status-pills.tsx`'s header. */
+.aim-console .ac-prg h4 {
+  margin: 8px 5px 3px;
+  font: 600 9.5px/1 var(--mono);
+  letter-spacing: 0.6px;
+  text-transform: uppercase;
   color: var(--faint);
 }
-.aim-console .ac-stub-stage {
-  font-family: var(--mono);
+.aim-console .ac-prempty {
+  margin: 3px 7px 6px;
   font-size: 11px;
-  letter-spacing: 1px;
-  color: var(--cyan);
-  border: 1px solid var(--cyan-d);
-  border-radius: 3px;
-  padding: 2px 9px;
+  color: var(--faint);
 }
-.aim-console .ac-stub-note {
-  margin: 0;
+.aim-console .ac-pi {
+  display: flex;
+  gap: 7px;
+  align-items: baseline;
+  padding: 6px 7px;
+}
+.aim-console .ac-pi:hover {
+  background: var(--line-2);
+}
+/* The shared `.ac-repo` pill carries a left margin for its S2 (Aim-pane)
+   context; as a PR-row's first child it sits flush after the row padding. */
+.aim-console .ac-pi .ac-repo {
+  margin-left: 0;
+}
+.aim-console .ac-pn {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--faint);
+  flex: none;
+}
+.aim-console .ac-pt {
+  flex: 1;
+  min-width: 0;
   font-size: 11.5px;
-  line-height: 1.5;
-  max-width: 36ch;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.aim-console .ac-psts {
+  display: inline-flex;
+  flex: none;
+  align-items: center;
+  gap: 4px;
+}
+.aim-console .ac-pst {
+  font-family: var(--mono);
+  font-size: 8.5px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid transparent;
+  flex: none;
+}
+.aim-console .ac-pst.o {
+  color: var(--green);
+  border-color: var(--green-d);
+}
+.aim-console .ac-pst.r {
+  color: var(--amber);
+  background: var(--amber-d);
+  border-color: #3a2e14;
+}
+.aim-console .ac-pst.d {
+  color: var(--dim);
+  border-color: var(--line);
+}
+.aim-console .ac-pst.m {
+  color: var(--violet);
+  border-color: var(--violet-d);
+}
+.aim-console .ac-pst.f {
+  color: var(--danger);
+  background: #221111;
+  border-color: #3a1d1d;
 }
 
 /* ════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Resolves #801. Final reproduction stage (S5) of the **aim-ui console** destination rebuild — fills the PR-rail's expand/collapse shell (built in S1) with real per-repo PR + Issue lists and wires the collapsed rail to live counts. **COEXIST, opt-in behind the StatusBar toggle; the existing ProducerConsole stays default.**

## What changed

- **New `PrRail.tsx`** (keeps `AimConsole.tsx` lean). Renders the whole `.ac-pr` inner content:
  - **Collapsed rail** (`.ac-prrail`): vertical `PR {openPrCount}` (static amber `.ac-v.w` accent) · `Issue {openIssueCount}` · `‹ EXTERNAL`, wired to the real totals.
  - **Expanded panel** (`.ac-prfull`): header `PR / ISSUE — unit {u} · {N} repos` + ✕; body = two groups — `Pull Requests · N` / `Issues · N`. Each row: repo pill (primary highlighted) + `#{number}` (mono) + single-line ellipsised title + categorical status pill(s). Per-repo grouped across the whole unit (primary-first).
- **Reuse by import only**: `useUnitPrs` / `useUnitIssues` (one poll each — feeds both the counts and the lists, no double-poll) + the `prStatusPills` / `issueStatusPills` categorization. Pills render as dev-tool `.ac-pst` spans (mock fidelity) mapping the **same** categorical tone → colour (lifecycle/CI state, never urgency — `2026-05-26-tmai-states-facts-not-appraisals`).
- **Display-only**: no click-to-viewer, no github.com link-out, no new attention wire (attention stays `useUnitAttention`, out of S5 scope).
- **Mechanism untouched**: the `prOpen` state + `.pr-open` modifier + grid transition stay in `AimConsole`; `PrRail` only renders content and calls back `onExpand` / `onCollapse`.
- **CSS**: ported the mock's `.prg` / `.pi` / `.pst` into `.ac-*` scoped tokens; removed the now-dead `PaneStub` + `.ac-stub*` (S5 was the last stub).

## Coexist-safe bounding
Touches **only** `clients/react/src/components/aim-console/**` + `clients/react/src/styles/aim-console.css`. No producer-console (`RPrsSection` / `RIssuesSection` / `RPanel` / `r-viewer`) or its CSS touched. No new wire/types. No new npm deps.

## Tests / gate (all green from `clients/react/`)
- `PrRail.test.tsx`: mocks `useUnitPrs` / `useUnitIssues`; asserts per-repo grouping (primary highlighted), group counts, categorical status pills + tones, collapsed-rail counts, header repo-count, and expand/collapse callbacks.
- Updated `AimConsole.test.tsx` (no more S5 stub; all three panes real).
- `biome check` ✓ · `tsc -b` ✓ · `vite build` ✓ · `vitest run` — **813 passed**, 2 skipped.

> Note: the repo has no `pnpm typecheck` script; `pnpm build` (`tsc -b && vite build`) covers the typecheck step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * PR/Issue レールにリポジトリ横断的なプルリクエストと課題の統合一覧表示機能が実装されました
  * 展開時にはリポジトリ別にグループ分けされ、各項目のステータスが色分けされた表示で確認できます

* **Tests**
  * 新しいレール機能のテストカバレッジが充実しました

* **Style**
  * PR/Issue レールのスタイル定義が追加されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->