### PR TITLE
S6: aim-ui console — conversation-panel control surface re-design (hot/cold-wire language: shead + mode strip + bash footer) (#803)

### DIFF
--- a/clients/react/src/components/aim-console/BashFooter.tsx
+++ b/clients/react/src/components/aim-console/BashFooter.tsx
@@ -11,8 +11,10 @@
 // exist — this footer does NOT add a new PTY layer.
 //   - `api.spawnPty({ command: "bash", cwd })` opens a shell PTY in a repo's
 //     cwd (`bash` is an existing spawn-allow-list runtime);
-//   - `TerminalPanel` renders the live PTY by the resolved agent target
-//     (reused AS-IS — its internals are untouched);
+//   - each pane renders the live PTY via `WireTerminal` (S6) — the SAME
+//     hot/cold-wire surface as the Session conversation, shell-green spine
+//     + its own mini status strip around the reused chromeless
+//     `TerminalPanel`;
 //   - the live agent list (App's `useAgents`, threaded in as `agents`) lets
 //     the footer DISCOVER an already-running bash for a repo's cwd and
 //     RE-ATTACH to it rather than spawn a duplicate.
@@ -25,10 +27,10 @@
 // ad-hoc tab kills its PTY (`api.killAgent`) so we never strand orphan shells.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { TerminalPanel } from "@/components/terminal/TerminalPanel";
 import { type AgentSnapshot, api, isAiAgentLoose, normalizeGitDir } from "@/lib/api";
 import { cn } from "@/lib/utils";
 import type { UnitRepoWire } from "@/types/generated/UnitRepoWire";
+import { WireTerminal } from "./WireTerminal";
 
 interface BashFooterProps {
   /** The focused unit's repos (primary first; the same `repos[]` order the
@@ -294,10 +296,16 @@ export function BashFooter({ repos, primaryPath, agents }: BashFooterProps) {
         )}
         <div className="ac-ftbody">
           {agent ? (
-            // Reuse TerminalPanel AS-IS, keyed on the resolved target so a
-            // tab switch tears down and re-attaches cleanly (PTY-server
-            // replays scrollback — tmai-core #227).
-            <TerminalPanel key={agent.target} agentId={agent.target} />
+            // The S6 hot/cold-wire surface (shell-green spine + mini strip
+            // around the reused chromeless TerminalPanel), keyed on the
+            // resolved target so a tab switch tears down and re-attaches
+            // cleanly (PTY-server replays scrollback — tmai-core #227).
+            <WireTerminal
+              key={agent.target}
+              agentId={agent.target}
+              who="shell"
+              addressee={tab.label}
+            />
           ) : (
             <div className="ac-fthint">starting bash in {tab.cwd}…</div>
           )}

--- a/clients/react/src/components/aim-console/SessionPane.tsx
+++ b/clients/react/src/components/aim-console/SessionPane.tsx
@@ -12,11 +12,12 @@
 // agent conversations. This pane wires the SAME infra into the aim-console:
 //   - session tabs ← the live agent list (Producer via `findProducerForUnit`
 //     + the unit's workers);
-//   - shead ← `ProducerConversationHeader` for the Producer (model / cwd /
-//     ctx% + the App-lifted Handoff & restart ritual), a plain model / cwd
-//     bar for a worker;
-//   - term ← `TerminalPanel` (live PTY) / `PreviewPanel` (between selections),
-//     UNCHANGED.
+//   - shead ← the aim-console's own `Shead` (S6) — Producer variant carries
+//     the ctx bar + threshold marker + the App-lifted Handoff & restart
+//     ritual; worker variant the model / repo / cwd line;
+//   - term ← `WireTerminal` (S6: spine + chromeless `TerminalPanel` +
+//     status strip — the hot/cold-wire control surface) for a live PTY /
+//     `PreviewPanel` (between selections), UNCHANGED.
 //
 // The aim console is a full-screen TAKEOVER (App renders ONLY `<AimConsole>`
 // in aim mode), so the selected SESSION is LOCAL state here — NOT App's
@@ -26,8 +27,6 @@
 
 import { useMemo, useState } from "react";
 import { PreviewPanel } from "@/components/agent/PreviewPanel";
-import { ProducerConversationHeader } from "@/components/producer-console/ProducerConversationHeader";
-import { TerminalPanel } from "@/components/terminal/TerminalPanel";
 import {
   type AgentSnapshot,
   isAiAgentLoose,
@@ -38,6 +37,9 @@ import { findProducerForUnit } from "@/lib/producer";
 import { cn } from "@/lib/utils";
 import type { UnitRepoWire } from "@/types/generated/UnitRepoWire";
 import { BashFooter } from "./BashFooter";
+import { Shead } from "./Shead";
+import { statusClass, statusWord } from "./session-status";
+import { WireTerminal } from "./WireTerminal";
 
 interface SessionPaneProps {
   /** Live agent list (App's `useAgents`). The Producer is resolved via
@@ -61,10 +63,6 @@ interface SessionPaneProps {
   repos: UnitRepoWire[];
 }
 
-function repoBasename(path: string): string {
-  return path.split("/").filter(Boolean).pop() ?? path;
-}
-
 // Does this agent belong to the focused unit? Prefer the wire `unit` field
 // (a `[[unit]]` can span several repos, so a worker at a SECONDARY repo still
 // carries the unit's name — #439); fall back to a primary-repo-dir match for
@@ -80,22 +78,6 @@ function agentInUnit(
   }
   if (primaryPath === null) return false;
   return normalizeGitDir(agent.git_common_dir ?? agent.cwd) === normalizeGitDir(primaryPath);
-}
-
-// Tab status dot colour — reuse ProducerConversationHeader's flat `attention`
-// mapping (tmai-core@2026-05-09 Phase 4): `halted` → at a permission prompt,
-// `started` / `completed` → waiting on the operator, `null` → running.
-function statusClass(attention: AgentSnapshot["attention"]): string {
-  if (attention === "halted") return "halt";
-  if (attention === "started" || attention === "completed") return "wait";
-  return "run";
-}
-
-function statusWord(attention: AgentSnapshot["attention"]): string {
-  if (attention === "halted") return "Halted";
-  if (attention === "completed") return "Done";
-  if (attention === "started") return "Started";
-  return "Active";
 }
 
 export function SessionPane({
@@ -168,37 +150,35 @@ export function SessionPane({
         </span>
       </div>
 
-      {/* ── shead (mock `.shead`) ── Producer gets the full
-          ProducerConversationHeader (ctx% + the Handoff & restart ritual);
-          a worker gets a plain model / cwd bar. */}
-      {selectedAgent &&
-        (isProducerSelected ? (
-          <ProducerConversationHeader
-            agents={agents}
-            currentProjectPath={currentProjectPath}
-            unitName={unitName}
-            trigger={trigger}
-            onOpenSettings={onOpenSettings}
-          />
-        ) : (
-          <div className="ac-shead">
-            <span className="m">
-              {selectedAgent.model_display_name ?? selectedAgent.model_id ?? "—"}
-            </span>
-            <span className="w">
-              repo {repoBasename(selectedAgent.git_common_dir ?? selectedAgent.cwd)}
-              {selectedAgent.git_branch ? ` · ${selectedAgent.git_branch}` : ""} ·{" "}
-              {selectedAgent.display_cwd}
-            </span>
-          </div>
-        ))}
+      {/* ── shead (mock `.shead`) ── the aim-console's own S6 bar: Producer
+          variant carries the ctx bar + ┊ threshold marker + the Handoff &
+          restart ritual; worker variant the model / repo / cwd line. */}
+      {selectedAgent && (
+        <Shead
+          agent={selectedAgent}
+          isProducer={isProducerSelected}
+          unitName={unitName}
+          currentProjectPath={currentProjectPath}
+          trigger={trigger}
+          onOpenSettings={onOpenSettings}
+        />
+      )}
 
       {/* ── term (mock `.term`) ── the raw-CC conversation. Live PTY →
-          TerminalPanel; between selections (no live PTY) → PreviewPanel. */}
+          WireTerminal (S6 spine + chromeless TerminalPanel + status strip,
+          accent = addressee); between selections (no live PTY) →
+          PreviewPanel, UNCHANGED. */}
       <div className="ac-term">
         {selectedAgent ? (
           selectedAgent.pty_session_id ? (
-            <TerminalPanel key={selectedAgent.target} agentId={selectedAgent.target} />
+            <WireTerminal
+              key={selectedAgent.target}
+              agentId={selectedAgent.target}
+              who={isProducerSelected ? "producer" : "worker"}
+              addressee={isProducerSelected ? "producer" : selectedAgent.display_name}
+              ctxPct={selectedAgent.ctx_usage?.pct ?? null}
+              hint
+            />
           ) : (
             <PreviewPanel key={selectedAgent.target} agentId={selectedAgent.target} />
           )

--- a/clients/react/src/components/aim-console/Shead.tsx
+++ b/clients/react/src/components/aim-console/Shead.tsx
@@ -1,0 +1,276 @@
+// Shead — the aim-console's own per-session header bar (S6).
+//
+// Replaces the borrowed `ProducerConversationHeader` (Tailwind look) inside
+// `SessionPane` with the design contract's `.shead`
+// (`origin/mock/aim-ui-s6` → `assets/s6-conversation-panel-mock.html`):
+// a single 27px mono-first bar in the dev-tool tokens.
+//
+//   Producer: dot · name · model · ctx bar (with the auto-handoff threshold
+//             marker ┊) · pct · auto N% · unit/cwd · ⤺ handoff & restart ·
+//             ⚙ settings · ✕ kill
+//   Worker:   dot · name · model · ctx bar (violet accent) · pct ·
+//             repo/cwd · ✕ kill
+//
+// REUSE, DON'T REBUILD (issue #803): the ctx readout reuses
+// `ProducerCtxHeader`'s exported helpers (`formatThousands` / `renderBar` /
+// `thresholdColorClass`, import-only) and the same one-shot
+// `getOrchestratorSettings` threshold fetch; the handoff button fires the
+// SAME App-lifted ritual `trigger` with the SAME confirm flow as
+// `ProducerConversationHeader` (which itself is untouched — the existing
+// console keeps using it).
+
+import type { ReactNode } from "react";
+import { useEffect, useState } from "react";
+import {
+  formatThousands,
+  renderBar,
+  thresholdColorClass,
+} from "@/components/producer-console/ProducerCtxHeader";
+import {
+  type AgentSnapshot,
+  api,
+  normalizeGitDir,
+  type TriggerHandoffRitualRequest,
+} from "@/lib/api";
+import { cn } from "@/lib/utils";
+import { statusClass, statusWord } from "./session-status";
+
+interface SheadProps {
+  /** The selected session agent this bar describes. */
+  agent: AgentSnapshot;
+  /** Producer variant (ctx threshold marker + handoff ritual + settings)
+   *  vs worker variant (repo/cwd + kill only). */
+  isProducer: boolean;
+  /** Unit name — keys the handoff ritual endpoint (Producer variant). */
+  unitName: string | null;
+  /** Repo root for the focused unit — scopes the threshold fetch
+   *  (Producer variant; same contract as ProducerCtxHeader). */
+  currentProjectPath: string | null;
+  /** App-level lifted handoff ritual trigger (one `useHandoffRitual`
+   *  instance, in App). */
+  trigger: (unit: string, body: TriggerHandoffRitualRequest) => Promise<void>;
+  /** ⚙ deep-link into Settings (auto-handoff threshold). */
+  onOpenSettings: () => void;
+}
+
+function repoBasename(path: string): string {
+  return path.split("/").filter(Boolean).pop() ?? path;
+}
+
+// Best-effort kill — same shape as the existing console's handlers
+// (swallow the error: an already-dead agent shouldn't throw to the operator).
+function killAgent(target: string): void {
+  api.killAgent(target).catch(() => {});
+}
+
+// Map `thresholdColorClass`'s Tailwind token names onto the aim-console's
+// own tokens. The helper is reused for its BANDING (>= threshold / within
+// 10% / calm — the same bands the auto-trigger fires on), not its class
+// strings, which belong to the existing console's palette.
+function pctToneClass(pct: number | null, threshold: number): string {
+  const tone = thresholdColorClass(pct, threshold);
+  if (tone === "text-destructive") return "hot";
+  if (tone === "text-warning") return "hi";
+  return "";
+}
+
+// The 10-segment ctx bar with the auto-handoff threshold marker `┊` spliced
+// in at the threshold's segment boundary (75% → between segment 7 and 8).
+// `markerIdx === null` (no/disabled threshold, worker variant) renders the
+// bare bar.
+function CtxBar({ pct, markerIdx }: { pct: number; markerIdx: number | null }) {
+  const bar = renderBar(pct);
+  const cells: ReactNode[] = [];
+  for (let i = 0; i <= 10; i++) {
+    if (markerIdx === i) {
+      cells.push(
+        <span key="tk" className="tk">
+          ┊
+        </span>,
+      );
+    }
+    if (i < 10) {
+      cells.push(
+        <span key={i} className={i < bar.filled ? "f" : "e"}>
+          {bar.chars[i]}
+        </span>,
+      );
+    }
+  }
+  return (
+    <span className="bar" aria-hidden="true">
+      {cells}
+    </span>
+  );
+}
+
+function StatusDot({ attention }: { attention: AgentSnapshot["attention"] }) {
+  const word = statusWord(attention);
+  return (
+    <span role="img" className={cn("dd", statusClass(attention))} title={word} aria-label={word} />
+  );
+}
+
+function KillButton({ target }: { target: string }) {
+  return (
+    <button
+      type="button"
+      className="ic kill"
+      onClick={() => killAgent(target)}
+      title="Kill agent"
+      aria-label="Kill agent"
+    >
+      ✕
+    </button>
+  );
+}
+
+export function Shead({
+  agent,
+  isProducer,
+  unitName,
+  currentProjectPath,
+  trigger,
+  onOpenSettings,
+}: SheadProps) {
+  return isProducer ? (
+    <ProducerShead
+      agent={agent}
+      unitName={unitName}
+      currentProjectPath={currentProjectPath}
+      trigger={trigger}
+      onOpenSettings={onOpenSettings}
+    />
+  ) : (
+    <WorkerShead agent={agent} />
+  );
+}
+
+function ProducerShead({
+  agent,
+  unitName,
+  currentProjectPath,
+  trigger,
+  onOpenSettings,
+}: Omit<SheadProps, "isProducer">) {
+  const ctx = agent.ctx_usage ?? null;
+  const [threshold, setThreshold] = useState<number | null>(null);
+
+  // One-shot fetch on mount, re-fetched on currentProjectPath change —
+  // same contract as ProducerCtxHeader (threshold edits aren't on the
+  // SSE fanout; the next mount picks up a new value).
+  useEffect(() => {
+    let cancelled = false;
+    api
+      .getOrchestratorSettings(currentProjectPath ?? undefined)
+      .then((s) => {
+        if (!cancelled) setThreshold(s.auto_handoff_threshold_pct);
+      })
+      .catch(() => {
+        if (!cancelled) setThreshold(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [currentProjectPath]);
+
+  const effectiveThreshold = threshold ?? 0;
+  const thresholdLabel =
+    threshold === null ? "auto —" : effectiveThreshold === 0 ? "auto off" : `auto ${threshold}%`;
+  // Threshold marker position: segment boundary nearest the threshold
+  // (mirrors renderBar's `Math.round` segment rule). Hidden when disabled.
+  const markerIdx =
+    effectiveThreshold > 0 ? Math.max(0, Math.min(10, Math.round(effectiveThreshold / 10))) : null;
+
+  const handleHandoff = () => {
+    if (unitName === null) return;
+    const ok = window.confirm(
+      "Kill the current Producer and start a fresh one bridged via hand-off?",
+    );
+    if (!ok) return;
+    void trigger(unitName, { trigger: "manual" });
+  };
+
+  return (
+    <div className="ac-shead ac-who-p" data-testid="ac-shead-producer">
+      <StatusDot attention={agent.attention} />
+      <span className="nm">{agent.display_name}</span>
+      <span className="md">{agent.model_display_name ?? agent.model_id ?? "—"}</span>
+      {ctx ? (
+        <>
+          <CtxBar pct={ctx.pct} markerIdx={markerIdx} />
+          <span
+            className={cn("pct", pctToneClass(ctx.pct, effectiveThreshold))}
+            title={`ctx: ${formatThousands(ctx.used)} / ${formatThousands(ctx.total)} (${ctx.pct}%)`}
+          >
+            {ctx.pct}%
+          </span>
+        </>
+      ) : (
+        <span className="pct" title="ctx: — / —">
+          —
+        </span>
+      )}
+      <span className="md">{thresholdLabel}</span>
+      <span className="cwd">
+        unit {unitName ?? "—"} · cwd {agent.display_cwd}
+      </span>
+      <span className="acts">
+        <button
+          type="button"
+          className="ho"
+          onClick={handleHandoff}
+          disabled={unitName === null}
+          title={
+            unitName === null
+              ? "No unit in focus"
+              : "Kill the current Producer and start a fresh one, bridged via a hand-off file"
+          }
+        >
+          ⤺ handoff &amp; restart
+        </button>
+        <button
+          type="button"
+          className="ic"
+          onClick={onOpenSettings}
+          title="Open settings — auto-handoff threshold"
+          aria-label="Open settings — auto-handoff threshold"
+        >
+          ⚙
+        </button>
+        <KillButton target={agent.target} />
+      </span>
+    </div>
+  );
+}
+
+function WorkerShead({ agent }: { agent: AgentSnapshot }) {
+  const ctx = agent.ctx_usage ?? null;
+  return (
+    <div className="ac-shead ac-who-w" data-testid="ac-shead-worker">
+      <StatusDot attention={agent.attention} />
+      <span className="nm">{agent.display_name}</span>
+      <span className="md">{agent.model_display_name ?? agent.model_id ?? "—"}</span>
+      {ctx && (
+        <>
+          <CtxBar pct={ctx.pct} markerIdx={null} />
+          <span
+            className="pct"
+            title={`ctx: ${formatThousands(ctx.used)} / ${formatThousands(ctx.total)} (${ctx.pct}%)`}
+          >
+            {ctx.pct}%
+          </span>
+        </>
+      )}
+      <span className="cwd">
+        {/* normalizeGitDir first — `git_common_dir` is the `/.git` dir on the
+            wire, and its bare basename would read "repo .git". */}
+        repo {repoBasename(normalizeGitDir(agent.git_common_dir ?? agent.cwd))}
+        {agent.git_branch ? ` · ${agent.git_branch}` : ""} · {agent.display_cwd}
+      </span>
+      <span className="acts">
+        <KillButton target={agent.target} />
+      </span>
+    </div>
+  );
+}

--- a/clients/react/src/components/aim-console/StatusStrip.tsx
+++ b/clients/react/src/components/aim-console/StatusStrip.tsx
@@ -1,0 +1,113 @@
+// StatusStrip — the aim-console's PTY control strip (S6).
+//
+// Replaces TerminalPanel's footer (`⌨ Input/📋 Select`, `⇩ Auto` pills)
+// within the aim-console with the design contract's `.status` row
+// (`origin/mock/aim-ui-s6` → `assets/s6-conversation-panel-mock.html`):
+//
+//   [⌁ INPUT | ⌖ SELECT]  │  follow  │  → addressee  ·  ctx N%
+//
+// plus the one-line mode hint in `--faint`. The segmented control DRIVES the
+// existing xterm mode semantics (it only flips the controlled `inputMode`
+// prop — mousedown→select / Enter-in-select→input stay inside
+// TerminalPanel); `follow` replaces "⇩ Auto" over the SAME per-agent
+// persisted store (`useAutoScrollPerAgent`, held by the host WireTerminal).
+//
+// The mock's hint says ⎋ leaves INPUT mode — in the real app Esc is a CC
+// REPL keystroke (it interrupts the agent) and the existing semantics have
+// no Esc handler, so the hint describes the real exits instead
+// (drag-select → SELECT, ⏎ → INPUT).
+
+import { cn } from "@/lib/utils";
+
+interface StatusStripProps {
+  /** Resolved Input/Select mode — mirrors the controlled TerminalPanel. */
+  inputMode: boolean;
+  onModeChange: (inputMode: boolean) => void;
+  /** Auto-scroll / follow-tail — the shared per-agent store's value. */
+  follow: boolean;
+  onFollowToggle: () => void;
+  /** Addressee display name (`→ producer` / worker name / shell label). */
+  addressee: string;
+  /** ctx % readout (mirrors the shead). `null` hides it (shells). */
+  ctxPct: number | null;
+  /** Render the one-line mode hint under the strip (Session pane). The
+   *  bash footer's mini strips omit it. */
+  hint?: boolean;
+}
+
+export function StatusStrip({
+  inputMode,
+  onModeChange,
+  follow,
+  onFollowToggle,
+  addressee,
+  ctxPct,
+  hint = false,
+}: StatusStripProps) {
+  return (
+    <>
+      <div className="ac-strip" data-testid="ac-strip">
+        <div className="ac-seg2">
+          {/* preventDefault on mousedown so clicking the control doesn't
+              steal focus from xterm (same trick as terminal/controls.tsx). */}
+          <button
+            type="button"
+            data-mode="input"
+            aria-pressed={inputMode}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => onModeChange(true)}
+            title="Input mode — keystrokes flow to the addressee"
+          >
+            <span className="lead">⌁</span>INPUT
+          </button>
+          <button
+            type="button"
+            data-mode="select"
+            aria-pressed={!inputMode}
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={() => onModeChange(false)}
+            title="Select mode — output text is selectable/copyable"
+          >
+            <span className="lead">⌖</span>SELECT
+          </button>
+        </div>
+        <span className="ac-dv" aria-hidden="true" />
+        <button
+          type="button"
+          className={cn("ac-follow", follow && "on")}
+          aria-pressed={follow}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={onFollowToggle}
+          title="Auto-scroll / follow tail"
+        >
+          <span className="sw" aria-hidden="true" />
+          follow
+        </button>
+        <span className="ac-dv" aria-hidden="true" />
+        <div className="ac-addr" title="宛先 = アクティブ session（tab に従う）">
+          <span className="d" aria-hidden="true" />→ <b>{addressee}</b>
+        </div>
+        {ctxPct !== null && (
+          <span className="ac-ctxr">
+            ctx <b>{ctxPct}%</b>
+          </span>
+        )}
+      </div>
+      {hint && (
+        <div className="ac-hint">
+          {inputMode ? (
+            <span>
+              <b>INPUT</b> — キーストロークは agent に渡る。出力をドラッグ選択するか SELECT
+              でキーボードを解放してコピー可能に。
+            </span>
+          ) : (
+            <span>
+              <b>SELECT</b> — 出力テキストを選択/コピーできる（term 左端も cold wire）。
+              <span className="hk">⏎</span> または INPUT でキャプチャへ戻る。
+            </span>
+          )}
+        </div>
+      )}
+    </>
+  );
+}

--- a/clients/react/src/components/aim-console/WireTerminal.tsx
+++ b/clients/react/src/components/aim-console/WireTerminal.tsx
@@ -1,0 +1,99 @@
+// WireTerminal — the aim-console's PTY surface (S6): hot-wire ⊥ cold-wire.
+//
+// One coherent control language for EVERY PTY surface (the Session
+// conversation AND each bash-footer terminal), per the design contract
+// (`origin/mock/aim-ui-s6` → `assets/s6-conversation-panel-mock.html`):
+//
+//   · a 3px left spine on the terminal area — INPUT mode = a LIVE wire in
+//     the addressee's accent (slow travelling pulse), keystrokes flow to
+//     the agent through xterm; SELECT mode = the wire goes COLD
+//     ochre/static and the terminal's left edge carries the cold marker;
+//   · the accent names the addressee, everywhere — producer cyan / worker
+//     violet / shell green (`--who`, a scoped custom property);
+//   · a status strip (`StatusStrip`) below: [⌁ INPUT | ⌖ SELECT] · follow ·
+//     → addressee · ctx %.
+//
+// The mock's "input field with caret" is CONCEPTUAL — keystrokes go
+// directly into xterm (the CC REPL has its own prompt), so there is NO
+// separate text input here. The terminal is the reused `TerminalPanel`
+// rendered chromeless with CONTROLLED `inputMode`: the strip's segmented
+// control flips the prop, while the panel's own internal semantics
+// (mousedown→select, Enter-in-select→input, keyboard attach) stay the
+// single implementation and report back via `onInputModeChange`.
+//
+// `follow` is the same per-agent persisted store the existing footer's
+// "⇩ Auto" used (`useAutoScrollPerAgent(agentId)`) — the chromeless
+// TerminalPanel's internal consumer of that store picks the toggle up live.
+
+import { useState } from "react";
+import { TerminalPanel } from "@/components/terminal/TerminalPanel";
+import { useAutoScrollPerAgent } from "@/hooks/useAutoScrollPerAgent";
+import { cn } from "@/lib/utils";
+import { StatusStrip } from "./StatusStrip";
+
+export type WireWho = "producer" | "worker" | "shell";
+
+interface WireTerminalProps {
+  /** Canonical agent id — TerminalPanel subscribes the PTY plane on it. */
+  agentId: string;
+  /** Addressee kind — picks the hot-wire accent (cyan/violet/green). */
+  who: WireWho;
+  /** Addressee display name in the strip (`→ {name}`). */
+  addressee: string;
+  /** ctx % readout in the strip (mirrors the shead); null hides it. */
+  ctxPct?: number | null;
+  /** Show the one-line mode hint (Session pane yes, footer mini strip no). */
+  hint?: boolean;
+}
+
+const WHO_CLASS: Record<WireWho, string> = {
+  producer: "ac-who-p",
+  worker: "ac-who-w",
+  shell: "ac-who-sh",
+};
+
+export function WireTerminal({
+  agentId,
+  who,
+  addressee,
+  ctxPct = null,
+  hint = false,
+}: WireTerminalProps) {
+  // The controlled Input/Select mode — one value shared by the spine, the
+  // strip's segmented control, and the chromeless TerminalPanel.
+  const [inputMode, setInputMode] = useState(true);
+  const [follow, setFollow] = useAutoScrollPerAgent(agentId);
+
+  return (
+    <div
+      className={cn("ac-wire", WHO_CLASS[who], inputMode ? "input" : "select")}
+      data-testid="ac-wire"
+      data-wire-mode={inputMode ? "input" : "select"}
+    >
+      <div className="ac-wire-row">
+        <span
+          className="ac-spine"
+          aria-hidden="true"
+          title="hot wire = INPUT(addressee accent) ⊥ cold wire = SELECT(ochre)"
+        />
+        <div className="ac-wire-term">
+          <TerminalPanel
+            agentId={agentId}
+            chromeless
+            inputMode={inputMode}
+            onInputModeChange={setInputMode}
+          />
+        </div>
+      </div>
+      <StatusStrip
+        inputMode={inputMode}
+        onModeChange={setInputMode}
+        follow={follow}
+        onFollowToggle={() => setFollow((v) => !v)}
+        addressee={addressee}
+        ctxPct={ctxPct}
+        hint={hint}
+      />
+    </div>
+  );
+}

--- a/clients/react/src/components/aim-console/__tests__/SessionPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/SessionPane.test.tsx
@@ -1,18 +1,19 @@
 // @vitest-environment jsdom
 //
-// SessionPane (S3) test. The Session pane is a faithful reproduction of the
-// mock's `.session` section (session tabs + shead + term), wiring the EXISTING
-// console infra into the aim-console:
+// SessionPane (S3 + the S6 control surface) test. The Session pane wires the
+// EXISTING console infra into the aim-console:
 //   - tabs ← the live agent list (Producer via `findProducerForUnit` + the
 //     unit's workers);
-//   - shead ← ProducerConversationHeader for the Producer (the Handoff &
-//     restart ritual), a plain model/cwd bar for a worker;
-//   - term ← TerminalPanel (live PTY) / PreviewPanel (no live PTY).
+//   - shead ← the aim-console's own `Shead` (S6): Producer variant carries
+//     the ctx bar + the Handoff & restart ritual, worker variant the
+//     model/repo/cwd line;
+//   - term ← `WireTerminal` (S6: spine + chromeless TerminalPanel + status
+//     strip; accent = addressee) for a live PTY / PreviewPanel otherwise.
 //
 // TerminalPanel / PreviewPanel are heavy (xterm + the PTY plane), so they are
 // stubbed to the agentId they receive — the pane logic under test is the tab
-// list, the LOCAL session selection, and the shead split. `api` is mocked so
-// ProducerConversationHeader's settings fetch never hits the network.
+// list, the LOCAL session selection, the shead split, and the addressee
+// threading. `api` is mocked so Shead's settings fetch never hits the network.
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -179,16 +180,30 @@ describe("SessionPane — S3 Session conversation", () => {
     expect(screen.getByTestId("ac-term-terminal").textContent).toBe("claude:w1");
   });
 
-  it("renders the Handoff & restart shead for the Producer, a plain bar for a worker", () => {
+  it("renders the Producer shead with the handoff ritual, the worker variant without", () => {
     renderPane();
-    // Producer selected by default → the ProducerConversationHeader shead
-    // carries the Handoff & restart ritual.
-    expect(screen.getByRole("button", { name: /Handoff & restart/ })).toBeTruthy();
+    // Producer selected by default → the S6 Producer shead carries the
+    // ⤺ handoff & restart ritual (and the cyan accent).
+    expect(screen.getByTestId("ac-shead-producer")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /handoff & restart/i })).toBeTruthy();
 
-    // Switch to a worker → no Handoff ritual; plain model/cwd bar instead.
+    // Switch to a worker → the worker shead: no Handoff ritual, model/cwd line.
     fireEvent.click(screen.getByRole("tab", { name: /attention-ui/ }));
-    expect(screen.queryByRole("button", { name: /Handoff & restart/ })).toBeNull();
+    expect(screen.getByTestId("ac-shead-worker")).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /handoff & restart/i })).toBeNull();
     expect(screen.getByText("sonnet-4.6")).toBeTruthy();
+  });
+
+  it("threads the addressee accent into the wire — it follows the selected tab", () => {
+    renderPane();
+    // Producer tab → cyan accent, `→ producer` in the strip.
+    expect(screen.getByTestId("ac-wire").className).toContain("ac-who-p");
+    expect(screen.getByTestId("ac-strip").textContent).toContain("producer");
+
+    // Worker tab → violet accent, the worker's name as addressee.
+    fireEvent.click(screen.getByRole("tab", { name: /attention-ui/ }));
+    expect(screen.getByTestId("ac-wire").className).toContain("ac-who-w");
+    expect(screen.getByTestId("ac-strip").textContent).toContain("attention-ui");
   });
 
   it("docks the S4 bash footer at the bottom of the pane", () => {

--- a/clients/react/src/components/aim-console/__tests__/Shead.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/Shead.test.tsx
@@ -1,0 +1,195 @@
+// @vitest-environment jsdom
+//
+// Shead (S6) test — the aim-console's own per-session header bar, replacing
+// the borrowed ProducerConversationHeader inside SessionPane.
+//
+//   Producer variant: status dot · name · model · ctx bar with the
+//   auto-handoff threshold marker ┊ · pct · ⤺ handoff & restart (the
+//   App-lifted ritual `trigger`, confirm flow preserved) · ⚙ · ✕ kill.
+//   Worker variant: dot · name · model · repo/cwd · ✕ kill — violet accent.
+//
+// `getOrchestratorSettings` (the threshold fetch) and `killAgent` are
+// mocked; the rest of the api stays real.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { type AgentSnapshot, api, type OrchestratorSettings } from "@/lib/api";
+import { Shead } from "../Shead";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getOrchestratorSettings: vi.fn(),
+      killAgent: vi.fn(),
+    },
+  };
+});
+
+const getOrchestratorSettings = vi.mocked(api.getOrchestratorSettings);
+const killAgent = vi.mocked(api.killAgent);
+
+function stubAgent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot {
+  return {
+    id: partial.id,
+    target: partial.target ?? partial.id,
+    agent_type: partial.agent_type ?? "ClaudeCode",
+    title: partial.title ?? partial.id,
+    cwd: partial.cwd ?? "/home/u/tmai",
+    display_cwd: partial.display_cwd ?? "~/tmai",
+    display_name: partial.display_name ?? partial.id,
+    detection_source: partial.detection_source ?? "IpcSocket",
+    git_branch: partial.git_branch ?? "main",
+    git_dirty: partial.git_dirty ?? false,
+    is_worktree: partial.is_worktree ?? false,
+    git_common_dir: partial.git_common_dir ?? "/home/u/tmai/.git",
+    unit: partial.unit,
+    worktree_name: partial.worktree_name ?? null,
+    worktree_base_branch: partial.worktree_base_branch ?? null,
+    effort_level: partial.effort_level ?? null,
+    active_subagents: partial.active_subagents ?? 0,
+    compaction_count: partial.compaction_count ?? 0,
+    pty_session_id: partial.pty_session_id ?? null,
+    send_capability: partial.send_capability ?? "Ipc",
+    is_virtual: partial.is_virtual ?? false,
+    team_info: partial.team_info ?? null,
+    attention: partial.attention ?? null,
+    model_id: partial.model_id,
+    model_display_name: partial.model_display_name,
+    ctx_usage: partial.ctx_usage ?? null,
+  };
+}
+
+const PRODUCER = stubAgent({
+  id: "claude:prod",
+  display_name: "Producer",
+  model_display_name: "opus-4.8",
+  unit: "tmai",
+  ctx_usage: { used: 114000n, total: 200000n, pct: 57, updated_at: "2026-06-11T00:00:00Z" },
+});
+
+const WORKER = stubAgent({
+  id: "claude:w1",
+  display_name: "attention-ui",
+  model_display_name: "sonnet-4.6",
+  is_worktree: true,
+  git_common_dir: "/home/u/tmai/.git",
+  display_cwd: "../tmai-wt-attn-ui",
+  ctx_usage: { used: 82000n, total: 200000n, pct: 41, updated_at: "2026-06-11T00:00:00Z" },
+});
+
+function renderShead(overrides: Partial<Parameters<typeof Shead>[0]> = {}) {
+  const props = {
+    agent: PRODUCER,
+    isProducer: true,
+    unitName: "tmai" as string | null,
+    currentProjectPath: "/home/u/tmai" as string | null,
+    trigger: vi.fn(() => Promise.resolve()),
+    onOpenSettings: vi.fn(),
+    ...overrides,
+  };
+  render(<Shead {...props} />);
+  return props;
+}
+
+beforeEach(() => {
+  getOrchestratorSettings.mockReset();
+  killAgent.mockReset();
+  getOrchestratorSettings.mockResolvedValue({
+    auto_handoff_threshold_pct: 75,
+  } as OrchestratorSettings);
+  killAgent.mockResolvedValue(undefined);
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Shead — Producer variant", () => {
+  it("renders dot · name · model · ctx bar (with ┊ threshold marker) · pct", async () => {
+    const { container } = render(
+      <Shead
+        agent={PRODUCER}
+        isProducer
+        unitName="tmai"
+        currentProjectPath="/home/u/tmai"
+        trigger={vi.fn(() => Promise.resolve())}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+    const head = screen.getByTestId("ac-shead-producer");
+    expect(head.className).toContain("ac-who-p");
+    expect(screen.getByText("Producer")).toBeTruthy();
+    expect(screen.getByText("opus-4.8")).toBeTruthy();
+    expect(screen.getByText("57%")).toBeTruthy();
+    // 10-segment bar: 57% → 6 filled.
+    const bar = container.querySelector(".bar");
+    expect(bar?.textContent).toContain("▮");
+    // The ┊ threshold marker lands once the threshold fetch (75%) resolves.
+    await waitFor(() => expect(bar?.textContent).toContain("┊"));
+    expect(screen.getByText("auto 75%")).toBeTruthy();
+  });
+
+  it("fires the handoff ritual trigger behind the confirm flow", async () => {
+    const confirmSpy = vi.spyOn(window, "confirm").mockReturnValue(true);
+    const props = renderShead();
+    fireEvent.click(screen.getByRole("button", { name: /handoff & restart/i }));
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(props.trigger).toHaveBeenCalledWith("tmai", { trigger: "manual" });
+  });
+
+  it("does NOT trigger when the confirm is declined", () => {
+    vi.spyOn(window, "confirm").mockReturnValue(false);
+    const props = renderShead();
+    fireEvent.click(screen.getByRole("button", { name: /handoff & restart/i }));
+    expect(props.trigger).not.toHaveBeenCalled();
+  });
+
+  it("opens settings via ⚙ and kills via ✕", () => {
+    const props = renderShead();
+    fireEvent.click(screen.getByRole("button", { name: "Open settings — auto-handoff threshold" }));
+    expect(props.onOpenSettings).toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Kill agent" }));
+    expect(killAgent).toHaveBeenCalledWith("claude:prod");
+  });
+
+  it("renders 'auto off' and no ┊ marker when the threshold is 0 (disabled)", async () => {
+    getOrchestratorSettings.mockResolvedValue({
+      auto_handoff_threshold_pct: 0,
+    } as OrchestratorSettings);
+    const { container } = render(
+      <Shead
+        agent={PRODUCER}
+        isProducer
+        unitName="tmai"
+        currentProjectPath="/home/u/tmai"
+        trigger={vi.fn(() => Promise.resolve())}
+        onOpenSettings={vi.fn()}
+      />,
+    );
+    await waitFor(() => expect(screen.getByText("auto off")).toBeTruthy());
+    expect(container.querySelector(".bar")?.textContent).not.toContain("┊");
+  });
+});
+
+describe("Shead — worker variant", () => {
+  it("renders dot · name · model · repo/cwd with the violet accent and kill only", () => {
+    renderShead({ agent: WORKER, isProducer: false });
+    const head = screen.getByTestId("ac-shead-worker");
+    expect(head.className).toContain("ac-who-w");
+    expect(screen.getByText("attention-ui")).toBeTruthy();
+    expect(screen.getByText("sonnet-4.6")).toBeTruthy();
+    expect(screen.getByText(/repo tmai · main · \.\.\/tmai-wt-attn-ui/)).toBeTruthy();
+    // No handoff ritual, no settings — the worker bar carries kill only.
+    expect(screen.queryByRole("button", { name: /handoff & restart/i })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Open settings — auto-handoff threshold" }),
+    ).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Kill agent" }));
+    expect(killAgent).toHaveBeenCalledWith("claude:w1");
+    // The worker variant never fetches the (Producer-only) threshold.
+    expect(getOrchestratorSettings).not.toHaveBeenCalled();
+  });
+});

--- a/clients/react/src/components/aim-console/__tests__/WireTerminal.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/WireTerminal.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+//
+// WireTerminal + StatusStrip (S6) test — the hot/cold-wire PTY surface.
+//
+// TerminalPanel (xterm + the PTY plane) is stubbed to a props recorder, so
+// the unit under test is the wire's own plumbing: the strip's segmented
+// [⌁ INPUT | ⌖ SELECT] control DRIVING the controlled `inputMode` prop, the
+// panel's internal transitions surfacing back via `onInputModeChange`, the
+// `follow` toggle flipping the SHARED per-agent auto-scroll store (the same
+// store the chromeless TerminalPanel consumes internally — asserted via a
+// live probe), and the addressee accent (`ac-who-*`) / ctx readout / hint.
+
+import { act, fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { useAutoScrollPerAgent } from "@/hooks/useAutoScrollPerAgent";
+import { WireTerminal } from "../WireTerminal";
+
+interface RecordedPanelProps {
+  agentId: string;
+  chromeless?: boolean;
+  inputMode?: boolean;
+  onInputModeChange?: (v: boolean) => void;
+}
+let panelProps: RecordedPanelProps | null = null;
+
+vi.mock("@/components/terminal/TerminalPanel", () => ({
+  TerminalPanel: (props: RecordedPanelProps) => {
+    panelProps = props;
+    return <div data-testid="wt-terminal">{props.agentId}</div>;
+  },
+}));
+
+// A second live consumer of the shared per-agent auto-scroll store — stands
+// in for the chromeless TerminalPanel's internal `useAutoScrollPerAgent`
+// (the real panel is stubbed above). The strip's `follow` toggle must reach
+// it WHILE BOTH ARE MOUNTED.
+function FollowProbe({ agentId }: { agentId: string }) {
+  const [follow] = useAutoScrollPerAgent(agentId);
+  return <div data-testid="follow-probe">{String(follow)}</div>;
+}
+
+describe("WireTerminal — hot/cold-wire surface (S6)", () => {
+  it("renders the chromeless TerminalPanel in INPUT mode with the addressee accent", () => {
+    render(<WireTerminal agentId="claude:p" who="producer" addressee="producer" ctxPct={57} />);
+    const wire = screen.getByTestId("ac-wire");
+    expect(wire.className).toContain("ac-who-p");
+    expect(wire.className).toContain("input");
+    expect(panelProps).toMatchObject({
+      agentId: "claude:p",
+      chromeless: true,
+      inputMode: true,
+    });
+  });
+
+  it("strip segmented control drives the controlled inputMode prop (and the cold wire)", () => {
+    render(<WireTerminal agentId="claude:p2" who="producer" addressee="producer" />);
+    fireEvent.click(screen.getByRole("button", { name: /SELECT/ }));
+    expect(screen.getByTestId("ac-wire").className).toContain("select");
+    expect(panelProps?.inputMode).toBe(false);
+    fireEvent.click(screen.getByRole("button", { name: /INPUT/ }));
+    expect(screen.getByTestId("ac-wire").className).toContain("input");
+    expect(panelProps?.inputMode).toBe(true);
+  });
+
+  it("the panel's internal mode transitions surface back to the wire + strip", () => {
+    render(<WireTerminal agentId="claude:p3" who="producer" addressee="producer" />);
+    // e.g. mousedown-in-terminal → select, reported via onInputModeChange.
+    act(() => panelProps?.onInputModeChange?.(false));
+    expect(screen.getByTestId("ac-wire").className).toContain("select");
+    expect(screen.getByRole("button", { name: /SELECT/ }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+  });
+
+  it("follow flips the SHARED per-agent store — a simultaneous consumer sees it live", () => {
+    render(
+      <>
+        <WireTerminal agentId="claude:f1" who="worker" addressee="attention-ui" />
+        <FollowProbe agentId="claude:f1" />
+      </>,
+    );
+    const follow = screen.getByRole("button", { name: "follow" });
+    expect(follow.getAttribute("aria-pressed")).toBe("true");
+    expect(screen.getByTestId("follow-probe").textContent).toBe("true");
+    fireEvent.click(follow);
+    expect(follow.getAttribute("aria-pressed")).toBe("false");
+    // The OTHER mounted consumer (the stand-in for TerminalPanel's internal
+    // auto-scroll hook) re-rendered with the new value — no remount needed.
+    expect(screen.getByTestId("follow-probe").textContent).toBe("false");
+  });
+
+  it("worker and shell addressees pick the violet / green accents", () => {
+    const { unmount } = render(
+      <WireTerminal agentId="claude:w" who="worker" addressee="drift-cycle" />,
+    );
+    expect(screen.getByTestId("ac-wire").className).toContain("ac-who-w");
+    expect(screen.getByTestId("ac-strip").textContent).toContain("drift-cycle");
+    unmount();
+    render(<WireTerminal agentId="bash:1" who="shell" addressee="tmai" />);
+    expect(screen.getByTestId("ac-wire").className).toContain("ac-who-sh");
+  });
+
+  it("shows the ctx readout only when a pct is given (shells pass none)", () => {
+    const { unmount } = render(
+      <WireTerminal agentId="claude:c" who="producer" addressee="producer" ctxPct={57} />,
+    );
+    expect(screen.getByTestId("ac-strip").textContent).toContain("ctx 57%");
+    unmount();
+    render(<WireTerminal agentId="bash:2" who="shell" addressee="tmai" />);
+    expect(screen.getByTestId("ac-strip").textContent).not.toContain("ctx");
+  });
+
+  it("renders the one-line mode hint only with `hint`, following the mode", () => {
+    render(<WireTerminal agentId="claude:h" who="producer" addressee="producer" hint />);
+    expect(screen.getByText(/キーストロークは agent に渡る/)).toBeTruthy();
+    fireEvent.click(screen.getByRole("button", { name: /SELECT/ }));
+    expect(screen.getByText(/出力テキストを選択\/コピーできる/)).toBeTruthy();
+  });
+
+  it("omits the hint by default (footer mini strips)", () => {
+    render(<WireTerminal agentId="bash:3" who="shell" addressee="tmai" />);
+    expect(screen.queryByText(/キーストロークは agent に渡る/)).toBeNull();
+  });
+});

--- a/clients/react/src/components/aim-console/session-status.ts
+++ b/clients/react/src/components/aim-console/session-status.ts
@@ -1,0 +1,21 @@
+// Shared `attention` → status-dot mapping for the aim-console's session
+// surfaces (the stab dots and the shead dot use the same language).
+//
+// Mirrors the existing console's flat `attention` enum reading
+// (tmai-core@2026-05-09 Phase 4): `halted` → at a permission prompt,
+// `started` / `completed` → waiting on the operator, `null` → running.
+
+import type { AgentSnapshot } from "@/lib/api";
+
+export function statusClass(attention: AgentSnapshot["attention"]): string {
+  if (attention === "halted") return "halt";
+  if (attention === "started" || attention === "completed") return "wait";
+  return "run";
+}
+
+export function statusWord(attention: AgentSnapshot["attention"]): string {
+  if (attention === "halted") return "Halted";
+  if (attention === "completed") return "Done";
+  if (attention === "started") return "Started";
+  return "Active";
+}

--- a/clients/react/src/components/terminal/TerminalPanel.tsx
+++ b/clients/react/src/components/terminal/TerminalPanel.tsx
@@ -10,15 +10,33 @@ interface TerminalPanelProps {
   /** Canonical agent id (`<scheme>:<id>`). The terminal-plane stream
    *  scopes on this; ticket subscription happens inside `useTerminal`. */
   agentId: string;
+  /** Suppress this panel's own chrome — no `TerminalSessionHeader`, no
+   *  footer bar, no focus shadow — for hosts that draw their own (the
+   *  aim-console's spine + status strip, #803). Default `false` keeps the
+   *  existing rendering unchanged. */
+  chromeless?: boolean;
+  /** Controlled Input/Select mode (#803). When provided, the host owns the
+   *  mode value (e.g. the aim-console status strip); the internal semantics
+   *  (mousedown→select, Enter-in-select→input, xterm keyboard attach) stay
+   *  this one implementation and report transitions via `onInputModeChange`.
+   *  When absent, the original internal `useState` behavior is unchanged. */
+  inputMode?: boolean;
+  onInputModeChange?: (v: boolean) => void;
 }
 
 // Single terminal panel connected to a PTY session via the rev3
 // terminal plane (#174 Phase 3a).
 // Shares the same Input/Select + Auto-scroll footer pattern as PreviewPanel.
-export function TerminalPanel({ agentId }: TerminalPanelProps) {
+export function TerminalPanel({
+  agentId,
+  chromeless = false,
+  inputMode: inputModeProp,
+  onInputModeChange,
+}: TerminalPanelProps) {
   const sectionRef = useRef<HTMLElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [inputMode, setInputMode] = useState(true);
+  const [internalInputMode, setInternalInputMode] = useState(true);
+  const inputMode = inputModeProp ?? internalInputMode;
   const [hasFocus, setHasFocus] = useState(false);
   const [autoScroll, setAutoScroll] = useAutoScrollPerAgent(agentId);
 
@@ -57,15 +75,27 @@ export function TerminalPanel({ agentId }: TerminalPanelProps) {
 
   // Switch to input mode (xterm captures keyboard)
   const enterInputMode = useCallback(() => {
-    setInputMode(true);
+    setInternalInputMode(true);
+    onInputModeChange?.(true);
     setAttachable(true);
-  }, [setAttachable]);
+  }, [setAttachable, onInputModeChange]);
 
   // Switch to select mode (text selection enabled, keyboard capture off)
   const enterSelectMode = useCallback(() => {
-    setInputMode(false);
+    setInternalInputMode(false);
+    onInputModeChange?.(false);
     setAttachable(false);
-  }, [setAttachable]);
+  }, [setAttachable, onInputModeChange]);
+
+  // Controlled mode: the host can flip `inputMode` from its own UI (the
+  // aim-console strip) without going through the handlers above — keep
+  // xterm's keyboard attachment in lock-step with the resolved mode.
+  // `setAttachable` is idempotent (it guards on the live disposables), so
+  // the redundant call after an internal transition is a no-op, as is the
+  // mount-time call (the create-effect already attached).
+  useEffect(() => {
+    setAttachable(inputMode);
+  }, [inputMode, setAttachable]);
 
   // In select mode, listen for Enter key on the container to switch to input mode
   useEffect(() => {
@@ -85,13 +115,17 @@ export function TerminalPanel({ agentId }: TerminalPanelProps) {
   return (
     <section
       ref={sectionRef}
-      className={`relative flex h-full w-full flex-col transition-shadow ${
-        hasFocus
-          ? "shadow-[inset_0_0_0_2px_rgba(34,211,238,0.55),inset_0_0_24px_rgba(34,211,238,0.06)]"
-          : "shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)]"
-      }`}
+      className={
+        chromeless
+          ? "relative flex h-full w-full flex-col"
+          : `relative flex h-full w-full flex-col transition-shadow ${
+              hasFocus
+                ? "shadow-[inset_0_0_0_2px_rgba(34,211,238,0.55),inset_0_0_24px_rgba(34,211,238,0.06)]"
+                : "shadow-[inset_0_0_0_1px_rgba(255,255,255,0.04)]"
+            }`
+      }
     >
-      <TerminalSessionHeader agentId={agentId} agent={agent} />
+      {!chromeless && <TerminalSessionHeader agentId={agentId} agent={agent} />}
       {/* biome-ignore lint/a11y/noStaticElementInteractions: terminal container needs pointer events for selection mode */}
       <div
         ref={containerRef}
@@ -114,15 +148,20 @@ export function TerminalPanel({ agentId }: TerminalPanelProps) {
       />
 
       {/* Footer status bar */}
-      <div className="flex items-center gap-2 border-t border-hairline px-3 py-1.5">
-        <ModeToggleButton
-          inputMode={inputMode}
-          onToggle={inputMode ? enterSelectMode : enterInputMode}
-        />
-        <AutoScrollToggleButton autoScroll={autoScroll} onToggle={() => setAutoScroll((v) => !v)} />
-        <div className="flex-1" />
-        <ModeHint inputMode={inputMode} />
-      </div>
+      {!chromeless && (
+        <div className="flex items-center gap-2 border-t border-hairline px-3 py-1.5">
+          <ModeToggleButton
+            inputMode={inputMode}
+            onToggle={inputMode ? enterSelectMode : enterInputMode}
+          />
+          <AutoScrollToggleButton
+            autoScroll={autoScroll}
+            onToggle={() => setAutoScroll((v) => !v)}
+          />
+          <div className="flex-1" />
+          <ModeHint inputMode={inputMode} />
+        </div>
+      )}
     </section>
   );
 }

--- a/clients/react/src/components/terminal/__tests__/TerminalPanel.test.tsx
+++ b/clients/react/src/components/terminal/__tests__/TerminalPanel.test.tsx
@@ -1,0 +1,128 @@
+// @vitest-environment jsdom
+//
+// TerminalPanel chrome / mode-prop contract (#803).
+//
+// S6 added OPTIONAL, default-unchanged props so the aim-console can draw its
+// own chrome around the panel: `chromeless` (no TerminalSessionHeader, no
+// footer bar, no focus shadow) and controlled `inputMode` +
+// `onInputModeChange`. The DEFAULT rendering must stay exactly the existing
+// one — header + footer present, internal mode state — which is what the
+// first tests pin down. `useTerminal` (xterm + the PTY plane) is stubbed; the
+// unit under test is the panel's chrome and its mode plumbing.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { TerminalPanel } from "../TerminalPanel";
+
+const setAttachable = vi.fn();
+vi.mock("@/hooks/useTerminal", () => ({
+  useTerminal: () => ({
+    terminal: { current: null },
+    fit: vi.fn(),
+    writeText: vi.fn(),
+    sendKeys: vi.fn(),
+    setAttachable,
+    attached: true,
+  }),
+}));
+vi.mock("@/hooks/useAgents", () => ({
+  useAgents: () => ({ agents: [], attentionCount: 0, loading: false, refresh: vi.fn() }),
+}));
+vi.mock("../TerminalSessionHeader", () => ({
+  TerminalSessionHeader: () => <div data-testid="terminal-session-header" />,
+}));
+
+// The xterm container div (the panel's only direct child div carrying the
+// mouse handlers) — no testid by design (props-only additive change).
+function termContainer(container: HTMLElement): HTMLElement {
+  const el = container.querySelector("section > div.flex-1");
+  if (!el) throw new Error("terminal container not found");
+  return el as HTMLElement;
+}
+
+beforeEach(() => {
+  setAttachable.mockClear();
+});
+
+describe("TerminalPanel — default chrome (must stay unchanged)", () => {
+  it("renders the session header AND the Input/Auto footer by default", () => {
+    render(<TerminalPanel agentId="claude:a1" />);
+    expect(screen.getByTestId("terminal-session-header")).toBeTruthy();
+    expect(screen.getByRole("button", { name: /⌨ Input/ })).toBeTruthy();
+    expect(screen.getByRole("button", { name: /⇩ Auto/ })).toBeTruthy();
+  });
+
+  it("keeps the internal (uncontrolled) mode toggle working", () => {
+    const { container } = render(<TerminalPanel agentId="claude:a2" />);
+    fireEvent.click(screen.getByRole("button", { name: /⌨ Input/ }));
+    expect(screen.getByRole("button", { name: /📋 Select/ })).toBeTruthy();
+    expect(setAttachable).toHaveBeenLastCalledWith(false);
+    // mousedown in select mode + empty selection on mouseup → back to input.
+    fireEvent.mouseUp(termContainer(container));
+    expect(screen.getByRole("button", { name: /⌨ Input/ })).toBeTruthy();
+    expect(setAttachable).toHaveBeenLastCalledWith(true);
+  });
+});
+
+describe("TerminalPanel — chromeless (#803 aim-console)", () => {
+  it("hides the header, footer and focus shadow", () => {
+    const { container } = render(<TerminalPanel agentId="claude:a3" chromeless />);
+    expect(screen.queryByTestId("terminal-session-header")).toBeNull();
+    expect(screen.queryByRole("button", { name: /⌨ Input/ })).toBeNull();
+    expect(screen.queryByRole("button", { name: /⇩ Auto/ })).toBeNull();
+    const section = container.querySelector("section");
+    expect(section?.className).not.toContain("shadow");
+  });
+
+  it("reports internal mode transitions through onInputModeChange (controlled)", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <TerminalPanel
+        agentId="claude:a4"
+        chromeless
+        inputMode={true}
+        onInputModeChange={onChange}
+      />,
+    );
+    // mousedown on the terminal → the panel's own select-mode semantics fire
+    // and surface to the host instead of (only) internal state.
+    fireEvent.mouseDown(termContainer(container));
+    expect(onChange).toHaveBeenCalledWith(false);
+    expect(setAttachable).toHaveBeenLastCalledWith(false);
+  });
+
+  it("follows a host-driven inputMode prop flip (keyboard attach in lock-step)", () => {
+    const { rerender } = render(
+      <TerminalPanel
+        agentId="claude:a5"
+        chromeless
+        inputMode={true}
+        onInputModeChange={() => {}}
+      />,
+    );
+    expect(setAttachable).toHaveBeenLastCalledWith(true);
+    rerender(
+      <TerminalPanel
+        agentId="claude:a5"
+        chromeless
+        inputMode={false}
+        onInputModeChange={() => {}}
+      />,
+    );
+    expect(setAttachable).toHaveBeenLastCalledWith(false);
+  });
+
+  it("returns to input mode on Enter while in select mode (existing semantics, controlled)", () => {
+    const onChange = vi.fn();
+    const { container } = render(
+      <TerminalPanel
+        agentId="claude:a6"
+        chromeless
+        inputMode={false}
+        onInputModeChange={onChange}
+      />,
+    );
+    fireEvent.keyDown(termContainer(container), { key: "Enter" });
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+});

--- a/clients/react/src/hooks/__tests__/useAutoScrollPerAgent.test.tsx
+++ b/clients/react/src/hooks/__tests__/useAutoScrollPerAgent.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+//
+// useAutoScrollPerAgent — per-agent persisted auto-scroll preference.
+//
+// S6 (#803) rebased the hook from per-instance `useState` (synced from the
+// module Map only on `agentId` change) onto `useSyncExternalStore`, because
+// the aim-console mounts TWO live consumers for the same agent at once: the
+// status strip's `follow` toggle and the chromeless TerminalPanel's internal
+// auto-scroll. These tests pin the original contract (default true, persists
+// across remounts, per-agent isolation, updater-function setter) AND the new
+// one (a set in one mounted instance reaches the other live).
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { useAutoScrollPerAgent } from "../useAutoScrollPerAgent";
+
+// Module-level store persists across tests — every test uses its own
+// agent id so they stay independent.
+
+describe("useAutoScrollPerAgent", () => {
+  it("defaults to true for an unseen agent", () => {
+    const { result } = renderHook(() => useAutoScrollPerAgent("as:default"));
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("persists the chosen value across unmount/remount", () => {
+    const first = renderHook(() => useAutoScrollPerAgent("as:persist"));
+    act(() => first.result.current[1](false));
+    expect(first.result.current[0]).toBe(false);
+    first.unmount();
+
+    const second = renderHook(() => useAutoScrollPerAgent("as:persist"));
+    expect(second.result.current[0]).toBe(false);
+  });
+
+  it("supports the useState-style updater function", () => {
+    const { result } = renderHook(() => useAutoScrollPerAgent("as:updater"));
+    act(() => result.current[1]((prev) => !prev));
+    expect(result.current[0]).toBe(false);
+    act(() => result.current[1]((prev) => !prev));
+    expect(result.current[0]).toBe(true);
+  });
+
+  it("isolates agents from each other", () => {
+    const a = renderHook(() => useAutoScrollPerAgent("as:iso-a"));
+    const b = renderHook(() => useAutoScrollPerAgent("as:iso-b"));
+    act(() => a.result.current[1](false));
+    expect(a.result.current[0]).toBe(false);
+    expect(b.result.current[0]).toBe(true);
+  });
+
+  it("syncs SIMULTANEOUSLY mounted consumers of the same agent live (#803)", () => {
+    const strip = renderHook(() => useAutoScrollPerAgent("as:live"));
+    const panel = renderHook(() => useAutoScrollPerAgent("as:live"));
+    act(() => strip.result.current[1](false));
+    // The other mounted instance picks the toggle up WITHOUT a remount —
+    // this is what lets the aim-console strip drive the chromeless
+    // TerminalPanel's internal auto-scroll.
+    expect(panel.result.current[0]).toBe(false);
+    act(() => panel.result.current[1](true));
+    expect(strip.result.current[0]).toBe(true);
+  });
+
+  it("re-reads the store when the same instance swaps agents", () => {
+    const seed = renderHook(() => useAutoScrollPerAgent("as:swap-target"));
+    act(() => seed.result.current[1](false));
+
+    const { result, rerender } = renderHook(({ id }) => useAutoScrollPerAgent(id), {
+      initialProps: { id: "as:swap-origin" },
+    });
+    expect(result.current[0]).toBe(true);
+    rerender({ id: "as:swap-target" });
+    expect(result.current[0]).toBe(false);
+  });
+});

--- a/clients/react/src/hooks/useAutoScrollPerAgent.ts
+++ b/clients/react/src/hooks/useAutoScrollPerAgent.ts
@@ -1,10 +1,24 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useSyncExternalStore } from "react";
 
-// Module-level Map so the user's per-agent auto-scroll preference survives
+// Module-level store so the user's per-agent auto-scroll preference survives
 // across remounts and across host components (e.g. switching between
-// `TerminalPanel` and `PreviewPanel` for the same agent). Living here
-// rather than per-component state lets both consumers see the same value.
+// `TerminalPanel` and `PreviewPanel` for the same agent).
+//
+// Backed by `useSyncExternalStore` (not per-instance `useState` synced from
+// the Map) because consumers can be mounted SIMULTANEOUSLY for the same
+// agent: the aim-console status strip's `follow` toggle (#803) and the
+// chromeless `TerminalPanel` it sits under each call this hook, and a toggle
+// in one must reach the other live — a mount-time snapshot would leave the
+// terminal pinned to a stale value until remount.
 const autoScrollByAgent = new Map<string, boolean>();
+const listeners = new Set<() => void>();
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
 
 /**
  * `useState`-shaped wrapper that persists the chosen value into a per-agent
@@ -12,28 +26,23 @@ const autoScrollByAgent = new Map<string, boolean>();
  *
  * The setter accepts both a value and an updater function, mirroring the
  * `useState` setter shape so callers can drop it in without changing
- * call sites. When `agentId` changes (the parent reuses the same component
- * instance with a different agent), the state is re-synchronized from the
- * cache so the UI reflects the previously-toggled preference for the
- * newly-focused agent.
+ * call sites. All mounted consumers of the same store re-render on a set,
+ * so the value reads the same everywhere — including when `agentId` changes
+ * (the snapshot function closes over the current id).
  */
 export function useAutoScrollPerAgent(
   agentId: string,
 ): [boolean, (next: boolean | ((prev: boolean) => boolean)) => void] {
-  const [autoScroll, setRaw] = useState<boolean>(() => autoScrollByAgent.get(agentId) ?? true);
-
-  // Re-sync from the cache when the host swaps agents without remounting.
-  useEffect(() => {
-    setRaw(autoScrollByAgent.get(agentId) ?? true);
-  }, [agentId]);
+  const autoScroll = useSyncExternalStore(subscribe, () => autoScrollByAgent.get(agentId) ?? true);
 
   const setAutoScroll = useCallback(
     (next: boolean | ((prev: boolean) => boolean)) => {
-      setRaw((prev) => {
-        const value = typeof next === "function" ? next(prev) : next;
-        autoScrollByAgent.set(agentId, value);
-        return value;
-      });
+      const prev = autoScrollByAgent.get(agentId) ?? true;
+      const value = typeof next === "function" ? next(prev) : next;
+      autoScrollByAgent.set(agentId, value);
+      for (const listener of listeners) {
+        listener();
+      }
     },
     [agentId],
   );

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -360,29 +360,127 @@
   font-size: 14px;
 }
 
-/* ── shead (mock `.shead`) — the WORKER plain model/cwd bar. The Producer
-   reuses ProducerConversationHeader (its own tokens), not this. ─────────── */
+/* ── who accent (S6 mock `--who`) — the addressee names the accent on every
+   PTY surface: producer cyan / worker violet / shell green. Scoped custom
+   property; the spine, strip and shead resolve against it. ──────────────── */
+.aim-console .ac-who-p {
+  --who: var(--cyan);
+  --who-d: var(--cyan-d);
+}
+.aim-console .ac-who-w {
+  --who: var(--violet);
+  --who-d: var(--violet-d);
+}
+.aim-console .ac-who-sh {
+  --who: var(--green);
+  --who-d: var(--green-d);
+}
+
+/* ── shead (S6 mock `.shead`) — one compact 27px mono-first bar per session:
+   dot · name · model · ctx bar (┊ = auto-handoff threshold) · pct ·
+   unit-or-repo/cwd · actions (handoff/settings/kill). Replaces the borrowed
+   ProducerConversationHeader inside the aim-console. ──────────────────────── */
 .aim-console .ac-shead {
   display: flex;
   align-items: center;
-  gap: 9px;
+  gap: 10px;
+  height: var(--rh);
   flex: none;
-  padding: 7px 12px;
+  padding: 0 11px;
   border-bottom: 1px solid var(--line-2);
   background: var(--panel);
-  font-size: 11px;
-  color: var(--dim);
-}
-.aim-console .ac-shead .m {
   font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--dim);
+  white-space: nowrap;
+  overflow: hidden;
+}
+.aim-console .ac-shead .dd {
+  width: 6px;
+  height: 6px;
+  flex: none;
+  background: var(--faint);
+}
+.aim-console .ac-shead .dd.run {
+  background: var(--green);
+  animation: ac-pulse 2.4s ease-in-out infinite;
+}
+.aim-console .ac-shead .dd.wait {
+  background: var(--amber);
+}
+.aim-console .ac-shead .dd.halt {
+  background: var(--danger);
+}
+.aim-console .ac-shead .nm {
+  color: var(--txt);
+  font-weight: 500;
+}
+.aim-console .ac-shead .md {
+  color: var(--faint);
+}
+.aim-console .ac-shead .bar {
+  letter-spacing: 1px;
+  color: var(--faint);
+}
+.aim-console .ac-shead .bar .f {
+  color: var(--who);
+}
+.aim-console .ac-shead .bar .tk {
+  color: var(--amber);
+}
+.aim-console .ac-shead .pct {
   color: var(--txt);
 }
-.aim-console .ac-shead .w {
-  font-family: var(--mono);
+.aim-console .ac-shead .pct.hi {
+  color: var(--amber);
+}
+.aim-console .ac-shead .pct.hot {
+  color: var(--danger);
+}
+.aim-console .ac-shead .cwd {
   color: var(--faint);
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+}
+.aim-console .ac-shead .acts {
+  margin-left: auto;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: none;
+}
+.aim-console .ac-shead .ho {
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--dim);
+  border: 1px solid var(--line);
+  background: none;
+  cursor: pointer;
+  padding: 2.5px 8px;
+  letter-spacing: 0.3px;
+}
+.aim-console .ac-shead .ho:hover {
+  color: var(--amber);
+  border-color: #3a2e14;
+  background: var(--amber-d);
+}
+.aim-console .ac-shead .ho:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+.aim-console .ac-shead .ic {
+  color: var(--faint);
+  font-size: 11px;
+  padding: 2px 4px;
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.aim-console .ac-shead .ic:hover {
+  color: var(--txt);
+}
+.aim-console .ac-shead .ic.kill:hover {
+  color: var(--danger);
 }
 
 /* ── term (mock `.term`) — the conversation surface. TerminalPanel /
@@ -402,6 +500,191 @@
   font-family: var(--mono);
   font-size: 11px;
   color: var(--faint);
+}
+
+/* ── hot-wire ⊥ cold-wire (S6 mock `.spine`/`.status`/`.hint`) ────────────
+   WireTerminal: a 3px left spine on the terminal area — INPUT = live wire
+   in the addressee's accent with a slow travelling pulse; SELECT = cold
+   ochre/static, and the terminal's left edge carries the cold marker. The
+   status strip below replaces TerminalPanel's footer inside the aim-console. */
+.aim-console .ac-wire {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+}
+.aim-console .ac-wire-row {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  align-items: stretch;
+}
+.aim-console .ac-spine {
+  width: 3px;
+  flex: none;
+  background: var(--faint);
+  position: relative;
+  overflow: hidden;
+  transition: background 0.18s;
+}
+.aim-console .ac-wire.input .ac-spine {
+  background: var(--who);
+}
+.aim-console .ac-wire.input .ac-spine::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  width: 100%;
+  height: 46%;
+  background: linear-gradient(180deg, transparent, rgba(255, 255, 255, 0.75), transparent);
+  animation: ac-wire-pulse 2.6s ease-in-out infinite;
+}
+.aim-console .ac-wire.select .ac-spine {
+  background: var(--ochre);
+  opacity: 0.65;
+}
+.aim-console .ac-wire-term {
+  flex: 1;
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid transparent;
+  transition: border-color 0.18s;
+}
+.aim-console .ac-wire.select .ac-wire-term {
+  border-left-color: rgba(177, 137, 79, 0.55);
+}
+
+/* status strip — [⌁ INPUT | ⌖ SELECT] · follow · → addressee · ctx % */
+.aim-console .ac-strip {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 0 12px 0 15px;
+  height: 26px;
+  flex: none;
+  border-top: 1px solid var(--line-2);
+  background: var(--panel);
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--faint);
+}
+.aim-console .ac-seg2 {
+  display: flex;
+  border: 1px solid var(--line);
+}
+.aim-console .ac-seg2 button {
+  display: flex;
+  gap: 5px;
+  align-items: center;
+  padding: 2.5px 10px;
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.8px;
+  color: var(--faint);
+  background: none;
+  border: none;
+  cursor: pointer;
+}
+.aim-console .ac-seg2 .lead {
+  font-size: 11px;
+}
+.aim-console .ac-wire.input .ac-seg2 button[data-mode="input"] {
+  color: var(--who);
+  background: var(--who-d);
+}
+.aim-console .ac-wire.select .ac-seg2 button[data-mode="select"] {
+  color: var(--ochre);
+  background: var(--ochre-d);
+}
+.aim-console .ac-dv {
+  width: 1px;
+  height: 13px;
+  background: var(--line);
+  flex: none;
+}
+.aim-console .ac-follow {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  color: var(--faint);
+  cursor: pointer;
+  letter-spacing: 0.5px;
+  background: none;
+  border: none;
+  font-family: var(--mono);
+  font-size: 10px;
+}
+.aim-console .ac-follow .sw {
+  width: 16px;
+  height: 8px;
+  border: 1px solid var(--line);
+  position: relative;
+}
+.aim-console .ac-follow .sw::before {
+  content: "";
+  position: absolute;
+  top: 1px;
+  left: 1px;
+  width: 5px;
+  height: 4px;
+  background: var(--faint);
+  transition:
+    left 0.15s,
+    background 0.15s;
+}
+.aim-console .ac-follow.on {
+  color: var(--txt);
+}
+.aim-console .ac-follow.on .sw {
+  border-color: var(--who-d);
+}
+.aim-console .ac-follow.on .sw::before {
+  left: 8px;
+  background: var(--who);
+}
+.aim-console .ac-addr {
+  display: flex;
+  gap: 6px;
+  align-items: center;
+  color: var(--dim);
+  letter-spacing: 0.4px;
+}
+.aim-console .ac-addr .d {
+  width: 5px;
+  height: 5px;
+  background: var(--who);
+}
+.aim-console .ac-addr b {
+  color: var(--who);
+  font-weight: 500;
+}
+.aim-console .ac-ctxr {
+  margin-left: auto;
+  color: var(--faint);
+}
+.aim-console .ac-ctxr b {
+  color: var(--txt);
+  font-weight: 500;
+}
+.aim-console .ac-hint {
+  padding: 3px 15px 6px;
+  flex: none;
+  font-size: 10px;
+  color: var(--faint);
+  font-family: var(--mono);
+  letter-spacing: 0.2px;
+  background: var(--panel);
+}
+.aim-console .ac-hint .hk {
+  border: 1px solid var(--line);
+  padding: 0 4px;
+  color: var(--dim);
+}
+.aim-console .ac-hint b {
+  color: var(--dim);
+  font-weight: 500;
 }
 
 /* ── docked bash footer (mock `.footer`/`.fbar`/`.ftab`/`.ftwrap`) ────────
@@ -1586,6 +1869,16 @@
   }
   50% {
     opacity: 1;
+  }
+}
+
+/* the live wire's slow travelling pulse (S6 mock `@keyframes pulse`) */
+@keyframes ac-wire-pulse {
+  0% {
+    top: -50%;
+  }
+  100% {
+    top: 105%;
   }
 }
 


### PR DESCRIPTION
Resolves #803. First RE-DESIGN stage of the aim-ui console: the Session pane (and every bash-footer terminal) gets the aim-console's OWN control surface in the hot/cold-wire language from the design contract (`mock/aim-ui-s6` → `assets/s6-conversation-panel-mock.html`). Drag-resize from the mock is S7 and NOT included.

## What's in

- **`WireTerminal`** (new): the shared PTY surface — a 3px left **spine** on the terminal area (INPUT = live wire in the addressee's accent with a slow travelling pulse; SELECT = cold ochre/static + the cold marker on the terminal's left edge) around a **chromeless `TerminalPanel`**, with a **`StatusStrip`** below replacing TerminalPanel's footer inside the aim-console: segmented `[⌁ INPUT | ⌖ SELECT]` (drives the existing xterm mode semantics — mousedown→select / Enter-in-select→input stay as-is, inside TerminalPanel), `follow` toggle (same per-agent store as the old `⇩ Auto`), `→ addressee` with accent dot (follows the selected tab), ctx % readout, and the one-line JP mode hint. Accent = addressee everywhere: producer `--cyan` / worker `--violet` / shell `--green` (`--who` scoped custom property).
- **`Shead`** (new): replaces `ProducerConversationHeader` usage inside `SessionPane` only (the component itself is untouched and still serves the existing console). Producer: dot · name · model · mono ctx bar with the auto-handoff threshold marker `┊` · pct · `auto N%` · unit/cwd · `⤺ handoff & restart` (threaded `trigger`, confirm flow preserved) · ⚙ · ✕. Worker: dot · name · model · repo/cwd · ✕, violet accent. Reuses `formatThousands` / `renderBar` / `thresholdColorClass` from `ProducerCtxHeader` (import-only) + the same threshold fetch pattern.
- **`BashFooter`**: each terminal pane now renders through `WireTerminal` (green spine + its own mini strip) — one control language for every PTY surface.
- **`TerminalPanel`** (allowed additive change): optional, default-unchanged props only — `chromeless` and controlled `inputMode` / `onInputModeChange`. The mode/attachable/Enter/mouse semantics remain the single internal implementation (no fork). A new test pins the DEFAULT rendering (header + footer present).
- All new CSS scoped under `.aim-console` with `.ac-*` classes, existing tokens only.

## ⚠ One out-of-list edit (flagging loudly)

`src/hooks/useAutoScrollPerAgent.ts` is outside the TOUCH list, but the issue's own contract — *"follow toggle … same per-agent persisted state via `useAutoScrollPerAgent(agentId)`"* — is unimplementable without it: the hook was per-instance `useState` synced from the module Map only on `agentId` change, so a toggle in the strip would never reach the chromeless TerminalPanel's internal consumer **while both are mounted** (follow would silently do nothing until a remount). Rebased it onto `useSyncExternalStore` over the same Map: identical API, identical single-consumer behavior, now live across simultaneous consumers. Covered by a new dedicated test (`useAutoScrollPerAgent.test.tsx`) incl. the simultaneous-consumers case. The in-bounds alternative was remounting the terminal (PTY re-attach + scrollback replay) on every follow toggle — judged worse; happy to split/revert if you prefer that route.

## Other deliberate calls (vs the mock)

- **Mode-hint text**: the mock's INPUT hint claims `⎋` frees the keyboard — in the real app Esc is a CC REPL keystroke (it interrupts the agent) and the existing semantics have no Esc handler ("stays as-is" per the issue), so the hint describes the real exits (drag-select → SELECT, `⏎` → INPUT) instead of advertising a binding that would be wrong.
- **Worker shead ctx bar**: the issue's worker line omits it, but the mock renders it (violet fill = the "violet accent") and workers do report `ctx_usage`; rendered when present, without the `┊` marker (no auto-handoff for workers).
- Worker shead now shows `repo tmai` instead of S3's `repo .git` (`git_common_dir` is the `/.git` dir on the wire; normalized first).

## Tests

New: `WireTerminal.test.tsx` (mode toggle drives the controlled prop / internal transitions surface back / follow flips the shared store live via a probe / accent + ctx + hint), `Shead.test.tsx` (Producer ctx bar + `┊` marker + confirm-gated trigger + ⚙/✕, threshold-disabled case, worker variant), `TerminalPanel.test.tsx` (default chrome unchanged; chromeless; controlled mode), `useAutoScrollPerAgent.test.tsx`. Updated: `SessionPane.test.tsx` (shead split, addressee accent follows the selected tab).

## Gate (from `clients/react/`)

- `pnpm lint` ✅ (1 pre-existing warning in an untouched file)
- `tsc -b` ✅ · `pnpm build` ✅
- `pnpm test` ✅ 103 files, 840 passed / 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * セッションヘッダー表示をプロデューサー/ワーカーで切り替え対応
  * ターミナルに入力/選択モードの切り替え機能を追加
  * エージェントごとのオートスクロール制御機能を追加
  * コンテキスト利用率バーを表示
  * エージェントステータスの可視化を改善

* **UI/UX Improvements**
  * ターミナルコントロールパネルを新設し、モード切り替えと自動スクロール設定を一元管理

<!-- end of auto-generated comment: release notes by coderabbit.ai -->