### PR TITLE
R panel: remote Δ freshness — close-act cursor + unobserved-fact accents (UI half) (#822)

### DIFF
--- a/clients/react/src/components/producer-console/r-panel/RIssuesSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RIssuesSection.tsx
@@ -19,8 +19,10 @@ import { useUnitIssues } from "@/hooks/useUnitIssues";
 import type { IssueInfo, IssueSummaryWire, RepoIssuesWire } from "@/lib/api";
 import { RowAttentionMarker } from "./AttentionMarker";
 import { type SelectedIssue, selectedIssueKey } from "./r-viewer/RIssueViewer";
+import { issueVocabTimestamp, isUnobserved, unobservedIssueCount } from "./remote-delta";
 import { Section } from "./Section";
 import { ExternalSourceBadge, issueStatusPills, StatusPills } from "./status-pills";
+import { UnobservedDelta } from "./UnobservedDelta";
 
 interface RIssuesSectionProps {
   unitName: string | null;
@@ -37,6 +39,12 @@ interface RIssuesSectionProps {
    *  When present each issue row shows its attention marker; absent (e.g. in
    *  isolation tests) the rows render marker-free. */
   attention?: AttentionControls;
+  /** Remote-Δ effective cursor for this section (#822) — MAX(panel close,
+   *  Issues-section close), threaded from `RPanel`. `null` = no close act
+   *  recorded yet (first run → every row unobserved); `undefined` = no
+   *  freshness wiring at all (e.g. isolation tests), rows render
+   *  accent-free. */
+  deltaCursor?: string | null;
 }
 
 export function RIssuesSection({
@@ -46,9 +54,12 @@ export function RIssuesSection({
   onSelectIssue,
   selectedKey,
   attention,
+  deltaCursor,
 }: RIssuesSectionProps) {
   const { data, loading, error } = useUnitIssues(unitName);
   const total = data === null ? 0 : data.repos.reduce((n, r) => n + r.issues.length, 0);
+  const unobserved =
+    deltaCursor === undefined ? undefined : unobservedIssueCount(data?.repos ?? null, deltaCursor);
 
   return (
     <Section
@@ -59,6 +70,7 @@ export function RIssuesSection({
       expanded={expanded}
       onToggle={onToggle}
       headerNote={<ExternalSourceBadge />}
+      unobservedCount={unobserved}
     >
       <Body
         unitName={unitName}
@@ -68,6 +80,7 @@ export function RIssuesSection({
         onSelectIssue={onSelectIssue}
         selectedKey={selectedKey ?? null}
         attention={attention}
+        deltaCursor={deltaCursor}
       />
     </Section>
   );
@@ -81,6 +94,7 @@ interface BodyProps {
   onSelectIssue?: (sel: SelectedIssue) => void;
   selectedKey: string | null;
   attention?: AttentionControls;
+  deltaCursor?: string | null;
 }
 
 function Body({
@@ -91,6 +105,7 @@ function Body({
   onSelectIssue,
   selectedKey,
   attention,
+  deltaCursor,
 }: BodyProps) {
   if (unitName === null) {
     return <p className="text-subtle-foreground">Pick a project to see issues.</p>;
@@ -115,6 +130,7 @@ function Body({
           onSelectIssue={onSelectIssue}
           selectedKey={selectedKey}
           attention={attention}
+          deltaCursor={deltaCursor}
         />
       ))}
     </div>
@@ -127,12 +143,14 @@ function RepoBlock({
   onSelectIssue,
   selectedKey,
   attention,
+  deltaCursor,
 }: {
   repo: RepoIssuesWire;
   multiRepo: boolean;
   onSelectIssue?: (sel: SelectedIssue) => void;
   selectedKey: string | null;
   attention?: AttentionControls;
+  deltaCursor?: string | null;
 }) {
   if (repo.issues.length === 0) return null;
   return (
@@ -152,6 +170,9 @@ function RepoBlock({
             onSelectIssue={onSelectIssue}
             selected={selectedKey === selectedIssueKey(repo.repo_path, Number(issue.number))}
             attention={attention}
+            unobserved={
+              deltaCursor !== undefined && isUnobserved(issueVocabTimestamp(issue), deltaCursor)
+            }
           />
         ))}
       </ul>
@@ -166,6 +187,7 @@ function IssueRow({
   onSelectIssue,
   selected,
   attention,
+  unobserved,
 }: {
   issue: IssueSummaryWire;
   repoPath: string;
@@ -173,6 +195,7 @@ function IssueRow({
   onSelectIssue?: (sel: SelectedIssue) => void;
   selected: boolean;
   attention?: AttentionControls;
+  unobserved?: boolean;
 }) {
   // The whole row is a button that opens the issue in the R₂ viewer —
   // there is NO github.com link-out anymore; the issue's full content is
@@ -206,6 +229,9 @@ function IssueRow({
         }`}
       >
         <span>
+          {/* Remote-Δ accent (#822): leading Δ when this row's vocab ts is
+              newer than the close-act cursor. Observed rows render unchanged. */}
+          {unobserved === true && <UnobservedDelta />}
           <span className="font-mono text-foreground">#{Number(issue.number)}</span>{" "}
           <span className="text-foreground">{issue.title}</span>
         </span>

--- a/clients/react/src/components/producer-console/r-panel/RPanel.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPanel.tsx
@@ -32,6 +32,8 @@
 import { useCallback } from "react";
 import { makeSplitKeyHandler, RATIO_STEP } from "@/hooks/useSplitPane";
 import { useUnitAttention } from "@/hooks/useUnitAttention";
+import { useUnitIssues } from "@/hooks/useUnitIssues";
+import { useUnitPrs } from "@/hooks/useUnitPrs";
 import { ATTENTION_STRIP_WIDTH_MAX, ATTENTION_STRIP_WIDTH_MIN } from "@/lib/ui-prefs";
 import { useUIPref } from "@/lib/ui-prefs-provider";
 import { RAimsSection } from "./RAimsSection";
@@ -45,6 +47,12 @@ import { RPrsSection } from "./RPrsSection";
 import type { SelectedIssue } from "./r-viewer/RIssueViewer";
 import type { SelectedPr } from "./r-viewer/RPrViewer";
 import type { SelectedRecord } from "./r-viewer/RRecordViewer";
+import {
+  advanceCursor,
+  effectiveCursor,
+  unobservedIssueCount,
+  unobservedPrCount,
+} from "./remote-delta";
 
 export interface RPanelResize {
   width: number;
@@ -129,12 +137,50 @@ export function RPanel({
   // and is NOT given the controls.
   const attention = useUnitAttention(unitName);
 
+  // Remote-Δ freshness cursors (#822) — client state only (ui-prefs), never
+  // sent to core; the Producer never reads it. Exactly TWO acts advance a
+  // cursor: the panel collapse and a PRs/Issues section collapse, both
+  // below. Nothing else (no visibilitychange / scroll / per-row marking /
+  // timers) may call advanceCursor.
+  const [cursors, setCursors] = useUIPref("remoteDeltaCursors");
+  const prsCursor = unitName === null ? null : effectiveCursor(cursors, unitName, "prs");
+  const issuesCursor = unitName === null ? null : effectiveCursor(cursors, unitName, "issues");
+
+  // Collapsed-rail Δ count: the rail still shows the unit total of
+  // unobserved PR + issue rows, but the section components (which normally
+  // own the fetch) are unmounted while collapsed — so the panel polls in
+  // their stead. Parked (null unit) while expanded so panel and sections
+  // never double-poll the same unit.
+  const railUnit = collapsed ? unitName : null;
+  const railPrs = useUnitPrs(railUnit);
+  const railIssues = useUnitIssues(railUnit);
+  const railUnobserved =
+    unobservedPrCount(railPrs.data?.repos ?? null, prsCursor) +
+    unobservedIssueCount(railIssues.data?.repos ?? null, issuesCursor);
+
   const toggle = useCallback(
     (id: string) => {
-      setExpanded(expanded.includes(id) ? expanded.filter((x) => x !== id) : [...expanded, id]);
+      const closing = expanded.includes(id);
+      // Section-collapse act: stamp that section's cursor. Only the CLOSE
+      // direction advances — expanding is the start of looking, not the end.
+      if (closing && unitName !== null && (id === "prs" || id === "issues")) {
+        setCursors(advanceCursor(cursors, unitName, id, new Date().toISOString()));
+      }
+      setExpanded(closing ? expanded.filter((x) => x !== id) : [...expanded, id]);
     },
-    [expanded, setExpanded],
+    [expanded, setExpanded, cursors, setCursors, unitName],
   );
+
+  // Panel-collapse act: stamp the unit's `panel` cursor (the coarse "when
+  // the operator last stopped looking" timestamp) then collapse. The
+  // expand button on the collapsed rail uses the plain onToggleCollapsed —
+  // opening is not a close act.
+  const collapsePanel = useCallback(() => {
+    if (unitName !== null) {
+      setCursors(advanceCursor(cursors, unitName, "panel", new Date().toISOString()));
+    }
+    onToggleCollapsed();
+  }, [cursors, setCursors, unitName, onToggleCollapsed]);
 
   if (collapsed) {
     return (
@@ -159,6 +205,19 @@ export function RPanel({
         >
           R · Inventory
         </span>
+        {/* Remote-Δ unit total (#822): unobserved PR + issue rows since the
+            close acts. Within-unit count only — info-tone freshness fact,
+            never the owed amber; no cross-unit accent (deferred until a
+            second unit exists). */}
+        {railUnobserved > 0 && (
+          <span
+            data-testid="r-rail-unobserved"
+            title={`${railUnobserved} unobserved remote ${railUnobserved === 1 ? "change" : "changes"} since you last looked`}
+            className="mt-2 select-none font-mono text-[10px] text-info"
+          >
+            Δ{railUnobserved}
+          </span>
+        )}
       </aside>
     );
   }
@@ -211,7 +270,7 @@ export function RPanel({
             <h2 className="text-sm font-semibold text-foreground">R · Inventory</h2>
             <button
               type="button"
-              onClick={onToggleCollapsed}
+              onClick={collapsePanel}
               title="Collapse R panel"
               aria-label="Collapse R panel"
               aria-expanded={true}
@@ -229,6 +288,7 @@ export function RPanel({
               onSelectPr={onSelectPr}
               selectedKey={selectedPrKey}
               attention={attention}
+              deltaCursor={prsCursor}
             />
             <RIssuesSection
               unitName={unitName}
@@ -237,6 +297,7 @@ export function RPanel({
               onSelectIssue={onSelectIssue}
               selectedKey={selectedIssueKey}
               attention={attention}
+              deltaCursor={issuesCursor}
             />
             <RDecisionsSection
               unitName={unitName}

--- a/clients/react/src/components/producer-console/r-panel/RPrsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RPrsSection.tsx
@@ -23,8 +23,10 @@ import { useUnitPrs } from "@/hooks/useUnitPrs";
 import type { PrSummaryWire, RepoPrsWire } from "@/lib/api";
 import { RowAttentionMarker } from "./AttentionMarker";
 import { type SelectedPr, selectedPrKey } from "./r-viewer/RPrViewer";
+import { isUnobserved, prVocabTimestamp, unobservedPrCount } from "./remote-delta";
 import { Section } from "./Section";
 import { ExternalSourceBadge, prStatusPills, StatusPills } from "./status-pills";
+import { UnobservedDelta } from "./UnobservedDelta";
 
 interface RPrsSectionProps {
   unitName: string | null;
@@ -43,6 +45,12 @@ interface RPrsSectionProps {
    *  When present each PR row shows its attention marker; absent (e.g. in
    *  isolation tests) the rows render marker-free. */
   attention?: AttentionControls;
+  /** Remote-Δ effective cursor for this section (#822) — MAX(panel close,
+   *  PRs-section close), threaded from `RPanel`. `null` = no close act
+   *  recorded yet (first run → every row unobserved); `undefined` = no
+   *  freshness wiring at all (e.g. isolation tests), rows render
+   *  accent-free. */
+  deltaCursor?: string | null;
 }
 
 export function RPrsSection({
@@ -52,9 +60,12 @@ export function RPrsSection({
   onSelectPr,
   selectedKey,
   attention,
+  deltaCursor,
 }: RPrsSectionProps) {
   const { data, loading, error } = useUnitPrs(unitName);
   const total = data === null ? 0 : data.repos.reduce((n, r) => n + r.prs.length, 0);
+  const unobserved =
+    deltaCursor === undefined ? undefined : unobservedPrCount(data?.repos ?? null, deltaCursor);
 
   return (
     <Section
@@ -65,6 +76,7 @@ export function RPrsSection({
       expanded={expanded}
       onToggle={onToggle}
       headerNote={<ExternalSourceBadge />}
+      unobservedCount={unobserved}
     >
       <Body
         unitName={unitName}
@@ -74,6 +86,7 @@ export function RPrsSection({
         onSelectPr={onSelectPr}
         selectedKey={selectedKey ?? null}
         attention={attention}
+        deltaCursor={deltaCursor}
       />
     </Section>
   );
@@ -87,9 +100,19 @@ interface BodyProps {
   onSelectPr?: (sel: SelectedPr) => void;
   selectedKey: string | null;
   attention?: AttentionControls;
+  deltaCursor?: string | null;
 }
 
-function Body({ unitName, repos, loading, error, onSelectPr, selectedKey, attention }: BodyProps) {
+function Body({
+  unitName,
+  repos,
+  loading,
+  error,
+  onSelectPr,
+  selectedKey,
+  attention,
+  deltaCursor,
+}: BodyProps) {
   if (unitName === null) {
     return <p className="text-subtle-foreground">Pick a project to see open PRs.</p>;
   }
@@ -113,6 +136,7 @@ function Body({ unitName, repos, loading, error, onSelectPr, selectedKey, attent
           onSelectPr={onSelectPr}
           selectedKey={selectedKey}
           attention={attention}
+          deltaCursor={deltaCursor}
         />
       ))}
     </div>
@@ -125,12 +149,14 @@ function RepoBlock({
   onSelectPr,
   selectedKey,
   attention,
+  deltaCursor,
 }: {
   repo: RepoPrsWire;
   multiRepo: boolean;
   onSelectPr?: (sel: SelectedPr) => void;
   selectedKey: string | null;
   attention?: AttentionControls;
+  deltaCursor?: string | null;
 }) {
   if (repo.prs.length === 0) return null;
   // billing-dead lives on the REPO, not the PR. Thread it into the R₂
@@ -155,6 +181,9 @@ function RepoBlock({
             onSelectPr={onSelectPr}
             selected={selectedKey === selectedPrKey(repo.repo_path, pr.number)}
             attention={attention}
+            unobserved={
+              deltaCursor !== undefined && isUnobserved(prVocabTimestamp(pr), deltaCursor)
+            }
           />
         ))}
       </ul>
@@ -170,6 +199,7 @@ function PrRow({
   onSelectPr,
   selected,
   attention,
+  unobserved,
 }: {
   pr: PrSummaryWire;
   repoPath: string;
@@ -178,6 +208,7 @@ function PrRow({
   onSelectPr?: (sel: SelectedPr) => void;
   selected: boolean;
   attention?: AttentionControls;
+  unobserved?: boolean;
 }) {
   // Colour-coded status pills (C2) — categorical lifecycle / review / CI
   // state, NOT severity appraisal (see `status-pills.tsx`). The whole row
@@ -206,6 +237,9 @@ function PrRow({
         }`}
       >
         <span>
+          {/* Remote-Δ accent (#822): leading Δ when this row's vocab ts is
+              newer than the close-act cursor. Observed rows render unchanged. */}
+          {unobserved === true && <UnobservedDelta />}
           <span className="font-mono text-foreground">#{Number(pr.number)}</span>{" "}
           <span className="text-foreground">{pr.title}</span>
         </span>

--- a/clients/react/src/components/producer-console/r-panel/Section.tsx
+++ b/clients/react/src/components/producer-console/r-panel/Section.tsx
@@ -10,7 +10,9 @@
 //   - collapsed by default; only operator-toggled expand;
 //   - count uses `text-subtle-foreground` ONLY — never warning /
 //     destructive / success accents. The R panel's whole job is to
-//     show the inventory without tmai-side appraisal.
+//     show the inventory without tmai-side appraisal. The one trailing
+//     addition is the remote-Δ `unobservedCount` badge (#822): info-tone
+//     because it is a neutral freshness fact, never the owed amber.
 //
 // `id` is the persistence key (string slug) the parent uses to
 // remember which sections the operator has expanded across reloads.
@@ -33,6 +35,15 @@ interface SectionProps {
    *  sections to carry the "EXTERNAL · github = source of truth" framing
    *  (C2) — those are the github-resident artifacts on this panel. */
   headerNote?: ReactNode;
+  /** Remote-Δ freshness (#822): how many of this section's rows are
+   *  UNOBSERVED (vocab timestamp newer than the operator's close-act
+   *  cursor). Shown on the header ONLY while the section is collapsed —
+   *  open sections accent the rows themselves. Info-tone (cyan family),
+   *  never the warning/owed amber: this is a neutral freshness FACT
+   *  ("changed since you last looked"), not a tmai-side appraisal, so it
+   *  does not breach the count rule above. `undefined` = the section has
+   *  no freshness wiring (e.g. isolation tests). */
+  unobservedCount?: number;
 }
 
 export function Section({
@@ -44,6 +55,7 @@ export function Section({
   onToggle,
   children,
   headerNote,
+  unobservedCount,
 }: SectionProps) {
   return (
     <section data-testid={`r-section-${id}`} data-expanded={expanded ? "true" : "false"}>
@@ -62,6 +74,15 @@ export function Section({
         </span>
         <h3 className="text-sm font-semibold text-foreground">{label}</h3>
         <span className="text-[11px] text-subtle-foreground">{count}</span>
+        {!expanded && unobservedCount !== undefined && unobservedCount > 0 && (
+          <span
+            data-testid={`r-section-unobserved-${id}`}
+            title={`${unobservedCount} unobserved remote ${unobservedCount === 1 ? "change" : "changes"} since you last looked`}
+            className="font-mono text-[10px] text-info"
+          >
+            Δ{unobservedCount}
+          </span>
+        )}
         {headerNote}
       </button>
       {expanded && (

--- a/clients/react/src/components/producer-console/r-panel/UnobservedDelta.tsx
+++ b/clients/react/src/components/producer-console/r-panel/UnobservedDelta.tsx
@@ -1,0 +1,20 @@
+// Remote-Δ unobserved-row accent (#822) — the small leading Δ glyph on a
+// PR / issue row whose vocab timestamp is newer than the operator's
+// close-act cursor (see remote-delta.ts).
+//
+// Info-tone (the cyan-family `info` token), NEVER the warning/owed amber:
+// "unobserved" is a neutral freshness FACT ("changed since you last
+// looked / 見ていた"), not an appraisal and not a debt. Observed rows
+// render with no counterpart element at all — observed is the unmarked
+// default state, not a second badge.
+export function UnobservedDelta() {
+  return (
+    <span
+      data-testid="unobserved-delta"
+      title="unobserved — changed since you last looked"
+      className="mr-1 font-mono text-info"
+    >
+      Δ
+    </span>
+  );
+}

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RIssuesSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RIssuesSection.test.tsx
@@ -202,3 +202,100 @@ describe("RIssuesSection", () => {
     expect(row1?.getAttribute("aria-current")).toBeNull();
   });
 });
+
+// ── Remote-Δ freshness (#822) — issues twin of the RPrsSection cases ──
+//
+// Issue vocab = max(created_at, closed_at). The accent is info-tone (a
+// freshness FACT, never the warning amber); observed rows render unchanged.
+describe("RIssuesSection — remote-Δ freshness accents", () => {
+  const CURSOR = "2026-06-12T00:00:00Z";
+
+  it("accents rows newer than the cursor; observed rows render unchanged", async () => {
+    unitIssuesMock.mockResolvedValue(
+      response([
+        repo({
+          issues: [
+            issue({ number: 2n, title: "new issue", created_at: "2026-06-13T00:00:00Z" }),
+            issue({ number: 1n, title: "old issue", created_at: "2026-06-11T00:00:00Z" }),
+          ],
+        }),
+      ]),
+    );
+    render(<RIssuesSection unitName="u" expanded={true} onToggle={vi.fn()} deltaCursor={CURSOR} />);
+    await waitFor(() => expect(screen.getByText("new issue")).toBeTruthy());
+
+    const deltas = screen.getAllByTestId("unobserved-delta");
+    expect(deltas).toHaveLength(1);
+    expect(screen.getByText("new issue").closest("button")?.textContent).toContain("Δ");
+    expect(screen.getByText("old issue").closest("button")?.textContent).not.toContain("Δ");
+    expect(deltas[0].className).toContain("text-info");
+    expect(deltas[0].className).not.toMatch(/warning/);
+  });
+
+  it("a close newer than the cursor accents the row (closed_at counts)", async () => {
+    // Recently-transitioned rows from the 7-day window now appear in the
+    // list — a closed issue renders its muted lifecycle pill plus the Δ.
+    unitIssuesMock.mockResolvedValue(
+      response([
+        repo({
+          issues: [
+            issue({
+              number: 1n,
+              title: "closed issue",
+              state: "closed",
+              created_at: "2026-06-01T00:00:00Z",
+              closed_at: "2026-06-13T00:00:00Z",
+            }),
+          ],
+        }),
+      ]),
+    );
+    render(<RIssuesSection unitName="u" expanded={true} onToggle={vi.fn()} deltaCursor={CURSOR} />);
+    await waitFor(() => expect(screen.getByText("closed issue")).toBeTruthy());
+    expect(screen.getAllByTestId("unobserved-delta")).toHaveLength(1);
+    const pill = screen.getByText("closed").closest("[data-testid='status-pill']");
+    expect(pill?.getAttribute("data-tone")).toBe("muted");
+  });
+
+  it("first run (deltaCursor null) — every row is unobserved", async () => {
+    unitIssuesMock.mockResolvedValue(
+      response([repo({ issues: [issue(), issue({ number: 2n, title: "Issue 2" })] })]),
+    );
+    render(<RIssuesSection unitName="u" expanded={true} onToggle={vi.fn()} deltaCursor={null} />);
+    await waitFor(() => expect(screen.getByText("Issue 1")).toBeTruthy());
+    expect(screen.getAllByTestId("unobserved-delta")).toHaveLength(2);
+  });
+
+  it("renders NO accents when deltaCursor is absent (isolation / no wiring)", async () => {
+    unitIssuesMock.mockResolvedValue(
+      response([repo({ issues: [issue({ created_at: "2026-06-13T00:00:00Z" })] })]),
+    );
+    render(<RIssuesSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("Issue 1")).toBeTruthy());
+    expect(screen.queryByTestId("unobserved-delta")).toBeNull();
+  });
+
+  it("collapsed header shows the unobserved COUNT; expanded header does not", async () => {
+    unitIssuesMock.mockResolvedValue(
+      response([
+        repo({
+          issues: [
+            issue({ number: 1n, created_at: "2026-06-13T00:00:00Z" }),
+            issue({ number: 2n, created_at: "2026-06-11T00:00:00Z" }),
+          ],
+        }),
+      ]),
+    );
+    const { rerender } = render(
+      <RIssuesSection unitName="u" expanded={false} onToggle={vi.fn()} deltaCursor={CURSOR} />,
+    );
+    await waitFor(() => expect(screen.getByText(/2 open/)).toBeTruthy());
+    expect(screen.getByTestId("r-section-unobserved-issues").textContent).toBe("Δ1");
+
+    rerender(
+      <RIssuesSection unitName="u" expanded={true} onToggle={vi.fn()} deltaCursor={CURSOR} />,
+    );
+    await waitFor(() => expect(screen.getAllByTestId("unobserved-delta")).toHaveLength(1));
+    expect(screen.queryByTestId("r-section-unobserved-issues")).toBeNull();
+  });
+});

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RPanel.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RPanel.test.tsx
@@ -8,7 +8,7 @@
 // §3-2b (#772), so they are no longer wired or mocked here.
 
 import { fireEvent, screen, within } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { renderWithProviders } from "@/test/render";
 
 // The panel owns one `useUnitAttention` instance (threaded to the four
@@ -24,6 +24,25 @@ vi.mock("@/hooks/useUnitAttention", () => ({
     settingKey: null,
   }),
 }));
+
+// The panel itself polls the PR / issue lists for the collapsed rail's
+// remote-Δ count (#822) — mocked so no real fetch fires; individual tests
+// override the implementation to feed rail data.
+const useUnitPrsMock = vi.fn();
+const useUnitIssuesMock = vi.fn();
+vi.mock("@/hooks/useUnitPrs", () => ({
+  useUnitPrs: (unit: string | null) => useUnitPrsMock(unit),
+}));
+vi.mock("@/hooks/useUnitIssues", () => ({
+  useUnitIssues: (unit: string | null) => useUnitIssuesMock(unit),
+}));
+
+beforeEach(() => {
+  useUnitPrsMock.mockReset();
+  useUnitIssuesMock.mockReset();
+  useUnitPrsMock.mockReturnValue({ data: null, loading: false, error: null });
+  useUnitIssuesMock.mockReturnValue({ data: null, loading: false, error: null });
+});
 
 vi.mock("../RPrsSection", () => ({
   RPrsSection: ({ expanded, onToggle }: { expanded: boolean; onToggle: () => void }) => (
@@ -212,5 +231,203 @@ describe("RPanel — accordion shell", () => {
     expect(screen.queryByText(/needs you/i)).toBeNull();
     expect(screen.queryByText(/sort by/i)).toBeNull();
     expect(screen.queryByText(/priority/i)).toBeNull();
+  });
+});
+
+// ── Remote-Δ freshness — close-act cursor (#822) ──
+//
+// Exactly TWO acts advance a cursor: the panel collapse (`panel`) and a
+// PRs/Issues section collapse (`prs`/`issues`). The cursor is CLIENT STATE
+// ONLY (ui-prefs blob) — never sent to any endpoint, never read by the
+// Producer; there is no per-row read-marking and no mute affordance.
+
+function readStoredCursors(): Record<string, Record<string, string>> {
+  const raw = localStorage.getItem("tmai:ui:prefs") ?? "{}";
+  return (
+    (JSON.parse(raw) as { remoteDeltaCursors?: Record<string, Record<string, string>> })
+      .remoteDeltaCursors ?? {}
+  );
+}
+
+function freshPrefs(extra: Record<string, unknown> = {}): void {
+  localStorage.setItem(
+    "tmai:ui:prefs",
+    JSON.stringify({ rPanelExpandedSections: [], remoteDeltaCursors: {}, ...extra }),
+  );
+}
+
+describe("RPanel — remote-Δ close-act cursor (#822)", () => {
+  it("the panel collapse button stamps the unit's `panel` cursor", () => {
+    freshPrefs();
+    const onToggle = vi.fn();
+    renderWithProviders(<RPanel {...makeProps({ onToggleCollapsed: onToggle })} />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Collapse R panel/ }));
+
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    const cursors = readStoredCursors();
+    expect(typeof cursors.u?.panel).toBe("string");
+    expect(Number.isNaN(Date.parse(cursors.u.panel))).toBe(false);
+  });
+
+  it("a close act never leaves the client — it fires no fetch", () => {
+    freshPrefs();
+    const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}"));
+    try {
+      renderWithProviders(<RPanel {...makeProps()} />);
+      // Unrelated sections fetch on mount (RInventorySection is not stubbed
+      // here) — snapshot the count, then prove the close act adds nothing.
+      const callsBeforeAct = fetchSpy.mock.calls.length;
+      fireEvent.click(screen.getByRole("button", { name: /Collapse R panel/ }));
+      // The cursor landed in localStorage only — no endpoint receives it
+      // (core stays states-facts; the Producer never reads it).
+      const stamped = readStoredCursors().u?.panel;
+      expect(stamped).toBeTruthy();
+      expect(fetchSpy.mock.calls.length).toBe(callsBeforeAct);
+      // And no request so far ever carried the cursor.
+      for (const call of fetchSpy.mock.calls) {
+        expect(JSON.stringify(call)).not.toContain(stamped);
+      }
+    } finally {
+      fetchSpy.mockRestore();
+    }
+  });
+
+  it("collapsing the PRs section stamps `prs`; re-expanding does NOT advance", () => {
+    freshPrefs({ rPanelExpandedSections: ["prs"] });
+    renderWithProviders(<RPanel {...makeProps()} />);
+
+    // Close act → stamp.
+    fireEvent.click(screen.getByTestId("prs-section"));
+    const stamped = readStoredCursors().u?.prs;
+    expect(typeof stamped).toBe("string");
+
+    // Re-expand = the start of looking, not the end — cursor unchanged.
+    fireEvent.click(screen.getByTestId("prs-section"));
+    expect(readStoredCursors().u?.prs).toBe(stamped);
+  });
+
+  it("collapsing the Issues section stamps `issues` (and only that key)", () => {
+    freshPrefs({ rPanelExpandedSections: ["issues"] });
+    renderWithProviders(<RPanel {...makeProps()} />);
+
+    fireEvent.click(screen.getByTestId("issues-section"));
+    const cursors = readStoredCursors();
+    expect(typeof cursors.u?.issues).toBe("string");
+    expect(cursors.u?.prs).toBeUndefined();
+    expect(cursors.u?.panel).toBeUndefined();
+  });
+
+  it("collapsing a non-PR/Issue section advances NO cursor", () => {
+    freshPrefs({ rPanelExpandedSections: ["decisions"] });
+    renderWithProviders(<RPanel {...makeProps()} />);
+
+    fireEvent.click(screen.getByTestId("decisions-section"));
+    expect(readStoredCursors()).toEqual({});
+  });
+
+  it("the collapsed rail's EXPAND button advances NO cursor (open ≠ close act)", () => {
+    freshPrefs();
+    const onToggle = vi.fn();
+    renderWithProviders(
+      <RPanel {...makeProps({ collapsed: true, onToggleCollapsed: onToggle })} />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /Expand R panel/ }));
+    expect(onToggle).toHaveBeenCalledTimes(1);
+    expect(readStoredCursors()).toEqual({});
+  });
+});
+
+describe("RPanel — collapsed-rail Δ count (#822)", () => {
+  // Minimal wire rows: the rail count only reads the vocab timestamps.
+  const railData = {
+    prs: {
+      data: {
+        unit: "u",
+        repos: [
+          {
+            repo_path: "/p/u",
+            repo_label: "u",
+            primary: true,
+            prs: [
+              {
+                created_at: "2026-06-13T01:00:00Z",
+                merged_at: null,
+                closed_at: null,
+                ci_completed_at: null,
+              },
+              {
+                created_at: "2026-06-10T00:00:00Z",
+                merged_at: null,
+                closed_at: null,
+                ci_completed_at: null,
+              },
+            ],
+          },
+        ],
+      },
+      loading: false,
+      error: null,
+    },
+    issues: {
+      data: {
+        unit: "u",
+        repos: [
+          {
+            repo_path: "/p/u",
+            repo_label: "u",
+            primary: true,
+            issues: [{ created_at: "2026-06-13T02:00:00Z", closed_at: null }],
+          },
+        ],
+      },
+      loading: false,
+      error: null,
+    },
+  };
+
+  it("shows the unit total of unobserved PR + issue rows on the rail", () => {
+    // Cursor at 2026-06-12: the 06-13 PR and the 06-13 issue are unobserved,
+    // the 06-10 PR is observed → Δ2.
+    freshPrefs({ remoteDeltaCursors: { u: { panel: "2026-06-12T00:00:00Z" } } });
+    useUnitPrsMock.mockReturnValue(railData.prs);
+    useUnitIssuesMock.mockReturnValue(railData.issues);
+
+    renderWithProviders(<RPanel {...makeProps({ collapsed: true })} />);
+
+    const badge = screen.getByTestId("r-rail-unobserved");
+    expect(badge.textContent).toBe("Δ2");
+    // Info-tone (cyan family) — a freshness fact, never the owed amber.
+    expect(badge.className).toContain("text-info");
+    expect(badge.className).not.toMatch(/warning/);
+    // The rail polls the unit itself while the sections are unmounted.
+    expect(useUnitPrsMock).toHaveBeenCalledWith("u");
+    expect(useUnitIssuesMock).toHaveBeenCalledWith("u");
+  });
+
+  it("first run (no cursor) — every row is unobserved on the rail", () => {
+    freshPrefs();
+    useUnitPrsMock.mockReturnValue(railData.prs);
+    useUnitIssuesMock.mockReturnValue(railData.issues);
+
+    renderWithProviders(<RPanel {...makeProps({ collapsed: true })} />);
+    expect(screen.getByTestId("r-rail-unobserved").textContent).toBe("Δ3");
+  });
+
+  it("renders no badge when everything has been observed", () => {
+    freshPrefs({ remoteDeltaCursors: { u: { panel: "2026-06-14T00:00:00Z" } } });
+    useUnitPrsMock.mockReturnValue(railData.prs);
+    useUnitIssuesMock.mockReturnValue(railData.issues);
+
+    renderWithProviders(<RPanel {...makeProps({ collapsed: true })} />);
+    expect(screen.queryByTestId("r-rail-unobserved")).toBeNull();
+  });
+
+  it("parks the rail polls (null unit) while the panel is expanded — no double-fetch", () => {
+    freshPrefs();
+    renderWithProviders(<RPanel {...makeProps({ collapsed: false })} />);
+    expect(useUnitPrsMock).toHaveBeenCalledWith(null);
+    expect(useUnitIssuesMock).toHaveBeenCalledWith(null);
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RPrsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RPrsSection.test.tsx
@@ -263,6 +263,147 @@ describe("RPrsSection — per-artifact attention markers", () => {
   });
 });
 
+// ── Remote-Δ freshness (#822) ──
+//
+// A row is UNOBSERVED when its vocab timestamp (max of created / merged /
+// closed / ci_completed) is strictly newer than the effective close-act
+// cursor threaded in as `deltaCursor`. The accent is info-tone (cyan
+// family) — a freshness FACT, never the warning/owed amber. No per-row
+// read-marking, no mute affordance — the only acts are the two collapses
+// (tested on RPanel).
+describe("RPrsSection — remote-Δ freshness accents", () => {
+  const CURSOR = "2026-06-12T00:00:00Z";
+
+  it("accents rows newer than the cursor; observed rows render unchanged", async () => {
+    unitPrsMock.mockResolvedValue(
+      response([
+        pr({ number: 101n, title: "new PR", created_at: "2026-06-13T00:00:00Z" }),
+        pr({ number: 100n, title: "old PR", created_at: "2026-06-11T00:00:00Z" }),
+      ]),
+    );
+    render(<RPrsSection unitName="u" expanded={true} onToggle={vi.fn()} deltaCursor={CURSOR} />);
+    await waitFor(() => expect(screen.getByText("new PR")).toBeTruthy());
+
+    const deltas = screen.getAllByTestId("unobserved-delta");
+    expect(deltas).toHaveLength(1);
+    // The Δ sits on the unobserved row…
+    expect(screen.getByText("new PR").closest("button")?.textContent).toContain("Δ");
+    // …and the observed row carries no counterpart element at all.
+    expect(screen.getByText("old PR").closest("button")?.textContent).not.toContain("Δ");
+    // Info-tone, never the warning amber (fact, not appraisal).
+    expect(deltas[0].className).toContain("text-info");
+    expect(deltas[0].className).not.toMatch(/warning/);
+  });
+
+  it("a state transition newer than the cursor accents the row (merged_at counts)", async () => {
+    unitPrsMock.mockResolvedValue(
+      response([
+        pr({
+          number: 100n,
+          title: "merged PR",
+          state: "MERGED",
+          created_at: "2026-06-01T00:00:00Z",
+          merged_at: "2026-06-13T00:00:00Z",
+          closed_at: "2026-06-13T00:00:00Z",
+        }),
+      ]),
+    );
+    render(<RPrsSection unitName="u" expanded={true} onToggle={vi.fn()} deltaCursor={CURSOR} />);
+    await waitFor(() => expect(screen.getByText("merged PR")).toBeTruthy());
+    expect(screen.getAllByTestId("unobserved-delta")).toHaveLength(1);
+  });
+
+  it("first run (deltaCursor null) — every row is unobserved (一度も見ていない)", async () => {
+    unitPrsMock.mockResolvedValue(
+      response([
+        pr({ number: 100n, created_at: "2020-01-01T00:00:00Z" }),
+        // Even a row without vocab timestamps is unobserved on first run.
+        pr({ number: 101n, title: "no-ts PR" }),
+      ]),
+    );
+    render(<RPrsSection unitName="u" expanded={true} onToggle={vi.fn()} deltaCursor={null} />);
+    await waitFor(() => expect(screen.getByText("PR title")).toBeTruthy());
+    expect(screen.getAllByTestId("unobserved-delta")).toHaveLength(2);
+  });
+
+  it("renders NO accents when deltaCursor is absent (isolation / no wiring)", async () => {
+    unitPrsMock.mockResolvedValue(response([pr({ created_at: "2026-06-13T00:00:00Z" })]));
+    render(<RPrsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("PR title")).toBeTruthy());
+    expect(screen.queryByTestId("unobserved-delta")).toBeNull();
+  });
+
+  it("collapsed header shows the unobserved COUNT; expanded header does not", async () => {
+    unitPrsMock.mockResolvedValue(
+      response([
+        pr({ number: 101n, created_at: "2026-06-13T00:00:00Z" }),
+        pr({ number: 102n, ci_completed_at: "2026-06-13T01:00:00Z" }),
+        pr({ number: 100n, created_at: "2026-06-11T00:00:00Z" }),
+      ]),
+    );
+    const { rerender } = render(
+      <RPrsSection unitName="u" expanded={false} onToggle={vi.fn()} deltaCursor={CURSOR} />,
+    );
+    await waitFor(() => expect(screen.getByText(/3 open/)).toBeTruthy());
+    const badge = screen.getByTestId("r-section-unobserved-prs");
+    expect(badge.textContent).toBe("Δ2");
+    expect(badge.className).toContain("text-info");
+
+    // Open section: the rows carry the accents, the header badge is gone.
+    rerender(<RPrsSection unitName="u" expanded={true} onToggle={vi.fn()} deltaCursor={CURSOR} />);
+    await waitFor(() => expect(screen.getAllByTestId("unobserved-delta")).toHaveLength(2));
+    expect(screen.queryByTestId("r-section-unobserved-prs")).toBeNull();
+  });
+
+  it("no badge when the section is collapsed but everything is observed", async () => {
+    unitPrsMock.mockResolvedValue(response([pr({ created_at: "2026-06-11T00:00:00Z" })]));
+    render(<RPrsSection unitName="u" expanded={false} onToggle={vi.fn()} deltaCursor={CURSOR} />);
+    await waitFor(() => expect(screen.getByText(/1 open/)).toBeTruthy());
+    expect(screen.queryByTestId("r-section-unobserved-prs")).toBeNull();
+  });
+});
+
+// Recently-transitioned rows (#822 scope 6): the unit list now includes
+// merged/closed rows from the 7-day window — the section must render their
+// lifecycle pills and keep the wire order (newest first by number) intact.
+describe("RPrsSection — recently-transitioned rows", () => {
+  it("renders a merged row's lifecycle pill and keeps wire order stable", async () => {
+    unitPrsMock.mockResolvedValue(
+      response([
+        pr({ number: 102n, title: "open PR" }),
+        pr({
+          number: 101n,
+          title: "merged PR",
+          state: "MERGED",
+          merged_at: "2026-06-12T00:00:00Z",
+          closed_at: "2026-06-12T00:00:00Z",
+          review_decision: null,
+          check_status: null,
+        }),
+        pr({
+          number: 100n,
+          title: "closed PR",
+          state: "CLOSED",
+          closed_at: "2026-06-11T00:00:00Z",
+          review_decision: null,
+          check_status: null,
+        }),
+      ]),
+    );
+    const { container } = render(<RPrsSection unitName="u" expanded={true} onToggle={vi.fn()} />);
+    await waitFor(() => expect(screen.getByText("merged PR")).toBeTruthy());
+
+    // Lifecycle pills for the non-open states.
+    expect(screen.getByText("merged")).toBeTruthy();
+    expect(screen.getByText("closed")).toBeTruthy();
+    // Wire order preserved — newest first by number, no client-side re-sort.
+    const rows = Array.from(container.querySelectorAll("li")).map((li) => li.textContent ?? "");
+    expect(rows[0]).toContain("#102");
+    expect(rows[1]).toContain("#101");
+    expect(rows[2]).toContain("#100");
+  });
+});
+
 // `Section` has no File variant by construction, so a File row can never carry
 // an attention marker (File is attention-exempt, contract §3). These are
 // COMPILE-TIME exact-union assertions, not runtime containment checks: a

--- a/clients/react/src/components/producer-console/r-panel/__tests__/remote-delta.test.ts
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/remote-delta.test.ts
@@ -1,0 +1,215 @@
+// remote-delta — pure helpers for the remote-Δ freshness instrument (#822;
+// design: tmai-core doc/slack/2026-06-12-161334.md §3).
+//
+// Pinned exclusions (operator-ratified): the cursor is CLIENT STATE ONLY —
+// it is never sent to any endpoint and the Producer never reads it; there
+// is no per-row read-marking and no mute affordance; the cross-unit tab
+// accent is deferred until a second unit exists. `advanceCursor` is the
+// single mutation door and only the two close acts (panel collapse /
+// section collapse) call it.
+
+import { describe, expect, it } from "vitest";
+import type { IssueSummaryWire, PrSummaryWire, RepoIssuesWire, RepoPrsWire } from "@/lib/api";
+import {
+  advanceCursor,
+  effectiveCursor,
+  issueVocabTimestamp,
+  isUnobserved,
+  prVocabTimestamp,
+  unobservedIssueCount,
+  unobservedPrCount,
+} from "../remote-delta";
+
+function pr(overrides: Partial<PrSummaryWire> = {}): PrSummaryWire {
+  return {
+    number: 100n,
+    title: "PR title",
+    state: "OPEN",
+    head_branch: "feat/x",
+    head_sha: "abc1234",
+    base_branch: "main",
+    url: "https://github.com/o/r/pull/100",
+    review_decision: null,
+    check_status: null,
+    is_draft: false,
+    additions: 10n,
+    deletions: 1n,
+    comments: 0n,
+    reviews: 0n,
+    author: "me",
+    merge_commit_sha: null,
+    created_at: null,
+    merged_at: null,
+    closed_at: null,
+    ci_completed_at: null,
+    ...overrides,
+  };
+}
+
+function issue(overrides: Partial<IssueSummaryWire> = {}): IssueSummaryWire {
+  return {
+    number: 1n,
+    title: "Issue 1",
+    state: "open",
+    url: "https://github.com/o/r/issues/1",
+    labels: [],
+    assignees: [],
+    created_at: null,
+    closed_at: null,
+    ...overrides,
+  };
+}
+
+describe("effectiveCursor — MAX(panel, section)", () => {
+  it("returns null when the unit has no cursor at all (first run)", () => {
+    expect(effectiveCursor({}, "u", "prs")).toBeNull();
+  });
+
+  it("returns the panel cursor when only the panel was closed", () => {
+    const cursors = { u: { panel: "2026-06-13T10:00:00Z" } };
+    expect(effectiveCursor(cursors, "u", "prs")).toBe("2026-06-13T10:00:00Z");
+    expect(effectiveCursor(cursors, "u", "issues")).toBe("2026-06-13T10:00:00Z");
+  });
+
+  it("returns the section cursor when it is newer than the panel cursor", () => {
+    const cursors = {
+      u: { panel: "2026-06-13T10:00:00Z", prs: "2026-06-13T12:00:00Z" },
+    };
+    expect(effectiveCursor(cursors, "u", "prs")).toBe("2026-06-13T12:00:00Z");
+    // The issues section has no own cursor → the panel close still covers it.
+    expect(effectiveCursor(cursors, "u", "issues")).toBe("2026-06-13T10:00:00Z");
+  });
+
+  it("returns the panel cursor when it is newer than the section cursor", () => {
+    const cursors = {
+      u: { panel: "2026-06-13T12:00:00Z", prs: "2026-06-13T10:00:00Z" },
+    };
+    expect(effectiveCursor(cursors, "u", "prs")).toBe("2026-06-13T12:00:00Z");
+  });
+
+  it("is per-unit — another unit's cursor never leaks", () => {
+    const cursors = { other: { panel: "2026-06-13T10:00:00Z" } };
+    expect(effectiveCursor(cursors, "u", "prs")).toBeNull();
+  });
+});
+
+describe("vocab timestamps — max of the row's non-null vocab events", () => {
+  it("PR vocab = max(created, merged, closed, ci_completed)", () => {
+    expect(
+      prVocabTimestamp(
+        pr({
+          created_at: "2026-06-10T00:00:00Z",
+          merged_at: "2026-06-12T00:00:00Z",
+          closed_at: "2026-06-12T00:00:01Z",
+          ci_completed_at: "2026-06-11T00:00:00Z",
+        }),
+      ),
+    ).toBe("2026-06-12T00:00:01Z");
+  });
+
+  it("ignores null fields and returns the remaining max", () => {
+    expect(prVocabTimestamp(pr({ created_at: "2026-06-10T00:00:00Z" }))).toBe(
+      "2026-06-10T00:00:00Z",
+    );
+  });
+
+  it("returns null when a row carries no vocab timestamps (older payload)", () => {
+    expect(prVocabTimestamp(pr())).toBeNull();
+    expect(issueVocabTimestamp(issue())).toBeNull();
+  });
+
+  it("issue vocab = max(created, closed)", () => {
+    expect(
+      issueVocabTimestamp(
+        issue({ created_at: "2026-06-10T00:00:00Z", closed_at: "2026-06-12T00:00:00Z" }),
+      ),
+    ).toBe("2026-06-12T00:00:00Z");
+  });
+});
+
+describe("isUnobserved", () => {
+  it("first run (no cursor) → every row is unobserved, even without vocab ts", () => {
+    // Honest 「一度も見ていない」 — self-clears on the first collapse act.
+    expect(isUnobserved("2026-06-13T00:00:00Z", null)).toBe(true);
+    expect(isUnobserved(null, null)).toBe(true);
+  });
+
+  it("vocab ts strictly newer than the cursor → unobserved", () => {
+    expect(isUnobserved("2026-06-13T00:00:01Z", "2026-06-13T00:00:00Z")).toBe(true);
+  });
+
+  it("vocab ts at or before the cursor → observed", () => {
+    expect(isUnobserved("2026-06-13T00:00:00Z", "2026-06-13T00:00:00Z")).toBe(false);
+    expect(isUnobserved("2026-06-12T00:00:00Z", "2026-06-13T00:00:00Z")).toBe(false);
+  });
+
+  it("a row without vocab timestamps can never claim to be newer than a cursor", () => {
+    expect(isUnobserved(null, "2026-06-13T00:00:00Z")).toBe(false);
+  });
+});
+
+describe("advanceCursor — the single mutation door for the two close acts", () => {
+  it("stamps the panel cursor for a unit, immutably", () => {
+    const before = {};
+    const after = advanceCursor(before, "u", "panel", "2026-06-13T10:00:00Z");
+    expect(after).toEqual({ u: { panel: "2026-06-13T10:00:00Z" } });
+    expect(before).toEqual({});
+  });
+
+  it("stamps a section cursor without disturbing the unit's other keys", () => {
+    const before = { u: { panel: "2026-06-13T10:00:00Z" } };
+    const after = advanceCursor(before, "u", "prs", "2026-06-13T11:00:00Z");
+    expect(after.u).toEqual({ panel: "2026-06-13T10:00:00Z", prs: "2026-06-13T11:00:00Z" });
+  });
+
+  it("keeps other units' cursors intact (counts and cursors are within-unit)", () => {
+    const before = { other: { issues: "2026-06-01T00:00:00Z" } };
+    const after = advanceCursor(before, "u", "issues", "2026-06-13T10:00:00Z");
+    expect(after.other).toEqual({ issues: "2026-06-01T00:00:00Z" });
+  });
+});
+
+describe("unobserved counts (within-unit only)", () => {
+  const cursor = "2026-06-13T00:00:00Z";
+
+  it("counts unobserved PR rows across repos", () => {
+    const repos: RepoPrsWire[] = [
+      {
+        repo_path: "/p/a",
+        repo_label: "a",
+        primary: true,
+        prs: [
+          pr({ number: 1n, created_at: "2026-06-13T01:00:00Z" }), // unobserved
+          pr({ number: 2n, created_at: "2026-06-12T00:00:00Z" }), // observed
+        ],
+      },
+      {
+        repo_path: "/p/b",
+        repo_label: "b",
+        primary: false,
+        prs: [pr({ number: 3n, merged_at: "2026-06-13T02:00:00Z" })], // unobserved
+      },
+    ];
+    expect(unobservedPrCount(repos, cursor)).toBe(2);
+    // First run: every row counts.
+    expect(unobservedPrCount(repos, null)).toBe(3);
+    expect(unobservedPrCount(null, cursor)).toBe(0);
+  });
+
+  it("counts unobserved issue rows across repos", () => {
+    const repos: RepoIssuesWire[] = [
+      {
+        repo_path: "/p/a",
+        repo_label: "a",
+        primary: true,
+        issues: [
+          issue({ number: 1n, created_at: "2026-06-13T01:00:00Z" }), // unobserved
+          issue({ number: 2n, created_at: "2026-06-12T00:00:00Z" }), // observed
+        ],
+      },
+    ];
+    expect(unobservedIssueCount(repos, cursor)).toBe(1);
+    expect(unobservedIssueCount(repos, null)).toBe(2);
+    expect(unobservedIssueCount(null, cursor)).toBe(0);
+  });
+});

--- a/clients/react/src/components/producer-console/r-panel/remote-delta.ts
+++ b/clients/react/src/components/producer-console/r-panel/remote-delta.ts
@@ -1,0 +1,105 @@
+// Remote-Δ freshness — pure helpers (#822; design: tmai-core
+// `doc/slack/2026-06-12-161334.md` §3, aim `aim-remote-delta-freshness`,
+// anchor 「リモートに変化があった場合、未観測の事実として表示する」).
+//
+// A row is UNOBSERVED when its newest vocab event timestamp is newer than
+// the operator's effective close-act cursor for that section. The vocab is
+// deliberately conservative (flood control, inherited from the old
+// fingerprint.rs judgement): PR created / merged / closed / CI conclusion;
+// issue created / closed. Label / assignee churn is NOT a vocab event.
+//
+// This is a freshness instrument, not a confirmation ledger — see the
+// `RemoteDeltaCursor` doc in ui-prefs.ts for the load-bearing exclusions
+// (client-state only, never sent to core, exactly two advance acts, no
+// read-marking / mute, no cross-unit accent until a second unit exists).
+
+import type { IssueSummaryWire, PrSummaryWire, RepoIssuesWire, RepoPrsWire } from "@/lib/api";
+import type { RemoteDeltaCursor } from "@/lib/ui-prefs";
+
+export type CursorSection = "prs" | "issues";
+export type CursorKey = "panel" | CursorSection;
+
+// Max of parseable ISO timestamps; unparseable / null entries are skipped
+// (a malformed wire timestamp must not poison the whole row's verdict).
+function maxIso(values: ReadonlyArray<string | null | undefined>): string | null {
+  let best: string | null = null;
+  let bestMs = Number.NEGATIVE_INFINITY;
+  for (const v of values) {
+    if (typeof v !== "string") continue;
+    const ms = Date.parse(v);
+    if (Number.isNaN(ms)) continue;
+    if (ms > bestMs) {
+      bestMs = ms;
+      best = v;
+    }
+  }
+  return best;
+}
+
+// The effective cursor for a section = MAX(unit panel cursor, section
+// cursor): closing the whole panel counts as having stopped looking at
+// every section in it. `null` = no close act recorded yet (first run).
+export function effectiveCursor(
+  cursors: Record<string, RemoteDeltaCursor>,
+  unit: string,
+  section: CursorSection,
+): string | null {
+  const c = cursors[unit];
+  if (c === undefined) return null;
+  return maxIso([c.panel, c[section]]);
+}
+
+// A row's vocab timestamp = max of its non-null vocab event timestamps.
+// `null` when the payload carries none (older wire) — such a row can never
+// claim to be newer than a cursor.
+export function prVocabTimestamp(pr: PrSummaryWire): string | null {
+  return maxIso([pr.created_at, pr.merged_at, pr.closed_at, pr.ci_completed_at]);
+}
+
+export function issueVocabTimestamp(issue: IssueSummaryWire): string | null {
+  return maxIso([issue.created_at, issue.closed_at]);
+}
+
+// UNOBSERVED = vocab_ts is strictly newer than the effective cursor.
+// No cursor yet (first run) → every row is unobserved — the honest
+// 「一度も見ていない」; it self-clears on the first collapse act.
+export function isUnobserved(vocabTs: string | null, cursor: string | null): boolean {
+  if (cursor === null) return true;
+  if (vocabTs === null) return false;
+  return Date.parse(vocabTs) > Date.parse(cursor);
+}
+
+// Immutable cursor advance for one of the EXACTLY TWO act kinds: the R
+// panel collapse (`panel`) and a section collapse (`prs` / `issues`).
+// Nothing else may call this — no visibilitychange, no scroll, no per-row
+// marking, no timers (operator-ratified exclusion list).
+export function advanceCursor(
+  cursors: Record<string, RemoteDeltaCursor>,
+  unit: string,
+  key: CursorKey,
+  nowIso: string,
+): Record<string, RemoteDeltaCursor> {
+  return { ...cursors, [unit]: { ...cursors[unit], [key]: nowIso } };
+}
+
+// Within-unit unobserved counts (collapsed section header / collapsed rail).
+// Counts stay within-unit only — the cross-unit tab accent is deferred
+// until a second unit exists, and even then carries presence, not a count.
+export function unobservedPrCount(repos: RepoPrsWire[] | null, cursor: string | null): number {
+  if (repos === null) return 0;
+  return repos.reduce(
+    (n, r) => n + r.prs.filter((pr) => isUnobserved(prVocabTimestamp(pr), cursor)).length,
+    0,
+  );
+}
+
+export function unobservedIssueCount(
+  repos: RepoIssuesWire[] | null,
+  cursor: string | null,
+): number {
+  if (repos === null) return 0;
+  return repos.reduce(
+    (n, r) => n + r.issues.filter((i) => isUnobserved(issueVocabTimestamp(i), cursor)).length,
+    0,
+  );
+}

--- a/clients/react/src/lib/__tests__/ui-prefs.test.ts
+++ b/clients/react/src/lib/__tests__/ui-prefs.test.ts
@@ -120,6 +120,42 @@ describe("ui-prefs", () => {
     expect(loaded.attentionStripWidth).toBe(440);
   });
 
+  it("defaults remoteDeltaCursors to {} and round-trips a cursor blob (#822)", () => {
+    expect(loadUIPrefs().remoteDeltaCursors).toEqual({});
+    const cursors = {
+      tmai: { panel: "2026-06-13T10:00:00Z", prs: "2026-06-13T11:00:00Z" },
+    };
+    saveUIPrefs({ ...DEFAULT_UI_PREFS, remoteDeltaCursors: cursors });
+    expect(loadUIPrefs().remoteDeltaCursors).toEqual(cursors);
+  });
+
+  it("drops non-ISO cursor fields and all-invalid unit entries on load (#822)", () => {
+    localStorage.setItem(
+      UI_PREFS_STORAGE_KEY,
+      JSON.stringify({
+        ...DEFAULT_UI_PREFS,
+        remoteDeltaCursors: {
+          tmai: { panel: "2026-06-13T10:00:00Z", prs: "not a timestamp", issues: 42 },
+          // An all-invalid entry is dropped entirely — "no cursor" (first
+          // run, every row unobserved) is the honest recovery.
+          broken: { panel: "garbage" },
+          alsoBroken: "not an object",
+        },
+      }),
+    );
+    expect(loadUIPrefs().remoteDeltaCursors).toEqual({
+      tmai: { panel: "2026-06-13T10:00:00Z" },
+    });
+  });
+
+  it("resets remoteDeltaCursors to {} when the field is not an object (#822)", () => {
+    localStorage.setItem(
+      UI_PREFS_STORAGE_KEY,
+      JSON.stringify({ ...DEFAULT_UI_PREFS, remoteDeltaCursors: ["x"] }),
+    );
+    expect(loadUIPrefs().remoteDeltaCursors).toEqual({});
+  });
+
   it("recovers gracefully when the blob is malformed JSON", () => {
     localStorage.setItem(UI_PREFS_STORAGE_KEY, "{not json");
     expect(loadUIPrefs()).toEqual(DEFAULT_UI_PREFS);

--- a/clients/react/src/lib/ui-prefs.ts
+++ b/clients/react/src/lib/ui-prefs.ts
@@ -33,6 +33,31 @@ export interface AimConsoleLayout {
   footer: number;
 }
 
+// Remote-Δ freshness cursors (#822; design: tmai-core
+// `doc/slack/2026-06-12-161334.md` §3, aim `aim-remote-delta-freshness`).
+// Per unit, the ISO timestamps of the operator's last CLOSE acts: `panel` =
+// the R panel collapse, `prs`/`issues` = that section's collapse. The
+// effective cursor for a section is the MAX of `panel` and the section's own
+// timestamp (see r-panel/remote-delta.ts).
+//
+// CLIENT STATE ONLY — load-bearing exclusions (operator-ratified):
+//   - never sent to any endpoint; the Producer never reads it (core stays
+//     states-facts: it serves event timestamps, it never learns what the
+//     operator looked at);
+//   - a freshness instrument, NOT a confirmation ledger — the cursor records
+//     "when the operator last stopped looking" (見ていた), it never claims
+//     anything was 確認済み;
+//   - exactly two advance acts (panel collapse / section collapse) — no
+//     visibilitychange, no scroll, no per-row read-marking, no timers, no
+//     mute affordance.
+// Multi-client divergence is semantically correct: each screen's cursor
+// means "what THIS screen last saw".
+export interface RemoteDeltaCursor {
+  panel?: string;
+  prs?: string;
+  issues?: string;
+}
+
 export interface UIPrefs {
   // WebUI colour theme. Presentation-only; lives here (not in tmai-core
   // config / api-spec) by the same convention as every other field.
@@ -60,6 +85,11 @@ export interface UIPrefs {
   // Drag-resized aim-console layout (S7); `null` until the operator drags a
   // gutter. WebUI-only by the same convention as every other field here.
   aimConsoleLayout: AimConsoleLayout | null;
+  // Remote-Δ freshness cursors keyed by unit name (#822). Empty until the
+  // first close act — an absent cursor renders EVERY row unobserved (the
+  // honest "一度も見ていない"; self-clears on the first collapse). See
+  // RemoteDeltaCursor for the load-bearing exclusions.
+  remoteDeltaCursors: Record<string, RemoteDeltaCursor>;
 }
 
 // Attention-strip width bounds (px). Floor keeps the section content
@@ -95,6 +125,7 @@ export const DEFAULT_UI_PREFS: UIPrefs = {
   rPanelExpandedSections: [],
   aimMode: "frontier",
   aimConsoleLayout: null,
+  remoteDeltaCursors: {},
 };
 
 export const UI_PREFS_STORAGE_KEY = "tmai:ui:prefs";
@@ -181,6 +212,35 @@ function coerceAimConsoleLayout(value: unknown): AimConsoleLayout | null {
   });
 }
 
+// A cursor value must be a parseable ISO timestamp; anything else is
+// dropped (an unparseable cursor would silently mis-classify every row).
+function coerceCursorField(value: unknown): string | undefined {
+  if (typeof value !== "string" || Number.isNaN(Date.parse(value))) return undefined;
+  return value;
+}
+
+function coerceRemoteDeltaCursors(value: unknown): Record<string, RemoteDeltaCursor> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) return {};
+  const out: Record<string, RemoteDeltaCursor> = {};
+  for (const [unit, raw] of Object.entries(value as Record<string, unknown>)) {
+    if (raw === null || typeof raw !== "object") continue;
+    const r = raw as Record<string, unknown>;
+    const cursor: RemoteDeltaCursor = {};
+    const panel = coerceCursorField(r.panel);
+    const prs = coerceCursorField(r.prs);
+    const issues = coerceCursorField(r.issues);
+    if (panel !== undefined) cursor.panel = panel;
+    if (prs !== undefined) cursor.prs = prs;
+    if (issues !== undefined) cursor.issues = issues;
+    // An all-invalid entry is dropped entirely: "no cursor" (= first-run,
+    // every row unobserved) is the honest recovery for a corrupt one.
+    if (panel !== undefined || prs !== undefined || issues !== undefined) {
+      out[unit] = cursor;
+    }
+  }
+  return out;
+}
+
 // Validate each field individually so a partially corrupt blob still
 // recovers the good fields and only resets the bad ones to default.
 function coercePrefs(raw: unknown): UIPrefs {
@@ -204,6 +264,7 @@ function coercePrefs(raw: unknown): UIPrefs {
       ? (r.aimMode as AimMode)
       : DEFAULT_UI_PREFS.aimMode,
     aimConsoleLayout: coerceAimConsoleLayout(r.aimConsoleLayout),
+    remoteDeltaCursors: coerceRemoteDeltaCursors(r.remoteDeltaCursors),
   };
 }
 


### PR DESCRIPTION
Resolves #822. UI half of the remote-Δ freshness design (aim: tmai-core `doc/aims/aim-remote-delta-freshness.md`; design source: tmai-core `doc/slack/2026-06-12-161334.md` §3, operator-ratified). The core half landed in tmai-core #525; generated types with the vocab timestamps are on main since #821.

**Framing (load-bearing):** this is a freshness instrument, not a confirmation ledger. The cursor records "when the operator last stopped looking" (見ていた) via existing zero-cost close acts; it never claims anything was 確認済み.

## What's in

- **Cursor store** — new ui-prefs key `remoteDeltaCursors: Record<unitName, { panel?, prs?, issues? }>` (ISO timestamps), with `coercePrefs` validation like the existing keys (non-ISO fields dropped; an all-invalid entry resets to "no cursor" = the honest first-run state). Effective cursor for a section = MAX(unit `panel` cursor, section cursor).
- **Advance acts — exactly these two:**
  - R panel collapse button → stamps the unit's `panel` cursor;
  - PRs / Issues section collapse → stamps that section's cursor.
  Nothing else advances a cursor: no visibilitychange, no scroll, no per-row marking, no timers. Expanding (panel or section) advances nothing.
- **Pure helpers** (`r-panel/remote-delta.ts`) — per-row vocab timestamp (PR: created / merged / closed / ci_completed; issue: created / closed; label/assignee churn is NOT vocab), unobserved predicate (`vocab_ts > effective cursor`; no cursor → every row unobserved, self-clears on first collapse), within-unit counts.
- **Open section rendering** — unobserved rows get a small leading Δ glyph in the **info (cyan-family) tone**, never the warning/owed amber (fact, not appraisal). Observed rows render unchanged.
- **Collapsed rendering** — a collapsed section header shows that section's unobserved count (`Δ N`); the collapsed R-panel rail shows the unit total (the panel polls the PR/issue lists itself while the sections are unmounted; the polls are parked while expanded so nothing double-fetches).
- **Recently-transitioned rows** — merged/closed rows from the 7-day window render via the existing lifecycle pills; a test pins the merged/closed pill rendering and that wire order (newest first by number) is preserved with no client-side re-sort.
- **Exclusions pinned in comments + tests** — the cursor is client state only (never sent to any endpoint; the Producer never reads it — a test snapshots fetch calls across a close act); no per-row read-marking, no mute affordance; no cross-unit tab accent (deferred until a second unit exists).

## Tests

Cursor advance on each act + non-acts (expand, non-PR/Issue sections), effective-cursor max logic, unobserved predicate incl. first run, section/rail count badges, merged-row render + stable sort, prefs coercion round-trip. 964 passed / 2 skipped.

## Gate (all under `clients/react/`)

- `pnpm lint` ✅ (1 pre-existing warning in `ProducerFeedChip.tsx`, untouched by this PR)
- `pnpm build` (includes `tsc -b`) ✅
- `pnpm test` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * PR・Issue セクションに未観測の変更を示す Δ バッジを追加しました。セクションが折りたたまれているときに、最後に確認後の変更件数がヘッダーに表示されます。新規作成、マージ、クローズなどの更新が自動的に追跡されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->