### PR TITLE
Stage B: slack tab — AimPane tab-ization [AIM | SLACK], capture box + per-repo ore terrain (reuse generated slack wire) (#809)

### DIFF
--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -27,6 +27,14 @@
 // UI state: the Frontier/Tree mode persists in `ui-prefs` (browser-side, same
 // `aimMode` key RAimsSection uses); the expanded-branch set + the search filter
 // stay component-local (a persisted filter would silently hide rows next open).
+//
+// Stage B (issue #809) tab-izes the pane: `AimPane` is now a thin two-face
+// shell — an [AIM | SLACK] switch over the UNCHANGED aim worklist (`AimFace`,
+// the entire pre-existing pane) and the slack ore terrain (`SlackFace`).
+// "木の横、木の中でなく" — one panel, two faces. The selected face is local
+// UI state (default AIM on mount, deliberately NOT persisted in this stage),
+// and the tab labels are text only: the slack tab is terrain, not a queue —
+// NO counters, NO badges, ever.
 
 import {
   type FormEvent,
@@ -67,6 +75,7 @@ import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
 import type { AimState } from "@/types/generated/AimState";
 import type { AimWire } from "@/types/generated/AimWire";
 import type { RepoAimsWire } from "@/types/generated/RepoAimsWire";
+import { SlackFace } from "./SlackFace";
 import { suggestSlug, validateAimSlug } from "./slug";
 
 // ── tone → presentation (mark-only: only the wire-derived tone drives this) ──
@@ -98,9 +107,51 @@ const repoKey = (r: RepoAimsWire): string => `repo:${r.repo_root}`;
 
 const EMPTY_FORBIDDEN: ReadonlySet<string> = new Set<string>();
 
-// ── orchestrator ──────────────────────────────────────────────────────
+// ── two-face shell — [AIM | SLACK] (Stage B, issue #809) ──────────────
+
+type PaneFace = "aim" | "slack";
 
 export function AimPane({ unitName }: { unitName: string | null }) {
+  const [face, setFace] = useState<PaneFace>("aim");
+  return (
+    <>
+      {/* Labels are TEXT ONLY — the slack tab is terrain, not a queue: no
+          unread counter, no badge, no count may ever ride on it. */}
+      <div className="ac-ftabs" data-testid="aim-face-tabs">
+        <button
+          type="button"
+          className={cn("ac-ftab", face === "aim" && "on")}
+          aria-pressed={face === "aim"}
+          onClick={() => setFace("aim")}
+        >
+          AIM
+        </button>
+        <button
+          type="button"
+          className={cn("ac-ftab", face === "slack" && "on")}
+          aria-pressed={face === "slack"}
+          onClick={() => setFace("slack")}
+        >
+          SLACK
+        </button>
+      </div>
+      {/* Both faces stay MOUNTED — switching hides (`[hidden]`), never
+          unmounts, so the AIM face's local state (selection / expansion /
+          filter / open modal) survives a SLACK detour byte-identically and
+          neither face re-fetches on a tab flip. */}
+      <div className="ac-face" hidden={face !== "aim"} data-testid="aim-face-aim">
+        <AimFace unitName={unitName} />
+      </div>
+      <div className="ac-face" hidden={face !== "slack"} data-testid="aim-face-slack">
+        <SlackFace unitName={unitName} />
+      </div>
+    </>
+  );
+}
+
+// ── AIM face orchestrator (the pre-#809 pane, behaviour unchanged) ────
+
+function AimFace({ unitName }: { unitName: string | null }) {
   const { data, loading, error, refresh } = useUnitAims(unitName);
   const repos = useMemo(() => repoForests(data), [data]);
   const allNodes = useMemo(() => flattenRepos(data), [data]);

--- a/clients/react/src/components/aim-console/SlackFace.tsx
+++ b/clients/react/src/components/aim-console/SlackFace.tsx
@@ -1,0 +1,192 @@
+// SlackFace — the AimPane's SLACK face (Stage B, issue #809): the UI half of
+// the slack artifact, pre-crystallization aim ore (結晶化前の aim の原石).
+// Design carrier: tmai-core `doc/aims/_incubator/2026-06-11-recoil-loop-
+// handoff.md` §6b–6d; wire = the generated `UnitSlackResponse` family (#807).
+//
+// Design invariants (operator-ratified — load-bearing, do not relax):
+//   - TERRAIN, NOT A QUEUE — no unread counters, no badges, no counts, no
+//     "mark as read". The face renders what exists; nothing nags.
+//   - CAPTURE IS TEXT ONLY — one textarea + a repo target. No category /
+//     care-level / importance field of any kind.
+//   - quoted/unmined is EDGE-DERIVED — `quoted_by` (same-repo aims citing the
+//     ore) renders as a quiet marker; empty = a faint 未採掘. Display only:
+//     no stored state, no client-side toggles.
+//   - Writer is the operator (this UI). No agent write path.
+//
+// Data: `useUnitSlack` (60s poll, same conventions as `useUnitPrs`) +
+// `api.captureSlack` for the POST; a successful capture clears the box and
+// `refresh()`es so the persisted ore appears immediately.
+
+import { type FormEvent, type ReactNode, useEffect, useRef, useState } from "react";
+import { useUnitSlack } from "@/hooks/useUnitSlack";
+import { api, type RepoSlackWire, type SlackOreWire } from "@/lib/api";
+import { cn } from "@/lib/utils";
+
+// Normalize a thrown API error into a short, operator-readable message — the
+// HTTP client throws `Error` whose message carries the backend's text.
+function writeErrorMessage(e: unknown): string {
+  return e instanceof Error ? e.message : String(e);
+}
+
+// An older running engine without the slack routes answers 404, and a
+// mid-rebuild engine doesn't answer at all (a fetch-level failure, no
+// `API error` prefix). Both are a quiet wait-state — "rebuild 待ち" — NOT an
+// error wall. Anything else (500 …) surfaces its message, still quietly.
+function terrainErrorNote(error: Error): string {
+  const msg = error.message;
+  if (msg.includes("API error 404") || !msg.includes("API error")) {
+    return "engine が slack 未対応（rebuild 待ち）";
+  }
+  return `slack の読み込みに失敗: ${msg}`;
+}
+
+export function SlackFace({ unitName }: { unitName: string | null }) {
+  const { data, loading, error, refresh } = useUnitSlack(unitName);
+  const repos = data?.repos ?? [];
+  const primaryRepo = repos.find((r) => r.primary) ?? repos[0] ?? null;
+
+  const [text, setText] = useState("");
+  // `null` = follow the unit's primary repo (the default target); a string =
+  // the operator pinned another repo. Ore never crosses repos — the pin only
+  // chooses which repo's doc/slack/ receives the capture.
+  const [pinnedRepoPath, setPinnedRepoPath] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const prevUnitRef = useRef(unitName);
+
+  // A unit change invalidates the capture state: a half-typed ore and a
+  // pinned repo are meaningless against the NEW unit's repos. Runs only on an
+  // actual change (same pattern as AimFace's unit-change reset).
+  useEffect(() => {
+    if (prevUnitRef.current === unitName) return;
+    prevUnitRef.current = unitName;
+    setText("");
+    setPinnedRepoPath(null);
+    setSubmitError(null);
+  }, [unitName]);
+
+  // Resolve the target: the pinned repo if it still exists in the wire,
+  // else the primary. (A stale pin after a repo disappears falls back.)
+  const targetRepo = repos.find((r) => r.repo_path === pinnedRepoPath) ?? primaryRepo;
+
+  // Reject-empty is server-side (422); this is the client-side mirror so the
+  // submit affordance never offers a doomed POST.
+  const canSubmit = unitName !== null && targetRepo !== null && text.trim() !== "" && !submitting;
+
+  async function onSubmit(e: FormEvent) {
+    e.preventDefault();
+    if (!canSubmit || unitName === null || targetRepo === null) return;
+    setSubmitting(true);
+    setSubmitError(null);
+    try {
+      // `text` goes verbatim (not trimmed) — the server writes the ore file
+      // byte-for-byte; the trim above only gates emptiness.
+      await api.captureSlack(unitName, { repo_path: targetRepo.repo_path, text });
+      setText("");
+      refresh();
+    } catch (err) {
+      setSubmitError(writeErrorMessage(err));
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  let terrain: ReactNode;
+  if (unitName === null) {
+    terrain = <div className="ac-hint">プロジェクトを選択すると slack が表示されます。</div>;
+  } else if (error !== null) {
+    terrain = <div className="ac-hint">{terrainErrorNote(error)}</div>;
+  } else if (loading && data === null) {
+    terrain = <div className="ac-hint">Loading…</div>;
+  } else {
+    terrain = repos.map((repo) => <SlackRepoGroup key={repo.repo_path} repo={repo} />);
+  }
+
+  return (
+    <>
+      {/* ── capture box — one textarea, a repo target, a submit. Nothing else. ── */}
+      <form className="ac-skcap" data-testid="slack-capture" onSubmit={onSubmit}>
+        <textarea
+          aria-label="slack capture"
+          value={text}
+          onChange={(e) => setText(e.target.value)}
+          placeholder="原石をそのまま置く — 整形しない、分類しない…"
+          disabled={unitName === null}
+        />
+        <div className="ac-skcap-row">
+          {repos.length > 1 ? (
+            <select
+              aria-label="capture target repo"
+              value={targetRepo?.repo_path ?? ""}
+              onChange={(e) => setPinnedRepoPath(e.target.value)}
+            >
+              {repos.map((r) => (
+                <option key={r.repo_path} value={r.repo_path}>
+                  {r.repo_label}
+                  {r.primary ? " (primary)" : ""}
+                </option>
+              ))}
+            </select>
+          ) : (
+            <span className="ac-skcap-repo">{targetRepo?.repo_label ?? "—"}</span>
+          )}
+          <button type="submit" className="ac-btn primary small" disabled={!canSubmit}>
+            {submitting ? "置いています…" : "置く"}
+          </button>
+        </div>
+        {submitError !== null && (
+          <p role="alert" className="ac-hint2 err">
+            {submitError}
+          </p>
+        )}
+      </form>
+
+      {/* ── ore terrain — per-repo groups, newest first ── */}
+      <div className="ac-sklist">{terrain}</div>
+    </>
+  );
+}
+
+// One repo's ore slice — repo banner (primary cyan-accented, same banner
+// language as the AIM face's Frontier sections) + the ores newest-first.
+function SlackRepoGroup({ repo }: { repo: RepoSlackWire }) {
+  // The wire returns ores ascending by ticket (= capture order); the terrain
+  // reads reverse-chronological, newest at the top.
+  const ores = [...repo.ores].reverse();
+  return (
+    <div data-testid="slack-repo-group" data-repo={repo.repo_label}>
+      <div className={cn("ac-repohead", "frontier", repo.primary && "pri")}>
+        <span className="ac-rh-name">{repo.repo_label}</span>
+      </div>
+      {ores.length === 0 ? (
+        <div className="ac-hint">ore なし — この repo にはまだ何も置かれていない。</div>
+      ) : (
+        ores.map((ore) => <OreRow key={ore.ticket} ore={ore} />)
+      )}
+    </div>
+  );
+}
+
+// One ore: capture time (mono, compact) + the quoted/unmined marker on the
+// meta line, the verbatim body below (multi-line preserved). Both marker
+// states are normal — an ore that never becomes an aim is 正規, so 未採掘
+// renders faint, never as a warning.
+function OreRow({ ore }: { ore: SlackOreWire }) {
+  return (
+    <article className="ac-ore" data-testid="slack-ore" data-ticket={ore.ticket}>
+      <div className="ac-ore-meta">
+        <span className="ac-ore-at">{ore.captured_at}</span>
+        {ore.quoted_by.length > 0 ? (
+          <span className="ac-ore-q" data-testid="slack-quoted">
+            引用: {ore.quoted_by.join(", ")}
+          </span>
+        ) : (
+          <span className="ac-ore-un" data-testid="slack-unmined">
+            未採掘
+          </span>
+        )}
+      </div>
+      <div className="ac-ore-body">{ore.body}</div>
+    </article>
+  );
+}

--- a/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
@@ -23,6 +23,7 @@ import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
 const aimsMock = vi.fn();
 const createAimMock = vi.fn();
 const editAimMock = vi.fn();
+const unitSlackMock = vi.fn();
 
 vi.mock("@/lib/api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
@@ -33,6 +34,7 @@ vi.mock("@/lib/api", async () => {
       aims: (...args: unknown[]) => aimsMock(...args),
       createAim: (...args: unknown[]) => createAimMock(...args),
       editAim: (...args: unknown[]) => editAimMock(...args),
+      unitSlack: (...args: unknown[]) => unitSlackMock(...args),
     },
   };
 });
@@ -170,13 +172,37 @@ beforeEach(() => {
   aimsMock.mockReset();
   createAimMock.mockReset();
   editAimMock.mockReset();
+  unitSlackMock.mockReset();
+  // The SLACK face mounts (hidden) alongside the AIM face, so its hook always
+  // fetches — give it a benign default with ores present, so the no-badge
+  // assertion below is meaningful (a count WOULD have something to show).
+  unitSlackMock.mockResolvedValue({
+    unit: "u",
+    repos: [
+      {
+        repo_path: "/p/tmai-core",
+        repo_label: "tmai-core",
+        primary: true,
+        ores: [
+          {
+            ticket: "2026-06-11-120000",
+            captured_at: "2026-06-11T12:00:00",
+            body: "an ore",
+            quoted_by: [],
+          },
+        ],
+      },
+    ],
+  });
 });
 
 describe("AimPane — load + ledger", () => {
   it("parks with a placeholder + no fetch when no unit is focused", () => {
     renderPane(null);
-    expect(screen.getByText(/プロジェクトを選択/)).toBeTruthy();
+    // Both faces park with their own placeholder (#809) — pin the AIM one.
+    expect(screen.getByText(/プロジェクトを選択すると aim が表示されます/)).toBeTruthy();
     expect(aimsMock).not.toHaveBeenCalled();
+    expect(unitSlackMock).not.toHaveBeenCalled();
   });
 
   it("surfaces a fetch error", async () => {
@@ -579,5 +605,67 @@ describe("AimPane — unit change", () => {
     // The previous unit's node is gone and its inspector selection cleared.
     expect(document.querySelector('[data-testid="aim-row"][data-slug="a-root"]')).toBeNull();
     expect(screen.queryByTestId("aim-inspector")).toBeNull();
+  });
+});
+
+describe("AimPane — [AIM | SLACK] faces (#809)", () => {
+  function faceEl(face: "aim" | "slack"): HTMLElement {
+    return screen.getByTestId(`aim-face-${face}`);
+  }
+
+  it("defaults to AIM; switching shows/hides the faces without unmounting AIM", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await awaitLoaded();
+    expect(faceEl("aim").hidden).toBe(false);
+    expect(faceEl("slack").hidden).toBe(true);
+
+    fireEvent.click(screen.getByRole("button", { name: "SLACK" }));
+    expect(faceEl("aim").hidden).toBe(true);
+    expect(faceEl("slack").hidden).toBe(false);
+    // AIM content untouched while SLACK is active — hidden, NOT unmounted:
+    // the worklist rows are still there, state intact.
+    expect(within(faceEl("aim")).getAllByTestId("aim-row").length).toBeGreaterThan(0);
+    await waitFor(() =>
+      expect(within(faceEl("slack")).getAllByTestId("slack-ore").length).toBeGreaterThan(0),
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "AIM" }));
+    expect(faceEl("aim").hidden).toBe(false);
+    expect(faceEl("slack").hidden).toBe(true);
+    // A tab round-trip re-fetches NOTHING — both faces stayed mounted.
+    expect(aimsMock).toHaveBeenCalledTimes(1);
+    expect(unitSlackMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("AIM face state (selection) survives a SLACK detour", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await awaitLoaded();
+    selectRow("amplify-human-judgment");
+    await screen.findByTestId("aim-inspector");
+
+    fireEvent.click(screen.getByRole("button", { name: "SLACK" }));
+    fireEvent.click(screen.getByRole("button", { name: "AIM" }));
+    // The inspector selection is exactly where it was left.
+    expect(screen.getByTestId("aim-inspector")).toBeTruthy();
+  });
+
+  it("tab labels carry NO badge / count — terrain, not a queue", async () => {
+    // The slack mock (beforeEach) returns 1 ore, so a counter WOULD have
+    // something to show; assert it never does.
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await awaitLoaded();
+    await waitFor(() =>
+      expect(within(faceEl("slack")).getAllByTestId("slack-ore").length).toBeGreaterThan(0),
+    );
+
+    const tabs = screen.getByTestId("aim-face-tabs");
+    expect(tabs.textContent).toBe("AIMSLACK");
+    const slackTab = screen.getByRole("button", { name: "SLACK" });
+    expect(slackTab.textContent).toBe("SLACK");
+    expect(slackTab.querySelector("*")).toBeNull();
+    expect(tabs.textContent).not.toMatch(/\d/);
   });
 });

--- a/clients/react/src/components/aim-console/__tests__/SlackFace.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/SlackFace.test.tsx
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+//
+// SlackFace — the AimPane's SLACK face (issue #809): capture box + per-repo
+// ore terrain over the generated slack wire. Covers the operator-ratified
+// invariants: capture is text only (one textarea, repo target, submit —
+// nothing else), submit disabled on empty/whitespace (the client mirror of
+// the server's 422), per-repo grouping with reverse-chronological ores,
+// the edge-derived quoted marker vs the faint 未採掘 (display only), and the
+// two quiet states (empty repo; endpoint unreachable/404 on an older engine).
+
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RepoSlackWire, SlackOreWire, UnitSlackResponse } from "@/lib/api";
+
+const unitSlackMock = vi.fn();
+const captureSlackMock = vi.fn();
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    unitSlack: (...args: unknown[]) => unitSlackMock(...args),
+    captureSlack: (...args: unknown[]) => captureSlackMock(...args),
+  },
+}));
+
+import { SlackFace } from "../SlackFace";
+
+function ore(ticket: string, body: string, quoted_by: string[] = []): SlackOreWire {
+  return {
+    ticket,
+    captured_at: `${ticket.slice(0, 10)}T${ticket.slice(11, 13)}:${ticket.slice(13, 15)}:${ticket.slice(15, 17)}`,
+    body,
+    quoted_by,
+  };
+}
+
+function repo(label: string, primary: boolean, ores: SlackOreWire[]): RepoSlackWire {
+  return { repo_path: `/p/${label}`, repo_label: label, primary, ores };
+}
+
+// Two repos, primary first (as the wire returns them). The primary's ores
+// arrive ASCENDING by ticket (= capture order) — the terrain must reverse.
+function responseStub(
+  repos: RepoSlackWire[] = [
+    repo("tmai-core", true, [
+      ore("2026-06-10-090000", "oldest ore", ["recoil-loop"]),
+      ore("2026-06-11-120000", "middle ore\nsecond line"),
+      ore("2026-06-11-153000", "newest ore"),
+    ]),
+    repo("tmai", false, []),
+  ],
+): UnitSlackResponse {
+  return { unit: "u", repos };
+}
+
+function renderFace(unitName: string | null = "u") {
+  return render(<SlackFace unitName={unitName} />);
+}
+
+function captureTextarea(): HTMLTextAreaElement {
+  return screen.getByLabelText("slack capture") as HTMLTextAreaElement;
+}
+
+function submitButton(): HTMLButtonElement {
+  return screen.getByRole("button", { name: /置く|置いています/ }) as HTMLButtonElement;
+}
+
+beforeEach(() => {
+  unitSlackMock.mockReset();
+  captureSlackMock.mockReset();
+});
+
+describe("SlackFace — terrain (per-repo groups, reverse-chron, markers)", () => {
+  it("parks with a placeholder + no fetch when no unit is focused", () => {
+    renderFace(null);
+    expect(screen.getByText(/プロジェクトを選択/)).toBeTruthy();
+    expect(unitSlackMock).not.toHaveBeenCalled();
+  });
+
+  it("groups per repo in wire order (primary first) and lists ores newest-first", async () => {
+    unitSlackMock.mockResolvedValue(responseStub());
+    renderFace();
+    const groups = await screen.findAllByTestId("slack-repo-group");
+    expect(groups.map((g) => g.dataset.repo)).toEqual(["tmai-core", "tmai"]);
+
+    // The wire's ascending capture order renders reversed — newest at the top.
+    const tickets = within(groups[0])
+      .getAllByTestId("slack-ore")
+      .map((o) => o.dataset.ticket);
+    expect(tickets).toEqual(["2026-06-11-153000", "2026-06-11-120000", "2026-06-10-090000"]);
+  });
+
+  it("preserves a multi-line body and shows the compact capture time", async () => {
+    unitSlackMock.mockResolvedValue(responseStub());
+    renderFace();
+    const middle = (await screen.findAllByTestId("slack-ore")).find(
+      (o) => o.dataset.ticket === "2026-06-11-120000",
+    );
+    expect(middle?.textContent).toContain("middle ore\nsecond line");
+    expect(middle?.textContent).toContain("2026-06-11T12:00:00");
+  });
+
+  it("marks quoted ores (引用: slug) and unquoted ones 未採掘 — display only", async () => {
+    unitSlackMock.mockResolvedValue(responseStub());
+    renderFace();
+    const ores = await screen.findAllByTestId("slack-ore");
+    const quoted = ores.find((o) => o.dataset.ticket === "2026-06-10-090000");
+    const unmined = ores.find((o) => o.dataset.ticket === "2026-06-11-153000");
+    if (!quoted || !unmined) throw new Error("fixture ores missing");
+
+    expect(within(quoted).getByTestId("slack-quoted").textContent).toContain("引用: recoil-loop");
+    expect(within(quoted).queryByTestId("slack-unmined")).toBeNull();
+    expect(within(unmined).getByTestId("slack-unmined").textContent).toBe("未採掘");
+    expect(within(unmined).queryByTestId("slack-quoted")).toBeNull();
+    // Display only — the marker is never a control.
+    expect(within(quoted).getByTestId("slack-quoted").tagName).not.toBe("BUTTON");
+    expect(within(unmined).getByTestId("slack-unmined").tagName).not.toBe("BUTTON");
+  });
+
+  it("renders a quiet one-liner for a repo with no ores", async () => {
+    unitSlackMock.mockResolvedValue(responseStub());
+    renderFace();
+    const groups = await screen.findAllByTestId("slack-repo-group");
+    expect(within(groups[1]).getByText(/ore なし/)).toBeTruthy();
+  });
+
+  it("renders the quiet rebuild-wait note on 404 (older engine, no slack routes)", async () => {
+    unitSlackMock.mockRejectedValue(new Error("API error 404: not found"));
+    renderFace();
+    await waitFor(() =>
+      expect(screen.getByText("engine が slack 未対応（rebuild 待ち）")).toBeTruthy(),
+    );
+  });
+
+  it("renders the same quiet note when the endpoint is unreachable (no API response)", async () => {
+    unitSlackMock.mockRejectedValue(new TypeError("Failed to fetch"));
+    renderFace();
+    await waitFor(() =>
+      expect(screen.getByText("engine が slack 未対応（rebuild 待ち）")).toBeTruthy(),
+    );
+  });
+
+  it("surfaces a non-404 API error quietly, with its message", async () => {
+    unitSlackMock.mockRejectedValue(new Error("API error 500: walk failed"));
+    renderFace();
+    await waitFor(() =>
+      expect(screen.getByText(/slack の読み込みに失敗: API error 500/)).toBeTruthy(),
+    );
+  });
+});
+
+describe("SlackFace — capture box", () => {
+  it("disables submit on empty and whitespace-only text", async () => {
+    unitSlackMock.mockResolvedValue(responseStub());
+    renderFace();
+    await screen.findAllByTestId("slack-repo-group");
+
+    expect(submitButton().disabled).toBe(true);
+    fireEvent.change(captureTextarea(), { target: { value: "   \n\t " } });
+    expect(submitButton().disabled).toBe(true);
+    fireEvent.change(captureTextarea(), { target: { value: "real ore" } });
+    expect(submitButton().disabled).toBe(false);
+  });
+
+  it("posts to the primary repo by default, clears the box, and refreshes", async () => {
+    unitSlackMock.mockResolvedValue(responseStub());
+    captureSlackMock.mockResolvedValue(ore("2026-06-11-160000", "raw text, verbatim"));
+    renderFace();
+    await screen.findAllByTestId("slack-repo-group");
+
+    fireEvent.change(captureTextarea(), { target: { value: "raw text, verbatim" } });
+    fireEvent.click(submitButton());
+
+    await waitFor(() =>
+      expect(captureSlackMock).toHaveBeenCalledWith("u", {
+        repo_path: "/p/tmai-core",
+        text: "raw text, verbatim",
+      }),
+    );
+    await waitFor(() => expect(captureTextarea().value).toBe(""));
+    // refresh() re-fetches the persisted terrain (initial fetch + 1).
+    await waitFor(() => expect(unitSlackMock).toHaveBeenCalledTimes(2));
+  });
+
+  it("lets the operator pin another repo — ore never crosses repos", async () => {
+    unitSlackMock.mockResolvedValue(responseStub());
+    captureSlackMock.mockResolvedValue(ore("2026-06-11-160000", "ui ore"));
+    renderFace();
+    await screen.findAllByTestId("slack-repo-group");
+
+    fireEvent.change(screen.getByLabelText("capture target repo"), {
+      target: { value: "/p/tmai" },
+    });
+    fireEvent.change(captureTextarea(), { target: { value: "ui ore" } });
+    fireEvent.click(submitButton());
+
+    await waitFor(() =>
+      expect(captureSlackMock).toHaveBeenCalledWith("u", {
+        repo_path: "/p/tmai",
+        text: "ui ore",
+      }),
+    );
+  });
+
+  it("shows a static repo label (no selector) for a single-repo unit", async () => {
+    unitSlackMock.mockResolvedValue(
+      responseStub([repo("tmai-core", true, [ore("2026-06-11-120000", "only")])]),
+    );
+    renderFace();
+    await screen.findAllByTestId("slack-repo-group");
+    expect(screen.queryByLabelText("capture target repo")).toBeNull();
+    expect(screen.getByText("tmai-core", { selector: ".ac-skcap-repo" })).toBeTruthy();
+  });
+
+  it("keeps the text and surfaces the message when the POST fails", async () => {
+    unitSlackMock.mockResolvedValue(responseStub());
+    captureSlackMock.mockRejectedValue(new Error("API error 422: empty"));
+    renderFace();
+    await screen.findAllByTestId("slack-repo-group");
+
+    fireEvent.change(captureTextarea(), { target: { value: "doomed" } });
+    fireEvent.click(submitButton());
+
+    await waitFor(() => expect(screen.getByRole("alert").textContent).toContain("422"));
+    // The half-written ore is NOT lost on a failed POST.
+    expect(captureTextarea().value).toBe("doomed");
+    expect(unitSlackMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("captures text only — no category / care-level / importance field", async () => {
+    unitSlackMock.mockResolvedValue(responseStub());
+    renderFace();
+    await screen.findAllByTestId("slack-repo-group");
+    const form = screen.getByTestId("slack-capture");
+    // One textarea + the repo target select — nothing else collects input.
+    expect(form.querySelectorAll("textarea")).toHaveLength(1);
+    expect(form.querySelectorAll("input")).toHaveLength(0);
+    expect(form.querySelectorAll("select")).toHaveLength(1);
+  });
+});

--- a/clients/react/src/hooks/__tests__/useUnitSlack.test.ts
+++ b/clients/react/src/hooks/__tests__/useUnitSlack.test.ts
@@ -1,0 +1,148 @@
+// @vitest-environment jsdom
+//
+// useUnitSlack — the per-repo slack-ore terrain poller behind the AimPane's
+// SLACK face (issue #809). We mock `api.unitSlack` so each test drives a
+// deterministic response and asserts the sibling-shaped contract (mirrors
+// useUnitPrs): `unit = null` parks (no fetch), the initial fetch flips
+// `loading`, errors surface without clearing into a fake success, a unit
+// change re-fetches, the 60s poll keeps the last response visible
+// (anti-flicker), and `refresh()` (the capture box's post-POST path,
+// mirrors useUnitAims) re-fetches in place.
+//
+// Timers stay real and the poll is exercised by capturing the
+// `window.setInterval` callback directly — `@testing-library`'s `waitFor`
+// cannot make progress under fake timers, and a real 60s wait is not viable
+// in a unit test.
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    unitSlack: vi.fn(),
+  },
+}));
+
+import type { UnitSlackResponse } from "@/lib/api";
+import { api } from "@/lib/api";
+import { useUnitSlack } from "../useUnitSlack";
+
+function response(unit: string, oreCount: number): UnitSlackResponse {
+  return {
+    unit,
+    repos: [
+      {
+        repo_path: `/home/u/works/${unit}`,
+        repo_label: unit,
+        primary: true,
+        ores: Array.from({ length: oreCount }, (_, i) => ({
+          ticket: `2026-06-11-10000${i}`,
+          captured_at: `2026-06-11T10:00:0${i}`,
+          body: `ore ${i + 1}`,
+          quoted_by: [],
+        })),
+      },
+    ],
+  };
+}
+
+describe("useUnitSlack", () => {
+  beforeEach(() => {
+    vi.mocked(api.unitSlack).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parks on unit=null — no fetch, not loading", () => {
+    const { result } = renderHook(() => useUnitSlack(null));
+    expect(api.unitSlack).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("fetches on a real unit and exposes the response", async () => {
+    vi.mocked(api.unitSlack).mockResolvedValue(response("tmai", 2));
+    const { result } = renderHook(() => useUnitSlack("tmai"));
+    expect(result.current.loading).toBe(true);
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false);
+    });
+    expect(api.unitSlack).toHaveBeenCalledWith("tmai");
+    expect(result.current.data?.repos[0]?.ores).toHaveLength(2);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("surfaces a fetch error without fabricating data", async () => {
+    vi.mocked(api.unitSlack).mockRejectedValue(new Error("API error 404: no route"));
+    const { result } = renderHook(() => useUnitSlack("tmai"));
+    await waitFor(() => {
+      expect(result.current.error?.message).toBe("API error 404: no route");
+    });
+    expect(result.current.data).toBeNull();
+  });
+
+  it("re-fetches when the unit changes and clears the previous list", async () => {
+    vi.mocked(api.unitSlack).mockImplementation((u: string) =>
+      Promise.resolve(response(u, u === "tmai" ? 3 : 1)),
+    );
+    const { result, rerender } = renderHook(({ u }) => useUnitSlack(u), {
+      initialProps: { u: "tmai" },
+    });
+    await waitFor(() => expect(result.current.data?.repos[0]?.ores).toHaveLength(3));
+
+    rerender({ u: "other" });
+    // Cleared synchronously on unit change so the old unit's terrain is
+    // never shown under the new header.
+    expect(result.current.data).toBeNull();
+    await waitFor(() => expect(result.current.data?.unit).toBe("other"));
+    expect(result.current.data?.repos[0]?.ores).toHaveLength(1);
+  });
+
+  it("keeps the last response visible across the 60s poll", async () => {
+    // Spy only — `vi.spyOn` calls through, so `waitFor`'s own internal
+    // `setInterval` polling still works (a `mockImplementation` here
+    // would deadlock waitFor). We read the captured callback and fire
+    // it by hand instead of waiting a real 60s.
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+
+    vi.mocked(api.unitSlack).mockResolvedValue(response("tmai", 2));
+    const { result } = renderHook(() => useUnitSlack("tmai"));
+    await waitFor(() => expect(result.current.data?.repos[0]?.ores).toHaveLength(2));
+
+    const tick = setIntervalSpy.mock.calls[0]?.[0] as (() => void) | undefined;
+    expect(typeof tick).toBe("function");
+
+    await act(async () => {
+      tick?.();
+    });
+    await waitFor(() => expect(api.unitSlack).toHaveBeenCalledTimes(2));
+    // Last response stays visible (anti-flicker) — never cleared on a poll.
+    expect(result.current.data?.repos[0]?.ores).toHaveLength(2);
+  });
+
+  it("refresh() re-fetches the current unit without clearing (anti-flicker)", async () => {
+    vi.mocked(api.unitSlack)
+      .mockResolvedValueOnce(response("tmai", 2))
+      .mockResolvedValue(response("tmai", 3));
+    const { result } = renderHook(() => useUnitSlack("tmai"));
+    await waitFor(() => expect(result.current.data?.repos[0]?.ores).toHaveLength(2));
+
+    await act(async () => {
+      result.current.refresh();
+    });
+    await waitFor(() => expect(api.unitSlack).toHaveBeenCalledTimes(2));
+    // The new response replaces the old in place — never cleared to null mid-refresh.
+    expect(result.current.data?.repos[0]?.ores).toHaveLength(3);
+  });
+
+  it("refresh() is a no-op while parked (unit=null)", async () => {
+    const { result } = renderHook(() => useUnitSlack(null));
+    await act(async () => {
+      result.current.refresh();
+    });
+    expect(api.unitSlack).not.toHaveBeenCalled();
+  });
+});

--- a/clients/react/src/hooks/useUnitSlack.ts
+++ b/clients/react/src/hooks/useUnitSlack.ts
@@ -1,0 +1,105 @@
+// Polling hook for the unit's SLACK tab — the per-repo slack-ore terrain
+// (`GET /api/units/{unit}/slack`, tmai-core
+// `doc/aims/_incubator/2026-06-11-recoil-loop-handoff.md` §6b–6d):
+// pre-crystallization aim ore grouped per repo (primary first), each ore
+// carrying its capture ticket, verbatim body, and the edge-derived
+// `quoted_by` slugs.
+//
+// Ores change on the timescale the operator captures one — human-paced. A
+// 60-second poll (same cadence as `useUnitPrs` / `useUnitAims`) is ample for
+// a terrain surface; no SSE here. Mirrors the siblings' shape exactly: keeps
+// the previous response visible while a re-fetch is in flight so the terrain
+// does not flicker; `loading` reflects only the initial fetch. `refresh`
+// follows `useUnitAims` — the capture box re-fetches the persisted state
+// after a successful POST instead of waiting on the next poll tick.
+//
+// `unit = null` parks the hook (no fetch, no interval) — used when no
+// project is selected so the face can render a placeholder rather than poll
+// a non-existent unit.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api, type UnitSlackResponse } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface UseUnitSlackResult {
+  data: UnitSlackResponse | null;
+  loading: boolean;
+  error: Error | null;
+  /**
+   * Imperatively re-fetch the current unit's ores, keeping the previous
+   * response visible while in flight (anti-flicker, same as the 60s poll). A
+   * no-op when the hook is parked (`unit = null`). The capture box uses this
+   * so a successful POST reflects the persisted ore immediately.
+   */
+  refresh: () => void;
+}
+
+export function useUnitSlack(unit: string | null): UseUnitSlackResult {
+  const [data, setData] = useState<UnitSlackResponse | null>(null);
+  const [loading, setLoading] = useState(unit !== null);
+  const [error, setError] = useState<Error | null>(null);
+  // An in-flight response from a previous unit must not stamp over a
+  // newer unit's data (same guard as useUnitPrs / useUnitAims).
+  const generationRef = useRef(0);
+  // The live unit, so the stable `refresh` callback re-fetches the *current*
+  // unit without being re-created on every unit change.
+  const unitRef = useRef(unit);
+  unitRef.current = unit;
+
+  // One gen-guarded fetch against `targetUnit`, keeping the previous response
+  // visible (anti-flicker). Shared by the initial fetch, the 60s poll, and
+  // `refresh`. Stable identity (no deps) so it doesn't re-trigger the effect.
+  const fetchFor = useCallback(async (targetUnit: string, gen: number) => {
+    try {
+      const res = await api.unitSlack(targetUnit);
+      if (gen !== generationRef.current) return;
+      setData(res);
+      setError(null);
+    } catch (e) {
+      if (gen !== generationRef.current) return;
+      setError(e instanceof Error ? e : new Error(String(e)));
+    } finally {
+      if (gen === generationRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  const refresh = useCallback(() => {
+    const u = unitRef.current;
+    if (!u) return;
+    // Re-fetch under the CURRENT generation, no data clear — the poll path's
+    // anti-flicker behaviour, triggered on demand after an operator capture.
+    void fetchFor(u, generationRef.current);
+  }, [fetchFor]);
+
+  useEffect(() => {
+    if (!unit) {
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    // Clear on unit *change* (this effect's only re-trigger — deps are
+    // [unit]) so the previous unit's ores are never shown under the new
+    // unit's header. The 60s same-unit re-poll and `refresh` go through
+    // fetchFor, which intentionally keeps the last response visible
+    // (anti-flicker); those paths are untouched. Mirrors useUnitPrs.
+    setData(null);
+    setError(null);
+    setLoading(true);
+
+    void fetchFor(unit, myGen);
+    const id = window.setInterval(() => {
+      void fetchFor(unit, myGen);
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      window.clearInterval(id);
+    };
+  }, [unit, fetchFor]);
+
+  return { data, loading, error, refresh };
+}

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -46,10 +46,13 @@ import type { RepoApproachesWire } from "@/types/generated/RepoApproachesWire";
 import type { RepoIssuesWire } from "@/types/generated/RepoIssuesWire";
 import type { RepoObservationsWire } from "@/types/generated/RepoObservationsWire";
 import type { RepoPrsWire } from "@/types/generated/RepoPrsWire";
+import type { RepoSlackWire } from "@/types/generated/RepoSlackWire";
 import type { ReviewExtensionWire } from "@/types/generated/ReviewExtensionWire";
 import type { ReviewTriggerWire } from "@/types/generated/ReviewTriggerWire";
 import type { RuntimeSnapshot } from "@/types/generated/RuntimeSnapshot";
 import type { Section } from "@/types/generated/Section";
+import type { SlackCaptureRequest } from "@/types/generated/SlackCaptureRequest";
+import type { SlackOreWire } from "@/types/generated/SlackOreWire";
 import type { SpawnRole } from "@/types/generated/SpawnRole";
 import type { SpawnRuntime } from "@/types/generated/SpawnRuntime";
 import type { TeamSnapshot } from "@/types/generated/TeamSnapshot";
@@ -60,6 +63,7 @@ import type { UnitIssuesResponse } from "@/types/generated/UnitIssuesResponse";
 import type { UnitPrsResponse } from "@/types/generated/UnitPrsResponse";
 import type { UnitRepoWire } from "@/types/generated/UnitRepoWire";
 import type { UnitResponse } from "@/types/generated/UnitResponse";
+import type { UnitSlackResponse } from "@/types/generated/UnitSlackResponse";
 import type { UnitsResponse } from "@/types/generated/UnitsResponse";
 import type { Vendor } from "@/types/generated/Vendor";
 import type { WorkerDispatchMap } from "@/types/generated/WorkerDispatchMap";
@@ -110,9 +114,12 @@ export type {
   RepoIssuesWire,
   RepoObservationsWire,
   RepoPrsWire,
+  RepoSlackWire,
   ReviewExtensionWire,
   ReviewTriggerWire,
   Section,
+  SlackCaptureRequest,
+  SlackOreWire,
   SpawnRole,
   SpawnRuntime,
   TerminalSubscription,
@@ -122,6 +129,7 @@ export type {
   UnitPrsResponse,
   UnitRepoWire,
   UnitResponse,
+  UnitSlackResponse,
   UnitsResponse,
   Vendor,
   WorkerDispatchMap,
@@ -1601,6 +1609,27 @@ export const api = {
   // merge/CI gate to override.
   unitIssues: (unit: string) =>
     apiFetch<UnitIssuesResponse>(`/units/${encodeURIComponent(unit)}/issues`),
+
+  // Unit-scoped slack-ore terrain (tmai-core
+  // `doc/aims/_incubator/2026-06-11-recoil-loop-handoff.md` §6b–6d) —
+  // pre-crystallization aim ore, grouped per repo (primary first, as the
+  // engine returns them). Terrain, not a queue: the wire carries no
+  // unread/new marker by design, and the UI must not synthesize one.
+  unitSlack: (unit: string) =>
+    apiFetch<UnitSlackResponse>(`/units/${encodeURIComponent(unit)}/slack`),
+
+  // Capture one ore — text only (no category / care-level / importance field
+  // of any kind, operator-ratified). The server derives the ticket from the
+  // capture time and writes `text` verbatim under `<repo_path>/doc/slack/`;
+  // empty / whitespace-only text or a `repo_path` outside the unit is `422`.
+  // Returns the captured ore (201) — callers refresh the list instead of
+  // splicing it in, same re-render-from-authoritative convention as
+  // `createAim`.
+  captureSlack: (unit: string, body: SlackCaptureRequest) =>
+    apiFetch<SlackOreWire>(`/units/${encodeURIComponent(unit)}/slack`, {
+      method: "POST",
+      body: JSON.stringify(body),
+    }),
 
   // Unit-scoped cross-record in-play inventory (tmai-core #485/#486) — the
   // nested projection behind the R panel's in-play section: every decision

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -15,6 +15,7 @@ import type {
   PrMergeMethod,
   PrMergeOverride,
   PrMonitorScope,
+  SlackCaptureRequest,
   SpawnRequest,
   SpawnRuntime,
   TriggerHandoffRitualRequest,
@@ -286,6 +287,11 @@ export const api = {
   // Unit-scoped cross-repo issue list — the issues peer of `unitPrs`
   // (HTTP only — gh-CLI passthrough fanned out over the unit's repos)
   unitIssues: (unit: string) => httpApi.unitIssues(unit),
+
+  // Unit-scoped slack-ore terrain + operator capture (HTTP only — file-backed
+  // doc/slack/ records served over the web API; no Tauri-specific path needed)
+  unitSlack: (unit: string) => httpApi.unitSlack(unit),
+  captureSlack: (unit: string, body: SlackCaptureRequest) => httpApi.captureSlack(unit, body),
 
   // Unit-scoped cross-record in-play inventory (HTTP only — on-demand JSON
   // projection of the unit's decisions + serving approaches; no

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -1982,6 +1982,157 @@
   border-top: 1px solid var(--line-2);
 }
 
+/* ── AIM pane faces — [AIM | SLACK] switch (Stage B, issue #809) ──────────
+   "木の横、木の中でなく" — one panel, two faces. The strip borrows the
+   session-tab language (mock `.stabs`) at a quieter size. The labels are
+   TEXT ONLY — the slack tab is terrain, not a queue: no counter, no badge,
+   no count ever rides on a face tab. */
+.aim-console .ac-ftabs {
+  display: flex;
+  gap: 2px;
+  flex: none;
+  height: 30px;
+  padding: 5px 8px 0;
+  background: var(--panel);
+  border-bottom: 1px solid var(--line-2);
+}
+.aim-console .ac-ftab {
+  display: flex;
+  align-items: center;
+  padding: 0 13px;
+  height: 25px;
+  color: var(--dim);
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 1px;
+  background: transparent;
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: 3px 3px 0 0;
+  position: relative;
+  top: 1px;
+  cursor: pointer;
+}
+.aim-console .ac-ftab:hover {
+  background: var(--line-2);
+  color: var(--txt);
+}
+.aim-console .ac-ftab.on {
+  background: var(--bg);
+  color: var(--txt);
+  border-color: var(--line-2);
+}
+
+/* A face fills the pane below the strip with the SAME flex-column context
+   `.ac-col` gave the pre-#809 pane children (header flex:none, list flex:1),
+   so the AIM face lays out byte-identically inside the wrapper. `[hidden]`
+   must beat the flex display — switching hides, never unmounts. */
+.aim-console .ac-face {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+  overflow: hidden;
+}
+.aim-console .ac-face[hidden] {
+  display: none;
+}
+
+/* ── SLACK face — capture box + per-repo ore terrain ──────────────────── */
+.aim-console .ac-skcap {
+  flex: none;
+  display: flex;
+  flex-direction: column;
+  gap: 7px;
+  padding: 10px 12px;
+  background: var(--panel);
+  border-bottom: 1px solid var(--line);
+}
+.aim-console .ac-skcap textarea {
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 8px 10px;
+  color: var(--txt);
+  font-family: var(--sans);
+  font-size: 12.5px;
+  line-height: 1.5;
+  outline: none;
+  resize: vertical;
+  min-height: 52px;
+}
+.aim-console .ac-skcap textarea:focus {
+  border-color: var(--cyan);
+}
+.aim-console .ac-skcap-row {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+}
+.aim-console .ac-skcap-row select {
+  background: var(--bg);
+  border: 1px solid var(--line);
+  border-radius: 5px;
+  padding: 4px 8px;
+  color: var(--txt);
+  font-family: var(--mono);
+  font-size: 11px;
+  outline: none;
+  min-width: 0;
+}
+.aim-console .ac-skcap-row select:focus {
+  border-color: var(--cyan);
+}
+.aim-console .ac-skcap-repo {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--dim);
+}
+.aim-console .ac-skcap-row .ac-btn {
+  margin-left: auto;
+}
+
+.aim-console .ac-sklist {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+}
+.aim-console .ac-ore {
+  padding: 8px 14px 9px;
+  border-bottom: 1px solid var(--line-2);
+}
+.aim-console .ac-ore-meta {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  margin-bottom: 3px;
+}
+.aim-console .ac-ore-at {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--faint);
+}
+/* quoted marker — quiet (structure cyan, never an alert tone) */
+.aim-console .ac-ore-q {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--cyan);
+}
+/* unmined — fainter still: a normal resting state, not a todo */
+.aim-console .ac-ore-un {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--faint);
+  opacity: 0.7;
+}
+.aim-console .ac-ore-body {
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--txt);
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 @keyframes ac-pulse {
   0%,
   100% {


### PR DESCRIPTION
Resolves #809 — the UI half of the **slack** artifact (pre-crystallization aim ore — 結晶化前の aim の原石). Engine half + generated wire types landed via tmai-core / gen-spec sync (#807). Design carrier: tmai-core `doc/aims/_incubator/2026-06-11-recoil-loop-handoff.md` §6b–6d.

## What

**Tab-ized AimPane** — `AimPane` is now a thin two-face shell with an `[AIM | SLACK]` switch (local UI state, default AIM, not persisted — per scope). The AIM face is the entire pre-existing pane, untouched; on a tab flip it is *hidden, never unmounted*, so its local state (selection / expansion / filter) and polling survive byte-identically and nothing re-fetches.

**SLACK face** (`SlackFace.tsx`):
- **Capture box**: one textarea + repo target (default = the unit's primary repo; a small selector appears only for multi-repo units — ore never crosses repos) + submit. POSTs `/api/units/{unit}/slack` `{ repo_path, text }` (text verbatim, untrimmed); success clears the box and `refresh()`es. Submit disabled on empty/whitespace client-side, mirroring the server's 422.
- **Ore terrain**: per-repo groups (primary first, wire order), ores reverse-chronological (the wire is ascending by ticket); mono compact `captured_at`, multi-line body preserved (`white-space: pre-wrap`), quoted marker `引用: <slugs>` when `quoted_by` non-empty, else a faint `未採掘` — display only, derived, no client state.
- **Quiet states**: repo with no ores = one-liner; endpoint 404/unreachable (older running engine without the slack routes) = "engine が slack 未対応（rebuild 待ち）" note — no crash, no error wall.

**Design invariants honoured (operator-ratified)**:
- Terrain, not a queue: NO unread counters, NO badges, NO counts on the tab — label is just `SLACK` (tests assert absence).
- Capture is text only: no category / care-level / importance field of any kind.
- quoted/unmined is edge-derived display; writer is the operator (no agent write path).

**Data layer**: new `hooks/useUnitSlack.ts` mirroring `useUnitPrs` (60s poll, generation guard, anti-flicker, park on `unit=null`) plus `refresh()` following `useUnitAims` for the post-capture refetch. `api.unitSlack` / `api.captureSlack` follow the existing `apiFetch` conventions; types are `import type` from `@/types/generated/` only (no hand-mirrored wire shapes), re-exported through `@/lib/api` like the other unit wires.

## Bounding

Touched only: `components/aim-console/**` (AimPane tab shell + new SlackFace + tests), `styles/aim-console.css` (additive `.ac-ftab*` / `.ac-face` / `.ac-sk*` / `.ac-ore*` under `.aim-console`), new `hooks/useUnitSlack.ts` (+ test), additive `lib/api-http.ts` / `lib/api-tauri.ts`. Generated types, producer-console, TerminalPanel/Gutters/WireTerminal, ui-prefs: untouched. No new npm deps.

## Tests

- `useUnitSlack.test.ts`: park / fetch / error / unit-change clear / 60s anti-flicker poll / refresh in place / parked refresh no-op.
- `SlackFace.test.tsx`: per-repo grouping + reverse-chron, multi-line body, quoted vs 未採掘 (and that markers are not controls), empty-repo one-liner, 404 + unreachable quiet note, non-404 quiet message, submit disabled on whitespace, default-primary POST + clear + refresh, repo pinning, single-repo static label, failed-POST keeps text, capture-is-text-only field census.
- `AimPane.test.tsx` (added): default AIM, switch shows/hides without unmounting (no re-fetch on a round-trip), AIM selection survives a SLACK detour, tab labels carry no badge/count (`AIMSLACK`, no digits, no child elements) even with ores present.

## Gate (from `clients/react/`)

`pnpm lint` ✓ · `tsc -b` (via `pnpm build`) ✓ · `pnpm build` ✓ · `pnpm test` ✓ — 106 files, 875 passed / 2 pre-existing skips. (Note: there is no `typecheck` script in package.json; `pnpm build` runs `tsc -b` as its first step, which is the CI-equivalent type gate.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)