### PR TITLE
conversation surface: copy-source button for fenced code blocks (relay fidelity) (#819)

### DIFF
--- a/clients/react/src/components/agent/PreviewPanel.tsx
+++ b/clients/react/src/components/agent/PreviewPanel.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import "@xterm/xterm/css/xterm.css";
+import { CopySourceOverlay } from "@/components/terminal/CopySourceOverlay";
 import { AutoScrollToggleButton, ModeHint, ModeToggleButton } from "@/components/terminal/controls";
 import { QueueBadge } from "@/components/ui/QueueBadge";
 import { QueuePopover } from "@/components/ui/QueuePopover";
@@ -74,7 +75,7 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
   // not xterm's onData — xterm v5's IME handling still has rough edges
   // on the Live preview surface; Phase 2 evaluates moving fully to
   // xterm-native input.
-  const { sendKeys } = useTerminal({
+  const { sendKeys, terminal } = useTerminal({
     agentId,
     containerRef: xtermContainerRef,
     autoScroll,
@@ -215,7 +216,7 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
           Transcript. */}
       <div
         style={{ display: activeTab === "live" ? undefined : "none" }}
-        className="flex-1 overflow-hidden"
+        className="relative flex-1 overflow-hidden"
       >
         <div
           ref={xtermContainerRef}
@@ -243,6 +244,9 @@ export function PreviewPanel({ agentId }: PreviewPanelProps) {
             }
           }}
         />
+        {/* Copy-source affordance for fenced code blocks (#819) — sibling of
+            the xterm container so its clicks don't toggle Input/Select. */}
+        <CopySourceOverlay terminalRef={terminal} agentId={agentId} />
       </div>
 
       {/* Transcript tab — JSONL records. Mounted only while active to

--- a/clients/react/src/components/terminal/CopySourceOverlay.tsx
+++ b/clients/react/src/components/terminal/CopySourceOverlay.tsx
@@ -1,0 +1,148 @@
+// Copy-source affordance for fenced code blocks on PTY surfaces (#819).
+//
+// Floats over the terminal canvas (top-right) whenever the scrollback
+// contains at least one CLOSED ``` fence. Copying goes through
+// `lib/fenced-code.ts`, which re-joins soft-wrapped grid rows — the copied
+// string is the LOGICAL source, not the rendered grid (no injected newlines
+// at wrap columns, no `\r`).
+//
+// DELIBERATE EXCLUSION — copy only, NO execute button: the operator's
+// paste + Enter stays the firing act. One-click execution of agent-authored
+// commands is the no-look-execution slide the design explicitly rejects
+// (tmai-core doc/slack/2026-06-12-163215.md); do not add a "run" affordance
+// here.
+
+import { useEffect, useRef, useState } from "react";
+import { type FenceScanTerminal, useFencedCodeBlocks } from "@/hooks/useFencedCodeBlocks";
+import type { FencedBlock } from "@/lib/fenced-code";
+
+interface CopySourceOverlayProps {
+  /** Ref to the live xterm instance (from `useTerminal`). */
+  terminalRef: React.RefObject<FenceScanTerminal | null>;
+  /** Re-scan key — `useTerminal` swaps the instance per agent. */
+  agentId: string | null;
+}
+
+type Feedback = "copied" | "failed";
+
+export function CopySourceOverlay({ terminalRef, agentId }: CopySourceOverlayProps) {
+  const blocks = useFencedCodeBlocks(terminalRef, agentId);
+  const [open, setOpen] = useState(false);
+  const [feedback, setFeedback] = useState<Feedback | null>(null);
+  const feedbackTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const rootRef = useRef<HTMLDivElement>(null);
+
+  // Close the block list on outside click (same pattern as QueuePopover).
+  useEffect(() => {
+    if (!open) return;
+    const onMouseDown = (e: MouseEvent) => {
+      if (rootRef.current && !rootRef.current.contains(e.target as Node)) {
+        setOpen(false);
+      }
+    };
+    document.addEventListener("mousedown", onMouseDown);
+    return () => document.removeEventListener("mousedown", onMouseDown);
+  }, [open]);
+
+  useEffect(() => {
+    return () => {
+      if (feedbackTimerRef.current !== null) clearTimeout(feedbackTimerRef.current);
+    };
+  }, []);
+
+  if (blocks.length === 0) return null;
+
+  const flash = (kind: Feedback) => {
+    setFeedback(kind);
+    if (feedbackTimerRef.current !== null) clearTimeout(feedbackTimerRef.current);
+    feedbackTimerRef.current = setTimeout(() => {
+      feedbackTimerRef.current = null;
+      setFeedback(null);
+    }, 1500);
+  };
+
+  const copy = (block: FencedBlock) => {
+    if (!navigator.clipboard) {
+      flash("failed");
+      return;
+    }
+    navigator.clipboard
+      .writeText(block.source)
+      .then(() => flash("copied"))
+      .catch(() => flash("failed"));
+  };
+
+  const label =
+    feedback === "copied"
+      ? "✓ Copied"
+      : feedback === "failed"
+        ? "✗ Copy failed"
+        : blocks.length === 1
+          ? "⧉ Copy code"
+          : `⧉ Copy code (${blocks.length})`;
+
+  return (
+    <div ref={rootRef} className="absolute right-2 top-2 z-10 flex flex-col items-end">
+      <button
+        type="button"
+        data-testid="copy-code-source"
+        // preventDefault keeps focus (and the panel's Input mode) on the
+        // terminal — the convention all footer controls follow.
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={() => {
+          if (blocks.length === 1) {
+            copy(blocks[0]);
+          } else {
+            setOpen((v) => !v);
+          }
+        }}
+        className={`touch-target-sm rounded border border-hairline bg-surface/80 px-2 py-1 text-xs backdrop-blur transition-colors ${
+          feedback === "copied"
+            ? "text-success"
+            : feedback === "failed"
+              ? "text-destructive"
+              : "text-muted-foreground hover:text-foreground"
+        }`}
+        title="Copy fenced code block SOURCE — soft-wrap line breaks are removed; paste + Enter stays your act"
+      >
+        {label}
+      </button>
+
+      {open && blocks.length > 1 && (
+        <div className="mt-1 max-h-60 w-72 overflow-y-auto rounded-lg border border-hairline-strong bg-popover shadow-xl">
+          {/* Latest first — the freshest block is the one the Producer just
+              handed over, which is the incident case this exists for. */}
+          {[...blocks].reverse().map((b) => (
+            <button
+              key={b.openLine}
+              type="button"
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={() => {
+                copy(b);
+                setOpen(false);
+              }}
+              className="block w-full border-b border-hairline px-3 py-2 text-left transition-colors last:border-b-0 hover:bg-surface-strong/50"
+            >
+              <p className="truncate font-mono text-[11px] text-foreground">
+                {firstLine(b.source)}
+              </p>
+              <p className="mt-0.5 text-[10px] text-muted-foreground">
+                {b.info ? `${b.info} · ` : ""}
+                {countLines(b.source)} line{countLines(b.source) !== 1 ? "s" : ""}
+              </p>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function firstLine(source: string): string {
+  const nl = source.indexOf("\n");
+  return nl === -1 ? source : source.slice(0, nl);
+}
+
+function countLines(source: string): number {
+  return source.length === 0 ? 0 : source.split("\n").length;
+}

--- a/clients/react/src/components/terminal/TerminalPanel.tsx
+++ b/clients/react/src/components/terminal/TerminalPanel.tsx
@@ -150,7 +150,10 @@ export function TerminalPanel({
             if (inputMode) enterSelectMode();
           }}
         />
-        <CopySourceOverlay terminalRef={terminal} agentId={agentId} />
+        {/* key: remount on agent switch so the previous session's detected
+            blocks (held in hook state for one render) can never flash or be
+            copied against the new agent's surface. */}
+        <CopySourceOverlay key={agentId} terminalRef={terminal} agentId={agentId} />
       </div>
 
       {/* Footer status bar */}

--- a/clients/react/src/components/terminal/TerminalPanel.tsx
+++ b/clients/react/src/components/terminal/TerminalPanel.tsx
@@ -3,6 +3,7 @@ import { useAgents } from "@/hooks/useAgents";
 import { useAutoScrollPerAgent } from "@/hooks/useAutoScrollPerAgent";
 import { useTerminal } from "@/hooks/useTerminal";
 import "@xterm/xterm/css/xterm.css";
+import { CopySourceOverlay } from "./CopySourceOverlay";
 import { AutoScrollToggleButton, ModeHint, ModeToggleButton } from "./controls";
 import { TerminalSessionHeader } from "./TerminalSessionHeader";
 
@@ -50,7 +51,7 @@ export function TerminalPanel({
     [agents, agentId],
   );
 
-  const { setAttachable } = useTerminal({ agentId, containerRef, autoScroll });
+  const { setAttachable, terminal } = useTerminal({ agentId, containerRef, autoScroll });
 
   // Surface "this panel is the active surface" — without it, after
   // spawning or switching agents users couldn't tell at a glance whether
@@ -126,26 +127,31 @@ export function TerminalPanel({
       }
     >
       {!chromeless && <TerminalSessionHeader agentId={agentId} agent={agent} />}
-      {/* biome-ignore lint/a11y/noStaticElementInteractions: terminal container needs pointer events for selection mode */}
-      <div
-        ref={containerRef}
-        className="flex-1 overflow-hidden bg-[var(--color-terminal-background)] p-1"
-        onMouseDown={() => {
-          if (inputMode) enterSelectMode();
-        }}
-        onMouseUp={() => {
-          if (!inputMode) {
-            const sel = window.getSelection();
-            if (!sel || sel.toString().length === 0) {
-              enterInputMode();
+      {/* Relative wrapper so the copy-source affordance (#819) can float over
+          the canvas without sitting INSIDE the xterm-owned container div. */}
+      <div className="relative flex-1 overflow-hidden">
+        {/* biome-ignore lint/a11y/noStaticElementInteractions: terminal container needs pointer events for selection mode */}
+        <div
+          ref={containerRef}
+          className="h-full w-full bg-[var(--color-terminal-background)] p-1"
+          onMouseDown={() => {
+            if (inputMode) enterSelectMode();
+          }}
+          onMouseUp={() => {
+            if (!inputMode) {
+              const sel = window.getSelection();
+              if (!sel || sel.toString().length === 0) {
+                enterInputMode();
+              }
             }
-          }
-        }}
-        onTouchStart={() => {
-          // On touch, switch to select mode so text is selectable/copyable
-          if (inputMode) enterSelectMode();
-        }}
-      />
+          }}
+          onTouchStart={() => {
+            // On touch, switch to select mode so text is selectable/copyable
+            if (inputMode) enterSelectMode();
+          }}
+        />
+        <CopySourceOverlay terminalRef={terminal} agentId={agentId} />
+      </div>
 
       {/* Footer status bar */}
       {!chromeless && (

--- a/clients/react/src/components/terminal/__tests__/CopySourceOverlay.test.tsx
+++ b/clients/react/src/components/terminal/__tests__/CopySourceOverlay.test.tsx
@@ -1,0 +1,86 @@
+// @vitest-environment jsdom
+//
+// Copy-source button for fenced code blocks (#819) — the acceptance bar is
+// FIDELITY: clicking copy must yield the logical source byte-exact (the
+// soft-wrap newlines the grid rendering introduces must not be copied, and
+// no `\r`), and the button must not exist over non-fenced text.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { FenceScanTerminal } from "@/hooks/useFencedCodeBlocks";
+import { makeBuffer } from "@/test/fake-xterm";
+import { CopySourceOverlay } from "../CopySourceOverlay";
+
+const writeText = vi.fn<(s: string) => Promise<void>>().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  writeText.mockClear();
+  Object.defineProperty(navigator, "clipboard", {
+    value: { writeText },
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+function fakeTerminal(logicalLines: string[], cols: number): FenceScanTerminal {
+  return {
+    cols,
+    buffer: { active: makeBuffer(logicalLines, cols) },
+    onWriteParsed: () => ({ dispose: () => {} }),
+    onResize: () => ({ dispose: () => {} }),
+  };
+}
+
+function renderOverlay(logicalLines: string[], cols: number) {
+  const term = fakeTerminal(logicalLines, cols);
+  return render(<CopySourceOverlay terminalRef={{ current: term }} agentId="claude:a1" />);
+}
+
+describe("CopySourceOverlay", () => {
+  it("renders no button when the buffer has no fenced block", () => {
+    renderOverlay(["⏺ plain conversation, nothing fenced", "$ prompt"], 30);
+    expect(screen.queryByTestId("copy-code-source")).toBeNull();
+  });
+
+  it("copies the EXACT source of a block whose rendering soft-wraps", async () => {
+    const cmd =
+      "gh api repos/owner/repo/branches/main/protection --method PUT --input protection.json";
+    // cols=24 forces the command across 4 grid rows — the incident shape.
+    renderOverlay(["⏺ Run this:", "```bash", cmd, "git push", "```"], 24);
+
+    fireEvent.click(screen.getByTestId("copy-code-source"));
+    expect(writeText).toHaveBeenCalledTimes(1);
+    expect(writeText).toHaveBeenCalledWith(`${cmd}\ngit push`);
+    await waitFor(() => {
+      expect(screen.getByTestId("copy-code-source").textContent).toContain("Copied");
+    });
+  });
+
+  it("guarantees the copied string carries no \\r", () => {
+    renderOverlay(["```", "foo\rbar", "```"], 80);
+    fireEvent.click(screen.getByTestId("copy-code-source"));
+    const copied = writeText.mock.calls[0][0];
+    expect(copied).not.toMatch(/\r/);
+  });
+
+  it("does not surface an unterminated (still-streaming) block", () => {
+    renderOverlay(["```bash", "half a command"], 80);
+    expect(screen.queryByTestId("copy-code-source")).toBeNull();
+  });
+
+  it("with several blocks, opens a list and copies the chosen block", () => {
+    renderOverlay(["```", "first block", "```", "```", "second block", "```"], 80);
+
+    const button = screen.getByTestId("copy-code-source");
+    expect(button.textContent).toContain("(2)");
+    fireEvent.click(button);
+    // latest first — the freshest hand-over is the incident case
+    const entries = screen.getAllByText(/block$/);
+    expect(entries[0].textContent).toBe("second block");
+    fireEvent.click(entries[0]);
+    expect(writeText).toHaveBeenCalledWith("second block");
+  });
+});

--- a/clients/react/src/components/terminal/__tests__/TerminalPanel.test.tsx
+++ b/clients/react/src/components/terminal/__tests__/TerminalPanel.test.tsx
@@ -33,9 +33,11 @@ vi.mock("../TerminalSessionHeader", () => ({
 }));
 
 // The xterm container div (the panel's only direct child div carrying the
-// mouse handlers) — no testid by design (props-only additive change).
+// mouse handlers) — since #819 it sits inside a relative wrapper so the
+// copy-source overlay can float over the canvas; the handler div is the
+// wrapper's `h-full` child.
 function termContainer(container: HTMLElement): HTMLElement {
-  const el = container.querySelector("section > div.flex-1");
+  const el = container.querySelector("section > div.relative > div.h-full");
   if (!el) throw new Error("terminal container not found");
   return el as HTMLElement;
 }

--- a/clients/react/src/hooks/useFencedCodeBlocks.ts
+++ b/clients/react/src/hooks/useFencedCodeBlocks.ts
@@ -1,0 +1,73 @@
+// Live fenced-code-block detection over an xterm buffer (#819).
+//
+// Subscribes to the terminal's write/resize events and re-scans the
+// scrollback (debounced — `onWriteParsed` fires per chunk during streaming,
+// so the scan runs once the stream goes quiet) for CLOSED ``` fences.
+// Extraction semantics live in `lib/fenced-code.ts`.
+
+import { type RefObject, useEffect, useState } from "react";
+import { type BufferLike, extractFencedBlocks, type FencedBlock } from "@/lib/fenced-code";
+
+/** Structural subset of `xterm.Terminal` — real terminals satisfy it, tests
+ *  can pass a plain fake. */
+export interface FenceScanTerminal {
+  readonly cols: number;
+  readonly buffer: { readonly active: BufferLike };
+  onWriteParsed(listener: () => void): { dispose(): void };
+  onResize(listener: (size: { cols: number; rows: number }) => void): { dispose(): void };
+}
+
+const SCAN_DEBOUNCE_MS = 400;
+
+export function useFencedCodeBlocks(
+  terminalRef: RefObject<FenceScanTerminal | null>,
+  agentId: string | null,
+): FencedBlock[] {
+  const [blocks, setBlocks] = useState<FencedBlock[]>([]);
+
+  // `agentId` is a dep although unused in the body: `useTerminal` rebuilds
+  // its Terminal instance when the agent changes, and this effect must
+  // re-subscribe on the NEW instance (both hooks live in the same component,
+  // so by call order the ref is already repopulated when this re-runs).
+  // biome-ignore lint/correctness/useExhaustiveDependencies: agentId is the re-subscribe trigger
+  useEffect(() => {
+    const term = terminalRef.current;
+    if (!term) {
+      setBlocks([]);
+      return;
+    }
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const scan = () => {
+      const next = extractFencedBlocks(term.buffer.active, term.cols);
+      // Keep the previous array identity when nothing changed so dependent
+      // renders don't churn on every quiet period.
+      setBlocks((prev) => (sameBlocks(prev, next) ? prev : next));
+    };
+    const schedule = () => {
+      if (timer !== null) clearTimeout(timer);
+      timer = setTimeout(() => {
+        timer = null;
+        scan();
+      }, SCAN_DEBOUNCE_MS);
+    };
+
+    scan();
+    const writeSub = term.onWriteParsed(schedule);
+    // Resize reflows soft-wrap boundaries without any write — rescan so the
+    // joined sources stay consistent with the new grid.
+    const resizeSub = term.onResize(schedule);
+    return () => {
+      writeSub.dispose();
+      resizeSub.dispose();
+      if (timer !== null) clearTimeout(timer);
+    };
+  }, [terminalRef, agentId]);
+
+  return blocks;
+}
+
+function sameBlocks(a: FencedBlock[], b: FencedBlock[]): boolean {
+  if (a.length !== b.length) return false;
+  return a.every((x, i) => x.source === b[i].source && x.info === b[i].info);
+}

--- a/clients/react/src/lib/__tests__/fenced-code.test.ts
+++ b/clients/react/src/lib/__tests__/fenced-code.test.ts
@@ -48,6 +48,13 @@ describe("findFencedBlocks — fence detection", () => {
     expect(findFencedBlocks(["```bash", "half-arrived command"])).toEqual([]);
   });
 
+  it("treats a backtick line indented deeper than the opening fence as body, not terminator", () => {
+    // e.g. a block quoting a markdown snippet that itself contains a fence
+    const blocks = findFencedBlocks(["```", "outer", "  ```", "still body", "```", "after"]);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].source).toBe("outer\n  ```\nstill body");
+  });
+
   it("strips the rendering gutter (fence indent) but keeps deeper indentation", () => {
     const blocks = findFencedBlocks(["  ```", "  echo hi", "    indented", "  ```"]);
     expect(blocks).toHaveLength(1);

--- a/clients/react/src/lib/__tests__/fenced-code.test.ts
+++ b/clients/react/src/lib/__tests__/fenced-code.test.ts
@@ -1,0 +1,86 @@
+// Fidelity contract of the fenced-code extraction (#819): the copied
+// string must be byte-exact w.r.t. the logical source — soft-wrap line
+// breaks introduced by the terminal grid must NOT appear, and no `\r`.
+
+import { describe, expect, it } from "vitest";
+import { extractFencedBlocks, extractLogicalLines, findFencedBlocks } from "@/lib/fenced-code";
+import { makeBuffer } from "@/test/fake-xterm";
+
+const WIDE = (ch: string) => /[　-鿿]/.test(ch);
+
+describe("extractLogicalLines — soft-wrap re-join", () => {
+  it("re-joins a line wrapped across several grid rows without injecting newlines", () => {
+    const long = "gh api repos/o/r/branches/main/protection --method PUT --input protection.json";
+    const buf = makeBuffer([long], 20);
+    // sanity: the fake actually wrapped (the scenario under test)
+    expect(buf.length).toBeGreaterThan(1);
+    expect(extractLogicalLines(buf, 20)).toEqual([long]);
+  });
+
+  it("preserves spaces that land exactly at the wrap column", () => {
+    const line = "aaaaaaaa  bbbbbbbb"; // double space spans the col-10 boundary
+    expect(extractLogicalLines(makeBuffer([line], 10), 10)).toEqual([line]);
+  });
+
+  it("does not inject a phantom space when a wide glyph wraps early", () => {
+    // cols=3: "ab" + null pad (漢 doesn't fit the last column) | "漢" row
+    expect(extractLogicalLines(makeBuffer(["ab漢"], 3, WIDE), 3)).toEqual(["ab漢"]);
+  });
+
+  it("keeps hard newlines as logical line boundaries", () => {
+    expect(extractLogicalLines(makeBuffer(["one", "two"], 80), 80)).toEqual(["one", "two"]);
+  });
+});
+
+describe("findFencedBlocks — fence detection", () => {
+  it("captures the body and info string of a closed block", () => {
+    const blocks = findFencedBlocks(["before", "```bash", "echo hi", "echo yo", "```", "after"]);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].source).toBe("echo hi\necho yo");
+    expect(blocks[0].info).toBe("bash");
+  });
+
+  it("reports nothing on non-fenced text", () => {
+    expect(findFencedBlocks(["plain text", "more `inline` code", "$ a prompt"])).toEqual([]);
+  });
+
+  it("does not report an unterminated (still-streaming) fence", () => {
+    expect(findFencedBlocks(["```bash", "half-arrived command"])).toEqual([]);
+  });
+
+  it("strips the rendering gutter (fence indent) but keeps deeper indentation", () => {
+    const blocks = findFencedBlocks(["  ```", "  echo hi", "    indented", "  ```"]);
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].source).toBe("echo hi\n  indented");
+  });
+
+  it("returns blocks in scrollback order", () => {
+    const blocks = findFencedBlocks(["```", "first", "```", "```", "second", "```"]);
+    expect(blocks.map((b) => b.source)).toEqual(["first", "second"]);
+  });
+});
+
+describe("extractFencedBlocks — end-to-end fidelity", () => {
+  it("a multi-line block whose rendering wraps copies the exact source", () => {
+    const cmd =
+      "gh api repos/owner/repo/branches/main/protection --method PUT --input protection.json";
+    const second = "git push origin main";
+    const buf = makeBuffer(["⏺ Run this:", "```bash", cmd, second, "```"], 24);
+    const blocks = extractFencedBlocks(buf, 24);
+    expect(blocks).toHaveLength(1);
+    // byte-exact: no newline at any wrap column, both hard lines intact
+    expect(blocks[0].source).toBe(`${cmd}\n${second}`);
+  });
+
+  it("never contains \\r, even if the substrate were to surface one", () => {
+    const buf = makeBuffer(["```", "foo\rbar", "```"], 80);
+    const [block] = extractFencedBlocks(buf, 80);
+    expect(block.source).not.toMatch(/\r/);
+    expect(block.source).toBe("foobar");
+  });
+
+  it("finds no blocks in a buffer of plain conversation", () => {
+    const buf = makeBuffer(["⏺ I looked at the file and it seems fine.", "Next step?"], 30);
+    expect(extractFencedBlocks(buf, 30)).toEqual([]);
+  });
+});

--- a/clients/react/src/lib/fenced-code.ts
+++ b/clients/react/src/lib/fenced-code.ts
@@ -1,0 +1,169 @@
+// Fenced-code-block extraction from an xterm.js buffer (#819).
+//
+// WHY this exists — relay fidelity on a privileged channel: when the
+// Producer hands the operator a command to run, copying it off the rendered
+// PTY grid picks up newlines injected at soft-wrap columns. A newline is a
+// shell statement separator, so the operator can end up executing a command
+// DIFFERENT from what the Producer authored (fired live 2026-06-12: a
+// wrapped paste dropped `--input` from a `gh api` call and bash executed a
+// JSON file line-by-line).
+//
+// CHOSEN EXTRACTION (investigated per the issue): the PTY plane delivers raw
+// ANSI bytes; the client-side substrate is xterm's buffer, which only offers
+// WRAPPED GRID ROWS — there is no logical-line stream to read from. xterm
+// does, however, mark every row that is a soft-wrap continuation of the row
+// above with `IBufferLine.isWrapped`, so logical lines are reconstructed
+// here by concatenating each row with its continuation rows WITHOUT a line
+// break. Hard newlines (real `\n` in the source) start a non-wrapped row and
+// survive as logical line boundaries. `\r` never reaches the buffer text
+// (the parser consumes CR as cursor motion), and is additionally stripped
+// below as a belt-and-braces guarantee.
+//
+// KNOWN SUBSTRATE LIMIT: trailing whitespace at the END of a logical line is
+// indistinguishable from the buffer's cell padding and is trimmed. Interior
+// whitespace — including spaces that happen to sit at a wrap column — is
+// preserved exactly (continuation-feeding rows are taken at full width,
+// untrimmed).
+
+/** Structural subset of xterm's `IBufferCell` (keeps tests xterm-free). */
+export interface CellLike {
+  getWidth(): number;
+  getChars(): string;
+}
+
+/** Structural subset of xterm's `IBufferLine`. */
+export interface BufferLineLike {
+  readonly isWrapped: boolean;
+  translateToString(trimRight?: boolean, startColumn?: number, endColumn?: number): string;
+  getCell(x: number): CellLike | undefined;
+}
+
+/** Structural subset of xterm's `IBuffer`. */
+export interface BufferLike {
+  readonly length: number;
+  getLine(y: number): BufferLineLike | undefined;
+}
+
+export interface FencedBlock {
+  /** Logical source of the block body — soft-wrap joins applied, no `\r`,
+   *  lines joined with `\n`, the rendering indent of the fence stripped. */
+  source: string;
+  /** Info string of the opening fence (e.g. `bash`), trimmed. */
+  info: string;
+  /** Buffer row index of the opening fence (scan-time; rows shift as the
+   *  scrollback trims, so use only as a per-scan identity/ordering key). */
+  openLine: number;
+}
+
+/**
+ * Re-join soft-wrapped grid rows into logical lines.
+ *
+ * A row whose SUCCESSOR has `isWrapped` feeds a continuation, so it is taken
+ * at full width WITHOUT right-trimming — trimming there would eat genuine
+ * spaces that landed exactly at the wrap column. Only the final row of each
+ * logical line is right-trimmed (its trailing cells are empty-cell padding).
+ *
+ * Wide-glyph edge (mirrors xterm's own selection logic,
+ * `SelectionService._getWrappedLineTrimmedLength`): when a CJK/wide glyph
+ * does not fit in the last column, xterm wraps it early and leaves a null
+ * cell at the row end; reading that cell as a space would inject a phantom
+ * space into the joined line, so it is excluded when the continuation row
+ * starts with a width-2 cell.
+ */
+export function extractLogicalLines(buffer: BufferLike, cols: number): string[] {
+  const out: string[] = [];
+  let current: string | null = null;
+
+  for (let y = 0; y < buffer.length; y++) {
+    const line = buffer.getLine(y);
+    if (!line) continue;
+    const next = buffer.getLine(y + 1);
+    const feedsContinuation = next?.isWrapped === true;
+
+    let text: string;
+    if (feedsContinuation) {
+      let end = cols;
+      const lastCell = line.getCell(cols - 1);
+      if (lastCell?.getChars() === "" && next?.getCell(0)?.getWidth() === 2) {
+        end = cols - 1;
+      }
+      text = line.translateToString(false, 0, end);
+    } else {
+      text = line.translateToString(true);
+    }
+
+    if (line.isWrapped && current !== null) {
+      current += text;
+    } else {
+      if (current !== null) out.push(current);
+      current = text;
+    }
+  }
+  if (current !== null) out.push(current);
+  return out;
+}
+
+// Opening fence: optional rendering indent (the conversation TUI draws
+// assistant content behind a gutter), a run of >=3 backticks, then an info
+// string that may not contain a backtick (CommonMark rule for ` fences).
+const OPENING_FENCE = /^([ \t]*)(`{3,})([^`]*)$/;
+
+/**
+ * Find CLOSED fenced code blocks among logical lines.
+ *
+ * Unterminated fences are deliberately NOT reported: while the agent is
+ * still streaming a block, exposing a copy of its half-arrived body would be
+ * its own fidelity hazard — the block becomes copyable once its closing
+ * fence lands.
+ *
+ * The opening fence's indent is stripped from body lines (it is rendering
+ * gutter, not source); lines indented deeper keep the excess.
+ */
+export function findFencedBlocks(lines: string[]): FencedBlock[] {
+  const blocks: FencedBlock[] = [];
+  let i = 0;
+  while (i < lines.length) {
+    const open = OPENING_FENCE.exec(lines[i]);
+    if (!open) {
+      i++;
+      continue;
+    }
+    const [, indent, fence, rawInfo] = open;
+
+    let close = -1;
+    for (let j = i + 1; j < lines.length; j++) {
+      const trimmed = lines[j].trim();
+      if (trimmed.length >= fence.length && /^`+$/.test(trimmed)) {
+        close = j;
+        break;
+      }
+    }
+    if (close === -1) {
+      i++;
+      continue;
+    }
+
+    const body = lines.slice(i + 1, close).map((l) => stripGutter(l, indent.length));
+    blocks.push({
+      // \r cannot occur in buffer text (see header comment) — strip anyway
+      // so the no-CR guarantee holds independent of the substrate.
+      source: body.join("\n").replace(/\r/g, ""),
+      info: rawInfo.trim(),
+      openLine: i,
+    });
+    i = close + 1;
+  }
+  return blocks;
+}
+
+/** Strip up to `width` leading whitespace chars (never into non-whitespace). */
+function stripGutter(line: string, width: number): string {
+  let k = 0;
+  while (k < width && k < line.length && (line[k] === " " || line[k] === "\t")) k++;
+  return line.slice(k);
+}
+
+/** One-shot scan: buffer grid → logical lines → closed fenced blocks. */
+export function extractFencedBlocks(buffer: BufferLike, cols: number): FencedBlock[] {
+  return findFencedBlocks(extractLogicalLines(buffer, cols));
+}

--- a/clients/react/src/lib/fenced-code.ts
+++ b/clients/react/src/lib/fenced-code.ts
@@ -50,8 +50,9 @@ export interface FencedBlock {
   source: string;
   /** Info string of the opening fence (e.g. `bash`), trimmed. */
   info: string;
-  /** Buffer row index of the opening fence (scan-time; rows shift as the
-   *  scrollback trims, so use only as a per-scan identity/ordering key). */
+  /** Index of the opening fence among the LOGICAL lines of the scan (after
+   *  wrap-joining — NOT a buffer row index). Indices shift as the
+   *  scrollback trims, so use only as a per-scan identity/ordering key. */
   openLine: number;
 }
 
@@ -130,10 +131,14 @@ export function findFencedBlocks(lines: string[]): FencedBlock[] {
     }
     const [, indent, fence, rawInfo] = open;
 
+    // Closing fence: a backtick-only line whose run is at least as long as
+    // the opening run AND whose indent does not exceed the opening fence's
+    // indent — per CommonMark, a backtick line indented DEEPER than the
+    // opening fence is block CONTENT, not a terminator.
     let close = -1;
     for (let j = i + 1; j < lines.length; j++) {
-      const trimmed = lines[j].trim();
-      if (trimmed.length >= fence.length && /^`+$/.test(trimmed)) {
+      const m = /^([ \t]*)(`+)[ \t]*$/.exec(lines[j]);
+      if (m && m[1].length <= indent.length && m[2].length >= fence.length) {
         close = j;
         break;
       }

--- a/clients/react/src/test/fake-xterm.ts
+++ b/clients/react/src/test/fake-xterm.ts
@@ -1,0 +1,103 @@
+// Test-only fake of the xterm buffer surface consumed by
+// `lib/fenced-code.ts` (#819). Simulates xterm's soft-wrap layout: a
+// logical line longer than `cols` is split into grid rows, every row after
+// the first carries `isWrapped`, and rows are padded to full width with
+// null cells (chars "", width 1) exactly like the real buffer — so the
+// extraction's trim/no-trim decisions are exercised for real.
+
+import type { BufferLike, BufferLineLike, CellLike } from "@/lib/fenced-code";
+
+export interface FakeCell {
+  chars: string;
+  width: number;
+}
+
+const NULL_CELL: FakeCell = { chars: "", width: 1 };
+
+/** Char → cells, marking chars in `wide` as width-2 (followed by the
+ *  width-0 spacer cell real xterm stores after a wide glyph). */
+export function cellsOf(text: string, wide: (ch: string) => boolean = () => false): FakeCell[] {
+  const cells: FakeCell[] = [];
+  for (const ch of text) {
+    if (wide(ch)) {
+      cells.push({ chars: ch, width: 2 }, { chars: "", width: 0 });
+    } else {
+      cells.push({ chars: ch, width: 1 });
+    }
+  }
+  return cells;
+}
+
+export class FakeBufferLine implements BufferLineLike {
+  constructor(
+    private cells: FakeCell[],
+    public readonly isWrapped: boolean,
+  ) {}
+
+  translateToString(trimRight = false, startColumn = 0, endColumn = this.cells.length): string {
+    let s = "";
+    for (let x = startColumn; x < Math.min(endColumn, this.cells.length); x++) {
+      const c = this.cells[x];
+      if (c.width === 0) continue; // spacer after a wide glyph
+      s += c.chars === "" ? " " : c.chars;
+    }
+    return trimRight ? s.replace(/\s+$/, "") : s;
+  }
+
+  getCell(x: number): CellLike | undefined {
+    const c = this.cells[x];
+    if (!c) return undefined;
+    return { getWidth: () => c.width, getChars: () => c.chars };
+  }
+}
+
+/** Soft-wrap one logical line into grid rows of `cols` cells (xterm
+ *  semantics: a wide glyph that doesn't fit the last column wraps early,
+ *  leaving a null cell at the row end). */
+export function wrapLine(cells: FakeCell[], cols: number): FakeBufferLine[] {
+  const rows: FakeCell[][] = [];
+  let row: FakeCell[] = [];
+  let i = 0;
+  while (i < cells.length) {
+    const c = cells[i];
+    if (c.width === 2 && row.length === cols - 1) {
+      row.push({ ...NULL_CELL });
+      rows.push(row);
+      row = [];
+      continue;
+    }
+    row.push(c);
+    i++;
+    if (row.length === cols) {
+      rows.push(row);
+      row = [];
+    }
+  }
+  // A logical line that fills rows exactly still has a (possibly empty)
+  // final row only when content remains; an empty trailing row would change
+  // wrap flags, so only emit `row` if it has cells OR nothing was emitted.
+  if (row.length > 0 || rows.length === 0) {
+    while (row.length < cols) row.push({ ...NULL_CELL });
+    rows.push(row);
+  }
+  return rows.map((r, idx) => new FakeBufferLine(r, idx > 0));
+}
+
+export class FakeBuffer implements BufferLike {
+  constructor(private lines: FakeBufferLine[]) {}
+  get length(): number {
+    return this.lines.length;
+  }
+  getLine(y: number): BufferLineLike | undefined {
+    return this.lines[y];
+  }
+}
+
+/** Build a buffer from logical lines, soft-wrapping each at `cols`. */
+export function makeBuffer(
+  logicalLines: string[],
+  cols: number,
+  wide: (ch: string) => boolean = () => false,
+): FakeBuffer {
+  return new FakeBuffer(logicalLines.flatMap((l) => wrapLine(cellsOf(l, wide), cols)));
+}


### PR DESCRIPTION
Resolves #819.

## What

A copy-source affordance over the PTY conversation surfaces: whenever the scrollback contains a closed fenced code block (``` … ```), a "⧉ Copy code" pill floats top-right of the terminal canvas. Clicking it copies the **logical source** of the block — not the rendered grid. With several blocks in scrollback the pill opens a picker (latest first).

## Fidelity (the acceptance bar)

**Investigated substrate:** the PTY plane delivers raw ANSI bytes rendered by xterm.js, so the only available representation is **wrapped grid rows** — there is no logical-line stream. xterm does mark every soft-wrap continuation row with `IBufferLine.isWrapped`, so `lib/fenced-code.ts` reconstructs logical lines by concatenating continuation rows **without** a line break (documented in the module header, per the issue):

- no newlines at wrap columns — continuation-feeding rows are taken at full width, untrimmed, so interior spaces sitting exactly at a wrap column survive;
- the wide-glyph early-wrap null cell is excluded (mirrors xterm's own `SelectionService._getWrappedLineTrimmedLength`), so CJK content doesn't gain a phantom space;
- no `\r` — CR can't reach buffer text (the parser consumes it as cursor motion) and is stripped anyway as a belt-and-braces guarantee;
- only **closed** fences are exposed: a half-streamed block would be its own fidelity hazard;
- known substrate limit (documented): trailing whitespace at the very end of a logical line is indistinguishable from cell padding and is trimmed — shell-harmless.

## Deliberately NO execute button

Pinned in a comment beside the button (`CopySourceOverlay.tsx`): the operator's paste + Enter stays the firing act; one-click execution of agent-authored commands is the no-look-execution slide the design rejects (tmai-core `doc/slack/2026-06-12-163215.md`).

## Surfaces

Both terminal twins get the overlay, so it covers the Producer conversation wherever it renders: `PreviewPanel` (Live tab) and `TerminalPanel` — chromeless included, which puts it on the aim-console session pane (`WireTerminal`) too. It sits as a sibling of the xterm container, so its clicks don't toggle Input/Select, and `onMouseDown` prevents default so terminal focus is kept (existing footer-control convention).

## Tests

`lib/__tests__/fenced-code.test.ts` + `__tests__/CopySourceOverlay.test.tsx` against a soft-wrapping fake of the xterm buffer (`src/test/fake-xterm.ts`):
- a multi-line fenced block whose rendering wraps → copy yields the exact source (the 2026-06-12 incident shape: a long `gh api … --input` line);
- copied string carries no `\r`;
- no button on non-fenced text; unterminated fence hidden; multi-block picker copies the chosen block.

One existing `TerminalPanel` test selector updated for the new relative wrapper around the xterm container.

## Gate (all run locally under `clients/react/`)

- `pnpm lint` ✓ (1 pre-existing warning in an unrelated file)
- `pnpm build` ✓ (includes `tsc -b`)
- `pnpm test` ✓ — 109 files, 920 passed / 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ターミナルに表示されたコードブロックをクリップボードにコピーする機能を追加しました。単数のブロックはワンクリックで、複数のブロックはパネルから選択してコピーできます。成功・失敗時に対応するフィードバックが表示されます。

* **Tests**
  * コードブロック検出とコピー機能に関するテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->