### PR TITLE
aim-console: render `working_delta` presence facts (drift-commit-boundary UI half) (#817)

### DIFF
--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -66,6 +66,10 @@ import {
   repoStats,
   rulerOrder,
   subtreeStats,
+  WORKING_DELTA_FACT,
+  WORKING_DELTA_GLYPH,
+  type WorkingDeltaKind,
+  workingDeltaKind,
 } from "@/components/producer-console/r-panel/aim-tree";
 import { useUnitAims } from "@/hooks/useUnitAims";
 import { api } from "@/lib/api";
@@ -775,6 +779,7 @@ function AimRow({
   onAddChild?: () => void;
 }) {
   const tone = aimTone(node);
+  const wd = workingDeltaKind(node);
   return (
     <div
       data-testid="aim-row"
@@ -810,6 +815,7 @@ function AimRow({
         title={`${node.slug} · ${AIM_STATE_LABEL[node.state]}`}
       >
         <ToneGlyph tone={tone} />
+        {wd !== null && <WorkingDeltaGlyph kind={wd} />}
         <span className="ac-ought">{node.aim}</span>
         {crumb !== undefined && <span className="ac-crumb-i">{crumb}</span>}
         {repoTag !== undefined && (
@@ -887,6 +893,32 @@ function ToneGlyph({ tone }: { tone: AimTone }) {
     default:
       return <span className="ac-gly" aria-hidden="true" />;
   }
+}
+
+// Working-delta presence glyph (#817) — a SEPARATE glyph from the drift ⚠;
+// the two may coexist on one row (drifted at HEAD AND dirty in the working
+// tree). Neutral-to-info tone, never the warning family: presence is a fact
+// about the instrument, not owed work. `an` = the uncommitted `aim:`-anchor
+// edit (info accent — the anchor on screen is not the anchor in HEAD), `nw` =
+// an untracked new node (dotted "new" reading).
+const WD_GLYPH_CLASS: Record<WorkingDeltaKind, string> = {
+  uncommitted: "",
+  "uncommitted-anchor": "an",
+  untracked: "nw",
+};
+
+function WorkingDeltaGlyph({ kind }: { kind: WorkingDeltaKind }) {
+  return (
+    <span
+      className={cn("ac-wd", WD_GLYPH_CLASS[kind])}
+      data-testid="aim-wd-badge"
+      data-wd={kind}
+      title={WORKING_DELTA_FACT[kind]}
+      aria-hidden="true"
+    >
+      {WORKING_DELTA_GLYPH}
+    </span>
+  );
 }
 
 // Tiny per-mark dots beside a row — confirmed = green, claimed = ochre,
@@ -985,6 +1017,7 @@ function Inspector({
 }) {
   const { node, repo, bySlug } = sel;
   const chain = useMemo(() => ancestry(node.slug, bySlug), [node.slug, bySlug]);
+  const wd = workingDeltaKind(node);
 
   return (
     <div className="ac-insp-in" data-testid="aim-inspector">
@@ -1042,6 +1075,14 @@ function Inspector({
           >
             ⚠ {node.state === "done" ? "done · " : ""}drift ← 祖先{" "}
             {node.drift.stale_from_ancestor_slug}
+          </span>
+        )}
+        {/* Working-delta fact line (#817) — presence only, beside (never inside)
+            the drift pill: a node can be both drifted at HEAD and dirty in the
+            working tree, and the two facts stay separately stated. */}
+        {wd !== null && (
+          <span className="ac-pill wd" data-testid="aim-wd-pill" data-wd={wd}>
+            {WORKING_DELTA_GLYPH} {WORKING_DELTA_FACT[wd]}
           </span>
         )}
       </div>

--- a/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
@@ -19,6 +19,7 @@ import type { AimsResponse, AimWire } from "@/lib/api";
 import { UIPrefsProvider } from "@/lib/ui-prefs-provider";
 import type { AimDriftWire } from "@/types/generated/AimDriftWire";
 import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
+import type { AimWorkingDeltaWire } from "@/types/generated/AimWorkingDeltaWire";
 
 const aimsMock = vi.fn();
 const createAimMock = vi.fn();
@@ -59,6 +60,12 @@ const pruned = (text: string, ref: string | null = null): AimInteriorWire => ({
   kind: "pruned",
   text,
   ref,
+});
+const wd = (overrides: Partial<AimWorkingDeltaWire> = {}): AimWorkingDeltaWire => ({
+  uncommitted: false,
+  uncommitted_anchor_change: false,
+  untracked: false,
+  ...overrides,
 });
 
 function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
@@ -788,6 +795,131 @@ describe("AimPane — resignation inventory (#811)", () => {
     expect(within(modal).getByTestId("resignation-inventory")).toBeTruthy();
     fireEvent.change(within(modal).getByLabelText("state"), { target: { value: "open" } });
     expect(within(modal).queryByTestId("resignation-inventory")).toBeNull();
+  });
+});
+
+describe("AimPane — working_delta presence facts (#817)", () => {
+  // A dedicated forest under one auto-expanded root: the three presence
+  // shapes, a both-drifted-and-dirty node, and a clean sibling.
+  const WDF: AimWire[] = [
+    aimStub({ slug: "wd-root", aim: "root bearing" }),
+    aimStub({
+      slug: "wd-plain",
+      aim: "dirty body",
+      parent: "wd-root",
+      working_delta: wd({ uncommitted: true }),
+    }),
+    aimStub({
+      slug: "wd-anchor",
+      aim: "dirty anchor",
+      parent: "wd-root",
+      working_delta: wd({ uncommitted: true, uncommitted_anchor_change: true }),
+    }),
+    aimStub({
+      slug: "wd-new",
+      aim: "untracked node",
+      parent: "wd-root",
+      working_delta: wd({ untracked: true }),
+    }),
+    aimStub({
+      slug: "wd-drift",
+      aim: "drifted AND dirty",
+      parent: "wd-root",
+      drift: driftFrom("wd-root"),
+      working_delta: wd({ uncommitted: true }),
+    }),
+    aimStub({ slug: "wd-clean", aim: "clean sibling", parent: "wd-root" }),
+  ];
+  const wdResponse = () => responseStub([{ label: "tmai-core", primary: true, aims: WDF }]);
+
+  function wdBadge(slug: string): HTMLElement | null {
+    return rowEl(slug).querySelector('[data-testid="aim-wd-badge"]');
+  }
+
+  it("each presence shape gets its own △ class; a clean row gets none", async () => {
+    aimsMock.mockResolvedValue(wdResponse());
+    renderPane();
+    await awaitLoaded();
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+
+    const plain = wdBadge("wd-plain");
+    expect(plain?.textContent).toBe("△");
+    expect(plain?.dataset.wd).toBe("uncommitted");
+    expect(plain?.classList.contains("ac-wd")).toBe(true);
+    expect(plain?.classList.contains("an")).toBe(false);
+    expect(plain?.classList.contains("nw")).toBe(false);
+
+    const anchor = wdBadge("wd-anchor");
+    expect(anchor?.dataset.wd).toBe("uncommitted-anchor");
+    expect(anchor?.classList.contains("an")).toBe(true);
+
+    const fresh = wdBadge("wd-new");
+    expect(fresh?.dataset.wd).toBe("untracked");
+    expect(fresh?.classList.contains("nw")).toBe(true);
+
+    expect(wdBadge("wd-clean")).toBeNull();
+  });
+
+  it("drift ⚠ and △ coexist on one row — two distinct glyphs, never merged", async () => {
+    aimsMock.mockResolvedValue(wdResponse());
+    renderPane();
+    await awaitLoaded();
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+
+    const row = rowEl("wd-drift");
+    // The tone (and its ⚠ glyph) stays pure drift — presence never restyles it.
+    expect(row.dataset.tone).toBe("drift");
+    expect(row.querySelector(".ac-gly.dr")?.textContent).toBe("⚠");
+    const badge = within(row).getByTestId("aim-wd-badge");
+    expect(badge.textContent).toBe("△");
+    expect(badge.classList.contains("ac-wd")).toBe(true);
+    expect(badge.classList.contains("dr")).toBe(false);
+  });
+
+  it("inspector states the presence fact line in the compose register", async () => {
+    aimsMock.mockResolvedValue(wdResponse());
+    renderPane();
+    await awaitLoaded();
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+    selectRow("wd-anchor");
+
+    const insp = await screen.findByTestId("aim-inspector");
+    const pill = within(insp).getByTestId("aim-wd-pill");
+    expect(pill.dataset.wd).toBe("uncommitted-anchor");
+    expect(pill.textContent).toContain("uncommitted edits including the `aim:` anchor line");
+    expect(pill.textContent).toContain("the drift verdict is HEAD-based and does not see this yet");
+    // Presence is NOT drift — no drift pill on a merely-dirty node.
+    expect(within(insp).queryByTestId("aim-drift-pill")).toBeNull();
+  });
+
+  it("no fact line on a clean node", async () => {
+    aimsMock.mockResolvedValue(wdResponse());
+    renderPane();
+    await awaitLoaded();
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+    selectRow("wd-clean");
+    const insp = await screen.findByTestId("aim-inspector");
+    expect(within(insp).queryByTestId("aim-wd-pill")).toBeNull();
+  });
+
+  it("presence is NEVER owed: not in the Frontier worklist, not in the ledger counts", async () => {
+    aimsMock.mockResolvedValue(wdResponse());
+    renderPane();
+    await awaitLoaded();
+
+    // Frontier (default mode): only the genuinely drifted node is owed; the
+    // three presence-only nodes are absent.
+    await waitFor(() => expect(rowEl("wd-drift")).toBeTruthy());
+    for (const slug of ["wd-plain", "wd-anchor", "wd-new", "wd-clean"]) {
+      expect(document.querySelector(`[data-testid="aim-row"][data-slug="${slug}"]`)).toBeNull();
+    }
+
+    // Ledger: drift counts ONLY wd-drift's committed-layer verdict; presence
+    // adds nothing to any bucket.
+    const ledger = screen.getByTestId("aim-ledger");
+    expect(ledger.textContent).toMatch(/1\s*drift/);
+    expect(ledger.textContent).toMatch(/0\s*claimed/);
+    expect(ledger.textContent).toMatch(/0\s*confirmed/);
   });
 });
 

--- a/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
@@ -67,6 +67,10 @@ import {
   repoStats,
   rulerOrder,
   subtreeStats,
+  WORKING_DELTA_FACT,
+  WORKING_DELTA_GLYPH,
+  type WorkingDeltaKind,
+  workingDeltaKind,
 } from "./aim-tree";
 import { Section } from "./Section";
 
@@ -141,6 +145,18 @@ const TONE_GUTTER: Record<AimTone, string> = {
   confirmed: "bg-success/30",
   root: "bg-info/60",
   neutral: "bg-hairline-strong",
+};
+
+// Working-delta presence glyph styling (#817) — a SEPARATE glyph from the
+// drift ⚠ (the two may coexist on one row); neutral-to-info, NEVER the
+// warning family (presence is a fact about the instrument, not owed work).
+// `uncommitted-anchor` gets the info accent (the anchor on screen is not the
+// anchor in HEAD); `untracked` gets a dotted "new" reading.
+const WD_GLYPH_CLASS: Record<WorkingDeltaKind, string> = {
+  uncommitted: "text-subtle-foreground",
+  "uncommitted-anchor": "text-info",
+  untracked:
+    "rounded-[2px] border border-dotted border-subtle-foreground/60 text-subtle-foreground leading-none",
 };
 
 // Ought-text styling per tone — calm for resolved/abandoned, lit for drift.
@@ -957,6 +973,7 @@ function AimRow({
   onAddChild?: () => void;
 }) {
   const tone = aimTone(node);
+  const wd = workingDeltaKind(node);
   return (
     <div
       data-testid="aim-row"
@@ -1014,6 +1031,20 @@ function AimRow({
             className="shrink-0 font-mono text-[11px] text-warning"
           >
             ⚠
+          </span>
+        )}
+        {/* Working-delta presence glyph (#817) — beside, never merged into,
+            the drift ⚠: a node can be both drifted at HEAD and dirty in the
+            working tree, and each fact keeps its own glyph. */}
+        {wd !== null && (
+          <span
+            data-testid="aim-wd-badge"
+            data-wd={wd}
+            aria-hidden="true"
+            title={WORKING_DELTA_FACT[wd]}
+            className={`shrink-0 font-mono text-[11px] ${WD_GLYPH_CLASS[wd]}`}
+          >
+            {WORKING_DELTA_GLYPH}
           </span>
         )}
         <span className={`truncate text-[12px] ${TONE_OUGHT_CLASS[tone]}`}>{node.aim}</span>
@@ -1260,6 +1291,7 @@ function MetaPills({
   repoLabel: string;
   repoPrimary: boolean;
 }) {
+  const wd = workingDeltaKind(node);
   return (
     <div className="mt-2 flex flex-wrap gap-1.5">
       <span
@@ -1274,6 +1306,17 @@ function MetaPills({
         {node.parent === null ? " · root" : ""}
       </span>
       {node.drift !== null && <DriftPill drift={node.drift} done={node.state === "done"} />}
+      {/* Working-delta fact line (#817) — presence only, beside (never inside)
+          the drift pill; info tone, not the drift amber. */}
+      {wd !== null && (
+        <span
+          data-testid="aim-wd-pill"
+          data-wd={wd}
+          className="rounded border border-dashed border-info/40 px-1.5 py-0.5 font-mono text-[9px] text-info"
+        >
+          {WORKING_DELTA_GLYPH} {WORKING_DELTA_FACT[wd]}
+        </span>
+      )}
     </div>
   );
 }

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RAimsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RAimsSection.test.tsx
@@ -17,6 +17,7 @@ import type { AimsResponse, AimWire } from "@/lib/api";
 import { UIPrefsProvider } from "@/lib/ui-prefs-provider";
 import type { AimDriftWire } from "@/types/generated/AimDriftWire";
 import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
+import type { AimWorkingDeltaWire } from "@/types/generated/AimWorkingDeltaWire";
 
 const aimsMock = vi.fn();
 const createAimMock = vi.fn();
@@ -55,6 +56,12 @@ const pruned = (text: string, ref: string | null = null): AimInteriorWire => ({
   kind: "pruned",
   text,
   ref,
+});
+const wd = (overrides: Partial<AimWorkingDeltaWire> = {}): AimWorkingDeltaWire => ({
+  uncommitted: false,
+  uncommitted_anchor_change: false,
+  untracked: false,
+  ...overrides,
 });
 
 function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
@@ -564,5 +571,117 @@ describe("RAimsSection — edit (pin #3: drift mirrors the engine on refetch)", 
     expect(options).not.toContain("attention-per-artifact"); // descendant
     expect(options).not.toContain("attention-backend"); // deeper descendant
     expect(options).toContain("aim-system"); // outside the subtree → allowed
+  });
+});
+
+describe("RAimsSection — working_delta presence facts (#817)", () => {
+  // The three presence shapes + a both-drifted-and-dirty node + a clean
+  // sibling, under one auto-expanded root (mirrors AimPane.test's forest).
+  const WDF: AimWire[] = [
+    aimStub({ slug: "wd-root", aim: "root bearing" }),
+    aimStub({
+      slug: "wd-plain",
+      aim: "dirty body",
+      parent: "wd-root",
+      working_delta: wd({ uncommitted: true }),
+    }),
+    aimStub({
+      slug: "wd-anchor",
+      aim: "dirty anchor",
+      parent: "wd-root",
+      working_delta: wd({ uncommitted: true, uncommitted_anchor_change: true }),
+    }),
+    aimStub({
+      slug: "wd-new",
+      aim: "untracked node",
+      parent: "wd-root",
+      working_delta: wd({ untracked: true }),
+    }),
+    aimStub({
+      slug: "wd-drift",
+      aim: "drifted AND dirty",
+      parent: "wd-root",
+      drift: driftFrom("wd-root"),
+      working_delta: wd({ uncommitted: true }),
+    }),
+    aimStub({ slug: "wd-clean", aim: "clean sibling", parent: "wd-root" }),
+  ];
+  const wdResponse = () => responseStub([{ label: "tmai-core", primary: true, aims: WDF }]);
+
+  async function openTree() {
+    await openPanel();
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+  }
+  function wdBadge(slug: string): HTMLElement | null {
+    return rowEl(slug).querySelector('[data-testid="aim-wd-badge"]');
+  }
+
+  it("rows carry the △ glyph per presence kind (info accent for the anchor edit, dotted for untracked); clean rows none", async () => {
+    aimsMock.mockResolvedValue(wdResponse());
+    renderPanel();
+    await openTree();
+
+    const plain = wdBadge("wd-plain");
+    expect(plain?.textContent).toBe("△");
+    expect(plain?.dataset.wd).toBe("uncommitted");
+    expect(plain?.className).not.toContain("text-info");
+    expect(plain?.className).not.toContain("text-warning");
+
+    const anchor = wdBadge("wd-anchor");
+    expect(anchor?.dataset.wd).toBe("uncommitted-anchor");
+    expect(anchor?.className).toContain("text-info");
+
+    const fresh = wdBadge("wd-new");
+    expect(fresh?.dataset.wd).toBe("untracked");
+    expect(fresh?.className).toContain("border-dotted");
+
+    expect(wdBadge("wd-clean")).toBeNull();
+  });
+
+  it("drift and presence coexist on one row, each with its own glyph; tone stays pure drift", async () => {
+    aimsMock.mockResolvedValue(wdResponse());
+    renderPanel();
+    await openTree();
+
+    const row = rowEl("wd-drift");
+    expect(row.dataset.tone).toBe("drift");
+    expect(row.textContent).toContain("⚠"); // the drift tone glyph
+    const badge = within(row).getByTestId("aim-wd-badge");
+    expect(badge.textContent).toBe("△");
+    expect(badge.className).not.toContain("text-warning"); // never restyled as drift
+  });
+
+  it("inspector adds the presence fact pill beside (not inside) the drift pill", async () => {
+    aimsMock.mockResolvedValue(wdResponse());
+    renderPanel();
+    await openTree();
+    selectRow("wd-drift");
+
+    const insp = await screen.findByTestId("aim-inspector");
+    // Both facts, separately stated.
+    expect(within(insp).getByTestId("aim-drift-pill").textContent).toContain("drift ← wd-root");
+    const pill = within(insp).getByTestId("aim-wd-pill");
+    expect(pill.dataset.wd).toBe("uncommitted");
+    expect(pill.textContent).toContain("uncommitted edits (anchor line untouched)");
+    expect(pill.textContent).toContain("the drift verdict is HEAD-based and does not see this yet");
+
+    selectRow("wd-clean");
+    await waitFor(() => expect(screen.queryByTestId("aim-wd-pill")).toBeNull());
+  });
+
+  it("presence is NEVER owed: Frontier and the ledger ignore it", async () => {
+    aimsMock.mockResolvedValue(wdResponse());
+    renderPanel();
+    await openPanel();
+
+    // Frontier (default): only the genuinely drifted node.
+    await waitFor(() => expect(rowEl("wd-drift")).toBeTruthy());
+    for (const slug of ["wd-plain", "wd-anchor", "wd-new", "wd-clean"]) {
+      expect(document.querySelector(`[data-testid="aim-row"][data-slug="${slug}"]`)).toBeNull();
+    }
+    const ledger = screen.getByTestId("aim-ledger");
+    expect(ledger.textContent).toMatch(/1\s*drift/);
+    expect(ledger.textContent).toMatch(/0\s*claimed/);
+    expect(ledger.textContent).toMatch(/0\s*confirmed/);
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/__tests__/aim-tree.test.ts
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/aim-tree.test.ts
@@ -9,6 +9,7 @@ import type { AimsResponse } from "@/lib/api";
 import type { AimDriftWire } from "@/types/generated/AimDriftWire";
 import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
 import type { AimWire } from "@/types/generated/AimWire";
+import type { AimWorkingDeltaWire } from "@/types/generated/AimWorkingDeltaWire";
 import {
   aimTone,
   ancestry,
@@ -30,6 +31,7 @@ import {
   repoStats,
   rulerOrder,
   subtreeStats,
+  workingDeltaKind,
 } from "../aim-tree";
 
 const DRIFT: AimDriftWire = {
@@ -47,6 +49,9 @@ function confirmed(text = "done", ref: string | null = "PR#1"): AimInteriorWire 
 }
 function pruned(text = "rejected", ref: string | null = "wrong premise"): AimInteriorWire {
   return { kind: "pruned", text, ref };
+}
+function wd(overrides: Partial<AimWorkingDeltaWire> = {}): AimWorkingDeltaWire {
+  return { uncommitted: false, uncommitted_anchor_change: false, untracked: false, ...overrides };
 }
 
 function aim(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
@@ -279,6 +284,74 @@ describe("ledgerCounts — straight off drift + is[]", () => {
   it("counts drift nodes (incl. done+drift, excl. dead) and is[] marks", () => {
     // pruned marks are in NO bucket — not claimed, not confirmed, not owed.
     expect(ledgerCounts(forest)).toEqual({ drift: 2, claimed: 2, confirmed: 3 });
+  });
+});
+
+describe("workingDeltaKind — presence facts, compose precedence (#817)", () => {
+  it("maps each wire shape to its kind (untracked › anchor › plain)", () => {
+    expect(workingDeltaKind(aim({ slug: "x" }))).toBeNull();
+    expect(workingDeltaKind(aim({ slug: "x", working_delta: wd({ uncommitted: true }) }))).toBe(
+      "uncommitted",
+    );
+    expect(
+      workingDeltaKind(
+        aim({
+          slug: "x",
+          working_delta: wd({ uncommitted: true, uncommitted_anchor_change: true }),
+        }),
+      ),
+    ).toBe("uncommitted-anchor");
+    expect(workingDeltaKind(aim({ slug: "x", working_delta: wd({ untracked: true }) }))).toBe(
+      "untracked",
+    );
+    // An all-false struct states no fact — same as a null wire.
+    expect(workingDeltaKind(aim({ slug: "x", working_delta: wd() }))).toBeNull();
+  });
+
+  it("NEVER makes a node owed — isOwed / frontierRows are untouched by presence", () => {
+    const dirty = aim({
+      slug: "dirty",
+      working_delta: wd({ uncommitted: true, uncommitted_anchor_change: true }),
+    });
+    expect(isOwed(dirty)).toBe(false);
+    expect(frontierRows([dirty])).toEqual([]);
+    // Presence beside a real owed fact changes nothing about the worklist.
+    const driftedDirty = aim({
+      slug: "dd",
+      drift: DRIFT,
+      working_delta: wd({ uncommitted: true }),
+    });
+    expect(frontierRows([driftedDirty, dirty]).map((n) => n.slug)).toEqual(["dd"]);
+  });
+
+  it("NEVER counts into the ledger — drift/claimed/confirmed identical with and without presence", () => {
+    const clean: AimWire[] = [
+      aim({ slug: "a", drift: DRIFT, is: [confirmed(), claimed()] }),
+      aim({ slug: "b", is: [claimed()] }),
+    ];
+    const dirty: AimWire[] = [
+      aim({
+        slug: "a",
+        drift: DRIFT,
+        is: [confirmed(), claimed()],
+        working_delta: wd({ uncommitted: true, uncommitted_anchor_change: true }),
+      }),
+      aim({ slug: "b", is: [claimed()], working_delta: wd({ untracked: true }) }),
+    ];
+    expect(ledgerCounts(dirty)).toEqual(ledgerCounts(clean));
+    // The repo/subtree rollups are presence-blind too.
+    expect(repoStats(dirty)).toEqual(repoStats(clean));
+  });
+
+  it("NEVER changes the tone — presence facts ride beside the tone, not into it", () => {
+    const presence = wd({ uncommitted: true, uncommitted_anchor_change: true });
+    expect(aimTone(aim({ slug: "x", parent: "root-a", working_delta: presence }))).toBe("neutral");
+    expect(aimTone(aim({ slug: "x", drift: DRIFT, working_delta: presence }))).toBe("drift");
+    expect(aimTone(aim({ slug: "x", state: "done", working_delta: presence }))).toBe("done");
+    expect(aimTone(aim({ slug: "x", state: "done", drift: DRIFT, working_delta: presence }))).toBe(
+      "done-drift",
+    );
+    expect(aimTone(aim({ slug: "x", working_delta: wd({ untracked: true }) }))).toBe("root");
   });
 });
 

--- a/clients/react/src/components/producer-console/r-panel/aim-tree.ts
+++ b/clients/react/src/components/producer-console/r-panel/aim-tree.ts
@@ -19,6 +19,7 @@
 import type { AimState } from "@/types/generated/AimState";
 import type { AimsResponse } from "@/types/generated/AimsResponse";
 import type { AimWire } from "@/types/generated/AimWire";
+import type { AimWorkingDeltaWire } from "@/types/generated/AimWorkingDeltaWire";
 import type { RepoAimsWire } from "@/types/generated/RepoAimsWire";
 
 // ── Glyphs / labels ───────────────────────────────────────────────────
@@ -116,6 +117,45 @@ export function aimTone(n: AimWire): AimTone {
   if (n.parent === null) return "root";
   return "neutral";
 }
+
+// ── Working-tree presence facts (#817) ────────────────────────────────
+//
+// Design B of tmai-core's `doc/aims/aim-drift-commit-boundary.md`: the
+// committed layer (`drift`) states ORDER judgments; `working_delta` states
+// PRESENCE only. The one fact it surfaces to the operator: "the drift verdict
+// on screen is HEAD-based and does not see your uncommitted edit yet" —
+// honesty-of-the-instrument, NOT owed work. So these helpers feed a SEPARATE
+// glyph (△, never restyled as the drift ⚠) and an inspector fact line, and
+// deliberately touch NOTHING else: not `isOwed`, not `ledgerCounts`, not
+// `aimTone`, not the rollups.
+
+export type WorkingDeltaKind = "untracked" | "uncommitted-anchor" | "uncommitted";
+
+// One kind per node, the compose-prose precedence (tmai-core render.rs):
+// `untracked` is mutually exclusive with `uncommitted` on the wire; an anchor
+// change implies `uncommitted` and is the ratification-relevant presence (the
+// anchor on screen is not the anchor in HEAD), so it outranks the plain edit.
+// An all-false struct states no fact → null, same as a null wire.
+export function workingDeltaKind(n: AimWire): WorkingDeltaKind | null {
+  const wd: AimWorkingDeltaWire | null = n.working_delta;
+  if (wd === null) return null;
+  if (wd.untracked) return "untracked";
+  if (wd.uncommitted_anchor_change) return "uncommitted-anchor";
+  if (wd.uncommitted) return "uncommitted";
+  return null;
+}
+
+export const WORKING_DELTA_GLYPH = "△";
+
+// The inspector fact line / glyph title — same register as the compose prose
+// (`**△ Aim working delta**`): presence facts only, no urgency verbs.
+export const WORKING_DELTA_FACT: Record<WorkingDeltaKind, string> = {
+  untracked: "a new, uncommitted node (no committed history yet)",
+  "uncommitted-anchor":
+    "uncommitted edits including the `aim:` anchor line — the drift verdict is HEAD-based and does not see this yet",
+  uncommitted:
+    "uncommitted edits (anchor line untouched) — the drift verdict is HEAD-based and does not see this yet",
+};
 
 // ── Tree skeleton ─────────────────────────────────────────────────────
 

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -1480,6 +1480,26 @@
 .aim-console .ac-gly.dd {
   color: var(--faint);
 }
+/* working-delta presence glyph (#817) — separate from the drift ⚠ (the two
+   may share a row); neutral-to-info, never the amber owed family. `an` =
+   uncommitted aim-anchor edit (info accent), `nw` = untracked new node
+   (dotted "new" reading). */
+.aim-console .ac-wd {
+  width: 14px;
+  text-align: center;
+  flex: none;
+  font-size: 10px;
+  color: var(--dim);
+}
+.aim-console .ac-wd.an {
+  color: var(--cyan);
+}
+.aim-console .ac-wd.nw {
+  color: var(--dim);
+  border: 1px dotted var(--faint);
+  border-radius: 2px;
+  line-height: 1.2;
+}
 .aim-console .ac-ought {
   flex: 1;
   min-width: 0;
@@ -1784,6 +1804,12 @@
 .aim-console .ac-pill.op {
   color: var(--cyan);
   border-color: var(--cyan-d);
+}
+/* working-delta fact pill (#817) — info tone, NOT the drift amber. */
+.aim-console .ac-pill.wd {
+  color: var(--cyan);
+  border-color: var(--cyan-d);
+  border-style: dashed;
 }
 .aim-console .ac-isec {
   font-family: var(--mono);


### PR DESCRIPTION
Resolves #817.

Renders the working-tree presence layer (Design B of tmai-core's `doc/aims/aim-drift-commit-boundary.md`; wire landed in tmai-core #518, generated types via sync #816) in the React client.

## What

- **`aim-tree.ts` (pure model)** — `workingDeltaKind()` classifies `AimWire.working_delta` into one presence kind with the compose-prose precedence (`untracked` › `uncommitted-anchor` › `uncommitted`; a null or all-false struct states no fact), plus `WORKING_DELTA_FACT` lines in the same register as the compose prose ("the drift verdict is HEAD-based and does not see this yet"). The helpers deliberately touch nothing else: `isOwed`, `ledgerCounts`, `aimTone`, and the rollups stay presence-blind.
- **Row glyph (AimPane + RAimsSection)** — a separate `△` glyph, never merged into or restyled as the drift `⚠` (the two coexist on one row: a node can be drifted at HEAD AND dirty in the working tree). Neutral-to-info tone, never the warning family:
  - `uncommitted` (anchor untouched): plain △
  - `uncommitted_anchor_change`: △ with the info accent (the anchor on screen is not the anchor in HEAD)
  - `untracked`: △ with a dotted "new" reading
- **Inspector (both surfaces)** — one fact line when `working_delta` is non-null, placed beside (not inside) the drift pill, stating the presence fact in the compose register.

## Semantics held (tested)

- NEVER in the owed/frontier worklist — `isOwed` unchanged.
- NEVER counted into the drift/claimed/confirmed ledger counts or rollups.
- NEVER merged into the drift ⚠ — a both-drifted-and-dirty row shows both glyphs, tone stays pure `drift`.
- `aimTone` unchanged — presence facts do not change a node's tone.

## Tests

Fixtures for each of the three fact shapes + an all-false struct; glyph class assertions on both row surfaces; inspector fact line; exclusion assertions (frontier, ledger, tone); the coexisting-badges row.

## Gate (all green locally under `clients/react/`)

- `pnpm lint` (biome check)
- `pnpm build` (includes `tsc -b`)
- `pnpm test` (107 files, 903 passed / 2 skipped)

🤖 Generated with [Claude Code](https://claude.com/claude-code)