### PR TITLE
chore(gen): sync generated spec + types from tmai-core@16127d4364

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -178,15 +178,16 @@
       "type": "object"
     },
     "AimInteriorKind": {
-      "description": "The kind of an interior mark — mirrors the `doc/aims/README.md` convention:\n`confirmed` = external ground-truth checked (test / PR / git ref), real,\nattention-zero; `claimed` = unverified, an operator confirm is owed. The\nprojection records which kind the author wrote — it never re-judges it.",
+      "description": "The kind of an interior mark — mirrors the `doc/aims/README.md` convention:\n`confirmed` = external ground-truth checked (test / PR / git ref), real,\nattention-zero; `claimed` = unverified, an operator confirm is owed;\n`pruned` = a rejected branch kept in the tree with its rejection reason\n(the recoil-ledger convention, `doc/aims/aim-recoil-ledger.md`). The\nprojection records which kind the author wrote — it never re-judges it.\nIn particular, `pruned` is valid on any node: pairing it with\n`state: dead` is authoring convention, not a parser rule.",
       "enum": [
         "confirmed",
-        "claimed"
+        "claimed",
+        "pruned"
       ],
       "type": "string"
     },
     "AimInteriorWire": {
-      "description": "One interior mark projected to the wire — a single `[claimed]` /\n`[confirmed: <ref>]` line from the node body. `text` is the line's prose with\nthe marker (and any leading list bullet) stripped; `reference` carries the\nconfirmed ref (the test / PR / git ref after the colon) and is `null` for a\nbare `[claimed]` (or a `[claimed — note]`, whose note is commentary, not a\nref). Wire key for `reference` is `ref` (mirroring\n[`super::approaches_view::ReviewTriggerWire`]).",
+      "description": "One interior mark projected to the wire — a single `[claimed]` /\n`[confirmed: <ref>]` / `[pruned: <reason>]` line from the node body. `text`\nis the line's prose with the marker (and any leading list bullet) stripped;\n`reference` carries the colon payload — the confirmed ref (the test / PR /\ngit ref) or the pruned rejection reason — and is `null` for a bare\n`[claimed]` / `[pruned]` (or a `[claimed — note]`, whose note is\ncommentary, not a ref). Wire key for `reference` is `ref` (mirroring\n[`super::approaches_view::ReviewTriggerWire`]).",
       "properties": {
         "kind": {
           "$ref": "#/$defs/AimInteriorKind"
@@ -246,7 +247,7 @@
           ]
         },
         "is": {
-          "description": "Interior `is[]` — the marked claims parsed from [`Self::body`]: each\n`[claimed]` / `[confirmed: <ref>]` line in the interior prose projected to\none entry. **Mark-only** (design pin #1 / `doc/aims/README.md`): the\nprojection surfaces what the author wrote (confirmed / claimed) and never\nre-judges, re-orders, or de-drifts it. Empty when the interior carries no\nmarkers. Wire key is `is` (the corpus spelling).",
+          "description": "Interior `is[]` — the marked claims parsed from [`Self::body`]: each\n`[claimed]` / `[confirmed: <ref>]` / `[pruned: <reason>]` line in the\ninterior prose projected to one entry. **Mark-only** (design pin #1 /\n`doc/aims/README.md`): the projection surfaces what the author wrote\n(confirmed / claimed / pruned) and never re-judges, re-orders, or\nde-drifts it. Empty when the interior carries no markers. Wire key is\n`is` (the corpus spelling).",
           "items": {
             "$ref": "#/$defs/AimInteriorWire"
           },

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -1285,15 +1285,16 @@
       },
       "AimInteriorKind": {
         "type": "string",
-        "description": "The kind of an interior mark — mirrors the `doc/aims/README.md` convention:\n`confirmed` = external ground-truth checked (test / PR / git ref), real,\nattention-zero; `claimed` = unverified, an operator confirm is owed. The\nprojection records which kind the author wrote — it never re-judges it.",
+        "description": "The kind of an interior mark — mirrors the `doc/aims/README.md` convention:\n`confirmed` = external ground-truth checked (test / PR / git ref), real,\nattention-zero; `claimed` = unverified, an operator confirm is owed;\n`pruned` = a rejected branch kept in the tree with its rejection reason\n(the recoil-ledger convention, `doc/aims/aim-recoil-ledger.md`). The\nprojection records which kind the author wrote — it never re-judges it.\nIn particular, `pruned` is valid on any node: pairing it with\n`state: dead` is authoring convention, not a parser rule.",
         "enum": [
           "confirmed",
-          "claimed"
+          "claimed",
+          "pruned"
         ]
       },
       "AimInteriorWire": {
         "type": "object",
-        "description": "One interior mark projected to the wire — a single `[claimed]` /\n`[confirmed: <ref>]` line from the node body. `text` is the line's prose with\nthe marker (and any leading list bullet) stripped; `reference` carries the\nconfirmed ref (the test / PR / git ref after the colon) and is `null` for a\nbare `[claimed]` (or a `[claimed — note]`, whose note is commentary, not a\nref). Wire key for `reference` is `ref` (mirroring\n[`super::approaches_view::ReviewTriggerWire`]).",
+        "description": "One interior mark projected to the wire — a single `[claimed]` /\n`[confirmed: <ref>]` / `[pruned: <reason>]` line from the node body. `text`\nis the line's prose with the marker (and any leading list bullet) stripped;\n`reference` carries the colon payload — the confirmed ref (the test / PR /\ngit ref) or the pruned rejection reason — and is `null` for a bare\n`[claimed]` / `[pruned]` (or a `[claimed — note]`, whose note is\ncommentary, not a ref). Wire key for `reference` is `ref` (mirroring\n[`super::approaches_view::ReviewTriggerWire`]).",
         "required": [
           "kind",
           "text"
@@ -1366,7 +1367,7 @@
             "items": {
               "$ref": "#/components/schemas/AimInteriorWire"
             },
-            "description": "Interior `is[]` — the marked claims parsed from [`Self::body`]: each\n`[claimed]` / `[confirmed: <ref>]` line in the interior prose projected to\none entry. **Mark-only** (design pin #1 / `doc/aims/README.md`): the\nprojection surfaces what the author wrote (confirmed / claimed) and never\nre-judges, re-orders, or de-drifts it. Empty when the interior carries no\nmarkers. Wire key is `is` (the corpus spelling)."
+            "description": "Interior `is[]` — the marked claims parsed from [`Self::body`]: each\n`[claimed]` / `[confirmed: <ref>]` / `[pruned: <reason>]` line in the\ninterior prose projected to one entry. **Mark-only** (design pin #1 /\n`doc/aims/README.md`): the projection surfaces what the author wrote\n(confirmed / claimed / pruned) and never re-judges, re-orders, or\nde-drifts it. Empty when the interior carries no markers. Wire key is\n`is` (the corpus spelling)."
           },
           "parent": {
             "type": [

--- a/clients/ratatui/src/types/generated/aim_interior_kind.rs
+++ b/clients/ratatui/src/types/generated/aim_interior_kind.rs
@@ -12,4 +12,5 @@ use std::collections::HashMap;
 pub enum AimInteriorKind {
     confirmed,
     claimed,
+    pruned,
 }

--- a/clients/react/src/types/generated/AimInteriorKind.ts
+++ b/clients/react/src/types/generated/AimInteriorKind.ts
@@ -3,7 +3,11 @@
 /**
  * The kind of an interior mark — mirrors the `doc/aims/README.md` convention:
  * `confirmed` = external ground-truth checked (test / PR / git ref), real,
- * attention-zero; `claimed` = unverified, an operator confirm is owed. The
+ * attention-zero; `claimed` = unverified, an operator confirm is owed;
+ * `pruned` = a rejected branch kept in the tree with its rejection reason
+ * (the recoil-ledger convention, `doc/aims/aim-recoil-ledger.md`). The
  * projection records which kind the author wrote — it never re-judges it.
+ * In particular, `pruned` is valid on any node: pairing it with
+ * `state: dead` is authoring convention, not a parser rule.
  */
-export type AimInteriorKind = "confirmed" | "claimed";
+export type AimInteriorKind = "confirmed" | "claimed" | "pruned";

--- a/clients/react/src/types/generated/AimInteriorWire.ts
+++ b/clients/react/src/types/generated/AimInteriorWire.ts
@@ -3,11 +3,12 @@ import type { AimInteriorKind } from "./AimInteriorKind";
 
 /**
  * One interior mark projected to the wire — a single `[claimed]` /
- * `[confirmed: <ref>]` line from the node body. `text` is the line's prose with
- * the marker (and any leading list bullet) stripped; `reference` carries the
- * confirmed ref (the test / PR / git ref after the colon) and is `null` for a
- * bare `[claimed]` (or a `[claimed — note]`, whose note is commentary, not a
- * ref). Wire key for `reference` is `ref` (mirroring
+ * `[confirmed: <ref>]` / `[pruned: <reason>]` line from the node body. `text`
+ * is the line's prose with the marker (and any leading list bullet) stripped;
+ * `reference` carries the colon payload — the confirmed ref (the test / PR /
+ * git ref) or the pruned rejection reason — and is `null` for a bare
+ * `[claimed]` / `[pruned]` (or a `[claimed — note]`, whose note is
+ * commentary, not a ref). Wire key for `reference` is `ref` (mirroring
  * [`super::approaches_view::ReviewTriggerWire`]).
  */
 export type AimInteriorWire = { kind: AimInteriorKind, text: string, ref: string | null, };

--- a/clients/react/src/types/generated/AimWire.ts
+++ b/clients/react/src/types/generated/AimWire.ts
@@ -61,10 +61,11 @@ body: string,
 drift: AimDriftWire | null, 
 /**
  * Interior `is[]` — the marked claims parsed from [`Self::body`]: each
- * `[claimed]` / `[confirmed: <ref>]` line in the interior prose projected to
- * one entry. **Mark-only** (design pin #1 / `doc/aims/README.md`): the
- * projection surfaces what the author wrote (confirmed / claimed) and never
- * re-judges, re-orders, or de-drifts it. Empty when the interior carries no
- * markers. Wire key is `is` (the corpus spelling).
+ * `[claimed]` / `[confirmed: <ref>]` / `[pruned: <reason>]` line in the
+ * interior prose projected to one entry. **Mark-only** (design pin #1 /
+ * `doc/aims/README.md`): the projection surfaces what the author wrote
+ * (confirmed / claimed / pruned) and never re-judges, re-orders, or
+ * de-drifts it. Empty when the interior carries no markers. Wire key is
+ * `is` (the corpus spelling).
  */
 is: Array<AimInteriorWire>, };


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@16127d43642b260a492addc6649dbfb1a7ae0d90

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/corevents.schema.json                           |  9 +++++----
 api-spec/openapi.json                                    |  9 +++++----
 clients/ratatui/src/types/generated/aim_interior_kind.rs |  1 +
 clients/react/src/types/generated/AimInteriorKind.ts     |  8 ++++++--
 clients/react/src/types/generated/AimInteriorWire.ts     | 11 ++++++-----
 clients/react/src/types/generated/AimWire.ts             | 11 ++++++-----
 6 files changed, 29 insertions(+), 20 deletions(-)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * API において、内部マークに「pruned（棄却）」状態が新たにサポートされました。これにより、除外された分岐を理由付きで表現できるようになります。

* **ドキュメント**
  * API スキーマ仕様書を更新し、pruned 状態の投影ルールと参照/null のセマンティクスを明記しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->