### PR TITLE
resignation inventory — at done-set, surface what is satisfied vs what is being parked (client-side view, zero new fields) (#811)

### DIFF
--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -75,6 +75,7 @@ import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
 import type { AimState } from "@/types/generated/AimState";
 import type { AimWire } from "@/types/generated/AimWire";
 import type { RepoAimsWire } from "@/types/generated/RepoAimsWire";
+import { RESIGNATION_FRONTIER, resignationInventory } from "./resignation";
 import { SlackFace } from "./SlackFace";
 import { suggestSlug, validateAimSlug } from "./slug";
 
@@ -1070,6 +1071,17 @@ function Inspector({
         )}
       </div>
 
+      {/* Resignation inventory (#811) — done is reversible attention-parking,
+          so on an already-done node the parked objects stay visible, quietly.
+          Read-only context for the (reversible) state edit — never a gate. */}
+      {node.state === "done" && (
+        <ResignationInventoryView
+          title="resignation inventory — この done が駐車したもの"
+          node={node}
+          nodes={repo.aims}
+        />
+      )}
+
       <div className="ac-insp-actions">
         <button type="button" className="ac-btn small" onClick={onEdit}>
           ✎ 編集
@@ -1077,6 +1089,93 @@ function Inspector({
         <button type="button" className="ac-btn small" onClick={() => onAddChild(node.slug)}>
           ＋ 子 aim を作成
         </button>
+      </div>
+    </div>
+  );
+}
+
+// ── resignation inventory (#811) ──────────────────────────────────────
+//
+// Renders the `resignationInventory` facts beside the done act: 満足 = the
+// node's own confirmed marks; 諦め = its claimed marks (confirm owed, parked
+// not settled) + descendants still open. Categorical tones only — the
+// existing confirmed/claimed tag tokens and the open/drift glyph conventions;
+// no severity ramp, no warning framing, no gate. The frontier line is
+// CONSTANT and unconditional — the unwritten remainder exists whether the
+// enumerable buckets are full or empty.
+function ResignationInventoryView({
+  title,
+  node,
+  nodes,
+}: {
+  title: string;
+  node: AimWire;
+  nodes: readonly AimWire[];
+}) {
+  const inv = useMemo(() => resignationInventory(node, nodes), [node, nodes]);
+  return (
+    <div className="ac-resig" data-testid="resignation-inventory">
+      <div className="ac-isec">{title}</div>
+
+      <div className="ac-resig-cap">満足 — confirmed</div>
+      {inv.satisfied.length === 0 ? (
+        <div className="ac-il dim">— confirmed mark なし —</div>
+      ) : (
+        inv.satisfied.map((m) => (
+          <div
+            className="ac-il"
+            key={`${m.kind}:${m.text}:${m.ref ?? ""}`}
+            data-testid="resig-satisfied"
+          >
+            <span className="ac-tg c">✓ confirmed</span>
+            <span>
+              {m.text}
+              {m.ref !== null && <span className="ac-ref"> [{m.ref}]</span>}
+            </span>
+          </div>
+        ))
+      )}
+
+      <div className="ac-resig-cap">諦め — 駐車されるもの</div>
+      {inv.parkedClaims.length === 0 && inv.parkedOpenDescendants.length === 0 ? (
+        <div className="ac-il dim">— 列挙できる駐車対象なし —</div>
+      ) : (
+        <>
+          {inv.parkedClaims.map((m) => (
+            <div
+              className="ac-il"
+              key={`${m.kind}:${m.text}:${m.ref ?? ""}`}
+              data-testid="resig-claimed"
+            >
+              <span className="ac-tg k">◌ claimed</span>
+              <span>{m.text}（未 confirm のまま駐車）</span>
+            </div>
+          ))}
+          {inv.parkedOpenDescendants.map((d) => (
+            <div className="ac-il" key={d.slug} data-testid="resig-open-desc" data-slug={d.slug}>
+              <span className="ac-tg o">○ open</span>
+              <span>
+                {d.aim} <span className="ac-resig-slug">{d.slug}</span>
+                {/* A drifted descendant is still open+drifted — its drift rides
+                    along with the existing ⚠ convention, untouched. */}
+                {d.drift !== null && (
+                  <span
+                    className="ac-resig-dr"
+                    data-testid="resig-drift-badge"
+                    title={`ancestor anchor moved ${d.drift.ancestor_change_date} (${d.drift.ancestor_change_sha})`}
+                  >
+                    {" "}
+                    ⚠ drift ← {d.drift.stale_from_ancestor_slug}
+                  </span>
+                )}
+              </span>
+            </div>
+          ))}
+        </>
+      )}
+
+      <div className="ac-resig-frontier" data-testid="resig-frontier">
+        {RESIGNATION_FRONTIER}
       </div>
     </div>
   );
@@ -1317,6 +1416,18 @@ function CreateEditModal({
                   <option value="done">done — aim 到達 / confirmed</option>
                   <option value="dead">dead — self-death（系譜は残す・親無傷）</option>
                 </select>
+                {/* Resignation inventory at done-set (#811): when the operator
+                    is putting this node TO done, show what this done will park
+                    — inline, beside the state control, BEFORE the commit.
+                    Strictly non-blocking: it never disables submit, never asks
+                    "are you sure" — facts beside the act, not a gate. */}
+                {state === "done" && editSel !== null && (
+                  <ResignationInventoryView
+                    title="resignation inventory — この done が駐車するもの"
+                    node={editSel.node}
+                    nodes={editSel.repo.aims}
+                  />
+                )}
               </div>
             )}
 

--- a/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
@@ -608,6 +608,155 @@ describe("AimPane — unit change", () => {
   });
 });
 
+describe("AimPane — resignation inventory (#811)", () => {
+  // A dedicated forest: a done node carrying both mark kinds, with a
+  // multi-level subtree mixing open (one drifted), open-under-open, and a
+  // done sibling — the buckets the inventory must (and must not) collect.
+  const RESIG: AimWire[] = [
+    aimStub({ slug: "resig-root", aim: "root bearing" }),
+    aimStub({
+      slug: "resig-done",
+      aim: "the parked bearing",
+      parent: "resig-root",
+      state: "done",
+      is: [confirmed("landed", "PR#9"), claimed("tail debt")],
+    }),
+    aimStub({
+      slug: "resig-open-child",
+      aim: "open child",
+      parent: "resig-done",
+      drift: driftFrom("resig-root"),
+    }),
+    aimStub({ slug: "resig-open-grand", aim: "open grandchild", parent: "resig-open-child" }),
+    aimStub({ slug: "resig-done-child", aim: "done child", parent: "resig-done", state: "done" }),
+  ];
+  const resigResponse = () => responseStub([{ label: "tmai-core", primary: true, aims: RESIG }]);
+
+  it("renders the inventory persistently on an already-done node (satisfied ⊥ parked ⊥ frontier)", async () => {
+    aimsMock.mockResolvedValue(resigResponse());
+    renderPane();
+    await awaitLoaded();
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+    selectRow("resig-done");
+
+    const insp = await screen.findByTestId("aim-inspector");
+    const inv = within(insp).getByTestId("resignation-inventory");
+
+    // 満足 — the node's own confirmed marks, ref shown.
+    const sat = within(inv).getAllByTestId("resig-satisfied");
+    expect(sat.map((s) => s.textContent)).toEqual(["✓ confirmedlanded [PR#9]"]);
+
+    // 諦め (a) — the node's own claimed marks, parked not settled.
+    const cl = within(inv).getAllByTestId("resig-claimed");
+    expect(cl).toHaveLength(1);
+    expect(cl[0].textContent).toContain("tail debt");
+
+    // 諦め (b) — open descendants at any depth; the done child is NOT parked.
+    const desc = within(inv).getAllByTestId("resig-open-desc");
+    expect(desc.map((d) => d.dataset.slug)).toEqual(["resig-open-child", "resig-open-grand"]);
+
+    // The drifted open descendant carries its drift badge (existing convention).
+    expect(within(desc[0]).getByTestId("resig-drift-badge").textContent).toContain(
+      "drift ← resig-root",
+    );
+    expect(within(desc[1]).queryByTestId("resig-drift-badge")).toBeNull();
+
+    // The constant frontier line closes the enumerable buckets.
+    expect(within(inv).getByTestId("resig-frontier").textContent).toBe(
+      "この先は書かれていない残余 — 諦めはそこにも届く",
+    );
+  });
+
+  it("renders NO inventory on an open node", async () => {
+    aimsMock.mockResolvedValue(resigResponse());
+    renderPane();
+    await awaitLoaded();
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+    selectRow("resig-root");
+    await screen.findByTestId("aim-inspector");
+    expect(screen.queryByTestId("resignation-inventory")).toBeNull();
+  });
+
+  it("frontier line is constant and unconditional — empty buckets, done-drift tone untouched (pin #2)", async () => {
+    // review-attention-budget: done+drift, no marks, no children — both
+    // enumerable buckets are empty, the frontier still renders.
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await awaitLoaded();
+    // Pin #2 first: the done-drift row tone keeps reading as done+⚠.
+    const row = rowEl("review-attention-budget");
+    expect(row.dataset.tone).toBe("done-drift");
+    expect(within(row).getByTestId("aim-drift-badge")).toBeTruthy();
+
+    selectRow("review-attention-budget");
+    const insp = await screen.findByTestId("aim-inspector");
+    const inv = within(insp).getByTestId("resignation-inventory");
+    expect(within(inv).queryAllByTestId("resig-satisfied")).toHaveLength(0);
+    expect(within(inv).queryAllByTestId("resig-claimed")).toHaveLength(0);
+    expect(within(inv).queryAllByTestId("resig-open-desc")).toHaveLength(0);
+    expect(within(inv).getByTestId("resig-frontier").textContent).toBe(
+      "この先は書かれていない残余 — 諦めはそこにも届く",
+    );
+  });
+
+  it("at done-set in the edit modal: inventory appears beside the state control, NEVER gates the act", async () => {
+    aimsMock.mockResolvedValue(resigResponse());
+    editAimMock.mockResolvedValue(
+      aimStub({ slug: "resig-root", aim: "root bearing", state: "done" }),
+    );
+    renderPane();
+    await awaitLoaded();
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+    selectRow("resig-root");
+    const insp = await screen.findByTestId("aim-inspector");
+    fireEvent.click(within(insp).getByRole("button", { name: /編集/ }));
+
+    const modal = await screen.findByTestId("aim-create-modal");
+    // state is open → no inventory yet.
+    expect(within(modal).queryByTestId("resignation-inventory")).toBeNull();
+
+    // Flip TO done → the inventory appears inline (what this done will park):
+    // resig-root's whole open subtree is gone except… resig-done is done, so
+    // parked = the open descendants under it too (subtree at any depth).
+    fireEvent.change(within(modal).getByLabelText("state"), { target: { value: "done" } });
+    const inv = within(modal).getByTestId("resignation-inventory");
+    expect(
+      within(inv)
+        .getAllByTestId("resig-open-desc")
+        .map((d) => d.dataset.slug),
+    ).toEqual(["resig-open-child", "resig-open-grand"]);
+    expect(within(inv).getByTestId("resig-frontier")).toBeTruthy();
+
+    // NOT a gate: submit stays enabled, no confirm step — one click commits.
+    const save = within(modal).getByRole("button", { name: "保存" }) as HTMLButtonElement;
+    expect(save.disabled).toBe(false);
+    fireEvent.click(save);
+    await waitFor(() =>
+      expect(editAimMock).toHaveBeenCalledWith("u", "resig-root", {
+        aim: "root bearing",
+        parent: null,
+        state: "done",
+      }),
+    );
+  });
+
+  it("flipping the state select back to open removes the inventory (reversible)", async () => {
+    aimsMock.mockResolvedValue(resigResponse());
+    renderPane();
+    await awaitLoaded();
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+    selectRow("resig-root");
+    const insp = await screen.findByTestId("aim-inspector");
+    fireEvent.click(within(insp).getByRole("button", { name: /編集/ }));
+
+    const modal = await screen.findByTestId("aim-create-modal");
+    fireEvent.change(within(modal).getByLabelText("state"), { target: { value: "done" } });
+    expect(within(modal).getByTestId("resignation-inventory")).toBeTruthy();
+    fireEvent.change(within(modal).getByLabelText("state"), { target: { value: "open" } });
+    expect(within(modal).queryByTestId("resignation-inventory")).toBeNull();
+  });
+});
+
 describe("AimPane — [AIM | SLACK] faces (#809)", () => {
   function faceEl(face: "aim" | "slack"): HTMLElement {
     return screen.getByTestId(`aim-face-${face}`);

--- a/clients/react/src/components/aim-console/__tests__/resignation.test.ts
+++ b/clients/react/src/components/aim-console/__tests__/resignation.test.ts
@@ -1,0 +1,121 @@
+// resignation.ts — the pure inventory computation behind the done-set view
+// (issue #811). Covers: confirmed/claimed bucketing from the interior marks
+// (mark-only — authored order kept), open-descendant collection across
+// multi-level subtrees via parent edges (done/dead descendants NOT counted,
+// open under a done intermediate still counted), a drifted open descendant
+// carrying its wire drift through, and the constant frontier line.
+
+import { describe, expect, it } from "vitest";
+import type { AimDriftWire } from "@/types/generated/AimDriftWire";
+import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
+import type { AimWire } from "@/types/generated/AimWire";
+import { RESIGNATION_FRONTIER, resignationInventory } from "../resignation";
+
+const claimed = (text: string): AimInteriorWire => ({ kind: "claimed", text, ref: null });
+const confirmed = (text: string, ref: string): AimInteriorWire => ({
+  kind: "confirmed",
+  text,
+  ref,
+});
+
+function driftFrom(slug: string): AimDriftWire {
+  return {
+    stale_from_ancestor_slug: slug,
+    ancestor_change_sha: "abc1234",
+    ancestor_change_date: "2026-06-01",
+    aim_change_date: "2026-05-01",
+  };
+}
+
+function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
+  return {
+    aim: `aim ${overrides.slug}`,
+    parent: null,
+    state: "open",
+    depends_on: [],
+    serves: [],
+    related: [],
+    body: "",
+    drift: null,
+    is: [],
+    ...overrides,
+  };
+}
+
+// node (the done candidate)
+//   open-child (open, drifted)
+//     open-grandchild (open)        ← multi-level: still collected
+//   done-child (done)               ← settled, NOT parked
+//     open-under-done (open)        ← open under a done intermediate: parked
+//   dead-child (dead)               ← abandoned, NOT parked
+const FOREST: AimWire[] = [
+  aimStub({
+    slug: "node",
+    is: [claimed("unverified tail"), confirmed("core path", "PR#1"), claimed("second debt")],
+  }),
+  aimStub({ slug: "open-child", parent: "node", drift: driftFrom("node") }),
+  aimStub({ slug: "open-grandchild", parent: "open-child" }),
+  aimStub({ slug: "done-child", parent: "node", state: "done" }),
+  aimStub({ slug: "open-under-done", parent: "done-child" }),
+  aimStub({ slug: "dead-child", parent: "node", state: "dead" }),
+  aimStub({ slug: "outside", is: [claimed("other tree")] }),
+];
+
+const byslug = (s: string): AimWire => {
+  const n = FOREST.find((x) => x.slug === s);
+  if (!n) throw new Error(`no fixture node ${s}`);
+  return n;
+};
+
+describe("resignationInventory — interior-mark bucketing (mark-only)", () => {
+  it("buckets confirmed → satisfied and claimed → parked, keeping authored order", () => {
+    const inv = resignationInventory(byslug("node"), FOREST);
+    expect(inv.satisfied.map((m) => m.text)).toEqual(["core path"]);
+    expect(inv.satisfied[0].ref).toBe("PR#1");
+    // The two claimed marks keep the order the author wrote them in.
+    expect(inv.parkedClaims.map((m) => m.text)).toEqual(["unverified tail", "second debt"]);
+  });
+
+  it("a markless node yields empty buckets (the inventory is still renderable)", () => {
+    const inv = resignationInventory(byslug("done-child"), FOREST);
+    expect(inv.satisfied).toEqual([]);
+    expect(inv.parkedClaims).toEqual([]);
+  });
+});
+
+describe("resignationInventory — open-descendant collection (parent edges)", () => {
+  it("collects open descendants at any depth; done/dead descendants are not parked", () => {
+    const inv = resignationInventory(byslug("node"), FOREST);
+    expect(inv.parkedOpenDescendants.map((n) => n.slug)).toEqual([
+      "open-child",
+      "open-grandchild",
+      "open-under-done",
+    ]);
+  });
+
+  it("does not collect nodes outside the subtree", () => {
+    const inv = resignationInventory(byslug("node"), FOREST);
+    expect(inv.parkedOpenDescendants.map((n) => n.slug)).not.toContain("outside");
+    expect(inv.parkedOpenDescendants.map((n) => n.slug)).not.toContain("node");
+  });
+
+  it("a drifted open descendant carries its wire drift through, untouched", () => {
+    const inv = resignationInventory(byslug("node"), FOREST);
+    const drifted = inv.parkedOpenDescendants.find((n) => n.slug === "open-child");
+    expect(drifted?.drift?.stale_from_ancestor_slug).toBe("node");
+    // The non-drifted ones stay non-drifted — no client-side cascade.
+    const calm = inv.parkedOpenDescendants.find((n) => n.slug === "open-grandchild");
+    expect(calm?.drift).toBeNull();
+  });
+
+  it("a leaf yields no parked descendants", () => {
+    const inv = resignationInventory(byslug("open-grandchild"), FOREST);
+    expect(inv.parkedOpenDescendants).toEqual([]);
+  });
+});
+
+describe("RESIGNATION_FRONTIER", () => {
+  it("is the constant quiet frontier line", () => {
+    expect(RESIGNATION_FRONTIER).toBe("この先は書かれていない残余 — 諦めはそこにも届く");
+  });
+});

--- a/clients/react/src/components/aim-console/resignation.ts
+++ b/clients/react/src/components/aim-console/resignation.ts
@@ -1,0 +1,65 @@
+// Resignation inventory — the pure computation behind the done-set view
+// (issue #811; aim node `aim-resignation-inventory`, parent `aim-recoil-loop`).
+//
+// done = the human's 満足と諦め status; the weight is on 諦め — accepting the
+// uninspected remainder WITHOUT knowing it. tmai does NOT mechanize done; it
+// mechanizes making the OBJECTS of resignation visible: at done-set, the
+// boundary between what is satisfied and what is being parked must be a
+// visible object, not darkness.
+//
+// Operator-ratified invariants this module embodies:
+//   - ZERO new asserted fields — everything here is computed client-side from
+//     data already on the wire (`state`, the `is[]` interior-mark projection,
+//     the `parent` edges). If a computation seems to need a new field or
+//     endpoint, the computation is wrong, not the wire.
+//   - Facts, not appraisals — this module buckets and lists; it never scores,
+//     ranks by severity, or judges. Mark-only (pin #1): the interior marks
+//     keep their authored kind AND order.
+//   - The enumerable buckets end at a CONSTANT frontier line: the unwritten
+//     remainder is not enumerable; the inventory shows the boundary, the dark
+//     stays dark but the BOUNDARY is visible.
+
+import {
+  buildChildren,
+  bySlugMap,
+  descendantsOf,
+} from "@/components/producer-console/r-panel/aim-tree";
+import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
+import type { AimWire } from "@/types/generated/AimWire";
+
+// The quiet frontier line — constant and unconditional: it renders verbatim
+// whether the enumerable buckets are full or empty, because the unwritten
+// remainder exists either way.
+export const RESIGNATION_FRONTIER = "この先は書かれていない残余 — 諦めはそこにも届く";
+
+export interface ResignationInventory {
+  /** 満足 — the node's own `confirmed` interior marks (text + ref), authored order. */
+  satisfied: AimInteriorWire[];
+  /** 諦め (a) — the node's own `claimed` marks (unverified; an operator confirm
+   *  is owed), authored order. done parks that debt, it does not settle it. */
+  parkedClaims: AimInteriorWire[];
+  /** 諦め (b) — descendants still `open` (subtree via `parent` edges, ANY
+   *  depth, including under a done/dead intermediate). done/dead descendants
+   *  are NOT here — they are settled or abandoned, not parked. A drifted open
+   *  descendant keeps its wire `drift` (the renderer badges it with the
+   *  existing convention). Slug-sorted for a stable listing. */
+  parkedOpenDescendants: AimWire[];
+}
+
+// Compute the inventory for `node` against its repo's loaded node set.
+export function resignationInventory(
+  node: AimWire,
+  nodes: readonly AimWire[],
+): ResignationInventory {
+  const childrenOf = buildChildren(nodes);
+  const bySlug = bySlugMap(nodes);
+  const parkedOpenDescendants = [...descendantsOf(node.slug, childrenOf)]
+    .map((slug) => bySlug.get(slug))
+    .filter((n): n is AimWire => n !== undefined && n.state === "open")
+    .sort((a, b) => a.slug.localeCompare(b.slug));
+  return {
+    satisfied: node.is.filter((m) => m.kind === "confirmed"),
+    parkedClaims: node.is.filter((m) => m.kind === "claimed"),
+    parkedOpenDescendants,
+  };
+}

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -1824,6 +1824,43 @@
   margin-top: 12px;
 }
 
+/* ── resignation inventory (issue #811) ───────────────────────────────────
+   Facts beside the done act — what this done is satisfied with vs what it
+   parks. Categorical tones only (the confirmed/claimed tag tokens above plus
+   a neutral `open` tag); NO severity ramp, no alert styling — this surface
+   must never read as a warning or a gate. */
+.aim-console .ac-resig {
+  margin-top: 10px;
+}
+.aim-console .ac-resig-cap {
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0.5px;
+  color: var(--dim);
+  margin: 7px 0 2px;
+}
+.aim-console .ac-tg.o {
+  color: var(--dim);
+  border: 1px solid var(--line);
+}
+.aim-console .ac-resig-slug {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--faint);
+}
+.aim-console .ac-resig-dr {
+  font-family: var(--mono);
+  font-size: 9.5px;
+  color: var(--amber);
+}
+.aim-console .ac-resig-frontier {
+  font-size: 10.5px;
+  color: var(--faint);
+  border-top: 1px dashed var(--line);
+  margin-top: 8px;
+  padding-top: 7px;
+}
+
 /* ── buttons (inspector + modal) ──────────────────────────────────────── */
 .aim-console .ac-btn {
   padding: 6px 12px;


### PR DESCRIPTION
Resolves #811. First implementation slice of aim node `aim-resignation-inventory` (tmai-core `doc/aims/aim-resignation-inventory.md`, parent `aim-recoil-loop`): when the operator declares done, the boundary between what they are satisfied with and what they are parking becomes a visible object, not darkness. done itself stays human-set and reversible — the inventory is read-only context for that act.

## What

- **`aim-console/resignation.ts`** — pure computation against the unit's already-loaded aims (reuses `aim-tree.ts`'s `buildChildren` / `descendantsOf` / `bySlugMap`):
  - **満足 (satisfied)** = the node's own interior `confirmed` marks (text + ref), authored order (pin #1 mark-only).
  - **諦め (parked)** = the node's own `claimed` marks (unverified — an operator confirm is owed; done parks that debt, it does not settle it) PLUS descendants still `open` via parent edges at any depth (including under a done/dead intermediate). done/dead descendants are not parked — settled or abandoned. A drifted open descendant carries its wire `drift` through, untouched.
  - The enumerable buckets end at a **constant, unconditional frontier line**: 「この先は書かれていない残余 — 諦めはそこにも届く」 — the unwritten remainder is not enumerable; the boundary is visible, the dark stays dark.
- **`AimPane`** — one shared `ResignationInventoryView`, rendered in two places:
  - **At done-set**: in the edit modal, when the state select is flipped to `done`, the inventory appears inline below the state control — what this done *will* park — before the commit.
  - **On an already-done node**: the same inventory persistently in the inspector — what this done *parked* (done is reversible attention-parking, so the parked objects stay visible, quietly).
- **`aim-console.css`** — `.ac-resig*` under `.aim-console`, categorical tones only: the existing confirmed/claimed tag tokens plus a neutral `open` tag; no severity colors, no alert styling.

## Invariants held (operator-ratified)

- **Zero new asserted fields, zero engine/wire changes** — everything is computed client-side from `state`, `is[]`, `drift`, and `parent` edges already on the wire. `useUnitAims` consumed as-is.
- **Facts, not appraisals; never a gate** — the inventory never disables submit, never asks "are you sure", never warns. One click still commits the edit.
- **Pin #2 untouched** — `done-drift` keeps reading as done+⚠ (covered by test).
- Frontier⊥Tree faces, SLACK tab, producer-console, engine: untouched.

## Tests

- `resignation.test.ts`: confirmed/claimed bucketing (authored order), multi-level open-descendant collection (done/dead not counted, open-under-done counted), drift carried through with no client cascade, the constant frontier string.
- `AimPane.test.tsx`: inventory renders persistently on a done node (all three buckets + drift badge + frontier); absent on an open node; appears at done-set in the modal and disappears when flipped back (reversible); submit stays enabled and `editAim` fires on one click (absence of any blocking/confirm gate); frontier line unconditional on an empty-bucket done+drift node with the done-drift tone intact.

## Gate (from `clients/react/`)

- `pnpm lint` ✓ (biome; 1 pre-existing warning in an unrelated file)
- `pnpm build` ✓ (= `tsc -b && vite build`; no standalone `typecheck` script exists — tsc is inside build)
- `pnpm test` ✓ (107 files, 887 passed / 2 pre-existing skips)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 完了した項目の「満足」「駐車」「フロンティア」状態を一覧表示
  * インスペクタで完了ノードの駐車内容を読み取り専用で表示
  * 編集モーダルで状態変更時にインベントリをプレビュー表示

* **テスト**
  * resignation inventory機能の動作検証テストを追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->