### PR TITLE
S7: aim-ui console — drag-resizable layout (pane gutters + bash-footer height, ui-prefs persistence) (#805)

### DIFF
--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -24,13 +24,24 @@
 // `TerminalPanel`); the PR-rail (right) is the real per-repo PR + Issue
 // inventory (`PrRail`, reusing `useUnitPrs` / `useUnitIssues` + the
 // `prStatusPills` / `issueStatusPills` derivation). The shell is now fully
-// filled in.
+// filled in. S7 makes the grid drag-resizable: the two pane seams are real
+// 5px gutter tracks (`Gutters`), the layout custom properties are driven
+// from the persisted `aimConsoleLayout` ui-pref, and drag end (not per-move)
+// writes it back.
 
-import { useState } from "react";
+import { type CSSProperties, useCallback, useState } from "react";
 import { useUnitAttention } from "@/hooks/useUnitAttention";
 import type { AgentSnapshot, TriggerHandoffRitualRequest, UnitResponse } from "@/lib/api";
+import {
+  AIM_CONSOLE_LAYOUT_DEFAULTS,
+  type AimConsoleLayout,
+  clampAimConsolePrWidth,
+  normalizeAimConsoleLayout,
+} from "@/lib/ui-prefs";
+import { useUIPref } from "@/lib/ui-prefs-provider";
 import { cn } from "@/lib/utils";
 import { AimPane } from "./AimPane";
+import { AimSessionGutter, SessionPrGutter } from "./Gutters";
 import { PrRail } from "./PrRail";
 import { SessionPane } from "./SessionPane";
 // Bundled dev-tool typography (offline-robust @fontsource, NOT a Google Fonts
@@ -96,9 +107,10 @@ export function AimConsole({
   onOpenSettings,
 }: AimConsoleProps) {
   // PR-rail expand state — the S1 shell's mechanism. The collapsed 46px rail
-  // expands to a 320px panel via the `.pr-open` modifier on the root (mock
-  // `body.pr-open { --pr: 320px }`). The state stays HERE; `PrRail` only
-  // renders the rail/panel CONTENT (S5) and calls back to toggle it.
+  // expands via the `.pr-open` modifier on the root + the inline `--pr`
+  // (S7: the persisted drag width, 320px default). The state stays HERE;
+  // `PrRail` only renders the rail/panel CONTENT (S5) and calls back to
+  // toggle it.
   const [prOpen, setPrOpen] = useState(false);
   const metaUnit = activeUnitName ?? units[0]?.name ?? "—";
   // The focused unit's repos drive the Session pane's per-repo bash footer
@@ -106,8 +118,63 @@ export function AimConsole({
   // `repos` is empty there — the footer falls back to `currentProjectPath`.
   const activeUnit = units.find((u) => u.name === activeUnitName) ?? null;
 
+  // S7 drag-resizable layout. The persisted pref IS the layout state — a drag
+  // adjusts the custom properties imperatively (no re-render per move, see
+  // `Gutters`) and commits here once on pointerup; the committed values then
+  // render as the same inline custom properties, so React reconciliation and
+  // the imperative drag agree. `null` = untouched → defaults.
+  const [storedLayout, setStoredLayout] = useUIPref("aimConsoleLayout");
+  const layout: AimConsoleLayout = storedLayout ?? AIM_CONSOLE_LAYOUT_DEFAULTS;
+  const layoutStyle = {
+    "--aim": `${layout.aim}fr`,
+    "--sess": `${layout.sess}fr`,
+    // Collapsed rail: leave `--pr` to the stylesheet's 46px so the stored
+    // expanded width survives without driving the collapsed track.
+    "--pr": prOpen ? `${clampAimConsolePrWidth(layout.pr)}px` : undefined,
+  } as CSSProperties;
+
+  const commitPanes = useCallback(
+    (aim: number, sess: number) =>
+      setStoredLayout(
+        normalizeAimConsoleLayout({ ...(storedLayout ?? AIM_CONSOLE_LAYOUT_DEFAULTS), aim, sess }),
+      ),
+    [storedLayout, setStoredLayout],
+  );
+  const resetPanes = useCallback(
+    () =>
+      setStoredLayout(
+        normalizeAimConsoleLayout({
+          ...(storedLayout ?? AIM_CONSOLE_LAYOUT_DEFAULTS),
+          aim: AIM_CONSOLE_LAYOUT_DEFAULTS.aim,
+          sess: AIM_CONSOLE_LAYOUT_DEFAULTS.sess,
+        }),
+      ),
+    [storedLayout, setStoredLayout],
+  );
+  const commitPr = useCallback(
+    (pr: number) =>
+      setStoredLayout(
+        normalizeAimConsoleLayout({ ...(storedLayout ?? AIM_CONSOLE_LAYOUT_DEFAULTS), pr }),
+      ),
+    [storedLayout, setStoredLayout],
+  );
+  const resetPr = useCallback(
+    () =>
+      setStoredLayout(
+        normalizeAimConsoleLayout({
+          ...(storedLayout ?? AIM_CONSOLE_LAYOUT_DEFAULTS),
+          pr: AIM_CONSOLE_LAYOUT_DEFAULTS.pr,
+        }),
+      ),
+    [storedLayout, setStoredLayout],
+  );
+
   return (
-    <div className={cn("aim-console", prOpen && "pr-open")} data-testid="aim-console">
+    <div
+      className={cn("aim-console", prOpen && "pr-open")}
+      data-testid="aim-console"
+      style={layoutStyle}
+    >
       {/* ── top bar ── */}
       <div className="ac-top">
         <div className="ac-brand">
@@ -143,12 +210,19 @@ export function AimConsole({
         </button>
       </div>
 
-      {/* ── 3-pane grid ── */}
+      {/* ── 3-pane grid + 5px gutter tracks (S7) ── */}
       <div className="ac-main">
         {/* AIM — S2 worklist (Frontier⊥Tree, ledger, ruler, inspector, modal) */}
         <section className="ac-col ac-aim" aria-label="Aim">
           <AimPane unitName={activeUnitName} />
         </section>
+
+        {/* gutter A — Aim|Session */}
+        <AimSessionGutter
+          aimShare={(layout.aim / (layout.aim + layout.sess)) * 100}
+          onCommit={commitPanes}
+          onReset={resetPanes}
+        />
 
         {/* SESSION — S3 conversation (tabs + shead + term) + S4 bash footer */}
         <section className="ac-col ac-session" aria-label="Session">
@@ -161,6 +235,14 @@ export function AimConsole({
             repos={activeUnit?.repos ?? []}
           />
         </section>
+
+        {/* gutter B — Session|PR (inert while the rail is collapsed) */}
+        <SessionPrGutter
+          open={prOpen}
+          prWidth={clampAimConsolePrWidth(layout.pr)}
+          onCommit={commitPr}
+          onReset={resetPr}
+        />
 
         {/* PR RAIL — collapsed rail ⇄ expanded panel (S1 mechanism); the
             per-repo PR + Issue lists + live counts are the real S5 content */}

--- a/clients/react/src/components/aim-console/BashFooter.tsx
+++ b/clients/react/src/components/aim-console/BashFooter.tsx
@@ -26,10 +26,18 @@
 // the partner pane). Ad-hoc shells spawn on the explicit `+`. Closing an
 // ad-hoc tab kills its PTY (`api.killAgent`) so we never strand orphan shells.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { type AgentSnapshot, api, isAiAgentLoose, normalizeGitDir } from "@/lib/api";
+import {
+  AIM_CONSOLE_FOOTER_MIN,
+  AIM_CONSOLE_LAYOUT_DEFAULTS,
+  clampAimConsoleFooterHeight,
+  normalizeAimConsoleLayout,
+} from "@/lib/ui-prefs";
+import { useUIPrefsOptional } from "@/lib/ui-prefs-provider";
 import { cn } from "@/lib/utils";
 import type { UnitRepoWire } from "@/types/generated/UnitRepoWire";
+import { FOOTER_MAX_SESSION_RATIO, FooterGutter } from "./Gutters";
 import { WireTerminal } from "./WireTerminal";
 
 interface BashFooterProps {
@@ -91,10 +99,66 @@ function resolveAgent(
 }
 
 export function BashFooter({ repos, primaryPath, agents }: BashFooterProps) {
-  // Collapsed (33px tab bar) ↔ expanded (210px) — the mock's `body.bash-on`,
-  // local here. Starts COLLAPSED so mount spawns nothing.
+  // Collapsed (33px tab bar) ↔ expanded — the mock's `body.bash-on`, local
+  // here. Starts COLLAPSED so mount spawns nothing.
   const [open, setOpen] = useState(false);
   const [splitOn, setSplitOn] = useState(false);
+
+  // S7 drag-resizable height. `--fh` is the TERMINAL-AREA height (the mock's
+  // `--fh` on `.ftwrap`); the footer's total expanded height is `--fh` + the
+  // 33px tab bar (see `.ac-footer.open`). The persisted pref seeds a LOCAL px
+  // state because the live 60%-of-session ceiling must re-apply on window
+  // resize WITHOUT persisting the transient clamp; only a drag end / reset
+  // writes the pref. Read via the OPTIONAL prefs hook so the footer (rendered
+  // provider-less in unit tests, like `useActiveTheme` deeper down) degrades
+  // to in-memory defaults instead of throwing.
+  const prefsCtx = useUIPrefsOptional();
+  const storedLayout = prefsCtx?.prefs.aimConsoleLayout ?? null;
+  const storedFooter = storedLayout?.footer ?? AIM_CONSOLE_LAYOUT_DEFAULTS.footer;
+  const [footerPx, setFooterPx] = useState(() => clampAimConsoleFooterHeight(storedFooter));
+  const footerRef = useRef<HTMLDivElement | null>(null);
+  // Reseed when the persisted value changes (drag commit, double-click
+  // reset, another tab) — the source of truth is the pref.
+  useEffect(() => {
+    setFooterPx(clampAimConsoleFooterHeight(storedFooter));
+  }, [storedFooter]);
+  // Re-apply the live ceiling (60% of the Session pane) on open + window
+  // resize. Local-only: a transiently small window must not shrink the
+  // PERSISTED height. Degenerate (zero) measurements mid-mount are skipped.
+  useEffect(() => {
+    if (!open) return;
+    const reclamp = () => {
+      const session = footerRef.current?.closest(".ac-session");
+      if (!session) return;
+      const max = Math.round(session.getBoundingClientRect().height * FOOTER_MAX_SESSION_RATIO);
+      // A ceiling below the floor means a degenerate (mid-mount / hidden)
+      // measurement — skip rather than clamp into an unusable height.
+      if (max <= AIM_CONSOLE_FOOTER_MIN) return;
+      setFooterPx((cur) => Math.min(cur, max));
+    };
+    reclamp();
+    window.addEventListener("resize", reclamp);
+    return () => window.removeEventListener("resize", reclamp);
+  }, [open]);
+
+  const persistFooter = useCallback(
+    (footer: number) => {
+      setFooterPx(footer);
+      if (!prefsCtx) return; // provider-less render — in-memory only
+      prefsCtx.setPref(
+        "aimConsoleLayout",
+        normalizeAimConsoleLayout({
+          ...(prefsCtx.prefs.aimConsoleLayout ?? AIM_CONSOLE_LAYOUT_DEFAULTS),
+          footer,
+        }),
+      );
+    },
+    [prefsCtx],
+  );
+  const resetFooter = useCallback(
+    () => persistFooter(AIM_CONSOLE_LAYOUT_DEFAULTS.footer),
+    [persistFooter],
+  );
   // Per-repo + ad-hoc tab → its live PTY id (a `spawnPty` session_id or a
   // re-attached agent target). A key is absent until its tab is first
   // surfaced — that absence is the lazy-spawn gate.
@@ -315,107 +379,115 @@ export function BashFooter({ repos, primaryPath, agents }: BashFooterProps) {
   };
 
   return (
-    <div
-      className={cn("ac-footer", open && "open")}
-      data-testid="aim-bash-footer"
-      data-open={open ? "true" : "false"}
-    >
-      <div className="ac-fbar">
-        <div className="ac-ftabs" role="tablist" aria-label="Bash terminals">
-          {tabs.map((tab) => {
-            const selected = tab.key === effectiveActiveKey;
-            const running = tab.closeable
-              ? resolveAgent(sessions[tab.key], agents) !== undefined
-              : resolveAgent(sessions[tab.key], agents) !== undefined ||
-                findExistingBash(tab.cwd, agents) !== undefined;
-            return (
-              <div
-                key={tab.key}
-                className={cn("ac-ftab", selected && "on")}
-                data-testid={`aim-bash-tab-${tab.label}`}
-              >
-                <button
-                  type="button"
-                  role="tab"
-                  aria-selected={selected}
-                  className="ac-ftab-btn"
-                  onClick={() => openOnto(tab.key)}
-                  title={`${tab.label} — ${tab.cwd}`}
+    <>
+      {/* footer height gutter (S7, mock gutF) — only while expanded */}
+      {open && (
+        <FooterGutter footerHeight={footerPx} onCommit={persistFooter} onReset={resetFooter} />
+      )}
+      <div
+        ref={footerRef}
+        className={cn("ac-footer", open && "open")}
+        data-testid="aim-bash-footer"
+        data-open={open ? "true" : "false"}
+        style={{ "--fh": `${footerPx}px` } as CSSProperties}
+      >
+        <div className="ac-fbar">
+          <div className="ac-ftabs" role="tablist" aria-label="Bash terminals">
+            {tabs.map((tab) => {
+              const selected = tab.key === effectiveActiveKey;
+              const running = tab.closeable
+                ? resolveAgent(sessions[tab.key], agents) !== undefined
+                : resolveAgent(sessions[tab.key], agents) !== undefined ||
+                  findExistingBash(tab.cwd, agents) !== undefined;
+              return (
+                <div
+                  key={tab.key}
+                  className={cn("ac-ftab", selected && "on")}
+                  data-testid={`aim-bash-tab-${tab.label}`}
                 >
-                  {running && (
-                    <span
-                      className="ac-rdot"
-                      aria-hidden="true"
-                      title="bash running in this repo"
-                    />
-                  )}
-                  <span>{tab.label}</span>
-                </button>
-                {tab.closeable && (
                   <button
                     type="button"
-                    className="ac-fclose"
-                    onClick={() => closeTab(tab.key)}
-                    title={`Close ${tab.label}`}
-                    aria-label={`Close ${tab.label}`}
+                    role="tab"
+                    aria-selected={selected}
+                    className="ac-ftab-btn"
+                    onClick={() => openOnto(tab.key)}
+                    title={`${tab.label} — ${tab.cwd}`}
                   >
-                    ×
+                    {running && (
+                      <span
+                        className="ac-rdot"
+                        aria-hidden="true"
+                        title="bash running in this repo"
+                      />
+                    )}
+                    <span>{tab.label}</span>
                   </button>
-                )}
-              </div>
-            );
-          })}
+                  {tab.closeable && (
+                    <button
+                      type="button"
+                      className="ac-fclose"
+                      onClick={() => closeTab(tab.key)}
+                      title={`Close ${tab.label}`}
+                      aria-label={`Close ${tab.label}`}
+                    >
+                      ×
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+          <button
+            type="button"
+            className="ac-fadd"
+            onClick={addAdhoc}
+            disabled={!primaryPath}
+            title="New ad-hoc terminal in the primary repo"
+            aria-label="New ad-hoc terminal"
+          >
+            +
+          </button>
+          <span className="ac-fsp" />
+          <button
+            type="button"
+            className={cn("ac-fsplit", splitOn && "on")}
+            onClick={toggleSplit}
+            disabled={tabs.length < 2}
+            aria-pressed={splitOn}
+            title="Split view (two terminals side by side)"
+            aria-label="Toggle split view"
+          >
+            ⊟
+          </button>
+          <button
+            type="button"
+            className="ac-fcar"
+            onClick={toggleOpen}
+            aria-expanded={open}
+            title="Open / close bash"
+            aria-label={open ? "Collapse bash footer" : "Expand bash footer"}
+          >
+            {open ? "▾" : "▴"}
+          </button>
         </div>
-        <button
-          type="button"
-          className="ac-fadd"
-          onClick={addAdhoc}
-          disabled={!primaryPath}
-          title="New ad-hoc terminal in the primary repo"
-          aria-label="New ad-hoc terminal"
-        >
-          +
-        </button>
-        <span className="ac-fsp" />
-        <button
-          type="button"
-          className={cn("ac-fsplit", splitOn && "on")}
-          onClick={toggleSplit}
-          disabled={tabs.length < 2}
-          aria-pressed={splitOn}
-          title="Split view (two terminals side by side)"
-          aria-label="Toggle split view"
-        >
-          ⊟
-        </button>
-        <button
-          type="button"
-          className="ac-fcar"
-          onClick={toggleOpen}
-          aria-expanded={open}
-          title="Open / close bash"
-          aria-label={open ? "Collapse bash footer" : "Expand bash footer"}
-        >
-          {open ? "▾" : "▴"}
-        </button>
-      </div>
 
-      {open && (
-        <div className={cn("ac-ftwrap", partnerTab && "split")}>
-          {activeTab ? (
-            partnerTab ? (
-              <>
-                {renderPane(activeTab, true)}
-                {renderPane(partnerTab, true)}
-              </>
+        {open && (
+          <div className={cn("ac-ftwrap", partnerTab && "split")}>
+            {activeTab ? (
+              partnerTab ? (
+                <>
+                  {renderPane(activeTab, true)}
+                  {renderPane(partnerTab, true)}
+                </>
+              ) : (
+                renderPane(activeTab, false)
+              )
             ) : (
-              renderPane(activeTab, false)
-            )
-          ) : (
-            <div className="ac-fthint">No repo to open a shell in — focus a unit first.</div>
-          )}
-        </div>
-      )}
-    </div>
+              <div className="ac-fthint">No repo to open a shell in — focus a unit first.</div>
+            )}
+          </div>
+        )}
+      </div>
+    </>
   );
 }

--- a/clients/react/src/components/aim-console/Gutters.tsx
+++ b/clients/react/src/components/aim-console/Gutters.tsx
@@ -314,9 +314,15 @@ export function FooterGutter({
     if (!session || !footer || !wrap) return false;
     const sessionH = session.getBoundingClientRect().height;
     if (sessionH <= 0) return false;
+    const max = Math.round(sessionH * FOOTER_MAX_SESSION_RATIO);
+    // A ceiling at or below the floor would INVERT onMove's
+    // min(max(v, floor), ceiling) and drive --fh below the 110px minimum —
+    // in that geometry (a very short Session pane) the drag must not start
+    // at all. Same degenerate guard as BashFooter's window-resize re-clamp.
+    if (max <= AIM_CONSOLE_FOOTER_MIN) return false;
     measureRef.current = {
       fh0: wrap.getBoundingClientRect().height,
-      max: Math.round(sessionH * FOOTER_MAX_SESSION_RATIO),
+      max,
       footer,
     };
     valueRef.current = null;

--- a/clients/react/src/components/aim-console/Gutters.tsx
+++ b/clients/react/src/components/aim-console/Gutters.tsx
@@ -1,0 +1,358 @@
+// Gutters — the aim-console's drag-resize affordances (S7).
+//
+// A faithful reproduction of the mock's drag-resize layer
+// (`origin/mock/aim-ui-s6` → `assets/s6-conversation-panel-mock.html`,
+// `gutA`/`gutB`/`gutF`): the 3-pane grid gains two REAL 5px gutter tracks
+// (Aim|Session and Session|PR) and the bash footer a 5px horizontal height
+// gutter. At rest each gutter shows the old hairline seam (1px centred in
+// the track); hover lights a thin cyan glow + a grip glyph (`⋮` / `⋯`);
+// while dragging the line goes solid cyan, the cursor turns col/row-resize
+// window-wide, and a small mono readout chip follows the pointer with the
+// live px values. Double-click resets that gutter's dimension(s) to the
+// defaults. The Session|PR gutter is inert while the rail is collapsed
+// (mock `.gut.off`).
+//
+// Drag mechanics: pointer capture on the gutter; per-move the CSS custom
+// properties (`--aim`/`--sess` as px-weight fr values, `--pr` px on the
+// `.aim-console` root; `--fh` px on the footer) are rewritten IMPERATIVELY —
+// React state is NOT touched per pointermove, so a live drag never re-renders
+// the pane subtrees (terminals). Only the readout chip (local to the gutter)
+// re-renders. The final value is committed ONCE on pointerup via `onCommit`
+// (→ ui-prefs persistence, the issue's "written on drag end, not per-move").
+
+import { useCallback, useRef, useState } from "react";
+import {
+  AIM_CONSOLE_FOOTER_MIN,
+  AIM_CONSOLE_PR_WIDTH_MAX,
+  AIM_CONSOLE_PR_WIDTH_MIN,
+  clampAimConsolePrWidth,
+} from "@/lib/ui-prefs";
+import { cn } from "@/lib/utils";
+
+// Drag clamps (mock gutA/gutF): pane floors keep the Aim worklist and the
+// Session conversation usable at the extremes; the footer may take at most
+// 60% of the Session pane so the conversation never collapses under it.
+export const AIM_PANE_MIN_PX = 230;
+export const SESSION_PANE_MIN_PX = 300;
+export const FOOTER_MAX_SESSION_RATIO = 0.6;
+
+interface ReadoutState {
+  x: number;
+  y: number;
+  text: string;
+}
+
+interface GutterDragSpec {
+  axis: "x" | "y";
+  /** Inert gutter (mock `.gut.off`) — pointer-events are off in CSS, but the
+   *  JS guard matters too: programmatic events (tests) bypass CSS hit-testing. */
+  disabled?: boolean;
+  /** Measure the panes at drag start. Return false to abort (degenerate
+   *  zero-size layout mid-mount — same guard useSplitPane carries). */
+  onStart: (gutter: HTMLElement) => boolean;
+  /** Apply the live value for a pointer delta (px along the axis) and return
+   *  the readout chip text. */
+  onMove: (gutter: HTMLElement, delta: number) => string;
+  /** Commit the final value — fired once, on pointerup/cancel. */
+  onEnd: () => void;
+  /** Double-click reset to defaults. */
+  onReset: () => void;
+}
+
+// Shared pointer plumbing for all three gutters: capture, live/readout state,
+// and the root drag classes (the mock's `body.dragging drag-col/drag-row`,
+// kept on `.aim-console` so everything stays inside the scope boundary —
+// cursor override, text-selection suppression, and grid/footer transition
+// suppression all hang off them).
+function useGutterDrag({ axis, disabled, onStart, onMove, onEnd, onReset }: GutterDragSpec) {
+  const [live, setLive] = useState(false);
+  const [readout, setReadout] = useState<ReadoutState | null>(null);
+  const liveRef = useRef(false);
+  const startRef = useRef(0);
+
+  const setRootDragging = useCallback(
+    (gutter: HTMLElement, on: boolean) => {
+      const root = gutter.closest(".aim-console");
+      root?.classList.toggle("ac-dragging", on);
+      root?.classList.toggle(axis === "x" ? "ac-drag-col" : "ac-drag-row", on);
+    },
+    [axis],
+  );
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (disabled || liveRef.current || e.button !== 0) return;
+    const gutter = e.currentTarget;
+    if (!onStart(gutter)) return;
+    startRef.current = axis === "x" ? e.clientX : e.clientY;
+    try {
+      gutter.setPointerCapture(e.pointerId);
+    } catch {
+      // jsdom has no pointer capture; real browsers route every move here.
+    }
+    liveRef.current = true;
+    setLive(true);
+    setRootDragging(gutter, true);
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!liveRef.current) return;
+    const pos = axis === "x" ? e.clientX : e.clientY;
+    const text = onMove(e.currentTarget, pos - startRef.current);
+    setReadout({ x: e.clientX, y: e.clientY, text });
+  };
+
+  const handlePointerEnd = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (!liveRef.current) return;
+    const gutter = e.currentTarget;
+    try {
+      gutter.releasePointerCapture(e.pointerId);
+    } catch {
+      // jsdom — see above.
+    }
+    liveRef.current = false;
+    setLive(false);
+    setReadout(null);
+    setRootDragging(gutter, false);
+    onEnd();
+    // Let xterm + other ResizeObserver users re-measure the settled tracks
+    // (the same convention as useSplitPane's drag end).
+    window.dispatchEvent(new Event("resize"));
+  };
+
+  const handleDoubleClick = () => {
+    if (disabled) return;
+    onReset();
+  };
+
+  return {
+    live,
+    readout,
+    handlers: {
+      onPointerDown: handlePointerDown,
+      onPointerMove: handlePointerMove,
+      onPointerUp: handlePointerEnd,
+      onPointerCancel: handlePointerEnd,
+      onDoubleClick: handleDoubleClick,
+    },
+  };
+}
+
+// The drag readout chip (mock `#readout`) — fixed-positioned, offset from the
+// pointer; pointer-events:none so it never steals the capture. Rendered
+// INSIDE the gutter element so the gutter stays a single grid/flex child.
+function ReadoutChip({ readout }: { readout: ReadoutState | null }) {
+  if (!readout) return null;
+  return (
+    <div
+      className="ac-readout"
+      data-testid="ac-gutter-readout"
+      style={{ left: readout.x + 14, top: readout.y + 14 }}
+    >
+      {readout.text}
+    </div>
+  );
+}
+
+function rootOf(gutter: HTMLElement): HTMLElement | null {
+  return gutter.closest<HTMLElement>(".aim-console");
+}
+
+/** Gutter A — Aim|Session. Rewrites BOTH fr tracks from the live px split
+ *  (mock gutA), so the two panes keep window-scaling after the drag while
+ *  honouring the px floors at drag time. `aimShare` (the committed Aim share
+ *  of the two panes, 0–100) feeds aria-valuenow. */
+export function AimSessionGutter({
+  aimShare,
+  onCommit,
+  onReset,
+}: {
+  aimShare: number;
+  onCommit: (aim: number, sess: number) => void;
+  onReset: () => void;
+}) {
+  const measureRef = useRef({ aim0: 0, total: 0 });
+  const valueRef = useRef<{ aim: number; sess: number } | null>(null);
+
+  const onStart = useCallback((gutter: HTMLElement) => {
+    const root = rootOf(gutter);
+    const aimEl = root?.querySelector(".ac-aim");
+    const sessEl = root?.querySelector(".ac-session");
+    if (!aimEl || !sessEl) return false;
+    const aim0 = aimEl.getBoundingClientRect().width;
+    const total = aim0 + sessEl.getBoundingClientRect().width;
+    if (total <= 0) return false;
+    measureRef.current = { aim0, total };
+    valueRef.current = null;
+    return true;
+  }, []);
+
+  const onMove = useCallback((gutter: HTMLElement, delta: number) => {
+    const { aim0, total } = measureRef.current;
+    const aim = Math.round(
+      Math.min(Math.max(aim0 + delta, AIM_PANE_MIN_PX), total - SESSION_PANE_MIN_PX),
+    );
+    const sess = Math.round(total) - aim;
+    valueRef.current = { aim, sess };
+    const root = rootOf(gutter);
+    root?.style.setProperty("--aim", `${aim}fr`);
+    root?.style.setProperty("--sess", `${sess}fr`);
+    return `aim ${aim}px · sess ${sess}px`;
+  }, []);
+
+  const onEnd = useCallback(() => {
+    const v = valueRef.current;
+    if (v) onCommit(v.aim, v.sess);
+  }, [onCommit]);
+
+  const { live, readout, handlers } = useGutterDrag({ axis: "x", onStart, onMove, onEnd, onReset });
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter (RPanel precedent)
+    <div
+      className={cn("ac-vgut", live && "live")}
+      role="separator"
+      tabIndex={0}
+      aria-orientation="vertical"
+      aria-label="Resize Aim / Session panes"
+      aria-valuenow={Math.round(aimShare)}
+      aria-valuemin={0}
+      aria-valuemax={100}
+      title="Drag to resize · double-click to reset"
+      {...handlers}
+    >
+      <ReadoutChip readout={readout} />
+    </div>
+  );
+}
+
+/** Gutter B — Session|PR rail. Adjusts `--pr` (px) while the rail is open;
+ *  inert (`off`) while it is collapsed to the 46px rail (mock gutB).
+ *  `prWidth` (the committed rail width) feeds aria-valuenow. */
+export function SessionPrGutter({
+  open,
+  prWidth,
+  onCommit,
+  onReset,
+}: {
+  open: boolean;
+  prWidth: number;
+  onCommit: (pr: number) => void;
+  onReset: () => void;
+}) {
+  const pr0Ref = useRef(0);
+  const valueRef = useRef<number | null>(null);
+
+  const onStart = useCallback((gutter: HTMLElement) => {
+    const prEl = rootOf(gutter)?.querySelector(".ac-pr");
+    if (!prEl) return false;
+    pr0Ref.current = prEl.getBoundingClientRect().width;
+    valueRef.current = null;
+    return true;
+  }, []);
+
+  const onMove = useCallback((gutter: HTMLElement, delta: number) => {
+    // The rail grows leftwards: pointer left = wider rail.
+    const pr = clampAimConsolePrWidth(pr0Ref.current - delta);
+    valueRef.current = pr;
+    rootOf(gutter)?.style.setProperty("--pr", `${pr}px`);
+    return `pr ${pr}px`;
+  }, []);
+
+  const onEnd = useCallback(() => {
+    if (valueRef.current !== null) onCommit(valueRef.current);
+  }, [onCommit]);
+
+  const { live, readout, handlers } = useGutterDrag({
+    axis: "x",
+    disabled: !open,
+    onStart,
+    onMove,
+    onEnd,
+    onReset,
+  });
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter (RPanel precedent)
+    <div
+      className={cn("ac-vgut", !open && "off", live && "live")}
+      role="separator"
+      tabIndex={open ? 0 : -1}
+      aria-orientation="vertical"
+      aria-label="Resize PR rail"
+      aria-disabled={!open}
+      aria-valuenow={Math.round(prWidth)}
+      aria-valuemin={AIM_CONSOLE_PR_WIDTH_MIN}
+      aria-valuemax={AIM_CONSOLE_PR_WIDTH_MAX}
+      title={open ? "Drag to resize · double-click to reset" : undefined}
+      {...handlers}
+    >
+      <ReadoutChip readout={readout} />
+    </div>
+  );
+}
+
+/** Gutter F — bash-footer height. Sits directly above the footer (only while
+ *  it is expanded); rewrites the footer's `--fh` (the terminal-area height,
+ *  mock gutF), clamped to [110px, 60% of the Session pane]. */
+export function FooterGutter({
+  footerHeight,
+  onCommit,
+  onReset,
+}: {
+  /** Committed terminal-area height (px) — feeds aria-valuenow. */
+  footerHeight: number;
+  onCommit: (footer: number) => void;
+  onReset: () => void;
+}) {
+  const measureRef = useRef<{ fh0: number; max: number; footer: HTMLElement } | null>(null);
+  const valueRef = useRef<number | null>(null);
+
+  const onStart = useCallback((gutter: HTMLElement) => {
+    const session = gutter.closest<HTMLElement>(".ac-session");
+    const footer = session?.querySelector<HTMLElement>(".ac-footer");
+    const wrap = session?.querySelector(".ac-ftwrap");
+    if (!session || !footer || !wrap) return false;
+    const sessionH = session.getBoundingClientRect().height;
+    if (sessionH <= 0) return false;
+    measureRef.current = {
+      fh0: wrap.getBoundingClientRect().height,
+      max: Math.round(sessionH * FOOTER_MAX_SESSION_RATIO),
+      footer,
+    };
+    valueRef.current = null;
+    return true;
+  }, []);
+
+  const onMove = useCallback((_gutter: HTMLElement, delta: number) => {
+    const m = measureRef.current;
+    if (!m) return "";
+    // Dragging UP (negative delta) grows the footer.
+    const fh = Math.round(Math.min(Math.max(m.fh0 - delta, AIM_CONSOLE_FOOTER_MIN), m.max));
+    valueRef.current = fh;
+    m.footer.style.setProperty("--fh", `${fh}px`);
+    return `footer ${fh}px`;
+  }, []);
+
+  const onEnd = useCallback(() => {
+    if (valueRef.current !== null) onCommit(valueRef.current);
+  }, [onCommit]);
+
+  const { live, readout, handlers } = useGutterDrag({ axis: "y", onStart, onMove, onEnd, onReset });
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter (RPanel precedent)
+    <div
+      className={cn("ac-hgut", live && "live")}
+      role="separator"
+      tabIndex={0}
+      aria-orientation="horizontal"
+      aria-label="Resize bash footer height"
+      aria-valuenow={Math.round(footerHeight)}
+      aria-valuemin={AIM_CONSOLE_FOOTER_MIN}
+      title="Drag to resize · double-click to reset"
+      {...handlers}
+    >
+      <ReadoutChip readout={readout} />
+    </div>
+  );
+}

--- a/clients/react/src/components/aim-console/__tests__/Gutters.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/Gutters.test.tsx
@@ -270,6 +270,25 @@ describe("FooterGutter — bash-footer height gutter", () => {
     expect(footer.style.getPropertyValue("--fh")).toBe("180px");
   });
 
+  it("refuses to start a drag when the session is so short the clamp would invert", () => {
+    renderFooter();
+    fireEvent.click(screen.getByRole("button", { name: "Expand bash footer" }));
+
+    const session = screen.getByTestId("session-col");
+    // ceiling = round(150 * 0.6) = 90 <= the 110px floor → min/max would
+    // invert and commit a below-min height; onStart must bail instead.
+    stubRect(session, { height: 150 });
+    stubRect(session.querySelector(".ac-ftwrap") as Element, { height: 180 });
+    const footer = screen.getByTestId("aim-bash-footer");
+    const sep = screen.getByRole("separator", { name: "Resize bash footer height" });
+
+    drag(sep, { x: 400, y: 500 }, { x: 400, y: 900 });
+    // The drag never engaged: no live --fh write, no readout, no persistence.
+    expect(footer.style.getPropertyValue("--fh")).toBe("180px");
+    expect(screen.queryByTestId("ac-gutter-readout")).toBeNull();
+    expect(storedLayout()).toBeNull();
+  });
+
   it("re-applies the 60% ceiling on window resize without persisting it", () => {
     seedLayout({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, footer: 300 });
     renderFooter();

--- a/clients/react/src/components/aim-console/__tests__/Gutters.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/Gutters.test.tsx
@@ -1,0 +1,329 @@
+// @vitest-environment jsdom
+//
+// S7 drag-resizable layout test — the pane gutters (Aim|Session, Session|PR)
+// and the bash-footer height gutter, plus the `aimConsoleLayout` ui-prefs
+// persistence. The drag engine works imperatively (CSS custom properties per
+// move, ONE prefs write on pointerup), so the assertions read the inline
+// custom properties off the root / footer and the persisted blob out of
+// localStorage.
+//
+// jsdom has no real layout: every pane the gutters measure gets its
+// getBoundingClientRect stubbed, and pointer capture (absent in jsdom) is
+// try/catch-guarded in the engine itself.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type {
+  AgentSnapshot,
+  AimsResponse,
+  UnitIssuesResponse,
+  UnitPrsResponse,
+  UnitResponse,
+} from "@/lib/api";
+import {
+  AIM_CONSOLE_LAYOUT_DEFAULTS,
+  loadUIPrefs,
+  UI_PREFS_STORAGE_KEY,
+  type UIPrefs,
+} from "@/lib/ui-prefs";
+import { UIPrefsProvider } from "@/lib/ui-prefs-provider";
+import { AimConsole } from "../AimConsole";
+import { BashFooter } from "../BashFooter";
+
+vi.mock("@/hooks/useUnitAttention", () => ({
+  useUnitAttention: () => ({ data: null, loading: false, error: null }),
+}));
+
+// Park every fetch/spawn in flight — the layout tests are data-agnostic.
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      aims: () => new Promise<AimsResponse>(() => {}),
+      unitPrs: () => new Promise<UnitPrsResponse>(() => {}),
+      unitIssues: () => new Promise<UnitIssuesResponse>(() => {}),
+      spawnPty: () => new Promise<{ session_id: string; pid: number; command: string }>(() => {}),
+    },
+  };
+});
+
+const UNITS: UnitResponse[] = [
+  {
+    name: "tmai",
+    repos: [
+      { path: "/home/u/tmai", primary: true },
+      { path: "/home/u/tmai-core", primary: false },
+    ],
+  },
+];
+
+function renderConsole() {
+  render(
+    <UIPrefsProvider>
+      <AimConsole
+        units={UNITS}
+        activeUnitName="tmai"
+        onSelectUnit={vi.fn()}
+        onAddUnit={vi.fn()}
+        onExit={vi.fn()}
+        agents={[] as AgentSnapshot[]}
+        currentProjectPath="/home/u/tmai"
+        trigger={vi.fn()}
+        onOpenSettings={vi.fn()}
+      />
+    </UIPrefsProvider>,
+  );
+}
+
+// jsdom reports zero-size rects; give the panes the gutters measure a real
+// footprint. Only the dimensions the engine reads are filled in.
+function stubRect(el: Element, size: { width?: number; height?: number }) {
+  vi.spyOn(el, "getBoundingClientRect").mockReturnValue({
+    x: 0,
+    y: 0,
+    top: 0,
+    left: 0,
+    right: size.width ?? 0,
+    bottom: size.height ?? 0,
+    width: size.width ?? 0,
+    height: size.height ?? 0,
+    toJSON: () => ({}),
+  } as DOMRect);
+}
+
+function drag(sep: HTMLElement, from: { x: number; y: number }, to: { x: number; y: number }) {
+  fireEvent.pointerDown(sep, { clientX: from.x, clientY: from.y, pointerId: 1, button: 0 });
+  fireEvent.pointerMove(sep, { clientX: to.x, clientY: to.y, pointerId: 1 });
+  fireEvent.pointerUp(sep, { clientX: to.x, clientY: to.y, pointerId: 1 });
+}
+
+function storedLayout(): UIPrefs["aimConsoleLayout"] {
+  return loadUIPrefs().aimConsoleLayout;
+}
+
+function seedLayout(layout: NonNullable<UIPrefs["aimConsoleLayout"]>) {
+  localStorage.setItem(UI_PREFS_STORAGE_KEY, JSON.stringify({ aimConsoleLayout: layout }));
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.restoreAllMocks();
+});
+
+describe("AimSessionGutter — Aim|Session pane gutter", () => {
+  function setup() {
+    renderConsole();
+    const root = screen.getByTestId("aim-console");
+    stubRect(root.querySelector(".ac-aim") as Element, { width: 590 });
+    stubRect(root.querySelector(".ac-session") as Element, { width: 500 });
+    const sep = screen.getByRole("separator", { name: "Resize Aim / Session panes" });
+    return { root, sep };
+  }
+
+  it("rewrites --aim/--sess per move and persists ONCE on pointerup", () => {
+    const { root, sep } = setup();
+    fireEvent.pointerDown(sep, { clientX: 600, clientY: 300, pointerId: 1, button: 0 });
+    fireEvent.pointerMove(sep, { clientX: 650, clientY: 300, pointerId: 1 });
+
+    // Live: the fr tracks follow the pointer (590+50 / 500-50 of total 1090)…
+    expect(root.style.getPropertyValue("--aim")).toBe("640fr");
+    expect(root.style.getPropertyValue("--sess")).toBe("450fr");
+    // …with the mono readout chip showing the live px…
+    expect(screen.getByTestId("ac-gutter-readout").textContent).toBe("aim 640px · sess 450px");
+    // …but NOTHING persisted yet (written on drag end, not per-move).
+    expect(storedLayout()).toBeNull();
+
+    fireEvent.pointerUp(sep, { clientX: 650, clientY: 300, pointerId: 1 });
+    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, aim: 640, sess: 450 });
+    // The chip is gone once the drag ends.
+    expect(screen.queryByTestId("ac-gutter-readout")).toBeNull();
+  });
+
+  it("clamps at both ends: aim >= 230px and session >= 300px", () => {
+    const { root, sep } = setup();
+    // Far left: aim floors at 230 (total 1090 → sess 860).
+    drag(sep, { x: 600, y: 300 }, { x: 0, y: 300 });
+    expect(root.style.getPropertyValue("--aim")).toBe("230fr");
+    expect(root.style.getPropertyValue("--sess")).toBe("860fr");
+
+    // Far right: session floors at 300 (aim caps at 1090-300=790).
+    drag(sep, { x: 600, y: 300 }, { x: 1900, y: 300 });
+    expect(root.style.getPropertyValue("--aim")).toBe("790fr");
+    expect(root.style.getPropertyValue("--sess")).toBe("300fr");
+    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, aim: 790, sess: 300 });
+  });
+
+  it("double-click resets to the defaults and clears the stored layout", () => {
+    const { root, sep } = setup();
+    drag(sep, { x: 600, y: 300 }, { x: 650, y: 300 });
+    expect(storedLayout()).not.toBeNull();
+
+    fireEvent.doubleClick(sep);
+    // Back to the untouched defaults — stored layout CLEARED, not re-pinned.
+    expect(storedLayout()).toBeNull();
+    expect(root.style.getPropertyValue("--aim")).toBe("1.18fr");
+    expect(root.style.getPropertyValue("--sess")).toBe("1fr");
+  });
+});
+
+describe("SessionPrGutter — Session|PR rail gutter", () => {
+  it("is inert while the rail is collapsed", () => {
+    renderConsole();
+    const root = screen.getByTestId("aim-console");
+    const sep = screen.getByRole("separator", { name: "Resize PR rail" });
+    expect(sep.className).toContain("off");
+
+    stubRect(root.querySelector(".ac-pr") as Element, { width: 46 });
+    drag(sep, { x: 1000, y: 300 }, { x: 900, y: 300 });
+    fireEvent.doubleClick(sep);
+    // No live track write, no persistence — the gutter ignored everything.
+    expect(root.style.getPropertyValue("--pr")).toBe("");
+    expect(storedLayout()).toBeNull();
+  });
+
+  it("drags the open rail within 240–520px and persists on pointerup", () => {
+    renderConsole();
+    const root = screen.getByTestId("aim-console");
+    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
+    // Open: the inline --pr carries the persisted (default) width.
+    expect(root.style.getPropertyValue("--pr")).toBe("320px");
+
+    const sep = screen.getByRole("separator", { name: "Resize PR rail" });
+    expect(sep.className).not.toContain("off");
+    stubRect(root.querySelector(".ac-pr") as Element, { width: 320 });
+
+    // Pointer left = wider rail: 320 - (-100) = 420.
+    drag(sep, { x: 1000, y: 300 }, { x: 900, y: 300 });
+    expect(root.style.getPropertyValue("--pr")).toBe("420px");
+    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, pr: 420 });
+
+    // Clamp floor (240) and ceiling (520).
+    drag(sep, { x: 1000, y: 300 }, { x: 1900, y: 300 });
+    expect(root.style.getPropertyValue("--pr")).toBe("240px");
+    drag(sep, { x: 1000, y: 300 }, { x: 0, y: 300 });
+    expect(root.style.getPropertyValue("--pr")).toBe("520px");
+    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, pr: 520 });
+
+    // Double-click resets the rail width (and clears the all-default blob).
+    fireEvent.doubleClick(sep);
+    expect(storedLayout()).toBeNull();
+    expect(root.style.getPropertyValue("--pr")).toBe("320px");
+  });
+});
+
+describe("FooterGutter — bash-footer height gutter", () => {
+  function renderFooter() {
+    render(
+      <UIPrefsProvider>
+        <div className="aim-console">
+          <div className="ac-col ac-session" data-testid="session-col">
+            <BashFooter repos={[]} primaryPath="/home/u/tmai" agents={[]} />
+          </div>
+        </div>
+      </UIPrefsProvider>,
+    );
+  }
+
+  it("is only present while the footer is expanded", () => {
+    renderFooter();
+    expect(screen.queryByRole("separator", { name: "Resize bash footer height" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Expand bash footer" }));
+    expect(screen.getByRole("separator", { name: "Resize bash footer height" })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Collapse bash footer" }));
+    expect(screen.queryByRole("separator", { name: "Resize bash footer height" })).toBeNull();
+  });
+
+  it("drags --fh within [110px, 60% of the session pane] and persists on pointerup", () => {
+    renderFooter();
+    fireEvent.click(screen.getByRole("button", { name: "Expand bash footer" }));
+
+    const session = screen.getByTestId("session-col");
+    stubRect(session, { height: 600 }); // ceiling = 360
+    stubRect(session.querySelector(".ac-ftwrap") as Element, { height: 180 });
+    const footer = screen.getByTestId("aim-bash-footer");
+    expect(footer.style.getPropertyValue("--fh")).toBe("180px");
+
+    const sep = screen.getByRole("separator", { name: "Resize bash footer height" });
+    // Dragging UP grows the footer: 180 - (-50) = 230.
+    fireEvent.pointerDown(sep, { clientX: 400, clientY: 500, pointerId: 1, button: 0 });
+    fireEvent.pointerMove(sep, { clientX: 400, clientY: 450, pointerId: 1 });
+    expect(footer.style.getPropertyValue("--fh")).toBe("230px");
+    expect(screen.getByTestId("ac-gutter-readout").textContent).toBe("footer 230px");
+    expect(storedLayout()).toBeNull(); // not yet — drag end persists
+    fireEvent.pointerUp(sep, { clientX: 400, clientY: 450, pointerId: 1 });
+    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, footer: 230 });
+
+    // Clamp floor (110) and the 60%-of-session ceiling (360).
+    drag(sep, { x: 400, y: 500 }, { x: 400, y: 900 });
+    expect(footer.style.getPropertyValue("--fh")).toBe("110px");
+    drag(sep, { x: 400, y: 500 }, { x: 400, y: 0 });
+    expect(footer.style.getPropertyValue("--fh")).toBe("360px");
+    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, footer: 360 });
+
+    // Double-click resets to 180 and clears the all-default blob.
+    fireEvent.doubleClick(sep);
+    expect(storedLayout()).toBeNull();
+    expect(footer.style.getPropertyValue("--fh")).toBe("180px");
+  });
+
+  it("re-applies the 60% ceiling on window resize without persisting it", () => {
+    seedLayout({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, footer: 300 });
+    renderFooter();
+    const session = screen.getByTestId("session-col");
+    stubRect(session, { height: 600 }); // ceiling 360 — 300 fits
+    fireEvent.click(screen.getByRole("button", { name: "Expand bash footer" }));
+    const footer = screen.getByTestId("aim-bash-footer");
+    expect(footer.style.getPropertyValue("--fh")).toBe("300px");
+
+    // The session pane shrinks (window resize): ceiling 0.6*400 = 240.
+    stubRect(session, { height: 400 });
+    fireEvent(window, new Event("resize"));
+    expect(footer.style.getPropertyValue("--fh")).toBe("240px");
+    // The transient clamp is NOT written back — the stored 300 survives.
+    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, footer: 300 });
+  });
+});
+
+describe("aimConsoleLayout prefs round-trip", () => {
+  it("restores a stored layout on mount (panes, rail, footer)", () => {
+    seedLayout({ aim: 700, sess: 380, pr: 400, footer: 240 });
+    renderConsole();
+    const root = screen.getByTestId("aim-console");
+    expect(root.style.getPropertyValue("--aim")).toBe("700fr");
+    expect(root.style.getPropertyValue("--sess")).toBe("380fr");
+    // The rail width applies once the rail opens.
+    expect(root.style.getPropertyValue("--pr")).toBe("");
+    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
+    expect(root.style.getPropertyValue("--pr")).toBe("400px");
+    // The footer restores its stored height when expanded.
+    fireEvent.click(screen.getByRole("button", { name: "Expand bash footer" }));
+    expect(screen.getByTestId("aim-bash-footer").style.getPropertyValue("--fh")).toBe("240px");
+  });
+
+  it("coerces a corrupt / out-of-range stored layout on load", () => {
+    localStorage.setItem(
+      UI_PREFS_STORAGE_KEY,
+      JSON.stringify({ aimConsoleLayout: { aim: -3, sess: "x", pr: 9999, footer: 12 } }),
+    );
+    // Bad fr weights fall back per-field; px values clamp to their windows.
+    expect(loadUIPrefs().aimConsoleLayout).toEqual({
+      aim: AIM_CONSOLE_LAYOUT_DEFAULTS.aim,
+      sess: AIM_CONSOLE_LAYOUT_DEFAULTS.sess,
+      pr: 520,
+      footer: 110,
+    });
+
+    // A non-object blob (or an all-defaults one) normalises to null.
+    localStorage.setItem(UI_PREFS_STORAGE_KEY, JSON.stringify({ aimConsoleLayout: "garbage" }));
+    expect(loadUIPrefs().aimConsoleLayout).toBeNull();
+    localStorage.setItem(
+      UI_PREFS_STORAGE_KEY,
+      JSON.stringify({ aimConsoleLayout: { ...AIM_CONSOLE_LAYOUT_DEFAULTS } }),
+    );
+    expect(loadUIPrefs().aimConsoleLayout).toBeNull();
+  });
+});

--- a/clients/react/src/lib/ui-prefs.ts
+++ b/clients/react/src/lib/ui-prefs.ts
@@ -19,6 +19,20 @@ import { DEFAULT_THEME_NAME, THEME_NAMES, type ThemeName } from "@/lib/theme";
 export type AimMode = "frontier" | "tree";
 export const AIM_MODES: readonly AimMode[] = ["frontier", "tree"];
 
+// Drag-resized aim-console layout (S7). `aim`/`sess` are the pane fr WEIGHTS
+// (the live px captured at drag end, used as `Nfr` so the panes keep scaling
+// with the window); `pr` the expanded PR-rail width in px; `footer` the bash
+// footer's terminal-area height in px (the mock's `--fh`). `null` = never
+// dragged / reset — the console then uses AIM_CONSOLE_LAYOUT_DEFAULTS, and a
+// double-click reset stores `null` rather than a copy of the defaults so a
+// future default change reaches untouched layouts.
+export interface AimConsoleLayout {
+  aim: number;
+  sess: number;
+  pr: number;
+  footer: number;
+}
+
 export interface UIPrefs {
   // WebUI colour theme. Presentation-only; lives here (not in tmai-core
   // config / api-spec) by the same convention as every other field.
@@ -43,6 +57,9 @@ export interface UIPrefs {
   // Aim panel mode. Default `frontier` — the owed worklist is the panel's
   // load-bearing thesis (NOT a passive full-tree dump). See AimMode.
   aimMode: AimMode;
+  // Drag-resized aim-console layout (S7); `null` until the operator drags a
+  // gutter. WebUI-only by the same convention as every other field here.
+  aimConsoleLayout: AimConsoleLayout | null;
 }
 
 // Attention-strip width bounds (px). Floor keeps the section content
@@ -53,6 +70,23 @@ export const ATTENTION_STRIP_WIDTH_MIN = 240;
 export const ATTENTION_STRIP_WIDTH_MAX = 560;
 export const ATTENTION_STRIP_WIDTH_DEFAULT = 320;
 
+// aim-console layout bounds (issue #805 / the S6 mock's drag clamps). The
+// PR-rail window keeps the rail's lists legible without starving the Session
+// pane; the footer floor keeps at least a couple of terminal rows visible.
+// The footer's UPPER bound is runtime-only (60% of the live Session pane
+// height) so it cannot be enforced here — the console re-applies it on mount,
+// drag and window resize.
+export const AIM_CONSOLE_PR_WIDTH_MIN = 240;
+export const AIM_CONSOLE_PR_WIDTH_MAX = 520;
+export const AIM_CONSOLE_FOOTER_MIN = 110;
+
+export const AIM_CONSOLE_LAYOUT_DEFAULTS: AimConsoleLayout = {
+  aim: 1.18,
+  sess: 1,
+  pr: 320,
+  footer: 180,
+};
+
 export const DEFAULT_UI_PREFS: UIPrefs = {
   theme: DEFAULT_THEME_NAME,
   terminalFontSize: 13,
@@ -60,6 +94,7 @@ export const DEFAULT_UI_PREFS: UIPrefs = {
   attentionStripWidth: ATTENTION_STRIP_WIDTH_DEFAULT,
   rPanelExpandedSections: [],
   aimMode: "frontier",
+  aimConsoleLayout: null,
 };
 
 export const UI_PREFS_STORAGE_KEY = "tmai:ui:prefs";
@@ -93,6 +128,59 @@ function clampStripWidth(value: unknown, fallback: number): number {
   return clampAttentionStripWidth(value);
 }
 
+// Same compose-with-coerce convention as clampAttentionStripWidth: the drag
+// commit path (aim-console Gutters) clamps with the rule coerce applies on
+// load, so neither a drag nor a hand-edited blob can persist out-of-range px.
+export function clampAimConsolePrWidth(value: number): number {
+  if (!Number.isFinite(value)) return AIM_CONSOLE_LAYOUT_DEFAULTS.pr;
+  return Math.max(AIM_CONSOLE_PR_WIDTH_MIN, Math.min(AIM_CONSOLE_PR_WIDTH_MAX, Math.round(value)));
+}
+
+// Floor-only: the footer's ceiling (60% of the Session pane) is a LIVE
+// measurement the storage layer cannot know — the console re-clamps it on
+// mount / drag / window resize.
+export function clampAimConsoleFooterHeight(value: number): number {
+  if (!Number.isFinite(value)) return AIM_CONSOLE_LAYOUT_DEFAULTS.footer;
+  return Math.max(AIM_CONSOLE_FOOTER_MIN, Math.round(value));
+}
+
+// Collapse an all-defaults layout back to `null` so a double-click reset
+// CLEARS the stored layout (the issue's contract) instead of pinning a copy
+// of today's defaults into every blob.
+export function normalizeAimConsoleLayout(layout: AimConsoleLayout): AimConsoleLayout | null {
+  const d = AIM_CONSOLE_LAYOUT_DEFAULTS;
+  if (
+    layout.aim === d.aim &&
+    layout.sess === d.sess &&
+    layout.pr === d.pr &&
+    layout.footer === d.footer
+  ) {
+    return null;
+  }
+  return layout;
+}
+
+// Pane fr weights are free-form positive numbers (1.18 at rest, live px after
+// a drag) — only reject the degenerate ones that would zero out a pane.
+function coerceFrWeight(value: unknown, fallback: number): number {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return fallback;
+  return value;
+}
+
+function coerceAimConsoleLayout(value: unknown): AimConsoleLayout | null {
+  if (value === null || value === undefined || typeof value !== "object") return null;
+  const v = value as Record<string, unknown>;
+  return normalizeAimConsoleLayout({
+    aim: coerceFrWeight(v.aim, AIM_CONSOLE_LAYOUT_DEFAULTS.aim),
+    sess: coerceFrWeight(v.sess, AIM_CONSOLE_LAYOUT_DEFAULTS.sess),
+    pr: typeof v.pr === "number" ? clampAimConsolePrWidth(v.pr) : AIM_CONSOLE_LAYOUT_DEFAULTS.pr,
+    footer:
+      typeof v.footer === "number"
+        ? clampAimConsoleFooterHeight(v.footer)
+        : AIM_CONSOLE_LAYOUT_DEFAULTS.footer,
+  });
+}
+
 // Validate each field individually so a partially corrupt blob still
 // recovers the good fields and only resets the bad ones to default.
 function coercePrefs(raw: unknown): UIPrefs {
@@ -115,6 +203,7 @@ function coercePrefs(raw: unknown): UIPrefs {
     aimMode: AIM_MODES.includes(r.aimMode as AimMode)
       ? (r.aimMode as AimMode)
       : DEFAULT_UI_PREFS.aimMode,
+    aimConsoleLayout: coerceAimConsoleLayout(r.aimConsoleLayout),
   };
 }
 

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -22,7 +22,9 @@
    S1 reproduces the TOKEN LAYER + the SHELL: top bar, 3-pane grid, and the
    PR-rail expand/collapse transition. The panes fill in over later stages —
    the worklist (S2), session (S3) + its docked bash footer (S4), and the
-   PR/Issue lists (S5).
+   PR/Issue lists (S5). S7 (mock `origin/mock/aim-ui-s6`) turns the pane
+   seams into real 5px drag-gutter tracks and the bash footer height into a
+   drag target — see the `ac-vgut` / `ac-hgut` / `ac-readout` block.
    ════════════════════════════════════════════════════════════════════════ */
 
 .aim-console {
@@ -51,8 +53,11 @@
   --mono: "IBM Plex Mono", ui-monospace, Menlo, monospace;
   --rh: 27px;
 
-  /* 3-pane column track (mock `.main`). The PR-rail collapses to a 46px
-     rail and expands to 320px via the `.pr-open` modifier below. */
+  /* 3-pane column tracks (mock `.main`) — S7 drag-resizable: the gutters
+     rewrite these (drag) and AimConsole drives them from the persisted
+     `aimConsoleLayout` ui-pref (inline, while the rail is open / after a
+     drag). These declarations are the untouched-layout defaults; the
+     collapsed rail always falls back to the 46px here. */
   --aim: 1.18fr;
   --sess: 1fr;
   --pr: 46px;
@@ -213,15 +218,16 @@
   border-color: var(--cyan-d);
 }
 
-/* ── 3-pane grid (mock `.main`) ───────────────────────────────────────── */
+/* ── 3-pane grid + 5px drag-gutter tracks (mock `.main`, S7) ──────────────
+   The gutters are REAL grid tracks, replacing the old `.ac-col` hairline
+   borders — the seam at rest is the gutter's own centred 1px line, so the
+   resting visual is identical. The PR-rail expand/collapse still animates
+   via the `--pr` change; a live drag suppresses the transition (below). */
 .aim-console .ac-main {
   display: grid;
-  grid-template-columns: var(--aim, 1.18fr) var(--sess, 1fr) var(--pr, 46px);
+  grid-template-columns: var(--aim, 1.18fr) 5px var(--sess, 1fr) 5px var(--pr, 46px);
   min-height: 0;
   transition: grid-template-columns 0.2s ease;
-}
-.aim-console.pr-open {
-  --pr: 320px;
 }
 .aim-console .ac-col {
   min-width: 0;
@@ -229,10 +235,121 @@
   display: flex;
   flex-direction: column;
   overflow: hidden;
-  border-right: 1px solid var(--line);
 }
-.aim-console .ac-col:last-child {
-  border-right: none;
+
+/* vertical pane gutter (mock `.gut`) — hairline at rest, cyan glow + `⋮`
+   grip on hover, solid while dragging (`.live`). `.off` = inert (the
+   Session|PR gutter while the rail is collapsed). */
+.aim-console .ac-vgut {
+  position: relative;
+  cursor: col-resize;
+}
+.aim-console .ac-vgut::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 2px;
+  width: 1px;
+  background: var(--line);
+  transition:
+    background 0.15s,
+    box-shadow 0.15s;
+}
+.aim-console .ac-vgut::after {
+  content: "⋮";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: var(--mono);
+  font-size: 10px;
+  color: transparent;
+  transition: color 0.15s;
+}
+.aim-console .ac-vgut:hover::before,
+.aim-console .ac-vgut.live::before {
+  background: var(--cyan);
+  box-shadow: 0 0 6px rgba(74, 163, 157, 0.5);
+}
+.aim-console .ac-vgut:hover::after {
+  color: var(--cyan);
+}
+.aim-console .ac-vgut.off {
+  cursor: default;
+  pointer-events: none;
+}
+
+/* horizontal footer gutter (mock `.guth`) — same affordance language, `⋯` */
+.aim-console .ac-hgut {
+  position: relative;
+  cursor: row-resize;
+  height: 5px;
+  flex: none;
+}
+.aim-console .ac-hgut::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 2px;
+  height: 1px;
+  background: var(--line);
+  transition:
+    background 0.15s,
+    box-shadow 0.15s;
+}
+.aim-console .ac-hgut::after {
+  content: "⋯";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: var(--mono);
+  font-size: 10px;
+  color: transparent;
+  transition: color 0.15s;
+}
+.aim-console .ac-hgut:hover::before,
+.aim-console .ac-hgut.live::before {
+  background: var(--cyan);
+  box-shadow: 0 0 6px rgba(74, 163, 157, 0.5);
+}
+.aim-console .ac-hgut:hover::after {
+  color: var(--cyan);
+}
+
+/* drag readout chip (mock `#readout`) — follows the pointer with live px */
+.aim-console .ac-readout {
+  position: fixed;
+  z-index: 50;
+  pointer-events: none;
+  font-family: var(--mono);
+  font-size: 10px;
+  color: var(--cyan);
+  background: var(--elev);
+  border: 1px solid var(--cyan-d);
+  padding: 2px 7px;
+}
+
+/* live-drag state (mock `body.dragging`, scoped on the root): suppress text
+   selection, force the resize cursor window-wide, and disable the grid /
+   footer height transitions so the tracks follow the pointer 1:1. */
+.aim-console.ac-dragging {
+  user-select: none;
+}
+.aim-console.ac-dragging * {
+  cursor: inherit !important;
+}
+.aim-console.ac-drag-col {
+  cursor: col-resize;
+}
+.aim-console.ac-drag-row {
+  cursor: row-resize;
+}
+.aim-console.ac-dragging .ac-main,
+.aim-console.ac-dragging .ac-footer {
+  transition: none;
 }
 
 /* ── AIM pane (header chrome + S2 stub) ───────────────────────────────── */
@@ -688,10 +805,13 @@
 }
 
 /* ── docked bash footer (mock `.footer`/`.fbar`/`.ftab`/`.ftwrap`) ────────
-   The Session pane's docked bash terminals (S4): a collapsed 33px tab bar
-   that expands to 210px (mock `body.bash-on .footer`), a tab strip (one per
-   repo + ad-hoc shells), `+` add, split toggle, and the open/close carat.
-   Each surfaced terminal is the reused TerminalPanel filling `.ac-ftbody`. */
+   The Session pane's docked bash terminals (S4): a collapsed 33px tab bar,
+   a tab strip (one per repo + ad-hoc shells), `+` add, split toggle, and the
+   open/close carat. Each surfaced terminal is the reused TerminalPanel
+   filling `.ac-ftbody`. S7 makes the expanded height drag-resizable: `--fh`
+   (the mock's name) is the TERMINAL-AREA height — BashFooter drives it
+   inline from the persisted layout, the footer gutter rewrites it live —
+   and the expanded total adds the 33px tab bar on top. */
 .aim-console .ac-footer {
   flex: none;
   height: 33px;
@@ -703,7 +823,7 @@
   flex-direction: column;
 }
 .aim-console .ac-footer.open {
-  height: 210px;
+  height: calc(var(--fh, 180px) + 33px);
 }
 .aim-console .ac-fbar {
   display: flex;


### PR DESCRIPTION
Resolves #805. Second re-design stage of the aim-ui console (S1–S6: #794 #796 #798 #800 #802 #804). Design contract: the drag-resize parts of `assets/s6-conversation-panel-mock.html` @ `mock/aim-ui-s6`.

## What

**1. Two vertical pane gutters (Aim|Session, Session|PR)** — `Gutters.tsx`
- Real 5px grid tracks (`grid-template-columns: var(--aim) 5px var(--sess) 5px var(--pr)`), replacing the `.ac-col` hairline borders; the resting seam is the gutter's own centred 1px line, so the visual at rest is identical.
- At rest: hairline. Hover: thin cyan glow + `⋮` grip. Dragging: solid cyan, `col-resize` window-wide, mono readout chip near the cursor with live px.
- Gutter A rewrites `--aim`/`--sess` as px-weight **fr** values (mock `gutA`) so the panes keep window-scaling after the drag; clamps aim ≥ 230px, session ≥ 300px.
- Gutter B adjusts `--pr` (px) clamped 240–520 while the rail is open; **inert** (`.off`, JS-guarded too) while collapsed (46px).
- Double-click resets to `1.18fr / 1fr / 320px`.

**2. Horizontal bash-footer gutter** — only while the footer is expanded; same affordance language (`⋯`, `row-resize`, readout). Rewrites the footer's `--fh` (the mock's terminal-area height; expanded total = `--fh` + the 33px tab bar), clamped 110px–60% of the Session pane. The 60% ceiling re-applies on window resize **without** persisting the transient clamp. Double-click resets (180px).

**3. Persistence** — one additive `ui-prefs` key `aimConsoleLayout: { aim, sess, pr, footer } | null` (localStorage `tmai:ui:prefs`; no core config). Restored on mount, written **once on drag end** (not per-move). An all-defaults layout normalises back to `null`, so double-click reset clears the stored layout instead of pinning a copy of today's defaults. `coercePrefs` clamps a hand-edited/stale blob per-field on load (same compose-with-coerce convention as `clampAttentionStripWidth`).

## How

- Drag engine: `setPointerCapture` (try/catch-guarded for jsdom), per-move **imperative** CSS custom-property writes — no React re-render of the pane subtrees (terminals) during a drag; only the chip (gutter-local state) re-renders. Root-scoped drag classes (`.ac-dragging` etc., the mock's `body.dragging` kept inside the `.aim-console` scope boundary) drive cursor override, `user-select: none`, and grid/footer **transition suppression** so tracks follow the pointer 1:1.
- `role="separator"` + `aria-orientation` + `aria-valuenow/-min/-max` + focusable, per the existing RPanel splitter precedent.
- `BashFooter` reads prefs via `useUIPrefsOptional` so provider-less unit renders degrade to in-memory defaults (same rationale as `useActiveTheme`).
- Drag end dispatches a window `resize` so xterm re-fits (same convention as `useSplitPane`).

## Bounding

TOUCH only: `aim-console/**` (new `Gutters.tsx`, mechanical integration in `AimConsole`/`BashFooter`), `styles/aim-console.css` (all new CSS scoped under `.aim-console`, `.ac-*`), `lib/ui-prefs.ts` (additive key only). S6 control-surface internals, `TerminalPanel`, producer-console, `App.tsx` untouched. No new wire/types, no new deps.

## Tests

`Gutters.test.tsx` (10 tests): drag updates the custom properties + persists on pointerup (not per-move); clamps hold at both ends (panes, rail, footer incl. the 60% ceiling); double-click resets and clears the stored layout; Session|PR gutter inert while collapsed; footer gutter only present when expanded; resize re-clamp is local-only; prefs round-trip (mount restores a stored layout); load-time coercion of corrupt blobs.

## Gate (from `clients/react/`)

- `pnpm lint` ✓ (1 pre-existing warning in `ProducerFeedChip`, untouched/out of scope)
- `tsc -b` ✓ (no `typecheck` script exists; `pnpm build` runs `tsc -b`)
- `pnpm build` ✓
- `pnpm test` ✓ — 104 files, 850 passed / 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Aim Console のレイアウトペイン（Aim、Session、PR、Bash フッター）がドラッグで自由に調整可能になりました。
  * 調整したレイアウトは自動保存され、次回の利用時に復元されます。
  * ダブルクリックでレイアウトをデフォルト状態にリセットできます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->