### PR TITLE
aim-console: render `pruned` interior marks (recoil-ledger UI half) (#814)

### DIFF
--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -889,7 +889,8 @@ function ToneGlyph({ tone }: { tone: AimTone }) {
   }
 }
 
-// Tiny per-mark dots beside a row — confirmed = green, claimed = ochre.
+// Tiny per-mark dots beside a row — confirmed = green, claimed = ochre,
+// pruned = neutral (adjudicated rejection: attention-zero, never owed).
 // Mark-only: order + kind are exactly the wire's.
 function InteriorDots({ marks }: { marks: readonly AimInteriorWire[] }) {
   if (marks.length === 0) return null;
@@ -899,7 +900,7 @@ function InteriorDots({ marks }: { marks: readonly AimInteriorWire[] }) {
         // Interior lines have no id; key off the prose (mark-only — never re-ordered).
         <i
           key={`${m.kind}:${m.text}:${m.ref ?? ""}`}
-          className={m.kind === "confirmed" ? "c" : "k"}
+          className={m.kind === "confirmed" ? "c" : m.kind === "claimed" ? "k" : "p"}
           aria-hidden="true"
         />
       ))}
@@ -1057,12 +1058,23 @@ function Inspector({
               data-testid="aim-mark"
               data-kind={m.kind}
             >
-              <span className={cn("ac-tg", m.kind === "confirmed" ? "c" : "k")}>
-                {m.kind === "confirmed" ? "✓ confirmed" : "◌ claimed"}
+              <span
+                className={cn(
+                  "ac-tg",
+                  m.kind === "confirmed" ? "c" : m.kind === "claimed" ? "k" : "p",
+                )}
+              >
+                {m.kind === "confirmed"
+                  ? "✓ confirmed"
+                  : m.kind === "claimed"
+                    ? "◌ claimed"
+                    : "⊘ pruned"}
               </span>
               <span>
                 {m.text}
-                {m.kind === "confirmed" && m.ref !== null && (
+                {/* `ref` carries the confirm evidence OR the pruned rejection
+                    reason — same slot on the wire, same layout here. */}
+                {m.kind !== "claimed" && m.ref !== null && (
                   <span className="ac-ref"> [{m.ref}]</span>
                 )}
               </span>

--- a/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
@@ -55,6 +55,11 @@ const confirmed = (text: string, ref: string): AimInteriorWire => ({
   text,
   ref,
 });
+const pruned = (text: string, ref: string | null = null): AimInteriorWire => ({
+  kind: "pruned",
+  text,
+  ref,
+});
 
 function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
   return {
@@ -74,7 +79,8 @@ function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
 // Two repos (same shape as RAimsSection's fixture):
 //   tmai-core (primary)
 //     amplify-human-judgment (root, open, claimed)               → owed (claimed)
-//       attention-per-artifact (open, drift←amplify, conf+claim)  → owed (drift)
+//       attention-per-artifact (open, drift←amplify,
+//                               conf+claim+pruned)                 → owed (drift)
 //         attention-backend (done, confirmed)                     → plain done
 //     aim-system (root, open, confirmed)                          → calm
 //       aim-honesty (dead)                                        → abandoned
@@ -88,7 +94,11 @@ const CORE: AimWire[] = [
     aim: "per-artifact attention",
     parent: "amplify-human-judgment",
     drift: driftFrom("amplify-human-judgment"),
-    is: [confirmed("storage + wire", "PR#490"), claimed("ancestor moved — re-confirm")],
+    is: [
+      confirmed("storage + wire", "PR#490"),
+      claimed("ancestor moved — re-confirm"),
+      pruned("CLI-flag route", "wrong premise — judgment lives in records"),
+    ],
   }),
   aimStub({
     slug: "attention-backend",
@@ -216,10 +226,12 @@ describe("AimPane — load + ledger", () => {
     renderPane();
     const ledger = await screen.findByTestId("aim-ledger");
     // drift=2 (attention-per-artifact open + review-attention-budget done; dead
-    // excluded), claimed marks=3, confirmed marks=3.
+    // excluded), claimed marks=3, confirmed marks=3. The pruned mark on
+    // attention-per-artifact lands in NO bucket (#814) — counts unchanged.
     await waitFor(() => expect(ledger.textContent).toMatch(/2\s*drift/));
     expect(ledger.textContent).toMatch(/3\s*claimed/);
     expect(ledger.textContent).toMatch(/3\s*confirmed/);
+    expect(ledger.textContent).not.toContain("pruned");
   });
 });
 
@@ -325,7 +337,7 @@ describe("AimPane — overview ruler", () => {
 });
 
 describe("AimPane — inspector", () => {
-  it("shows the drift←ancestor pill and the interior is[] (mark-only, ref for confirmed)", async () => {
+  it("shows the drift←ancestor pill and the interior is[] (mark-only, ref for confirmed/pruned)", async () => {
     aimsMock.mockResolvedValue(responseStub());
     renderPane();
     await awaitLoaded();
@@ -336,9 +348,25 @@ describe("AimPane — inspector", () => {
       "drift ← 祖先 amplify-human-judgment",
     );
     const marks = within(insp).getAllByTestId("aim-mark");
-    expect(marks.map((m) => m.dataset.kind)).toEqual(["confirmed", "claimed"]);
+    expect(marks.map((m) => m.dataset.kind)).toEqual(["confirmed", "claimed", "pruned"]);
     expect(marks[0].textContent).toContain("PR#490");
     expect(marks[1].textContent).toContain("ancestor moved");
+    // pruned (#814): its own tag (neutral `p` class — not ochre `k`, not green
+    // `c`) and the rejection reason riding `ref`, same layout as confirmed.
+    expect(marks[2].textContent).toContain("⊘ pruned");
+    expect(marks[2].textContent).toContain("[wrong premise — judgment lives in records]");
+    const prunedTag = marks[2].querySelector(".ac-tg");
+    expect(prunedTag?.classList.contains("p")).toBe(true);
+    expect(prunedTag?.classList.contains("k")).toBe(false);
+    expect(prunedTag?.classList.contains("c")).toBe(false);
+  });
+
+  it("interior dots are three-way: confirmed=c, claimed=k, pruned=p (#814)", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await awaitLoaded();
+    const dots = rowEl("attention-per-artifact").querySelectorAll(".ac-ism i");
+    expect([...dots].map((d) => d.className)).toEqual(["c", "k", "p"]);
   });
 
   it("breadcrumb climbs to an ancestor", async () => {
@@ -619,7 +647,9 @@ describe("AimPane — resignation inventory (#811)", () => {
       aim: "the parked bearing",
       parent: "resig-root",
       state: "done",
-      is: [confirmed("landed", "PR#9"), claimed("tail debt")],
+      // The pruned mark belongs to NEITHER bucket (#814): adjudicated ≠
+      // satisfied ≠ parked.
+      is: [confirmed("landed", "PR#9"), claimed("tail debt"), pruned("dead-end route")],
     }),
     aimStub({
       slug: "resig-open-child",
@@ -642,14 +672,17 @@ describe("AimPane — resignation inventory (#811)", () => {
     const insp = await screen.findByTestId("aim-inspector");
     const inv = within(insp).getByTestId("resignation-inventory");
 
-    // 満足 — the node's own confirmed marks, ref shown.
+    // 満足 — the node's own confirmed marks, ref shown. The pruned mark is
+    // NOT here (adjudicated ≠ satisfied).
     const sat = within(inv).getAllByTestId("resig-satisfied");
     expect(sat.map((s) => s.textContent)).toEqual(["✓ confirmedlanded [PR#9]"]);
 
-    // 諦め (a) — the node's own claimed marks, parked not settled.
+    // 諦め (a) — the node's own claimed marks, parked not settled. The pruned
+    // mark is NOT here either (adjudicated ≠ parked, #814).
     const cl = within(inv).getAllByTestId("resig-claimed");
     expect(cl).toHaveLength(1);
     expect(cl[0].textContent).toContain("tail debt");
+    expect(inv.textContent).not.toContain("dead-end route");
 
     // 諦め (b) — open descendants at any depth; the done child is NOT parked.
     const desc = within(inv).getAllByTestId("resig-open-desc");

--- a/clients/react/src/components/aim-console/__tests__/resignation.test.ts
+++ b/clients/react/src/components/aim-console/__tests__/resignation.test.ts
@@ -17,6 +17,11 @@ const confirmed = (text: string, ref: string): AimInteriorWire => ({
   text,
   ref,
 });
+const pruned = (text: string, ref: string | null = null): AimInteriorWire => ({
+  kind: "pruned",
+  text,
+  ref,
+});
 
 function driftFrom(slug: string): AimDriftWire {
   return {
@@ -51,7 +56,12 @@ function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
 const FOREST: AimWire[] = [
   aimStub({
     slug: "node",
-    is: [claimed("unverified tail"), confirmed("core path", "PR#1"), claimed("second debt")],
+    is: [
+      claimed("unverified tail"),
+      confirmed("core path", "PR#1"),
+      claimed("second debt"),
+      pruned("flag route", "wrong premise"),
+    ],
   }),
   aimStub({ slug: "open-child", parent: "node", drift: driftFrom("node") }),
   aimStub({ slug: "open-grandchild", parent: "open-child" }),
@@ -74,6 +84,12 @@ describe("resignationInventory — interior-mark bucketing (mark-only)", () => {
     expect(inv.satisfied[0].ref).toBe("PR#1");
     // The two claimed marks keep the order the author wrote them in.
     expect(inv.parkedClaims.map((m) => m.text)).toEqual(["unverified tail", "second debt"]);
+  });
+
+  it("a pruned mark lands in NEITHER bucket — adjudicated ≠ satisfied ≠ parked (#814)", () => {
+    const inv = resignationInventory(byslug("node"), FOREST);
+    expect(inv.satisfied.map((m) => m.text)).not.toContain("flag route");
+    expect(inv.parkedClaims.map((m) => m.text)).not.toContain("flag route");
   });
 
   it("a markless node yields empty buckets (the inventory is still renderable)", () => {

--- a/clients/react/src/components/aim-console/resignation.ts
+++ b/clients/react/src/components/aim-console/resignation.ts
@@ -57,6 +57,10 @@ export function resignationInventory(
     .map((slug) => bySlug.get(slug))
     .filter((n): n is AimWire => n !== undefined && n.state === "open")
     .sort((a, b) => a.slug.localeCompare(b.slug));
+  // `pruned` marks land in NEITHER bucket, intentionally: an adjudicated
+  // rejection is not 満足 (nothing was confirmed) and not 諦め (nothing is
+  // parked — the judgment is settled, no confirm is owed). adjudicated ≠
+  // satisfied ≠ parked.
   return {
     satisfied: node.is.filter((m) => m.kind === "confirmed"),
     parkedClaims: node.is.filter((m) => m.kind === "claimed"),

--- a/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
@@ -12,9 +12,9 @@
 // (the approach's named failure-signal). Pure model in `./aim-tree`.
 //
 // Design pins honoured:
-//   #1 mark-only — the `is[]` marks (confirmed / claimed) render as the author
-//      wrote them; we never re-judge / re-order / appraise (only the wire's
-//      `kind` drives styling).
+//   #1 mark-only — the `is[]` marks (confirmed / claimed / pruned) render as
+//      the author wrote them; we never re-judge / re-order / appraise (only the
+//      wire's `kind` drives styling).
 //   #2 done+drift distinct — a `state: done` node that is ALSO drifted gets the
 //      `done-drift` tone (a done ✓ AND a drift ⚠ badge), surfaced in its own
 //      Frontier cluster + the Tree, never suppressed or folded into plain owed.
@@ -25,7 +25,9 @@
 // Theme: the mock is the STRUCTURE/BEHAVIOUR reference, not its raw CSS. The
 // panel speaks the app's design tokens — drift = `warning`, claimed = `warning`
 // hollow (◌ vs ⚠ + gutter weight distinguish the two owed kinds), confirmed /
-// done = `success` (calm), root / selection = `info` / `primary`.
+// done = `success` (calm), root / selection = `info` / `primary`, pruned =
+// neutral/subtle (negative-calm: an adjudicated rejection is never owed and
+// never counted, #814).
 //
 // UI-only state: the mode (Frontier/Tree) persists in `ui-prefs` (browser-side,
 // not tmai-core config). The expanded-branch set + the search filter stay
@@ -1058,7 +1060,8 @@ function AimRow({
 }
 
 // Tiny per-mark dots beside a row — confirmed = filled success, claimed =
-// filled warning. Mark-only: order + kind are exactly the wire's.
+// filled warning, pruned = neutral (adjudicated rejection: attention-zero,
+// never owed). Mark-only: order + kind are exactly the wire's.
 function InteriorDots({ marks }: { marks: readonly AimInteriorWire[] }) {
   if (marks.length === 0) return null;
   return (
@@ -1069,7 +1072,13 @@ function InteriorDots({ marks }: { marks: readonly AimInteriorWire[] }) {
         <span
           key={`${m.kind}:${m.text}:${m.ref ?? ""}`}
           aria-hidden="true"
-          className={`h-1 w-1 rounded-[1px] ${m.kind === "confirmed" ? "bg-success" : "bg-warning"}`}
+          className={`h-1 w-1 rounded-[1px] ${
+            m.kind === "confirmed"
+              ? "bg-success"
+              : m.kind === "claimed"
+                ? "bg-warning"
+                : "bg-subtle-foreground/40"
+          }`}
         />
       ))}
     </span>
@@ -1281,8 +1290,9 @@ function DriftPill({ drift, done }: { drift: AimDriftWire; done: boolean }) {
   );
 }
 
-// The interior `is[]` list — mark-only: confirmed / claimed exactly as authored
-// (order + kind off the wire), `ref` shown for confirmed marks.
+// The interior `is[]` list — mark-only: confirmed / claimed / pruned exactly as
+// authored (order + kind off the wire), `ref` shown for confirmed (evidence)
+// and pruned (rejection reason) marks.
 function InteriorList({ marks }: { marks: readonly AimInteriorWire[] }) {
   return (
     <section className="mt-3">
@@ -1305,7 +1315,9 @@ function InteriorList({ marks }: { marks: readonly AimInteriorWire[] }) {
               <MarkTag kind={m.kind} />
               <span className="text-muted-foreground">
                 {m.text}
-                {m.kind === "confirmed" && m.ref !== null && (
+                {/* `ref` carries the confirm evidence OR the pruned rejection
+                    reason — same slot on the wire, same layout here. */}
+                {m.kind !== "claimed" && m.ref !== null && (
                   <span className="ml-1 font-mono text-[9px] text-info">[{m.ref}]</span>
                 )}
               </span>
@@ -1325,9 +1337,18 @@ function MarkTag({ kind }: { kind: AimInteriorKind }) {
       </span>
     );
   }
+  if (kind === "claimed") {
+    return (
+      <span className="shrink-0 rounded border border-dashed border-warning/50 px-1 py-px font-mono text-[9px] text-warning">
+        ◌ claimed
+      </span>
+    );
+  }
+  // pruned — negative-calm: neutral tone, never the owed warning or the
+  // success green (an adjudicated rejection is settled, not owed).
   return (
-    <span className="shrink-0 rounded border border-dashed border-warning/50 px-1 py-px font-mono text-[9px] text-warning">
-      ◌ claimed
+    <span className="shrink-0 rounded border border-hairline px-1 py-px font-mono text-[9px] text-subtle-foreground">
+      ⊘ pruned
     </span>
   );
 }

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RAimsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RAimsSection.test.tsx
@@ -51,6 +51,11 @@ const confirmed = (text: string, ref: string): AimInteriorWire => ({
   text,
   ref,
 });
+const pruned = (text: string, ref: string | null = null): AimInteriorWire => ({
+  kind: "pruned",
+  text,
+  ref,
+});
 
 function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
   return {
@@ -70,7 +75,8 @@ function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
 // Two repos:
 //   tmai-core (primary)
 //     amplify-human-judgment (root, open, claimed)            → owed (claimed)
-//       attention-per-artifact (open, drift←amplify, conf+claim) → owed (drift)
+//       attention-per-artifact (open, drift←amplify,
+//                               conf+claim+pruned)             → owed (drift)
 //         attention-backend (done, confirmed)                 → plain done
 //     aim-system (root, open, confirmed)                      → calm
 //       aim-honesty (dead)                                    → abandoned
@@ -84,7 +90,11 @@ const CORE: AimWire[] = [
     aim: "per-artifact attention",
     parent: "amplify-human-judgment",
     drift: driftFrom("amplify-human-judgment"),
-    is: [confirmed("storage + wire", "PR#490"), claimed("ancestor moved — re-confirm")],
+    is: [
+      confirmed("storage + wire", "PR#490"),
+      claimed("ancestor moved — re-confirm"),
+      pruned("CLI-flag route", "wrong premise — judgment lives in records"),
+    ],
   }),
   aimStub({
     slug: "attention-backend",
@@ -237,10 +247,12 @@ describe("RAimsSection — panel shell", () => {
     await openPanel();
     const ledger = screen.getByTestId("aim-ledger");
     // drift=2 (attention-per-artifact open + review-attention-budget done; dead
-    // excluded), claimed marks=3, confirmed marks=3.
+    // excluded), claimed marks=3, confirmed marks=3. The pruned mark on
+    // attention-per-artifact lands in NO bucket (#814) — counts unchanged.
     expect(ledger.textContent).toMatch(/2\s*drift/);
     expect(ledger.textContent).toMatch(/3\s*claimed/);
     expect(ledger.textContent).toMatch(/3\s*confirmed/);
+    expect(ledger.textContent).not.toContain("pruned");
   });
 });
 
@@ -332,7 +344,7 @@ describe("RAimsSection — Tree mode (per-repo navigator + rollups)", () => {
 });
 
 describe("RAimsSection — inspector", () => {
-  it("shows the drift←ancestor pill and the interior is[] list (mark-only, ref for confirmed)", async () => {
+  it("shows the drift←ancestor pill and the interior is[] list (mark-only, ref for confirmed/pruned)", async () => {
     aimsMock.mockResolvedValue(responseStub());
     renderPanel();
     await openPanel();
@@ -343,11 +355,28 @@ describe("RAimsSection — inspector", () => {
     expect(within(insp).getByTestId("aim-drift-pill").textContent).toContain(
       "drift ← amplify-human-judgment",
     );
-    // is[] list: a confirmed (with ref) + a claimed, exactly as authored.
+    // is[] list: a confirmed (with ref) + a claimed + a pruned, exactly as authored.
     const marks = within(insp).getAllByTestId("aim-mark");
-    expect(marks.map((m) => m.dataset.kind)).toEqual(["confirmed", "claimed"]);
+    expect(marks.map((m) => m.dataset.kind)).toEqual(["confirmed", "claimed", "pruned"]);
     expect(marks[0].textContent).toContain("PR#490"); // ref shown for confirmed
     expect(marks[1].textContent).toContain("ancestor moved");
+    // pruned (#814): its own neutral tag — never the warning or success tone —
+    // with the rejection reason riding `ref`, same layout as the confirmed ref.
+    expect(marks[2].textContent).toContain("⊘ pruned");
+    expect(marks[2].textContent).toContain("[wrong premise — judgment lives in records]");
+    expect(marks[2].querySelector(".text-warning")).toBeNull();
+    expect(marks[2].querySelector(".text-success")).toBeNull();
+  });
+
+  it("interior dots are three-way — the pruned dot is neutral, not warning/success (#814)", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPanel();
+    await openPanel();
+    const dots = rowEl("attention-per-artifact").querySelectorAll("span[aria-hidden].h-1.w-1");
+    expect(dots).toHaveLength(3);
+    expect(dots[0].className).toContain("bg-success");
+    expect(dots[1].className).toContain("bg-warning");
+    expect(dots[2].className).toContain("bg-subtle-foreground/40");
   });
 
   it("breadcrumb in the inspector lets you climb to an ancestor", async () => {

--- a/clients/react/src/components/producer-console/r-panel/__tests__/aim-tree.test.ts
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/aim-tree.test.ts
@@ -45,6 +45,9 @@ function claimed(text = "owed"): AimInteriorWire {
 function confirmed(text = "done", ref: string | null = "PR#1"): AimInteriorWire {
   return { kind: "confirmed", text, ref };
 }
+function pruned(text = "rejected", ref: string | null = "wrong premise"): AimInteriorWire {
+  return { kind: "pruned", text, ref };
+}
 
 function aim(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
   return {
@@ -129,6 +132,10 @@ describe("owed-status predicates", () => {
     expect(hasClaimed(n)).toBe(true);
     expect(hasConfirmed(n)).toBe(true);
     expect(hasClaimed(aim({ slug: "y", is: [confirmed()] }))).toBe(false);
+    // pruned (#814) is neither: an adjudicated rejection trips no predicate.
+    const p = aim({ slug: "z", is: [pruned()] });
+    expect(hasClaimed(p)).toBe(false);
+    expect(hasConfirmed(p)).toBe(false);
   });
 
   it("isOwed: an OPEN node that drifted or carries a claimed mark", () => {
@@ -136,6 +143,8 @@ describe("owed-status predicates", () => {
     expect(isOwed(aim({ slug: "k", is: [claimed()] }))).toBe(true);
     // A purely confirmed open node is calm, not owed.
     expect(isOwed(aim({ slug: "c", is: [confirmed()] }))).toBe(false);
+    // A purely pruned open node is negative-calm — NEVER owed (#814).
+    expect(isOwed(aim({ slug: "p", is: [pruned()] }))).toBe(false);
     // done / dead are never owed, even when drifted.
     expect(isOwed(aim({ slug: "dn", drift: DRIFT, state: "done" }))).toBe(false);
     expect(isOwed(aim({ slug: "dd", drift: DRIFT, state: "dead" }))).toBe(false);
@@ -168,6 +177,9 @@ describe("aimTone — pin #2: done+drift is distinct, not suppressed", () => {
     expect(aimTone(aim({ slug: "x", is: [confirmed()] }))).toBe("confirmed");
     expect(aimTone(aim({ slug: "x", parent: null }))).toBe("root");
     expect(aimTone(aim({ slug: "x", parent: "root-a" }))).toBe("neutral");
+    // pruned (#814) contributes NO tone of its own — a pruned-only child reads
+    // neutral, exactly as if unmarked.
+    expect(aimTone(aim({ slug: "x", parent: "root-a", is: [pruned()] }))).toBe("neutral");
   });
 
   it("dead always reads `dead`, even if the wire still carries drift", () => {
@@ -257,13 +269,14 @@ describe("rollups", () => {
 describe("ledgerCounts — straight off drift + is[]", () => {
   const forest: AimWire[] = [
     aim({ slug: "a", drift: DRIFT, is: [confirmed(), claimed()] }),
-    aim({ slug: "b", is: [claimed()] }),
+    aim({ slug: "b", is: [claimed(), pruned()] }), // pruned rides along, uncounted (#814)
     aim({ slug: "c", is: [confirmed()] }),
     aim({ slug: "d", state: "done", drift: DRIFT, is: [confirmed()] }), // pin #2: still drift
     aim({ slug: "e", state: "dead", drift: DRIFT }), // dead drift = noise, excluded
   ];
 
   it("counts drift nodes (incl. done+drift, excl. dead) and is[] marks", () => {
+    // pruned marks are in NO bucket — not claimed, not confirmed, not owed.
     expect(ledgerCounts(forest)).toEqual({ drift: 2, claimed: 2, confirmed: 3 });
   });
 });

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -1547,6 +1547,10 @@
 .aim-console .ac-ism i.k {
   background: var(--ochre);
 }
+/* pruned = adjudicated rejection, attention-zero: neutral, NOT ochre/green */
+.aim-console .ac-ism i.p {
+  background: var(--faint);
+}
 .aim-console .ac-slug {
   font-family: var(--mono);
   font-size: 9.5px;
@@ -1814,6 +1818,12 @@
 .aim-console .ac-tg.k {
   color: var(--ochre);
   border: 1px dashed #3a2e1a;
+}
+/* pruned mark tag — negative-calm: neutral tone, never the owed ochre or the
+   success green (an adjudicated rejection is settled, not owed) */
+.aim-console .ac-tg.p {
+  color: var(--dim);
+  border: 1px solid var(--line);
 }
 .aim-console .ac-ref {
   font-family: var(--mono);


### PR DESCRIPTION
Resolves #814. UI half of the `pruned` interior mark landed in tmai-core #515 (generated types synced in #813): **pruned = an adjudicated rejection kept in the tree** — attention-zero like `confirmed`, but negative-calm; never owed, never counted toward claimed/confirmed. Previously the mark-kind branches were binary ternaries, so a pruned mark would have rendered in the claimed (ochre / owed) style.

## Changes (clients/react only)

- **`AimPane.tsx`**
  - Interior ledger entry: three-way kind rendering — pruned gets its own `⊘ pruned` tag in a neutral/subtle tone (new `.ac-tg.p`), and shows `ref` (the rejection reason) when present, same layout as the confirmed ref.
  - `InteriorDots`: three-way dot class — pruned dot is neutral (new `.ac-ism i.p`).
  - Ledger counts untouched: `ledgerCounts` in `r-panel/aim-tree.ts` filters by kind equality, so pruned was already excluded from claimed/confirmed/owed — verified, no predicate change.
- **`aim-console.css`**: neutral `.ac-tg.p` (dim + solid hairline border) and `.ac-ism i.p` (faint fill) — deliberately NOT the warning ochre and NOT the success green.
- **`RAimsSection.tsx`**: same three-way treatment — `MarkTag` gains a neutral `⊘ pruned` variant, `InteriorDots` a neutral dot, and the inspector shows `ref` for pruned like for confirmed. The `AimTone`-keyed Record maps are unaffected (tone derivation unchanged).
- **`resignation.ts`**: no bucket changes — added a comment pinning that pruned belongs to neither 満足 (confirmed) nor 諦め (claimed): adjudicated ≠ satisfied ≠ parked.

## Tests

- `AimPane.test.tsx` / `RAimsSection.test.tsx`: pruned-mark fixture on the drifted node — ledger counts unchanged (pruned in no bucket), inspector shows the `⊘ pruned` tag + rejection reason from `ref`, dots render the neutral class, never warning/success.
- `aim-tree.test.ts`: pruned trips no owed predicate (`hasClaimed`/`hasConfirmed`/`isOwed` false), contributes no tone, excluded from `ledgerCounts`.
- `resignation.test.ts`: a pruned mark on a done node lands in neither inventory bucket.

## Out of scope (per issue)

Engine/wire changes (landed in tmai-core #515), `aim-tree.ts` tone/owed predicates, shaped-by constraint-edge promotion.

## Gate (all under `clients/react/`)

- `pnpm lint` ✅ (one pre-existing warning in an unrelated file)
- `pnpm exec tsc --noEmit` ✅
- `pnpm build` ✅
- `pnpm test` ✅ 890 passed | 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)