### PR TITLE
feat(aim): structured aim-body render in the inspector

### DIFF
--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -1095,12 +1095,13 @@ function Inspector({
         onNavigate={onSelectAncestor}
       />
 
-      <div className="ac-iis">
-        <div className="ac-isec">interior — is</div>
-        {node.is.length === 0 ? (
-          <div className="ac-il dim">— 純粋な ought —</div>
-        ) : (
-          node.is.map((m) => (
+      {/* Legacy interior marks — shown only for nodes that still carry them;
+          the structured body's `is/前提` section supersedes the empty "pure
+          ought" state for new-form nodes (marks machinery untouched). */}
+      {node.is.length > 0 && (
+        <div className="ac-iis">
+          <div className="ac-isec">interior — is</div>
+          {node.is.map((m) => (
             <div
               className="ac-il"
               key={`${m.kind}:${m.text}:${m.ref ?? ""}`}
@@ -1128,9 +1129,9 @@ function Inspector({
                 )}
               </span>
             </div>
-          ))
-        )}
-      </div>
+          ))}
+        </div>
+      )}
 
       {/* Resignation inventory (#811) — done is reversible attention-parking,
           so on an already-done node the parked objects stay visible, quietly.

--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -1090,6 +1090,7 @@ function Inspector({
 
       <AimBody
         body={node.body}
+        variant="console"
         resolves={(slug) => bySlug.has(slug)}
         onNavigate={onSelectAncestor}
       />

--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -45,6 +45,7 @@ import {
   useRef,
   useState,
 } from "react";
+import { AimBody } from "@/components/producer-console/r-panel/AimBody";
 import {
   AIM_STATE_LABEL,
   type AimTone,
@@ -1086,6 +1087,12 @@ function Inspector({
           </span>
         )}
       </div>
+
+      <AimBody
+        body={node.body}
+        resolves={(slug) => bySlug.has(slug)}
+        onNavigate={onSelectAncestor}
+      />
 
       <div className="ac-iis">
         <div className="ac-isec">interior — is</div>

--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -95,8 +95,8 @@ const TONE_ROW_CLASS: Record<AimTone, string> = {
   done: "done",
   dead: "dead",
   drift: "dr",
-  claimed: "cl",
-  confirmed: "cf",
+  todo: "cl",
+  progress: "cf",
   root: "rt",
   neutral: "ne",
 };
@@ -432,8 +432,8 @@ function depthOf(slug: string, bySlug: ReadonlyMap<string, AimWire>): number {
 // ── ledger strip ──────────────────────────────────────────────────────
 
 function Ledger({ counts, onOwedClick }: { counts: LedgerCounts; onOwedClick: () => void }) {
-  const owed = counts.drift + counts.claimed;
-  const total = owed + counts.confirmed || 1;
+  const owed = counts.drift + counts.todo;
+  const total = owed + counts.done || 1;
   return (
     <div className="ac-ledger" data-testid="aim-ledger">
       <button type="button" className="ac-lg dr" onClick={onOwedClick}>
@@ -442,15 +442,15 @@ function Ledger({ counts, onOwedClick }: { counts: LedgerCounts; onOwedClick: ()
       </button>
       <button type="button" className="ac-lg cl" onClick={onOwedClick}>
         <span className="sw" aria-hidden="true" />
-        <b>{counts.claimed}</b> claimed
+        <b>{counts.todo}</b> todo
       </button>
       <span className="ac-lg cf">
         <span className="sw" aria-hidden="true" />
-        <b>{counts.confirmed}</b> confirmed
+        <b>{counts.done}</b> done
       </span>
       <span className="ac-lbar" aria-hidden="true">
         <span className="o" style={{ width: `${(100 * owed) / total}%` }} />
-        <span className="c" style={{ width: `${(100 * counts.confirmed) / total}%` }} />
+        <span className="c" style={{ width: `${(100 * counts.done) / total}%` }} />
       </span>
     </div>
   );
@@ -494,10 +494,10 @@ function FrontierList({
     <>
       {sections.map(({ repo, bySlug, owed, doneDrift }) => {
         const driftN = owed.filter((n) => aimTone(n) === "drift").length;
-        const claimedN = owed.length - driftN;
+        const todoN = owed.length - driftN;
         return (
           <div key={repo.repo_root}>
-            <RepoBanner repo={repo} drift={driftN} claimed={claimedN} />
+            <RepoBanner repo={repo} drift={driftN} todo={todoN} />
             {owed.map((n) => (
               <AimRow
                 key={n.slug}
@@ -534,21 +534,13 @@ function FrontierList({
 
 // A non-collapsible repo banner used in Frontier sections (the repo is context,
 // not a toggle, here). Primary repo gets the cyan accent.
-function RepoBanner({
-  repo,
-  drift,
-  claimed,
-}: {
-  repo: RepoAimsWire;
-  drift: number;
-  claimed: number;
-}) {
+function RepoBanner({ repo, drift, todo }: { repo: RepoAimsWire; drift: number; todo: number }) {
   return (
     <div className={cn("ac-repohead", "frontier", repo.primary && "pri")}>
       <span className="ac-rh-name">{repo.repo_label}</span>
       <span className="ac-rh-stat">
         {drift > 0 && <span className="w">⚠{drift} </span>}
-        {claimed > 0 && <span className="k">◌{claimed}</span>}
+        {todo > 0 && <span className="k">◌{todo}</span>}
       </span>
     </div>
   );
@@ -674,7 +666,7 @@ function RepoHead({
         <span className="ac-rh-stat">
           {stats.count}
           {stats.drift > 0 && <span className="w"> ⚠{stats.drift}</span>}
-          {stats.claimed > 0 && <span className="k"> ◌{stats.claimed}</span>}
+          {stats.todo > 0 && <span className="k"> ◌{stats.todo}</span>}
         </span>
       </button>
       <button
@@ -826,7 +818,7 @@ function AimRow({
           <span className="ac-roll" data-testid="aim-rollup">
             {rollup.count}
             {rollup.drift > 0 && <span className="w"> ⚠{rollup.drift}</span>}
-            {rollup.claimed > 0 && <span className="k"> ◌{rollup.claimed}</span>}
+            {rollup.todo > 0 && <span className="k"> ◌{rollup.todo}</span>}
           </span>
         )}
         <InteriorDots marks={node.is} />
@@ -885,7 +877,7 @@ function ToneGlyph({ tone }: { tone: AimTone }) {
           ⚠
         </span>
       );
-    case "claimed":
+    case "todo":
       return (
         <span className="ac-gly cl" aria-hidden="true">
           ◌
@@ -979,7 +971,7 @@ function OverviewRuler({
             data-slug={t.slug}
             data-owed={t.owed}
             onClick={() => onReveal(t.slug)}
-            title={`${t.owed === "drift" ? "⚠ drift" : "◌ claimed"} · ${t.repoLabel} · ${t.slug}`}
+            title={`${t.owed === "drift" ? "⚠ drift" : "◌ todo"} · ${t.repoLabel} · ${t.slug}`}
             aria-label={`Reveal ${t.slug} (${t.owed})`}
             className={cn("ac-tick", t.owed === "drift" ? "dr" : "cl")}
             style={{ top }}

--- a/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
@@ -67,6 +67,15 @@ const wd = (overrides: Partial<AimWorkingDeltaWire> = {}): AimWorkingDeltaWire =
   untracked: false,
   ...overrides,
 });
+// A body with a `# PROCESS` section carrying todo/done units — the owed-signal
+// source (the panel reads progress, not the legacy `is[]` marks).
+const procBody = ({ todo = 0, done = 0 }: { todo?: number; done?: number } = {}): string => {
+  const items = [
+    ...Array.from({ length: todo }, (_, i) => `- [todo] todo ${i}`),
+    ...Array.from({ length: done }, (_, i) => `- [done] done ${i}`),
+  ];
+  return items.length === 0 ? "" : `# PROCESS\n${items.join("\n")}`;
+};
 
 function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
   return {
@@ -96,7 +105,12 @@ function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
 //   tmai
 //     inverted-ui (root, open, claimed)                           → owed (claimed)
 const CORE: AimWire[] = [
-  aimStub({ slug: "amplify-human-judgment", aim: "amplify judgment", is: [claimed("進行中")] }),
+  aimStub({
+    slug: "amplify-human-judgment",
+    aim: "amplify judgment",
+    is: [claimed("進行中")],
+    body: procBody({ todo: 1 }),
+  }),
   aimStub({
     slug: "attention-per-artifact",
     aim: "per-artifact attention",
@@ -107,6 +121,7 @@ const CORE: AimWire[] = [
       claimed("ancestor moved — re-confirm"),
       pruned("CLI-flag route", "wrong premise — judgment lives in records"),
     ],
+    body: procBody({ todo: 1, done: 1 }),
   }),
   aimStub({
     slug: "attention-backend",
@@ -114,11 +129,13 @@ const CORE: AimWire[] = [
     parent: "attention-per-artifact",
     state: "done",
     is: [confirmed("wired", "PR#500")],
+    body: procBody({ done: 1 }),
   }),
   aimStub({
     slug: "aim-system",
     aim: "records as structure",
     is: [confirmed("graduated", "PR#501")],
+    body: procBody({ done: 1 }),
   }),
   aimStub({ slug: "aim-honesty", aim: "confirmed ⊥ claimed", parent: "aim-system", state: "dead" }),
   aimStub({
@@ -130,7 +147,12 @@ const CORE: AimWire[] = [
   }),
 ];
 const UI: AimWire[] = [
-  aimStub({ slug: "inverted-ui", aim: "root to conversation", is: [claimed("frontier")] }),
+  aimStub({
+    slug: "inverted-ui",
+    aim: "root to conversation",
+    is: [claimed("frontier")],
+    body: procBody({ todo: 1 }),
+  }),
 ];
 
 function responseStub(
@@ -234,12 +256,11 @@ describe("AimPane — load + ledger", () => {
     renderPane();
     const ledger = await screen.findByTestId("aim-ledger");
     // drift=2 (attention-per-artifact open + review-attention-budget done; dead
-    // excluded), claimed marks=3, confirmed marks=3. The pruned mark on
-    // attention-per-artifact lands in NO bucket (#814) — counts unchanged.
+    // excluded), todo units=3 (amplify + attention-per-artifact + inverted-ui),
+    // done units=3 (attention-per-artifact + attention-backend + aim-system).
     await waitFor(() => expect(ledger.textContent).toMatch(/2\s*drift/));
-    expect(ledger.textContent).toMatch(/3\s*claimed/);
-    expect(ledger.textContent).toMatch(/3\s*confirmed/);
-    expect(ledger.textContent).not.toContain("pruned");
+    expect(ledger.textContent).toMatch(/3\s*todo/);
+    expect(ledger.textContent).toMatch(/3\s*done/);
   });
 });
 
@@ -248,11 +269,11 @@ describe("AimPane — Frontier mode (owed worklist)", () => {
     aimsMock.mockResolvedValue(responseStub());
     renderPane();
     await waitFor(() => expect(rowEl("attention-per-artifact").dataset.tone).toBe("drift"));
-    expect(rowEl("amplify-human-judgment").dataset.tone).toBe("claimed");
-    // A calm (confirmed-only) node is NOT in the worklist.
+    expect(rowEl("amplify-human-judgment").dataset.tone).toBe("todo");
+    // A calm (done-only) node is NOT in the worklist.
     expect(document.querySelector('[data-testid="aim-row"][data-slug="aim-system"]')).toBeNull();
     // Owed in the non-primary repo too.
-    expect(rowEl("inverted-ui").dataset.tone).toBe("claimed");
+    expect(rowEl("inverted-ui").dataset.tone).toBe("todo");
 
     // Pin #2: done+drift surfaced distinctly, with its badge, in its own cluster.
     const r = rowEl("review-attention-budget");
@@ -607,14 +628,14 @@ describe("AimPane — unit change", () => {
               {
                 label: "repo-a",
                 primary: true,
-                aims: [aimStub({ slug: "a-root", aim: "A root", is: [claimed("x")] })],
+                aims: [aimStub({ slug: "a-root", aim: "A root", body: procBody({ todo: 1 }) })],
               },
             ])
           : responseStub([
               {
                 label: "repo-b",
                 primary: true,
-                aims: [aimStub({ slug: "b-root", aim: "B root", is: [claimed("y")] })],
+                aims: [aimStub({ slug: "b-root", aim: "B root", body: procBody({ todo: 1 }) })],
               },
             ]),
       ),
@@ -918,8 +939,8 @@ describe("AimPane — working_delta presence facts (#817)", () => {
     // adds nothing to any bucket.
     const ledger = screen.getByTestId("aim-ledger");
     expect(ledger.textContent).toMatch(/1\s*drift/);
-    expect(ledger.textContent).toMatch(/0\s*claimed/);
-    expect(ledger.textContent).toMatch(/0\s*confirmed/);
+    expect(ledger.textContent).toMatch(/0\s*todo/);
+    expect(ledger.textContent).toMatch(/0\s*done/);
   });
 });
 

--- a/clients/react/src/components/producer-console/r-panel/AimBody.tsx
+++ b/clients/react/src/components/producer-console/r-panel/AimBody.tsx
@@ -299,7 +299,7 @@ function ProgressBadge({
   if (variant === "console") {
     return (
       <span className="ac-prog" data-testid="aim-means-progress">
-        実装 {done} / 未実装 {todo}
+        done {done} / todo {todo}
         <span className="ac-prog-bar" aria-hidden="true">
           <span className="done" style={{ width: `${donePct}%` }} />
         </span>
@@ -311,7 +311,7 @@ function ProgressBadge({
       data-testid="aim-means-progress"
       className="flex items-center gap-1.5 font-mono text-[9px] normal-case text-muted-foreground"
     >
-      実装 {done} / 未実装 {todo}
+      done {done} / todo {todo}
       <span className="flex h-1 w-10 overflow-hidden rounded-full border border-hairline">
         <span className="bg-success" style={{ width: `${donePct}%` }} />
         <span className="bg-warning/70" style={{ width: `${100 - donePct}%` }} />
@@ -320,17 +320,17 @@ function ProgressBadge({
   );
 }
 
-// A not-yet-converted means body: surface whichever of 実装済/未実装 the prose
-// mentions as a section-level chip. Best-effort — the chips are facts the
-// author wrote, never a re-judgement.
+// A not-yet-converted means body: surface whichever status the prose mentions
+// (done / todo, JP 実装済 / 未実装 too) as a section-level chip. Best-effort —
+// the chips are facts the author wrote, never a re-judgement.
 function FallbackStatusChips({ content, variant }: { content: string; variant: AimBodyVariant }) {
-  const statuses: ("実装済" | "未実装")[] = [];
-  if (content.includes("実装済")) statuses.push("実装済");
-  if (content.includes("未実装")) statuses.push("未実装");
+  const statuses: ("done" | "todo")[] = [];
+  if (/実装済|done/i.test(content)) statuses.push("done");
+  if (/未実装|todo/i.test(content)) statuses.push("todo");
   return (
     <>
       {statuses.map((s) => {
-        const done = s === "実装済";
+        const done = s === "done";
         const glyph = done ? "✓" : "◌";
         if (variant === "console") {
           return <span key={s} className={`ac-tg ${done ? "c" : "k"}`}>{`${glyph} ${s}`}</span>;

--- a/clients/react/src/components/producer-console/r-panel/AimBody.tsx
+++ b/clients/react/src/components/producer-console/r-panel/AimBody.tsx
@@ -1,105 +1,282 @@
 // ◎ Aim body — the agent-authored interior (`AimWire.body`) rendered as
-// markdown. Shared by BOTH aim surfaces (the R-panel `RAimsSection` inspector +
-// the aim-console `AimPane` inspector), the same way both already share
-// `aim-tree.ts`.
+// STRUCTURED sections in each inspector's own design idiom. Shared by both aim
+// surfaces (R-panel `RAimsSection` + aim-console `AimPane`), the same way both
+// share `aim-tree.ts`.
 //
-// WHY this exists: the rebuilt aim form expresses a node's structured-knowing as
-// PROSE (headings / lists / `[[slug]]` cross-edges to other aim nodes), NOT as
-// the old `[claimed]` / `[confirmed]` interior marks. The inspector's mark-list
-// (`is[]`) is parsed only from those marks, so a new-form node parses to an
-// EMPTY `is[]` and its whole body was invisible — the inspector showed only the
-// one-line `aim:` ought and "— a pure ought —", even when the file carries a
-// rich body. The body text is already on the wire (`AimWire.body`); this just
-// surfaces it.
+// WHY this exists: the rebuilt aim form expresses structured-knowing as
+// `#`-headed markdown — 障害 (escalation) / 手段 (means, with 実装済/未実装) /
+// history (却下手段) / DAG (`[[slug]]` cross-edges) — NOT the old `[claimed]` /
+// `[confirmed]` interior marks. So a new-form node parses to an empty `is[]`
+// and its whole body was invisible. A first cut rendered the raw body via
+// generic `prose`, which read as foreign next to the rest of the inspector;
+// this renders the body's SECTIONS as typed blocks that speak each surface's
+// tokens (`.ac-*` in the console, the app's prose / mark idioms in the R-panel).
 //
-// Render path REUSES the established stack (`react-markdown` + `remark-gfm` +
-// the shared `PROSE_CLASSES`) that `RRecordViewer` / `RPrViewer` use, so the
-// aim body reads like every other markdown surface in the WebUI. `[[slug]]`
-// wiki-links are rewritten to in-tree navigation: a slug that resolves to a
-// loaded aim node becomes a clickable cross-ref (selects that node); an
-// unresolved slug stays PLAIN text — a not-yet-authored node is not an error.
-//
-// Deliberately NOT a bespoke structured-knowing parser (障害 / 手段 / history
-// sections as typed blocks). This is the "暫定 raw" surface: show the whole
-// body now so the dogfood loop can decide what structured rendering, if any, is
-// actually worth building.
+// Parsing is client-side + section-level (`./aim-body-parse`) on purpose: the
+// form is still settling (a running dogfood trial), so its grammar is not
+// frozen into the wire yet. `[[slug]]` cross-edges become in-tree navigation
+// (resolved → clickable; unresolved → plain). When the body carries any
+// recognised section, the canonical 障害/手段/DAG/history scaffold is shown in
+// reading order with empty slots surfaced subtly; a non-conforming (pure-prose)
+// body is rendered verbatim without the scaffold.
 
 import { useMemo } from "react";
 import Markdown, { type Components, defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import {
+  type AimBodySection,
+  type AimBodySectionKind,
+  hasStructure,
+  parseAimBody,
+} from "./aim-body-parse";
 import { PROSE_CLASSES } from "./r-viewer/prose";
 
-// `[[slug]]` — the body's DAG cross-edge syntax. Same shape the record viewer's
-// excerpt uses; here the target is an aim node, not a decision/approach record.
+export type AimBodyVariant = "rpanel" | "console";
+
+// Canonical reading order: 障害 (the 律速 escalation) first … history (settled,
+// append-only) last. Means + DAG sit between.
+const CANONICAL: readonly AimBodySectionKind[] = ["obstacle", "means", "dag", "history"];
+
+const SECTION_LABEL: Record<AimBodySectionKind, string> = {
+  obstacle: "障害 — escalation",
+  means: "手段 — means",
+  dag: "DAG — cross-edges",
+  history: "history — 却下手段",
+  prose: "",
+};
+
+// The body's DAG cross-edge syntax. Same shape the record viewer's excerpt
+// uses; here the target is an aim node, not a decision/approach record.
 const WIKILINK = /\[\[([^[\]]+)\]\]/g;
 
-export function AimBody({
-  body,
-  resolves,
-  onNavigate,
-}: {
+// A stable render key for a parsed section — content-derived, not the array
+// index (sections have no id; this keeps React identity stable across re-parses
+// without an index key).
+const sectionKey = (s: AimBodySection): string =>
+  `${s.kind}:${s.heading}:${s.content.slice(0, 32)}`;
+
+interface AimBodyProps {
   body: string;
-  /** Does this slug name a loaded aim node (in the selection's repo)? Drives
-   *  whether a `[[slug]]` renders as a clickable cross-ref or plain text. */
+  /** Which surface's tokens to speak. */
+  variant: AimBodyVariant;
+  /** Does this slug name a loaded aim node (in the selection's repo)? */
   resolves: (slug: string) => boolean;
   /** Navigate the panel's selection to a resolved aim node. */
   onNavigate: (slug: string) => void;
-}) {
-  const trimmed = body.trim();
+}
 
-  // Rewrite `[[slug]]` → a markdown link with a synthetic `aim:` scheme, then
-  // intercept that scheme in the `a` override (mirrors `RRecordViewer`'s
-  // `record:` scheme). Done before render so react-markdown parses it as a link.
-  const withLinks = useMemo(
-    () => trimmed.replace(WIKILINK, (_m, slug: string) => `[${slug}](aim:${slug})`),
-    [trimmed],
+export function AimBody({ body, variant, resolves, onNavigate }: AimBodyProps) {
+  const sections = useMemo(() => parseAimBody(body), [body]);
+
+  // An empty body renders nothing (a pure-ought node stays clean).
+  if (sections.length === 0) return null;
+
+  const structured = hasStructure(sections);
+  const lead = sections.filter((s) => s.kind === "prose" && s.heading === "");
+  const otherProse = sections.filter((s) => s.kind === "prose" && s.heading !== "");
+
+  return (
+    <section
+      data-testid="aim-body"
+      className={variant === "console" ? "ac-body-sections" : "mt-3 space-y-3"}
+    >
+      {/* A lead block (content before any heading) is the section intro. */}
+      {lead.map((s) => (
+        <SectionView
+          key={`lead-${sectionKey(s)}`}
+          section={s}
+          variant={variant}
+          resolves={resolves}
+          onNavigate={onNavigate}
+        />
+      ))}
+
+      {/* Canonical scaffold — only when the body actually speaks the form. */}
+      {structured
+        ? CANONICAL.map((kind) => {
+            const present = sections.filter((s) => s.kind === kind);
+            if (present.length === 0) return <EmptySlot key={kind} kind={kind} variant={variant} />;
+            return present.map((s) => (
+              <SectionView
+                key={sectionKey(s)}
+                section={s}
+                variant={variant}
+                resolves={resolves}
+                onNavigate={onNavigate}
+              />
+            ));
+          })
+        : null}
+
+      {/* Unknown headed prose — after the canonical block (or alone, when the
+          body is not structured). Nothing the parser sees is ever dropped. */}
+      {otherProse.map((s) => (
+        <SectionView
+          key={`prose-${sectionKey(s)}`}
+          section={s}
+          variant={variant}
+          resolves={resolves}
+          onNavigate={onNavigate}
+        />
+      ))}
+    </section>
   );
+}
 
+// ── one section ───────────────────────────────────────────────────────
+
+function SectionView({
+  section,
+  variant,
+  resolves,
+  onNavigate,
+}: {
+  section: AimBodySection;
+  variant: AimBodyVariant;
+  resolves: (slug: string) => boolean;
+  onNavigate: (slug: string) => void;
+}) {
+  const label = SECTION_LABEL[section.kind] || section.heading;
+  // 実装済/未実装 are a means-section progress convention; surface whichever the
+  // author used as a header chip. Best-effort (the form is loose) — the chips
+  // are facts the author wrote, never a re-judgement.
+  const statuses = section.kind === "means" ? meansStatuses(section.content) : [];
+
+  const withLinks = useMemo(
+    () => section.content.replace(WIKILINK, (_m, slug: string) => `[${slug}](aim:${slug})`),
+    [section.content],
+  );
   const components = useMemo<Components>(
     () => ({
       a({ href, children }) {
         if (href?.startsWith("aim:")) {
           const slug = href.slice("aim:".length);
           if (!resolves(slug)) {
-            // Unresolved cross-edge — plain, not an error (the node may not be
-            // authored yet).
-            return <span className="text-muted-foreground">{children}</span>;
+            return <span className={UNRESOLVED_CLASS[variant]}>{children}</span>;
           }
           return (
-            <button
-              type="button"
-              onClick={() => onNavigate(slug)}
-              className="font-mono text-foreground underline decoration-dotted underline-offset-2 hover:decoration-solid"
-            >
+            <button type="button" onClick={() => onNavigate(slug)} className={LINK_CLASS[variant]}>
               {children}
             </button>
           );
         }
-        // Real links keep standard prose link rendering.
         return <a href={href}>{children}</a>;
       },
     }),
-    [resolves, onNavigate],
+    [variant, resolves, onNavigate],
   );
 
-  // An empty body renders nothing — the section only appears when there is
-  // interior prose to show (a pure-ought node stays clean).
-  if (trimmed === "") return null;
+  const md =
+    section.content === "" ? null : (
+      <Markdown
+        remarkPlugins={[remarkGfm]}
+        // Preserve the synthetic `aim:` scheme; sanitize everything else as
+        // react-markdown would by default.
+        urlTransform={(url) => (url.startsWith("aim:") ? url : defaultUrlTransform(url))}
+        components={components}
+      >
+        {withLinks}
+      </Markdown>
+    );
+
+  if (variant === "console") {
+    return (
+      <div className="ac-body-sec" data-testid="aim-body-section" data-kind={section.kind}>
+        <div className="ac-isec">
+          {label}
+          {statuses.map((s) => (
+            <StatusChip key={s} status={s} variant={variant} />
+          ))}
+        </div>
+        {md === null ? (
+          <div className="ac-il dim">— なし —</div>
+        ) : (
+          <div className="ac-body">{md}</div>
+        )}
+      </div>
+    );
+  }
 
   return (
-    <section className="mt-3" data-testid="aim-body">
-      <h4 className="font-mono text-[9px] uppercase tracking-wide text-subtle-foreground">body</h4>
-      <div className={`mt-1 ${PROSE_CLASSES}`}>
-        <Markdown
-          remarkPlugins={[remarkGfm]}
-          // Preserve the synthetic `aim:` scheme; sanitize everything else
-          // exactly as react-markdown would by default.
-          urlTransform={(url) => (url.startsWith("aim:") ? url : defaultUrlTransform(url))}
-          components={components}
-        >
-          {withLinks}
-        </Markdown>
-      </div>
+    <section data-testid="aim-body-section" data-kind={section.kind}>
+      <h4 className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-wide text-subtle-foreground">
+        <span>{label}</span>
+        {statuses.map((s) => (
+          <StatusChip key={s} status={s} variant={variant} />
+        ))}
+      </h4>
+      {md === null ? (
+        <p className="mt-0.5 text-[11px] italic text-subtle-foreground">— なし —</p>
+      ) : (
+        <div className={`mt-1 ${PROSE_CLASSES}`}>{md}</div>
+      )}
     </section>
   );
 }
+
+// An absent canonical section — a subtle present-but-empty slot, so the
+// 障害/手段/DAG/history structure stays legible (it scaffolds the write
+// surface). Subtle, never an alarm — a missing slot is not owed work.
+function EmptySlot({ kind, variant }: { kind: AimBodySectionKind; variant: AimBodyVariant }) {
+  if (variant === "console") {
+    return (
+      <div
+        className="ac-body-sec"
+        data-testid="aim-body-section"
+        data-kind={kind}
+        data-empty="true"
+      >
+        <div className="ac-isec">{SECTION_LABEL[kind]}</div>
+        <div className="ac-il dim">— なし —</div>
+      </div>
+    );
+  }
+  return (
+    <section data-testid="aim-body-section" data-kind={kind} data-empty="true">
+      <h4 className="font-mono text-[9px] uppercase tracking-wide text-subtle-foreground">
+        {SECTION_LABEL[kind]}
+      </h4>
+      <p className="mt-0.5 text-[11px] italic text-subtle-foreground">— なし —</p>
+    </section>
+  );
+}
+
+type MeansStatus = "実装済" | "未実装";
+
+// Detect the means-progress markers the author used. Distinct substrings (one
+// is not a substring of the other), so a plain test is safe.
+function meansStatuses(content: string): MeansStatus[] {
+  const out: MeansStatus[] = [];
+  if (content.includes("実装済")) out.push("実装済");
+  if (content.includes("未実装")) out.push("未実装");
+  return out;
+}
+
+// done = success/green (calm), undone = ochre/open (owed, not alarming).
+function StatusChip({ status, variant }: { status: MeansStatus; variant: AimBodyVariant }) {
+  const done = status === "実装済";
+  const glyph = done ? "✓" : "◌";
+  if (variant === "console") {
+    return <span className={`ac-tg ${done ? "c" : "k"}`}>{`${glyph} ${status}`}</span>;
+  }
+  return (
+    <span
+      className={`shrink-0 rounded border px-1 py-px font-mono text-[9px] ${
+        done ? "border-success/40 text-success" : "border-dashed border-warning/50 text-warning"
+      }`}
+    >
+      {glyph} {status}
+    </span>
+  );
+}
+
+// Resolved / unresolved `[[slug]]` link classes per surface.
+const LINK_CLASS: Record<AimBodyVariant, string> = {
+  rpanel:
+    "font-mono text-info underline decoration-dotted underline-offset-2 hover:decoration-solid",
+  console: "ac-bodylink",
+};
+const UNRESOLVED_CLASS: Record<AimBodyVariant, string> = {
+  rpanel: "text-muted-foreground",
+  console: "ac-bodylink dim",
+};

--- a/clients/react/src/components/producer-console/r-panel/AimBody.tsx
+++ b/clients/react/src/components/producer-console/r-panel/AimBody.tsx
@@ -36,16 +36,17 @@ import { PROSE_CLASSES } from "./r-viewer/prose";
 
 export type AimBodyVariant = "rpanel" | "console";
 
-// Canonical reading order: is/前提 (the premises you read first) → 障害 (the
-// 律速 escalation) → 手段 (the plan) → DAG → history (settled, append-only).
-const CANONICAL: readonly AimBodySectionKind[] = ["is", "obstacle", "means", "dag", "history"];
+// Canonical reading order (per `doc/aims/aim-body`): IS (the agent's reading
+// you check first) → ESCALATION (the 律速 blockers) → PROCESS (the plan) →
+// HISTORY (rejected means) → DAG (cross-tree dependencies).
+const CANONICAL: readonly AimBodySectionKind[] = ["is", "obstacle", "means", "history", "dag"];
 
 const SECTION_LABEL: Record<AimBodySectionKind, string> = {
-  is: "is — 前提",
-  obstacle: "障害 — escalation",
-  means: "手段 — means",
-  dag: "DAG — cross-edges",
-  history: "history — 却下手段",
+  is: "IS — 解釈",
+  obstacle: "ESCALATION — 障害",
+  means: "PROCESS — 実装手順",
+  history: "HISTORY — 却下手段",
+  dag: "DAG — 依存",
   prose: "",
 };
 

--- a/clients/react/src/components/producer-console/r-panel/AimBody.tsx
+++ b/clients/react/src/components/producer-console/r-panel/AimBody.tsx
@@ -4,21 +4,21 @@
 // share `aim-tree.ts`.
 //
 // WHY this exists: the rebuilt aim form expresses structured-knowing as
-// `#`-headed markdown — 障害 (escalation) / 手段 (means, with 実装済/未実装) /
-// history (却下手段) / DAG (`[[slug]]` cross-edges) — NOT the old `[claimed]` /
-// `[confirmed]` interior marks. So a new-form node parses to an empty `is[]`
-// and its whole body was invisible. A first cut rendered the raw body via
+// `#`-headed markdown — is/前提 (premises) / 障害 (escalation) / 手段 (means,
+// progress-bearing) / DAG (`[[slug]]` cross-edges) / history (却下手段). The
+// body is the PRODUCER's domain (authored for write ergonomics); the render is
+// the OPERATOR's (readable after parse). A first cut rendered the raw body via
 // generic `prose`, which read as foreign next to the rest of the inspector;
 // this renders the body's SECTIONS as typed blocks that speak each surface's
 // tokens (`.ac-*` in the console, the app's prose / mark idioms in the R-panel).
 //
-// Parsing is client-side + section-level (`./aim-body-parse`) on purpose: the
+// Parsing is client-side + section-level (`./aim-body-parse`) on purpose — the
 // form is still settling (a running dogfood trial), so its grammar is not
-// frozen into the wire yet. `[[slug]]` cross-edges become in-tree navigation
-// (resolved → clickable; unresolved → plain). When the body carries any
-// recognised section, the canonical 障害/手段/DAG/history scaffold is shown in
-// reading order with empty slots surfaced subtly; a non-conforming (pure-prose)
-// body is rendered verbatim without the scaffold.
+// frozen into the wire yet. The canonical is/障害/手段/DAG/history scaffold is
+// shown in reading order with empty slots surfaced subtly (operator-approved);
+// a non-conforming (pure-prose) body is rendered verbatim. 手段 is rendered as
+// a progress-bearing checklist (実装済 / 未実装 per item + a header ratio);
+// `[[slug]]` cross-edges become in-tree navigation (resolved → clickable).
 
 import { useMemo } from "react";
 import Markdown, { type Components, defaultUrlTransform } from "react-markdown";
@@ -27,17 +27,21 @@ import {
   type AimBodySection,
   type AimBodySectionKind,
   hasStructure,
+  type MeansItem,
+  type ParsedMeans,
   parseAimBody,
+  parseMeans,
 } from "./aim-body-parse";
 import { PROSE_CLASSES } from "./r-viewer/prose";
 
 export type AimBodyVariant = "rpanel" | "console";
 
-// Canonical reading order: 障害 (the 律速 escalation) first … history (settled,
-// append-only) last. Means + DAG sit between.
-const CANONICAL: readonly AimBodySectionKind[] = ["obstacle", "means", "dag", "history"];
+// Canonical reading order: is/前提 (the premises you read first) → 障害 (the
+// 律速 escalation) → 手段 (the plan) → DAG → history (settled, append-only).
+const CANONICAL: readonly AimBodySectionKind[] = ["is", "obstacle", "means", "dag", "history"];
 
 const SECTION_LABEL: Record<AimBodySectionKind, string> = {
+  is: "is — 前提",
   obstacle: "障害 — escalation",
   means: "手段 — means",
   dag: "DAG — cross-edges",
@@ -50,8 +54,7 @@ const SECTION_LABEL: Record<AimBodySectionKind, string> = {
 const WIKILINK = /\[\[([^[\]]+)\]\]/g;
 
 // A stable render key for a parsed section — content-derived, not the array
-// index (sections have no id; this keeps React identity stable across re-parses
-// without an index key).
+// index (sections have no id; keeps React identity stable across re-parses).
 const sectionKey = (s: AimBodySection): string =>
   `${s.kind}:${s.heading}:${s.content.slice(0, 32)}`;
 
@@ -137,46 +140,28 @@ function SectionView({
   onNavigate: (slug: string) => void;
 }) {
   const label = SECTION_LABEL[section.kind] || section.heading;
-  // 実装済/未実装 are a means-section progress convention; surface whichever the
-  // author used as a header chip. Best-effort (the form is loose) — the chips
-  // are facts the author wrote, never a re-judgement.
-  const statuses = section.kind === "means" ? meansStatuses(section.content) : [];
-
-  const withLinks = useMemo(
-    () => section.content.replace(WIKILINK, (_m, slug: string) => `[${slug}](aim:${slug})`),
-    [section.content],
-  );
-  const components = useMemo<Components>(
-    () => ({
-      a({ href, children }) {
-        if (href?.startsWith("aim:")) {
-          const slug = href.slice("aim:".length);
-          if (!resolves(slug)) {
-            return <span className={UNRESOLVED_CLASS[variant]}>{children}</span>;
-          }
-          return (
-            <button type="button" onClick={() => onNavigate(slug)} className={LINK_CLASS[variant]}>
-              {children}
-            </button>
-          );
-        }
-        return <a href={href}>{children}</a>;
-      },
-    }),
-    [variant, resolves, onNavigate],
+  // 手段 is progress-bearing: parse it into a checklist + a done/todo ratio.
+  const means = useMemo(
+    () => (section.kind === "means" ? parseMeans(section.content) : null),
+    [section.kind, section.content],
   );
 
-  const md =
-    section.content === "" ? null : (
-      <Markdown
-        remarkPlugins={[remarkGfm]}
-        // Preserve the synthetic `aim:` scheme; sanitize everything else as
-        // react-markdown would by default.
-        urlTransform={(url) => (url.startsWith("aim:") ? url : defaultUrlTransform(url))}
-        components={components}
-      >
-        {withLinks}
-      </Markdown>
+  const headerExtra =
+    section.kind === "means" ? (
+      means && means.done + means.todo > 0 ? (
+        <ProgressBadge done={means.done} todo={means.todo} variant={variant} />
+      ) : (
+        // Not-yet-converted body: fall back to whatever 実装済/未実装 the prose
+        // mentions, as section-level chips (the marks are facts, not a judgement).
+        <FallbackStatusChips content={section.content} variant={variant} />
+      )
+    ) : null;
+
+  const body =
+    means !== null ? (
+      <MeansBody means={means} variant={variant} resolves={resolves} onNavigate={onNavigate} />
+    ) : (
+      <Md content={section.content} variant={variant} resolves={resolves} onNavigate={onNavigate} />
     );
 
   if (variant === "console") {
@@ -184,14 +169,12 @@ function SectionView({
       <div className="ac-body-sec" data-testid="aim-body-section" data-kind={section.kind}>
         <div className="ac-isec">
           {label}
-          {statuses.map((s) => (
-            <StatusChip key={s} status={s} variant={variant} />
-          ))}
+          {headerExtra}
         </div>
-        {md === null ? (
+        {body === null ? (
           <div className="ac-il dim">— なし —</div>
         ) : (
-          <div className="ac-body">{md}</div>
+          <div className="ac-body">{body}</div>
         )}
       </div>
     );
@@ -201,21 +184,175 @@ function SectionView({
     <section data-testid="aim-body-section" data-kind={section.kind}>
       <h4 className="flex items-center gap-2 font-mono text-[9px] uppercase tracking-wide text-subtle-foreground">
         <span>{label}</span>
-        {statuses.map((s) => (
-          <StatusChip key={s} status={s} variant={variant} />
-        ))}
+        {headerExtra}
       </h4>
-      {md === null ? (
+      {body === null ? (
         <p className="mt-0.5 text-[11px] italic text-subtle-foreground">— なし —</p>
       ) : (
-        <div className={`mt-1 ${PROSE_CLASSES}`}>{md}</div>
+        <div className={`mt-1 ${PROSE_CLASSES}`}>{body}</div>
       )}
     </section>
   );
 }
 
+// ── 手段 (means) — the progress-bearing checklist ─────────────────────────
+
+function MeansBody({
+  means,
+  variant,
+  resolves,
+  onNavigate,
+}: {
+  means: ParsedMeans;
+  variant: AimBodyVariant;
+  resolves: (slug: string) => boolean;
+  onNavigate: (slug: string) => void;
+}) {
+  if (means.intro === "" && means.items.length === 0) return null;
+  return (
+    <>
+      {means.intro !== "" && (
+        <Md content={means.intro} variant={variant} resolves={resolves} onNavigate={onNavigate} />
+      )}
+      <ul className="ac-means-list">
+        {means.items.map((item) => (
+          <MeansItemRow
+            key={`${item.status ?? "·"}:${item.text}`}
+            item={item}
+            variant={variant}
+            resolves={resolves}
+            onNavigate={onNavigate}
+          />
+        ))}
+      </ul>
+    </>
+  );
+}
+
+function MeansItemRow({
+  item,
+  variant,
+  resolves,
+  onNavigate,
+}: {
+  item: MeansItem;
+  variant: AimBodyVariant;
+  resolves: (slug: string) => boolean;
+  onNavigate: (slug: string) => void;
+}) {
+  const glyph = item.status === "done" ? "✓" : item.status === "todo" ? "◌" : "·";
+  const glyphClass =
+    variant === "console"
+      ? item.status === "done"
+        ? "ac-means-g done"
+        : item.status === "todo"
+          ? "ac-means-g todo"
+          : "ac-means-g"
+      : item.status === "done"
+        ? "text-success"
+        : item.status === "todo"
+          ? "text-warning"
+          : "text-subtle-foreground";
+
+  return (
+    <li
+      className={variant === "console" ? "ac-means-item" : "flex flex-col gap-0.5"}
+      data-testid="aim-means-item"
+      data-status={item.status ?? "none"}
+    >
+      <span className={variant === "console" ? "ac-means-row" : "flex items-baseline gap-1.5"}>
+        <span aria-hidden="true" className={`shrink-0 font-mono ${glyphClass}`}>
+          {glyph}
+        </span>
+        <span className="min-w-0">
+          <Md
+            content={item.text}
+            variant={variant}
+            resolves={resolves}
+            onNavigate={onNavigate}
+            inline
+          />
+        </span>
+      </span>
+      {item.detail !== "" && (
+        <div className={variant === "console" ? "ac-means-detail" : "ml-4 text-subtle-foreground"}>
+          <Md content={item.detail} variant={variant} resolves={resolves} onNavigate={onNavigate} />
+        </div>
+      )}
+    </li>
+  );
+}
+
+// done = green/success (calm), todo = ochre/warning (owed, not alarming).
+function ProgressBadge({
+  done,
+  todo,
+  variant,
+}: {
+  done: number;
+  todo: number;
+  variant: AimBodyVariant;
+}) {
+  const total = done + todo;
+  const donePct = total === 0 ? 0 : Math.round((100 * done) / total);
+  if (variant === "console") {
+    return (
+      <span className="ac-prog" data-testid="aim-means-progress">
+        実装 {done} / 未実装 {todo}
+        <span className="ac-prog-bar" aria-hidden="true">
+          <span className="done" style={{ width: `${donePct}%` }} />
+        </span>
+      </span>
+    );
+  }
+  return (
+    <span
+      data-testid="aim-means-progress"
+      className="flex items-center gap-1.5 font-mono text-[9px] normal-case text-muted-foreground"
+    >
+      実装 {done} / 未実装 {todo}
+      <span className="flex h-1 w-10 overflow-hidden rounded-full border border-hairline">
+        <span className="bg-success" style={{ width: `${donePct}%` }} />
+        <span className="bg-warning/70" style={{ width: `${100 - donePct}%` }} />
+      </span>
+    </span>
+  );
+}
+
+// A not-yet-converted means body: surface whichever of 実装済/未実装 the prose
+// mentions as a section-level chip. Best-effort — the chips are facts the
+// author wrote, never a re-judgement.
+function FallbackStatusChips({ content, variant }: { content: string; variant: AimBodyVariant }) {
+  const statuses: ("実装済" | "未実装")[] = [];
+  if (content.includes("実装済")) statuses.push("実装済");
+  if (content.includes("未実装")) statuses.push("未実装");
+  return (
+    <>
+      {statuses.map((s) => {
+        const done = s === "実装済";
+        const glyph = done ? "✓" : "◌";
+        if (variant === "console") {
+          return <span key={s} className={`ac-tg ${done ? "c" : "k"}`}>{`${glyph} ${s}`}</span>;
+        }
+        return (
+          <span
+            key={s}
+            className={`shrink-0 rounded border px-1 py-px font-mono text-[9px] normal-case ${
+              done
+                ? "border-success/40 text-success"
+                : "border-dashed border-warning/50 text-warning"
+            }`}
+          >
+            {glyph} {s}
+          </span>
+        );
+      })}
+    </>
+  );
+}
+
 // An absent canonical section — a subtle present-but-empty slot, so the
-// 障害/手段/DAG/history structure stays legible (it scaffolds the write
+// is/障害/手段/DAG/history structure stays legible (it scaffolds the write
 // surface). Subtle, never an alarm — a missing slot is not owed work.
 function EmptySlot({ kind, variant }: { kind: AimBodySectionKind; variant: AimBodyVariant }) {
   if (variant === "console") {
@@ -241,32 +378,60 @@ function EmptySlot({ kind, variant }: { kind: AimBodySectionKind; variant: AimBo
   );
 }
 
-type MeansStatus = "実装済" | "未実装";
+// ── markdown with `[[slug]]` aim-node cross-refs ──────────────────────────
 
-// Detect the means-progress markers the author used. Distinct substrings (one
-// is not a substring of the other), so a plain test is safe.
-function meansStatuses(content: string): MeansStatus[] {
-  const out: MeansStatus[] = [];
-  if (content.includes("実装済")) out.push("実装済");
-  if (content.includes("未実装")) out.push("未実装");
-  return out;
-}
+function Md({
+  content,
+  variant,
+  resolves,
+  onNavigate,
+  inline = false,
+}: {
+  content: string;
+  variant: AimBodyVariant;
+  resolves: (slug: string) => boolean;
+  onNavigate: (slug: string) => void;
+  /** Unwrap the single top-level paragraph (for one-line item text). */
+  inline?: boolean;
+}) {
+  const withLinks = useMemo(
+    () => content.replace(WIKILINK, (_m, slug: string) => `[${slug}](aim:${slug})`),
+    [content],
+  );
+  const components = useMemo<Components>(
+    () => ({
+      a({ href, children }) {
+        if (href?.startsWith("aim:")) {
+          const slug = href.slice("aim:".length);
+          if (!resolves(slug)) {
+            return <span className={UNRESOLVED_CLASS[variant]}>{children}</span>;
+          }
+          return (
+            <button type="button" onClick={() => onNavigate(slug)} className={LINK_CLASS[variant]}>
+              {children}
+            </button>
+          );
+        }
+        return <a href={href}>{children}</a>;
+      },
+      // For inline item text, drop the wrapping <p> so the glyph + text stay on
+      // one baseline row.
+      ...(inline ? { p: ({ children }) => <>{children}</> } : {}),
+    }),
+    [variant, resolves, onNavigate, inline],
+  );
 
-// done = success/green (calm), undone = ochre/open (owed, not alarming).
-function StatusChip({ status, variant }: { status: MeansStatus; variant: AimBodyVariant }) {
-  const done = status === "実装済";
-  const glyph = done ? "✓" : "◌";
-  if (variant === "console") {
-    return <span className={`ac-tg ${done ? "c" : "k"}`}>{`${glyph} ${status}`}</span>;
-  }
+  if (content.trim() === "") return null;
   return (
-    <span
-      className={`shrink-0 rounded border px-1 py-px font-mono text-[9px] ${
-        done ? "border-success/40 text-success" : "border-dashed border-warning/50 text-warning"
-      }`}
+    <Markdown
+      remarkPlugins={[remarkGfm]}
+      // Preserve the synthetic `aim:` scheme; sanitize everything else as
+      // react-markdown would by default.
+      urlTransform={(url) => (url.startsWith("aim:") ? url : defaultUrlTransform(url))}
+      components={components}
     >
-      {glyph} {status}
-    </span>
+      {withLinks}
+    </Markdown>
   );
 }
 

--- a/clients/react/src/components/producer-console/r-panel/AimBody.tsx
+++ b/clients/react/src/components/producer-console/r-panel/AimBody.tsx
@@ -1,0 +1,105 @@
+// ◎ Aim body — the agent-authored interior (`AimWire.body`) rendered as
+// markdown. Shared by BOTH aim surfaces (the R-panel `RAimsSection` inspector +
+// the aim-console `AimPane` inspector), the same way both already share
+// `aim-tree.ts`.
+//
+// WHY this exists: the rebuilt aim form expresses a node's structured-knowing as
+// PROSE (headings / lists / `[[slug]]` cross-edges to other aim nodes), NOT as
+// the old `[claimed]` / `[confirmed]` interior marks. The inspector's mark-list
+// (`is[]`) is parsed only from those marks, so a new-form node parses to an
+// EMPTY `is[]` and its whole body was invisible — the inspector showed only the
+// one-line `aim:` ought and "— a pure ought —", even when the file carries a
+// rich body. The body text is already on the wire (`AimWire.body`); this just
+// surfaces it.
+//
+// Render path REUSES the established stack (`react-markdown` + `remark-gfm` +
+// the shared `PROSE_CLASSES`) that `RRecordViewer` / `RPrViewer` use, so the
+// aim body reads like every other markdown surface in the WebUI. `[[slug]]`
+// wiki-links are rewritten to in-tree navigation: a slug that resolves to a
+// loaded aim node becomes a clickable cross-ref (selects that node); an
+// unresolved slug stays PLAIN text — a not-yet-authored node is not an error.
+//
+// Deliberately NOT a bespoke structured-knowing parser (障害 / 手段 / history
+// sections as typed blocks). This is the "暫定 raw" surface: show the whole
+// body now so the dogfood loop can decide what structured rendering, if any, is
+// actually worth building.
+
+import { useMemo } from "react";
+import Markdown, { type Components, defaultUrlTransform } from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { PROSE_CLASSES } from "./r-viewer/prose";
+
+// `[[slug]]` — the body's DAG cross-edge syntax. Same shape the record viewer's
+// excerpt uses; here the target is an aim node, not a decision/approach record.
+const WIKILINK = /\[\[([^[\]]+)\]\]/g;
+
+export function AimBody({
+  body,
+  resolves,
+  onNavigate,
+}: {
+  body: string;
+  /** Does this slug name a loaded aim node (in the selection's repo)? Drives
+   *  whether a `[[slug]]` renders as a clickable cross-ref or plain text. */
+  resolves: (slug: string) => boolean;
+  /** Navigate the panel's selection to a resolved aim node. */
+  onNavigate: (slug: string) => void;
+}) {
+  const trimmed = body.trim();
+
+  // Rewrite `[[slug]]` → a markdown link with a synthetic `aim:` scheme, then
+  // intercept that scheme in the `a` override (mirrors `RRecordViewer`'s
+  // `record:` scheme). Done before render so react-markdown parses it as a link.
+  const withLinks = useMemo(
+    () => trimmed.replace(WIKILINK, (_m, slug: string) => `[${slug}](aim:${slug})`),
+    [trimmed],
+  );
+
+  const components = useMemo<Components>(
+    () => ({
+      a({ href, children }) {
+        if (href?.startsWith("aim:")) {
+          const slug = href.slice("aim:".length);
+          if (!resolves(slug)) {
+            // Unresolved cross-edge — plain, not an error (the node may not be
+            // authored yet).
+            return <span className="text-muted-foreground">{children}</span>;
+          }
+          return (
+            <button
+              type="button"
+              onClick={() => onNavigate(slug)}
+              className="font-mono text-foreground underline decoration-dotted underline-offset-2 hover:decoration-solid"
+            >
+              {children}
+            </button>
+          );
+        }
+        // Real links keep standard prose link rendering.
+        return <a href={href}>{children}</a>;
+      },
+    }),
+    [resolves, onNavigate],
+  );
+
+  // An empty body renders nothing — the section only appears when there is
+  // interior prose to show (a pure-ought node stays clean).
+  if (trimmed === "") return null;
+
+  return (
+    <section className="mt-3" data-testid="aim-body">
+      <h4 className="font-mono text-[9px] uppercase tracking-wide text-subtle-foreground">body</h4>
+      <div className={`mt-1 ${PROSE_CLASSES}`}>
+        <Markdown
+          remarkPlugins={[remarkGfm]}
+          // Preserve the synthetic `aim:` scheme; sanitize everything else
+          // exactly as react-markdown would by default.
+          urlTransform={(url) => (url.startsWith("aim:") ? url : defaultUrlTransform(url))}
+          components={components}
+        >
+          {withLinks}
+        </Markdown>
+      </div>
+    </section>
+  );
+}

--- a/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
@@ -1263,7 +1263,10 @@ function Inspector({
             resolves={(slug) => bySlug.has(slug)}
             onNavigate={onSelect}
           />
-          <InteriorList marks={node.is} />
+          {/* Legacy interior marks — shown only for nodes that still carry
+              them; the structured body's `is/前提` section supersedes the empty
+              "pure ought" state for new-form nodes (marks machinery untouched). */}
+          {node.is.length > 0 && <InteriorList marks={node.is} />}
           <CrossEdges node={node} />
           <div className="mt-3 flex items-center gap-2">
             <button

--- a/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
@@ -1257,7 +1257,12 @@ function Inspector({
         />
       ) : (
         <>
-          <AimBody body={node.body} resolves={(slug) => bySlug.has(slug)} onNavigate={onSelect} />
+          <AimBody
+            body={node.body}
+            variant="rpanel"
+            resolves={(slug) => bySlug.has(slug)}
+            onNavigate={onSelect}
+          />
           <InteriorList marks={node.is} />
           <CrossEdges node={node} />
           <div className="mt-3 flex items-center gap-2">

--- a/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
@@ -46,6 +46,7 @@ import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
 import type { AimState } from "@/types/generated/AimState";
 import type { AimWire } from "@/types/generated/AimWire";
 import type { RepoAimsWire } from "@/types/generated/RepoAimsWire";
+import { AimBody } from "./AimBody";
 import {
   AIM_STATE_LABEL,
   type AimTone,
@@ -1256,6 +1257,7 @@ function Inspector({
         />
       ) : (
         <>
+          <AimBody body={node.body} resolves={(slug) => bySlug.has(slug)} onNavigate={onSelect} />
           <InteriorList marks={node.is} />
           <CrossEdges node={node} />
           <div className="mt-3 flex items-center gap-2">

--- a/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
+++ b/clients/react/src/components/producer-console/r-panel/RAimsSection.tsx
@@ -117,8 +117,8 @@ const TONE_GLYPH: Record<AimTone, string> = {
   done: "✓",
   dead: "⊘",
   drift: "⚠",
-  claimed: "◌",
-  confirmed: "○",
+  todo: "◌",
+  progress: "○",
   root: "○",
   neutral: "○",
 };
@@ -128,8 +128,8 @@ const TONE_GLYPH_CLASS: Record<AimTone, string> = {
   done: "text-success",
   dead: "text-subtle-foreground",
   drift: "text-warning",
-  claimed: "text-warning",
-  confirmed: "text-subtle-foreground",
+  todo: "text-warning",
+  progress: "text-subtle-foreground",
   root: "text-info",
   neutral: "text-subtle-foreground",
 };
@@ -142,8 +142,8 @@ const TONE_GUTTER: Record<AimTone, string> = {
   done: "bg-success/40",
   dead: "bg-subtle-foreground/40",
   drift: "bg-warning",
-  claimed: "bg-warning/55",
-  confirmed: "bg-success/30",
+  todo: "bg-warning/55",
+  progress: "bg-success/30",
   root: "bg-info/60",
   neutral: "bg-hairline-strong",
 };
@@ -166,8 +166,8 @@ const TONE_OUGHT_CLASS: Record<AimTone, string> = {
   done: "text-subtle-foreground",
   dead: "text-subtle-foreground line-through",
   drift: "text-warning/90",
-  claimed: "text-foreground",
-  confirmed: "text-muted-foreground",
+  todo: "text-foreground",
+  progress: "text-muted-foreground",
   root: "text-foreground",
   neutral: "text-foreground",
 };
@@ -245,7 +245,7 @@ function AimsEntry({
   const [open, setOpen] = useState(false);
   const repoCount = useMemo(() => repoForests(data).length, [data]);
   const ledger = useMemo(() => ledgerCounts(nodes), [nodes]);
-  const owed = ledger.drift + ledger.claimed;
+  const owed = ledger.drift + ledger.todo;
 
   return (
     <div className="space-y-2">
@@ -278,10 +278,10 @@ function AimsEntry({
               {ledger.drift} drift
             </span>
           )}
-          {ledger.claimed > 0 && (
+          {ledger.todo > 0 && (
             <span className="flex items-center gap-1 text-warning/80">
               <span aria-hidden="true">◌</span>
-              {ledger.claimed} claimed
+              {ledger.todo} todo
             </span>
           )}
         </div>
@@ -531,10 +531,10 @@ function resolveSelection(slug: string | null, repos: readonly RepoAimsWire[]): 
 // ── Ledger strip ──────────────────────────────────────────────────────
 
 function Ledger({ counts }: { counts: LedgerCounts }) {
-  const owed = counts.drift + counts.claimed;
-  const total = owed + counts.confirmed;
+  const owed = counts.drift + counts.todo;
+  const total = owed + counts.done;
   const owedPct = total === 0 ? 0 : Math.round((100 * owed) / total);
-  const confirmedPct = total === 0 ? 0 : 100 - owedPct;
+  const donePct = total === 0 ? 0 : 100 - owedPct;
 
   return (
     <div
@@ -547,15 +547,15 @@ function Ledger({ counts }: { counts: LedgerCounts }) {
       </span>
       <span className="flex items-center gap-1.5 font-mono text-[11px] text-warning/80">
         <span aria-hidden="true" className="h-2.5 w-2.5 rounded-[2px] border border-warning/80" />
-        <b className="font-semibold">{counts.claimed}</b> claimed
+        <b className="font-semibold">{counts.todo}</b> todo
       </span>
       <span className="flex items-center gap-1.5 font-mono text-[11px] text-subtle-foreground">
         <span aria-hidden="true" className="h-2.5 w-2.5 rounded-[2px] bg-success/70" />
-        <b className="font-semibold text-muted-foreground">{counts.confirmed}</b> confirmed
+        <b className="font-semibold text-muted-foreground">{counts.done}</b> done
       </span>
       <div className="flex h-1.5 flex-1 overflow-hidden rounded-full border border-hairline">
         <div className="bg-warning" style={{ width: `${owedPct}%` }} />
-        <div className="bg-success/40" style={{ width: `${confirmedPct}%` }} />
+        <div className="bg-success/40" style={{ width: `${donePct}%` }} />
       </div>
     </div>
   );
@@ -669,10 +669,10 @@ function FrontierList({
     <div>
       {sections.map(({ repo, bySlug, owed, doneDrift }) => {
         const driftN = owed.filter((n) => aimTone(n) === "drift").length;
-        const claimedN = owed.length - driftN;
+        const todoN = owed.length - driftN;
         return (
           <div key={repo.repo_root}>
-            <RepoBanner repo={repo} drift={driftN} claimed={claimedN} />
+            <RepoBanner repo={repo} drift={driftN} todo={todoN} />
             {owed.map((n) => (
               <AimRow
                 key={n.slug}
@@ -709,15 +709,7 @@ function FrontierList({
 
 // A non-collapsible repo banner used in Frontier sections (the repo is context,
 // not a toggle, here). Primary repo gets the cyan/info accent.
-function RepoBanner({
-  repo,
-  drift,
-  claimed,
-}: {
-  repo: RepoAimsWire;
-  drift: number;
-  claimed: number;
-}) {
+function RepoBanner({ repo, drift, todo }: { repo: RepoAimsWire; drift: number; todo: number }) {
   return (
     <div
       className={`flex items-center gap-2 border-y border-hairline bg-surface/40 px-3 py-1 ${
@@ -733,7 +725,7 @@ function RepoBanner({
       </span>
       <span className="ml-auto font-mono text-[10px]">
         {drift > 0 && <span className="text-warning">⚠{drift} </span>}
-        {claimed > 0 && <span className="text-warning/80">◌{claimed}</span>}
+        {todo > 0 && <span className="text-warning/80">◌{todo}</span>}
       </span>
     </div>
   );
@@ -871,7 +863,7 @@ function RepoHead({
         <span className="font-mono text-[10px] text-subtle-foreground">
           {stats.count}
           {stats.drift > 0 && <span className="text-warning"> ⚠{stats.drift}</span>}
-          {stats.claimed > 0 && <span className="text-warning/80"> ◌{stats.claimed}</span>}
+          {stats.todo > 0 && <span className="text-warning/80"> ◌{stats.todo}</span>}
         </span>
       </button>
       <button
@@ -1070,7 +1062,7 @@ function AimRow({
           >
             {rollup.count}
             {rollup.drift > 0 && <span className="text-warning"> ⚠{rollup.drift}</span>}
-            {rollup.claimed > 0 && <span className="text-warning/80"> ◌{rollup.claimed}</span>}
+            {rollup.todo > 0 && <span className="text-warning/80"> ◌{rollup.todo}</span>}
           </span>
         )}
         <InteriorDots marks={node.is} />
@@ -1156,7 +1148,7 @@ function OverviewRuler({
             data-slug={t.slug}
             data-owed={t.owed}
             onClick={() => onReveal(t.slug)}
-            title={`${t.owed === "drift" ? "⚠ drift" : "◌ claimed"} · ${t.repoLabel} · ${t.slug}`}
+            title={`${t.owed === "drift" ? "⚠ drift" : "◌ todo"} · ${t.repoLabel} · ${t.slug}`}
             aria-label={`Reveal ${t.slug} (${t.owed})`}
             className={`absolute right-[2px] left-[2px] rounded-[1px] ${lit} ${
               t.owed === "drift" ? "h-[3px]" : "h-[2px]"

--- a/clients/react/src/components/producer-console/r-panel/__tests__/AimBody.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/AimBody.test.tsx
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+//
+// AimBody — the agent-authored interior (`AimWire.body`) rendered as markdown.
+// Covers: markdown prose actually renders (the gap that left new-form bodies
+// invisible), `[[slug]]` cross-edges become clickable nav when resolved + stay
+// plain when not, and an empty body renders nothing (a pure-ought node).
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { AimBody } from "../AimBody";
+
+const resolvesAll = () => true;
+const resolvesNone = () => false;
+const noop = () => {};
+
+describe("AimBody", () => {
+  it("renders the body markdown (heading + list)", () => {
+    render(
+      <AimBody body={"# 手段\n\n- phase 1\n- phase 2"} resolves={resolvesAll} onNavigate={noop} />,
+    );
+    // getByText throws if absent, so the lookup itself is the assertion.
+    expect(screen.getByText("手段")).toBeTruthy();
+    expect(screen.getByText("phase 1")).toBeTruthy();
+    expect(screen.getByText("phase 2")).toBeTruthy();
+  });
+
+  it("renders a resolved [[slug]] cross-edge as a nav button that calls onNavigate", () => {
+    const onNavigate = vi.fn();
+    render(
+      <AimBody
+        body={"depends on [[aim-body]] for the form"}
+        resolves={resolvesAll}
+        onNavigate={onNavigate}
+      />,
+    );
+    const link = screen.getByRole("button", { name: "aim-body" });
+    fireEvent.click(link);
+    expect(onNavigate).toHaveBeenCalledWith("aim-body");
+  });
+
+  it("renders an unresolved [[slug]] as plain text, not a button", () => {
+    render(
+      <AimBody body={"links to [[not-yet-authored]]"} resolves={resolvesNone} onNavigate={noop} />,
+    );
+    expect(screen.queryByRole("button", { name: "not-yet-authored" })).toBeNull();
+    // The slug text is still shown, just not interactive.
+    expect(screen.getByText("not-yet-authored")).toBeTruthy();
+  });
+
+  it("renders nothing for an empty / whitespace-only body", () => {
+    const { container } = render(
+      <AimBody body={"   \n  "} resolves={resolvesAll} onNavigate={noop} />,
+    );
+    expect(container.innerHTML).toBe("");
+    expect(screen.queryByTestId("aim-body")).toBeNull();
+  });
+});

--- a/clients/react/src/components/producer-console/r-panel/__tests__/AimBody.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/AimBody.test.tsx
@@ -1,55 +1,108 @@
 // @vitest-environment jsdom
 //
-// AimBody — the agent-authored interior (`AimWire.body`) rendered as markdown.
-// Covers: markdown prose actually renders (the gap that left new-form bodies
-// invisible), `[[slug]]` cross-edges become clickable nav when resolved + stay
-// plain when not, and an empty body renders nothing (a pure-ought node).
+// AimBody — the agent-authored interior (`AimWire.body`) rendered as STRUCTURED
+// sections. Covers: a structured body renders its sections as labelled blocks
+// in canonical order with empty canonical slots surfaced; `[[slug]]` cross-edges
+// become clickable nav when resolved + stay plain when not; the means-progress
+// (実装済/未実装) chip; a pure-prose body skips the scaffold; an empty body
+// renders nothing.
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { AimBody } from "../AimBody";
 
-const resolvesAll = () => true;
-const resolvesNone = () => false;
+const all = () => true;
+const none = () => false;
 const noop = () => {};
 
+const DRIFT_BODY = [
+  "# 手段",
+  "",
+  "drift 表面化機構（means・未実装）",
+  "",
+  "- 入力はローカル git の行レベル履歴",
+  "",
+  "# DAG",
+  "",
+  "- 依存: [[git-local-fact-source]]",
+].join("\n");
+
 describe("AimBody", () => {
-  it("renders the body markdown (heading + list)", () => {
-    render(
-      <AimBody body={"# 手段\n\n- phase 1\n- phase 2"} resolves={resolvesAll} onNavigate={noop} />,
-    );
-    // getByText throws if absent, so the lookup itself is the assertion.
-    expect(screen.getByText("手段")).toBeTruthy();
-    expect(screen.getByText("phase 1")).toBeTruthy();
-    expect(screen.getByText("phase 2")).toBeTruthy();
+  it("renders sections in canonical order with empty slots (rpanel)", () => {
+    render(<AimBody body={DRIFT_BODY} variant="rpanel" resolves={all} onNavigate={noop} />);
+    const sections = screen.getAllByTestId("aim-body-section");
+    expect(sections.map((s) => s.getAttribute("data-kind"))).toEqual([
+      "obstacle",
+      "means",
+      "dag",
+      "history",
+    ]);
+    // obstacle + history are absent → empty slots; means + dag carry content.
+    expect(sections[0].getAttribute("data-empty")).toBe("true");
+    expect(sections[3].getAttribute("data-empty")).toBe("true");
+    expect(sections[1].getAttribute("data-empty")).toBeNull();
+    expect(screen.getByText(/drift 表面化機構/)).toBeTruthy();
+    expect(screen.getByText(/入力はローカル git/)).toBeTruthy();
   });
 
-  it("renders a resolved [[slug]] cross-edge as a nav button that calls onNavigate", () => {
+  it("surfaces the means 未実装 progress chip", () => {
+    render(<AimBody body={DRIFT_BODY} variant="rpanel" resolves={all} onNavigate={noop} />);
+    // The chip text is exactly the glyph + status (the prose mention is a longer
+    // string, so an exact match hits only the chip).
+    expect(screen.getByText("◌ 未実装")).toBeTruthy();
+  });
+
+  it("renders a resolved [[slug]] cross-edge as a nav button calling onNavigate", () => {
     const onNavigate = vi.fn();
     render(
       <AimBody
-        body={"depends on [[aim-body]] for the form"}
-        resolves={resolvesAll}
+        body={"# DAG\n\n- 依存 [[git-local-fact-source]]"}
+        variant="rpanel"
+        resolves={all}
         onNavigate={onNavigate}
       />,
     );
-    const link = screen.getByRole("button", { name: "aim-body" });
-    fireEvent.click(link);
-    expect(onNavigate).toHaveBeenCalledWith("aim-body");
+    fireEvent.click(screen.getByRole("button", { name: "git-local-fact-source" }));
+    expect(onNavigate).toHaveBeenCalledWith("git-local-fact-source");
   });
 
   it("renders an unresolved [[slug]] as plain text, not a button", () => {
     render(
-      <AimBody body={"links to [[not-yet-authored]]"} resolves={resolvesNone} onNavigate={noop} />,
+      <AimBody
+        body={"# DAG\n\n- [[not-yet-authored]]"}
+        variant="rpanel"
+        resolves={none}
+        onNavigate={noop}
+      />,
     );
     expect(screen.queryByRole("button", { name: "not-yet-authored" })).toBeNull();
-    // The slug text is still shown, just not interactive.
     expect(screen.getByText("not-yet-authored")).toBeTruthy();
+  });
+
+  it("renders a pure-prose body verbatim, without the canonical scaffold", () => {
+    render(
+      <AimBody
+        body={"just a note, no headings"}
+        variant="rpanel"
+        resolves={all}
+        onNavigate={noop}
+      />,
+    );
+    // No canonical empty slots are forced onto a non-conforming body.
+    expect(screen.queryByText("障害 — escalation")).toBeNull();
+    expect(screen.getByText(/just a note/)).toBeTruthy();
+  });
+
+  it("renders the console variant's sections", () => {
+    render(<AimBody body={DRIFT_BODY} variant="console" resolves={all} onNavigate={noop} />);
+    const sections = screen.getAllByTestId("aim-body-section");
+    expect(sections.some((s) => s.getAttribute("data-kind") === "means")).toBe(true);
+    expect(screen.getByText(/drift 表面化機構/)).toBeTruthy();
   });
 
   it("renders nothing for an empty / whitespace-only body", () => {
     const { container } = render(
-      <AimBody body={"   \n  "} resolves={resolvesAll} onNavigate={noop} />,
+      <AimBody body={"   \n  "} variant="rpanel" resolves={all} onNavigate={noop} />,
     );
     expect(container.innerHTML).toBe("");
     expect(screen.queryByTestId("aim-body")).toBeNull();

--- a/clients/react/src/components/producer-console/r-panel/__tests__/AimBody.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/AimBody.test.tsx
@@ -1,11 +1,10 @@
 // @vitest-environment jsdom
 //
 // AimBody — the agent-authored interior (`AimWire.body`) rendered as STRUCTURED
-// sections. Covers: a structured body renders its sections as labelled blocks
-// in canonical order with empty canonical slots surfaced; `[[slug]]` cross-edges
-// become clickable nav when resolved + stay plain when not; the means-progress
-// (実装済/未実装) chip; a pure-prose body skips the scaffold; an empty body
-// renders nothing.
+// sections. Covers: the canonical is/障害/手段/DAG/history scaffold (reading
+// order + empty slots); the 手段 progress checklist (status glyphs + done/todo
+// ratio); `[[slug]]` cross-edges (clickable when resolved, plain when not); a
+// pure-prose body skipping the scaffold; an empty body rendering nothing.
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
@@ -16,11 +15,16 @@ const none = () => false;
 const noop = () => {};
 
 const DRIFT_BODY = [
+  "# is — 前提",
+  "",
+  "- git 行レベル履歴が安価に取れる",
+  "",
   "# 手段",
   "",
-  "drift 表面化機構（means・未実装）",
+  "drift 表面化機構",
   "",
-  "- 入力はローカル git の行レベル履歴",
+  "- [未実装] within-node: aim 行 ts vs body ts",
+  "- [実装済] 既存 parser split_frontmatter",
   "",
   "# DAG",
   "",
@@ -32,23 +36,39 @@ describe("AimBody", () => {
     render(<AimBody body={DRIFT_BODY} variant="rpanel" resolves={all} onNavigate={noop} />);
     const sections = screen.getAllByTestId("aim-body-section");
     expect(sections.map((s) => s.getAttribute("data-kind"))).toEqual([
+      "is",
       "obstacle",
       "means",
       "dag",
       "history",
     ]);
-    // obstacle + history are absent → empty slots; means + dag carry content.
-    expect(sections[0].getAttribute("data-empty")).toBe("true");
-    expect(sections[3].getAttribute("data-empty")).toBe("true");
-    expect(sections[1].getAttribute("data-empty")).toBeNull();
-    expect(screen.getByText(/drift 表面化機構/)).toBeTruthy();
-    expect(screen.getByText(/入力はローカル git/)).toBeTruthy();
+    // is / means / dag carry content; obstacle + history are empty slots.
+    expect(sections[1].getAttribute("data-empty")).toBe("true"); // obstacle
+    expect(sections[4].getAttribute("data-empty")).toBe("true"); // history
+    expect(sections[0].getAttribute("data-empty")).toBeNull(); // is
+    expect(screen.getByText(/git 行レベル履歴/)).toBeTruthy();
   });
 
-  it("surfaces the means 未実装 progress chip", () => {
+  it("renders 手段 as a progress checklist with a done/todo ratio", () => {
     render(<AimBody body={DRIFT_BODY} variant="rpanel" resolves={all} onNavigate={noop} />);
-    // The chip text is exactly the glyph + status (the prose mention is a longer
-    // string, so an exact match hits only the chip).
+    expect(screen.getByTestId("aim-means-progress").textContent).toContain("実装 1 / 未実装 1");
+    const items = screen.getAllByTestId("aim-means-item");
+    expect(items.map((i) => i.getAttribute("data-status"))).toEqual(["todo", "done"]);
+    expect(screen.getByText(/within-node/)).toBeTruthy();
+    expect(screen.getByText(/既存 parser/)).toBeTruthy();
+  });
+
+  it("falls back to a section status chip when means items carry no markers", () => {
+    render(
+      <AimBody
+        body={"# 手段\n\nfoo（means・未実装）\n\n- a detail bullet"}
+        variant="rpanel"
+        resolves={all}
+        onNavigate={noop}
+      />,
+    );
+    // No marked items → no ratio badge, but the prose 未実装 surfaces as a chip.
+    expect(screen.queryByTestId("aim-means-progress")).toBeNull();
     expect(screen.getByText("◌ 未実装")).toBeTruthy();
   });
 
@@ -88,7 +108,6 @@ describe("AimBody", () => {
         onNavigate={noop}
       />,
     );
-    // No canonical empty slots are forced onto a non-conforming body.
     expect(screen.queryByText("障害 — escalation")).toBeNull();
     expect(screen.getByText(/just a note/)).toBeTruthy();
   });
@@ -97,7 +116,7 @@ describe("AimBody", () => {
     render(<AimBody body={DRIFT_BODY} variant="console" resolves={all} onNavigate={noop} />);
     const sections = screen.getAllByTestId("aim-body-section");
     expect(sections.some((s) => s.getAttribute("data-kind") === "means")).toBe(true);
-    expect(screen.getByText(/drift 表面化機構/)).toBeTruthy();
+    expect(screen.getByTestId("aim-means-progress").textContent).toContain("実装 1 / 未実装 1");
   });
 
   it("renders nothing for an empty / whitespace-only body", () => {

--- a/clients/react/src/components/producer-console/r-panel/__tests__/AimBody.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/AimBody.test.tsx
@@ -39,12 +39,12 @@ describe("AimBody", () => {
       "is",
       "obstacle",
       "means",
-      "dag",
       "history",
+      "dag",
     ]);
     // is / means / dag carry content; obstacle + history are empty slots.
     expect(sections[1].getAttribute("data-empty")).toBe("true"); // obstacle
-    expect(sections[4].getAttribute("data-empty")).toBe("true"); // history
+    expect(sections[3].getAttribute("data-empty")).toBe("true"); // history
     expect(sections[0].getAttribute("data-empty")).toBeNull(); // is
     expect(screen.getByText(/git 行レベル履歴/)).toBeTruthy();
   });
@@ -108,7 +108,7 @@ describe("AimBody", () => {
         onNavigate={noop}
       />,
     );
-    expect(screen.queryByText("障害 — escalation")).toBeNull();
+    expect(screen.queryByText("ESCALATION — 障害")).toBeNull();
     expect(screen.getByText(/just a note/)).toBeTruthy();
   });
 

--- a/clients/react/src/components/producer-console/r-panel/__tests__/AimBody.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/AimBody.test.tsx
@@ -51,7 +51,7 @@ describe("AimBody", () => {
 
   it("renders 手段 as a progress checklist with a done/todo ratio", () => {
     render(<AimBody body={DRIFT_BODY} variant="rpanel" resolves={all} onNavigate={noop} />);
-    expect(screen.getByTestId("aim-means-progress").textContent).toContain("実装 1 / 未実装 1");
+    expect(screen.getByTestId("aim-means-progress").textContent).toContain("done 1 / todo 1");
     const items = screen.getAllByTestId("aim-means-item");
     expect(items.map((i) => i.getAttribute("data-status"))).toEqual(["todo", "done"]);
     expect(screen.getByText(/within-node/)).toBeTruthy();
@@ -69,7 +69,7 @@ describe("AimBody", () => {
     );
     // No marked items → no ratio badge, but the prose 未実装 surfaces as a chip.
     expect(screen.queryByTestId("aim-means-progress")).toBeNull();
-    expect(screen.getByText("◌ 未実装")).toBeTruthy();
+    expect(screen.getByText("◌ todo")).toBeTruthy();
   });
 
   it("renders a resolved [[slug]] cross-edge as a nav button calling onNavigate", () => {
@@ -116,7 +116,7 @@ describe("AimBody", () => {
     render(<AimBody body={DRIFT_BODY} variant="console" resolves={all} onNavigate={noop} />);
     const sections = screen.getAllByTestId("aim-body-section");
     expect(sections.some((s) => s.getAttribute("data-kind") === "means")).toBe(true);
-    expect(screen.getByTestId("aim-means-progress").textContent).toContain("実装 1 / 未実装 1");
+    expect(screen.getByTestId("aim-means-progress").textContent).toContain("done 1 / todo 1");
   });
 
   it("renders nothing for an empty / whitespace-only body", () => {

--- a/clients/react/src/components/producer-console/r-panel/__tests__/RAimsSection.test.tsx
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/RAimsSection.test.tsx
@@ -63,6 +63,15 @@ const wd = (overrides: Partial<AimWorkingDeltaWire> = {}): AimWorkingDeltaWire =
   untracked: false,
   ...overrides,
 });
+// A body with a `# PROCESS` section carrying todo/done units — the owed-signal
+// source (the panel reads progress, not the legacy `is[]` marks).
+const procBody = ({ todo = 0, done = 0 }: { todo?: number; done?: number } = {}): string => {
+  const items = [
+    ...Array.from({ length: todo }, (_, i) => `- [todo] todo ${i}`),
+    ...Array.from({ length: done }, (_, i) => `- [done] done ${i}`),
+  ];
+  return items.length === 0 ? "" : `# PROCESS\n${items.join("\n")}`;
+};
 
 function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
   return {
@@ -92,7 +101,12 @@ function aimStub(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
 //   tmai
 //     inverted-ui (root, open, claimed)                       → owed (claimed)
 const CORE: AimWire[] = [
-  aimStub({ slug: "amplify-human-judgment", aim: "amplify judgment", is: [claimed("進行中")] }),
+  aimStub({
+    slug: "amplify-human-judgment",
+    aim: "amplify judgment",
+    is: [claimed("進行中")],
+    body: procBody({ todo: 1 }),
+  }),
   aimStub({
     slug: "attention-per-artifact",
     aim: "per-artifact attention",
@@ -103,6 +117,7 @@ const CORE: AimWire[] = [
       claimed("ancestor moved — re-confirm"),
       pruned("CLI-flag route", "wrong premise — judgment lives in records"),
     ],
+    body: procBody({ todo: 1, done: 1 }),
   }),
   aimStub({
     slug: "attention-backend",
@@ -110,11 +125,13 @@ const CORE: AimWire[] = [
     parent: "attention-per-artifact",
     state: "done",
     is: [confirmed("wired", "PR#500")],
+    body: procBody({ done: 1 }),
   }),
   aimStub({
     slug: "aim-system",
     aim: "records as structure",
     is: [confirmed("graduated", "PR#501")],
+    body: procBody({ done: 1 }),
   }),
   aimStub({ slug: "aim-honesty", aim: "confirmed ⊥ claimed", parent: "aim-system", state: "dead" }),
   aimStub({
@@ -126,7 +143,12 @@ const CORE: AimWire[] = [
   }),
 ];
 const UI: AimWire[] = [
-  aimStub({ slug: "inverted-ui", aim: "root to conversation", is: [claimed("frontier")] }),
+  aimStub({
+    slug: "inverted-ui",
+    aim: "root to conversation",
+    is: [claimed("frontier")],
+    body: procBody({ todo: 1 }),
+  }),
 ];
 
 function responseStub(
@@ -255,12 +277,11 @@ describe("RAimsSection — panel shell", () => {
     await openPanel();
     const ledger = screen.getByTestId("aim-ledger");
     // drift=2 (attention-per-artifact open + review-attention-budget done; dead
-    // excluded), claimed marks=3, confirmed marks=3. The pruned mark on
-    // attention-per-artifact lands in NO bucket (#814) — counts unchanged.
+    // excluded), todo units=3 (amplify + attention-per-artifact + inverted-ui),
+    // done units=3 (attention-per-artifact + attention-backend + aim-system).
     expect(ledger.textContent).toMatch(/2\s*drift/);
-    expect(ledger.textContent).toMatch(/3\s*claimed/);
-    expect(ledger.textContent).toMatch(/3\s*confirmed/);
-    expect(ledger.textContent).not.toContain("pruned");
+    expect(ledger.textContent).toMatch(/3\s*todo/);
+    expect(ledger.textContent).toMatch(/3\s*done/);
   });
 });
 
@@ -270,13 +291,13 @@ describe("RAimsSection — Frontier mode (owed worklist)", () => {
     renderPanel();
     await openPanel();
 
-    // owed in core: drift (attention-per-artifact) then claimed (amplify…).
+    // owed in core: drift (attention-per-artifact) then todo (amplify…).
     expect(rowEl("attention-per-artifact").dataset.tone).toBe("drift");
-    expect(rowEl("amplify-human-judgment").dataset.tone).toBe("claimed");
-    // A calm (confirmed-only) node is NOT in the worklist.
+    expect(rowEl("amplify-human-judgment").dataset.tone).toBe("todo");
+    // A calm (done-only) node is NOT in the worklist.
     expect(document.querySelector('[data-testid="aim-row"][data-slug="aim-system"]')).toBeNull();
     // owed in the non-primary repo too.
-    expect(rowEl("inverted-ui").dataset.tone).toBe("claimed");
+    expect(rowEl("inverted-ui").dataset.tone).toBe("todo");
   });
 
   it("breadcrumbs each owed row with its ought-ancestry", async () => {
@@ -681,7 +702,7 @@ describe("RAimsSection — working_delta presence facts (#817)", () => {
     }
     const ledger = screen.getByTestId("aim-ledger");
     expect(ledger.textContent).toMatch(/1\s*drift/);
-    expect(ledger.textContent).toMatch(/0\s*claimed/);
-    expect(ledger.textContent).toMatch(/0\s*confirmed/);
+    expect(ledger.textContent).toMatch(/0\s*todo/);
+    expect(ledger.textContent).toMatch(/0\s*done/);
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/__tests__/aim-body-parse.test.ts
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/aim-body-parse.test.ts
@@ -24,18 +24,20 @@ describe("parseAimBody", () => {
     expect(sections[1].content).toContain("[[git-local-fact-source]]");
   });
 
-  it("classifies is / obstacle / history / english headings", () => {
+  it("classifies the canonical IS / ESCALATION / PROCESS / HISTORY / DAG labels", () => {
     const body = [
-      "# is — 前提",
-      "premise",
-      "# 障害",
+      "# IS",
+      "interpretation",
+      "# ESCALATION",
       "blocked on X",
-      "# history",
+      "# PROCESS",
+      "- [未実装] do Z",
+      "# HISTORY",
       "rejected Y",
-      "## Means",
-      "do Z",
+      "# DAG",
+      "- [[other]]",
     ].join("\n");
-    expect(kinds(parseAimBody(body))).toEqual(["is", "obstacle", "history", "means"]);
+    expect(kinds(parseAimBody(body))).toEqual(["is", "obstacle", "means", "history", "dag"]);
   });
 
   it("keeps a lead block before the first heading as a prose section", () => {

--- a/clients/react/src/components/producer-console/r-panel/__tests__/aim-body-parse.test.ts
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/aim-body-parse.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { type AimBodySection, hasStructure, parseAimBody } from "../aim-body-parse";
+
+const kinds = (s: AimBodySection[]) => s.map((x) => x.kind);
+
+describe("parseAimBody", () => {
+  it("splits a real drift-git-shaped body into means + dag sections", () => {
+    const body = [
+      "# 手段",
+      "",
+      "drift 表面化機構（means・未実装）",
+      "",
+      "- 入力はローカル git の行レベル履歴",
+      "- within-node: aim 行 ts vs body ts",
+      "",
+      "# DAG",
+      "",
+      "- 依存: [[git-local-fact-source]]",
+    ].join("\n");
+    const sections = parseAimBody(body);
+    expect(kinds(sections)).toEqual(["means", "dag"]);
+    expect(sections[0].heading).toBe("手段");
+    expect(sections[0].content).toContain("drift 表面化機構");
+    expect(sections[1].content).toContain("[[git-local-fact-source]]");
+  });
+
+  it("classifies obstacle / history / english headings", () => {
+    const body = ["# 障害", "blocked on X", "# history", "rejected Y", "## Means", "do Z"].join(
+      "\n",
+    );
+    expect(kinds(parseAimBody(body))).toEqual(["obstacle", "history", "means"]);
+  });
+
+  it("keeps a lead block before the first heading as a prose section", () => {
+    const sections = parseAimBody("intro line\n\n# 手段\n- a");
+    expect(sections[0]).toMatchObject({ kind: "prose", heading: "" });
+    expect(sections[0].content).toBe("intro line");
+    expect(sections[1].kind).toBe("means");
+  });
+
+  it("drops an empty lead block but keeps an empty headed slot", () => {
+    const sections = parseAimBody("\n\n# 手段\n");
+    expect(sections).toHaveLength(1);
+    expect(sections[0]).toMatchObject({ kind: "means", content: "" });
+  });
+
+  it("returns nothing for an empty body", () => {
+    expect(parseAimBody("   \n  ")).toEqual([]);
+  });
+
+  it("hasStructure is true only with a recognised section", () => {
+    expect(hasStructure(parseAimBody("# 手段\n- a"))).toBe(true);
+    expect(hasStructure(parseAimBody("just prose, no headings"))).toBe(false);
+    expect(hasStructure(parseAimBody("# 雑記\nfree notes"))).toBe(false);
+  });
+});

--- a/clients/react/src/components/producer-console/r-panel/__tests__/aim-body-parse.test.ts
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/aim-body-parse.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { type AimBodySection, hasStructure, parseAimBody } from "../aim-body-parse";
+import { type AimBodySection, hasStructure, parseAimBody, parseMeans } from "../aim-body-parse";
 
 const kinds = (s: AimBodySection[]) => s.map((x) => x.kind);
 
@@ -24,11 +24,18 @@ describe("parseAimBody", () => {
     expect(sections[1].content).toContain("[[git-local-fact-source]]");
   });
 
-  it("classifies obstacle / history / english headings", () => {
-    const body = ["# 障害", "blocked on X", "# history", "rejected Y", "## Means", "do Z"].join(
-      "\n",
-    );
-    expect(kinds(parseAimBody(body))).toEqual(["obstacle", "history", "means"]);
+  it("classifies is / obstacle / history / english headings", () => {
+    const body = [
+      "# is — 前提",
+      "premise",
+      "# 障害",
+      "blocked on X",
+      "# history",
+      "rejected Y",
+      "## Means",
+      "do Z",
+    ].join("\n");
+    expect(kinds(parseAimBody(body))).toEqual(["is", "obstacle", "history", "means"]);
   });
 
   it("keeps a lead block before the first heading as a prose section", () => {
@@ -52,5 +59,37 @@ describe("parseAimBody", () => {
     expect(hasStructure(parseAimBody("# 手段\n- a"))).toBe(true);
     expect(hasStructure(parseAimBody("just prose, no headings"))).toBe(false);
     expect(hasStructure(parseAimBody("# 雑記\nfree notes"))).toBe(false);
+  });
+});
+
+describe("parseMeans", () => {
+  it("parses status markers into a done/todo checklist with detail", () => {
+    const content = [
+      "drift 表面化機構",
+      "",
+      "- [未実装] within-node: aim 行 ts vs body ts",
+      "    - strict > 比較",
+      "- [実装済] 既存 parser split_frontmatter",
+    ].join("\n");
+    const m = parseMeans(content);
+    expect(m.intro).toBe("drift 表面化機構");
+    expect(m.items).toHaveLength(2);
+    expect(m.items[0]).toMatchObject({ status: "todo", text: "within-node: aim 行 ts vs body ts" });
+    expect(m.items[0].detail).toContain("strict >");
+    expect(m.items[1]).toMatchObject({ status: "done", text: "既存 parser split_frontmatter" });
+    expect(m.done).toBe(1);
+    expect(m.todo).toBe(1);
+  });
+
+  it("treats unmarked bullets as status-less items (no false checkboxes)", () => {
+    const m = parseMeans("- 作成 modal は bearing のみ\n- 純 ought の誕生も正規");
+    expect(m.items.map((i) => i.status)).toEqual([null, null]);
+    expect(m.done).toBe(0);
+    expect(m.todo).toBe(0);
+  });
+
+  it("accepts english done/todo markers", () => {
+    const m = parseMeans("- [done] a\n- [todo] b\n- [x] c");
+    expect(m.items.map((i) => i.status)).toEqual(["done", "todo", "done"]);
   });
 });

--- a/clients/react/src/components/producer-console/r-panel/__tests__/aim-tree.test.ts
+++ b/clients/react/src/components/producer-console/r-panel/__tests__/aim-tree.test.ts
@@ -1,13 +1,12 @@
 // Pure aim-forest model — no React, no DOM. Covers the owed/frontier ranking,
 // the per-repo + subtree rollups, the ledger counts, the ought-ancestry walk,
-// the overview-ruler order, and the pin-#2 done+drift tone. (The retired
-// tidy-tree geometry's tests retired with the canvas it served — Stage B's
-// panel is row-based, not a 2D canvas.)
+// the overview-ruler order, and the pin-#2 done+drift tone. The owed signal is
+// the body's `# PROCESS` done/todo (not the retired `is[]` marks), so the
+// fixtures author a PROCESS section via `procBody`.
 
 import { describe, expect, it } from "vitest";
 import type { AimsResponse } from "@/lib/api";
 import type { AimDriftWire } from "@/types/generated/AimDriftWire";
-import type { AimInteriorWire } from "@/types/generated/AimInteriorWire";
 import type { AimWire } from "@/types/generated/AimWire";
 import type { AimWorkingDeltaWire } from "@/types/generated/AimWorkingDeltaWire";
 import {
@@ -21,8 +20,8 @@ import {
   findRoots,
   flattenRepos,
   frontierRows,
-  hasClaimed,
-  hasConfirmed,
+  hasDone,
+  hasTodo,
   isDoneDrifted,
   isDrifted,
   isOwed,
@@ -41,15 +40,16 @@ const DRIFT: AimDriftWire = {
   aim_change_date: "2026-05-01",
 };
 
-function claimed(text = "owed"): AimInteriorWire {
-  return { kind: "claimed", text, ref: null };
+// A body with a `# PROCESS` section carrying `n` todo + `m` done units — the
+// owed-signal source (`meansProgress`). An empty spec yields no body.
+function procBody({ todo = 0, done = 0 }: { todo?: number; done?: number } = {}): string {
+  const items = [
+    ...Array.from({ length: todo }, (_, i) => `- [todo] todo unit ${i}`),
+    ...Array.from({ length: done }, (_, i) => `- [done] done unit ${i}`),
+  ];
+  return items.length === 0 ? "" : `# PROCESS\n${items.join("\n")}`;
 }
-function confirmed(text = "done", ref: string | null = "PR#1"): AimInteriorWire {
-  return { kind: "confirmed", text, ref };
-}
-function pruned(text = "rejected", ref: string | null = "wrong premise"): AimInteriorWire {
-  return { kind: "pruned", text, ref };
-}
+
 function wd(overrides: Partial<AimWorkingDeltaWire> = {}): AimWorkingDeltaWire {
   return { uncommitted: false, uncommitted_anchor_change: false, untracked: false, ...overrides };
 }
@@ -133,24 +133,24 @@ describe("owed-status predicates", () => {
     expect(isDrifted(aim({ slug: "x", drift: DRIFT, state: "done" }))).toBe(true);
   });
 
-  it("hasClaimed / hasConfirmed read the author's mark kind (mark-only)", () => {
-    const n = aim({ slug: "x", is: [confirmed(), claimed()] });
-    expect(hasClaimed(n)).toBe(true);
-    expect(hasConfirmed(n)).toBe(true);
-    expect(hasClaimed(aim({ slug: "y", is: [confirmed()] }))).toBe(false);
-    // pruned (#814) is neither: an adjudicated rejection trips no predicate.
-    const p = aim({ slug: "z", is: [pruned()] });
-    expect(hasClaimed(p)).toBe(false);
-    expect(hasConfirmed(p)).toBe(false);
+  it("hasTodo / hasDone read the body's PROCESS done/todo units", () => {
+    const n = aim({ slug: "x", body: procBody({ done: 1, todo: 1 }) });
+    expect(hasTodo(n)).toBe(true);
+    expect(hasDone(n)).toBe(true);
+    expect(hasTodo(aim({ slug: "y", body: procBody({ done: 1 }) }))).toBe(false);
+    // No PROCESS section → neither.
+    const p = aim({ slug: "z", body: "" });
+    expect(hasTodo(p)).toBe(false);
+    expect(hasDone(p)).toBe(false);
   });
 
-  it("isOwed: an OPEN node that drifted or carries a claimed mark", () => {
+  it("isOwed: an OPEN node that drifted or carries a todo unit", () => {
     expect(isOwed(aim({ slug: "d", drift: DRIFT }))).toBe(true);
-    expect(isOwed(aim({ slug: "k", is: [claimed()] }))).toBe(true);
-    // A purely confirmed open node is calm, not owed.
-    expect(isOwed(aim({ slug: "c", is: [confirmed()] }))).toBe(false);
-    // A purely pruned open node is negative-calm — NEVER owed (#814).
-    expect(isOwed(aim({ slug: "p", is: [pruned()] }))).toBe(false);
+    expect(isOwed(aim({ slug: "k", body: procBody({ todo: 1 }) }))).toBe(true);
+    // A purely done open node is calm, not owed.
+    expect(isOwed(aim({ slug: "c", body: procBody({ done: 1 }) }))).toBe(false);
+    // A no-progress open node is calm.
+    expect(isOwed(aim({ slug: "p", body: "" }))).toBe(false);
     // done / dead are never owed, even when drifted.
     expect(isOwed(aim({ slug: "dn", drift: DRIFT, state: "done" }))).toBe(false);
     expect(isOwed(aim({ slug: "dd", drift: DRIFT, state: "dead" }))).toBe(false);
@@ -167,7 +167,6 @@ describe("aimTone — pin #2: done+drift is distinct, not suppressed", () => {
   it("resolves done+drift to its OWN tone, distinct from done and from drift", () => {
     const doneDrift = aimTone(aim({ slug: "x", state: "done", drift: DRIFT }));
     expect(doneDrift).toBe("done-drift");
-    // Distinct from the two tones it must never collapse into.
     expect(doneDrift).not.toBe("done");
     expect(doneDrift).not.toBe("drift");
   });
@@ -177,15 +176,14 @@ describe("aimTone — pin #2: done+drift is distinct, not suppressed", () => {
     expect(aimTone(aim({ slug: "x", drift: DRIFT }))).toBe("drift");
   });
 
-  it("orders open tones drift › claimed › confirmed › root › neutral", () => {
-    expect(aimTone(aim({ slug: "x", drift: DRIFT, is: [claimed()] }))).toBe("drift");
-    expect(aimTone(aim({ slug: "x", is: [claimed(), confirmed()] }))).toBe("claimed");
-    expect(aimTone(aim({ slug: "x", is: [confirmed()] }))).toBe("confirmed");
+  it("orders open tones drift › todo › progress › root › neutral", () => {
+    expect(aimTone(aim({ slug: "x", drift: DRIFT, body: procBody({ todo: 1 }) }))).toBe("drift");
+    expect(aimTone(aim({ slug: "x", body: procBody({ todo: 1, done: 1 }) }))).toBe("todo");
+    expect(aimTone(aim({ slug: "x", body: procBody({ done: 1 }) }))).toBe("progress");
     expect(aimTone(aim({ slug: "x", parent: null }))).toBe("root");
     expect(aimTone(aim({ slug: "x", parent: "root-a" }))).toBe("neutral");
-    // pruned (#814) contributes NO tone of its own — a pruned-only child reads
-    // neutral, exactly as if unmarked.
-    expect(aimTone(aim({ slug: "x", parent: "root-a", is: [pruned()] }))).toBe("neutral");
+    // A no-progress non-root child reads neutral.
+    expect(aimTone(aim({ slug: "x", parent: "root-a", body: "" }))).toBe("neutral");
   });
 
   it("dead always reads `dead`, even if the wire still carries drift", () => {
@@ -195,10 +193,10 @@ describe("aimTone — pin #2: done+drift is distinct, not suppressed", () => {
 
 describe("frontierRows — owed worklist, drift-first", () => {
   const set: AimWire[] = [
-    aim({ slug: "calm", is: [confirmed()] }), // not owed
-    aim({ slug: "claim-b", is: [claimed()] }),
+    aim({ slug: "calm", body: procBody({ done: 1 }) }), // not owed
+    aim({ slug: "claim-b", body: procBody({ todo: 1 }) }),
     aim({ slug: "drift-z", drift: DRIFT }),
-    aim({ slug: "claim-a", is: [claimed()] }),
+    aim({ slug: "claim-a", body: procBody({ todo: 1 }) }),
     aim({ slug: "drift-a", drift: DRIFT }),
     aim({ slug: "done-drift", state: "done", drift: DRIFT }), // pin #2 — excluded
   ];
@@ -209,7 +207,7 @@ describe("frontierRows — owed worklist, drift-first", () => {
     expect(slugs).not.toContain("done-drift");
   });
 
-  it("ranks drift before claimed, then stable by slug", () => {
+  it("ranks drift before todo, then stable by slug", () => {
     expect(frontierRows(set).map((n) => n.slug)).toEqual([
       "drift-a",
       "drift-z",
@@ -241,18 +239,17 @@ describe("ancestry + breadcrumb", () => {
 
   it("does not hang on a malformed parent cycle", () => {
     const cyclic = bySlugMap([aim({ slug: "a", parent: "b" }), aim({ slug: "b", parent: "a" })]);
-    // Terminates; the exact chain is unimportant, the guard is.
     expect(ancestry("a", cyclic).length).toBeLessThanOrEqual(2);
   });
 });
 
 describe("rollups", () => {
-  // root with two owed descendants (one drift, one claimed) + one calm.
+  // root with two owed descendants (one drift, one todo) + one calm.
   const branch: AimWire[] = [
     aim({ slug: "root" }),
     aim({ slug: "d", parent: "root", drift: DRIFT }),
-    aim({ slug: "k", parent: "root", is: [claimed()] }),
-    aim({ slug: "c", parent: "root", is: [confirmed()] }),
+    aim({ slug: "k", parent: "root", body: procBody({ todo: 1 }) }),
+    aim({ slug: "c", parent: "root", body: procBody({ done: 1 }) }),
     aim({ slug: "deep", parent: "d", drift: DRIFT }),
   ];
 
@@ -261,29 +258,29 @@ describe("rollups", () => {
     const st = subtreeStats("root", childrenOf);
     expect(st.count).toBe(4); // d, k, c, deep
     expect(st.drift).toBe(2); // d, deep
-    expect(st.claimed).toBe(1); // k
+    expect(st.todo).toBe(1); // k
   });
 
-  it("repoStats rolls the whole repo (drift wins over claimed per node)", () => {
+  it("repoStats rolls the whole repo (drift wins over todo per node)", () => {
     const st = repoStats(branch);
     expect(st.count).toBe(5);
     expect(st.drift).toBe(2);
-    expect(st.claimed).toBe(1);
+    expect(st.todo).toBe(1);
   });
 });
 
-describe("ledgerCounts — straight off drift + is[]", () => {
+describe("ledgerCounts — drift nodes + PROCESS done/todo units", () => {
   const forest: AimWire[] = [
-    aim({ slug: "a", drift: DRIFT, is: [confirmed(), claimed()] }),
-    aim({ slug: "b", is: [claimed(), pruned()] }), // pruned rides along, uncounted (#814)
-    aim({ slug: "c", is: [confirmed()] }),
-    aim({ slug: "d", state: "done", drift: DRIFT, is: [confirmed()] }), // pin #2: still drift
+    aim({ slug: "a", drift: DRIFT, body: procBody({ done: 1, todo: 1 }) }),
+    aim({ slug: "b", body: procBody({ todo: 1 }) }),
+    aim({ slug: "c", body: procBody({ done: 1 }) }),
+    aim({ slug: "d", state: "done", drift: DRIFT, body: procBody({ done: 1 }) }), // pin #2: still drift
     aim({ slug: "e", state: "dead", drift: DRIFT }), // dead drift = noise, excluded
   ];
 
-  it("counts drift nodes (incl. done+drift, excl. dead) and is[] marks", () => {
-    // pruned marks are in NO bucket — not claimed, not confirmed, not owed.
-    expect(ledgerCounts(forest)).toEqual({ drift: 2, claimed: 2, confirmed: 3 });
+  it("counts drift nodes (incl. done+drift, excl. dead) and PROCESS units", () => {
+    // drift = a, d (nodes). todo = a, b (units). done = a, c, d (units).
+    expect(ledgerCounts(forest)).toEqual({ drift: 2, todo: 2, done: 3 });
   });
 });
 
@@ -304,7 +301,6 @@ describe("workingDeltaKind — presence facts, compose precedence (#817)", () =>
     expect(workingDeltaKind(aim({ slug: "x", working_delta: wd({ untracked: true }) }))).toBe(
       "untracked",
     );
-    // An all-false struct states no fact — same as a null wire.
     expect(workingDeltaKind(aim({ slug: "x", working_delta: wd() }))).toBeNull();
   });
 
@@ -315,7 +311,6 @@ describe("workingDeltaKind — presence facts, compose precedence (#817)", () =>
     });
     expect(isOwed(dirty)).toBe(false);
     expect(frontierRows([dirty])).toEqual([]);
-    // Presence beside a real owed fact changes nothing about the worklist.
     const driftedDirty = aim({
       slug: "dd",
       drift: DRIFT,
@@ -324,22 +319,21 @@ describe("workingDeltaKind — presence facts, compose precedence (#817)", () =>
     expect(frontierRows([driftedDirty, dirty]).map((n) => n.slug)).toEqual(["dd"]);
   });
 
-  it("NEVER counts into the ledger — drift/claimed/confirmed identical with and without presence", () => {
+  it("NEVER counts into the ledger — drift/todo/done identical with and without presence", () => {
     const clean: AimWire[] = [
-      aim({ slug: "a", drift: DRIFT, is: [confirmed(), claimed()] }),
-      aim({ slug: "b", is: [claimed()] }),
+      aim({ slug: "a", drift: DRIFT, body: procBody({ done: 1, todo: 1 }) }),
+      aim({ slug: "b", body: procBody({ todo: 1 }) }),
     ];
     const dirty: AimWire[] = [
       aim({
         slug: "a",
         drift: DRIFT,
-        is: [confirmed(), claimed()],
+        body: procBody({ done: 1, todo: 1 }),
         working_delta: wd({ uncommitted: true, uncommitted_anchor_change: true }),
       }),
-      aim({ slug: "b", is: [claimed()], working_delta: wd({ untracked: true }) }),
+      aim({ slug: "b", body: procBody({ todo: 1 }), working_delta: wd({ untracked: true }) }),
     ];
     expect(ledgerCounts(dirty)).toEqual(ledgerCounts(clean));
-    // The repo/subtree rollups are presence-blind too.
     expect(repoStats(dirty)).toEqual(repoStats(clean));
   });
 
@@ -368,7 +362,7 @@ describe("rulerOrder — repo-grouped DFS minimap", () => {
         aims: [
           aim({ slug: "r1" }),
           aim({ slug: "r1a", parent: "r1", drift: DRIFT }),
-          aim({ slug: "r1b", parent: "r1", is: [claimed()] }),
+          aim({ slug: "r1b", parent: "r1", body: procBody({ todo: 1 }) }),
         ],
       },
       {
@@ -376,7 +370,7 @@ describe("rulerOrder — repo-grouped DFS minimap", () => {
         repo_root: "/p/ui",
         primary: false,
         repo_head: null,
-        aims: [aim({ slug: "u1", is: [confirmed()] })],
+        aims: [aim({ slug: "u1", body: procBody({ done: 1 }) })],
       },
     ],
   };
@@ -385,10 +379,10 @@ describe("rulerOrder — repo-grouped DFS minimap", () => {
     expect(rulerOrder(res.repos).map((t) => t.slug)).toEqual(["r1", "r1a", "r1b", "u1"]);
   });
 
-  it("lights owed ticks (drift / claimed), leaves calm ticks null", () => {
+  it("lights owed ticks (drift / todo), leaves calm ticks null", () => {
     const ticks = rulerOrder(res.repos);
     expect(ticks.find((t) => t.slug === "r1a")?.owed).toBe("drift");
-    expect(ticks.find((t) => t.slug === "r1b")?.owed).toBe("claimed");
+    expect(ticks.find((t) => t.slug === "r1b")?.owed).toBe("todo");
     expect(ticks.find((t) => t.slug === "u1")?.owed).toBeNull();
   });
 

--- a/clients/react/src/components/producer-console/r-panel/aim-body-parse.ts
+++ b/clients/react/src/components/producer-console/r-panel/aim-body-parse.ts
@@ -1,0 +1,84 @@
+// Pure model — parse an aim node's markdown body into its semantic sections.
+// Shared by both aim surfaces (R-panel `RAimsSection` + aim-console `AimPane`),
+// the same way both share `aim-tree.ts`. No React, fully unit-testable.
+//
+// The rebuilt aim form expresses a node's structured-knowing as `#`-headed
+// markdown sections (`doc/aims/` self-describes the form):
+//   - 障害 (escalation) — the "Go だけで進めない理由" → Producer→operator escalation
+//   - 手段 (means)      — phase/condition-split implementation units (実装済/未実装)
+//   - history (却下手段) — append-only don't-repeat ledger of rejected means
+//   - DAG (cross-edges) — `[[slug]]` dependencies on other aim nodes
+//
+// The form is STILL SETTLING (a running trial — the operator is dogfooding it),
+// so this parser is deliberately section-level + tolerant: it classifies by
+// heading keyword and never imposes a rigid grammar. Anything it does not
+// recognise falls through to `prose`, rendered verbatim — nothing is dropped.
+// (Engine-side section parsing → typed wire is the eventual home, named in the
+// corpus as a new means; left client-side for now so a settling grammar is not
+// frozen into the wire — cf. the internal-contract-principle's "leave volatile
+// seams un-contracted".)
+
+export type AimBodySectionKind = "obstacle" | "means" | "history" | "dag" | "prose";
+
+export interface AimBodySection {
+  kind: AimBodySectionKind;
+  /** The heading text as authored. Empty for a lead block before any heading. */
+  heading: string;
+  /** The section's markdown content (everything below the heading, trimmed). */
+  content: string;
+}
+
+// A markdown ATX heading (`#`..`###` + text). The aim form uses `#`; we accept
+// up to `###` so a deeper authoring habit still classifies rather than dropping
+// into the body of the previous section.
+const HEADING = /^#{1,3}\s+(.+?)\s*$/;
+
+// Classify a heading by keyword (JP + EN variants). Order matters only in that
+// the first match wins; the buckets are disjoint in practice.
+function classify(heading: string): AimBodySectionKind {
+  const h = heading.toLowerCase();
+  if (/障害|escalation|obstacle|blocker/.test(h)) return "obstacle";
+  if (/手段|means/.test(h)) return "means";
+  if (/history|却下|履歴|recoil/.test(h)) return "history";
+  if (/dag|依存|cross.?edge/.test(h)) return "dag";
+  return "prose";
+}
+
+export function parseAimBody(body: string): AimBodySection[] {
+  const lines = body.replace(/\r\n/g, "\n").split("\n");
+  const sections: AimBodySection[] = [];
+  let heading = "";
+  let kind: AimBodySectionKind = "prose";
+  let buf: string[] = [];
+
+  const flush = () => {
+    const content = buf.join("\n").trim();
+    buf = [];
+    // Drop only a truly empty lead block (no heading AND no content); a headed
+    // section with an empty body is still a present (if empty) slot and is kept.
+    if (heading === "" && content === "") return;
+    sections.push({ kind, heading, content });
+  };
+
+  for (const line of lines) {
+    const m = line.match(HEADING);
+    if (m) {
+      flush();
+      heading = m[1];
+      kind = classify(heading);
+    } else {
+      buf.push(line);
+    }
+  }
+  flush();
+  return sections;
+}
+
+// True when the body carries at least one RECOGNISED structured section — i.e.
+// it speaks the aim form, not just free prose. Drives whether the renderer
+// shows the canonical 障害/手段/DAG/history scaffolding (with empty slots) or
+// simply renders the prose verbatim (a non-conforming body is not forced into
+// the scaffold).
+export function hasStructure(sections: readonly AimBodySection[]): boolean {
+  return sections.some((s) => s.kind !== "prose");
+}

--- a/clients/react/src/components/producer-console/r-panel/aim-body-parse.ts
+++ b/clients/react/src/components/producer-console/r-panel/aim-body-parse.ts
@@ -3,22 +3,25 @@
 // the same way both share `aim-tree.ts`. No React, fully unit-testable.
 //
 // The rebuilt aim form expresses a node's structured-knowing as `#`-headed
-// markdown sections (`doc/aims/` self-describes the form):
+// markdown. The body is the PRODUCER's domain (authored for write ergonomics);
+// this parser turns that into a shape the inspector renders for the operator:
+//   - is (前提)         — premises / assumptions implementation needs that the
+//                         aim (purpose) alone does not convey. Shown at the TOP.
 //   - 障害 (escalation) — the "Go だけで進めない理由" → Producer→operator escalation
-//   - 手段 (means)      — phase/condition-split implementation units (実装済/未実装)
+//   - 手段 (means)      — phase/condition-split implementation units, EACH
+//                         carrying progress (実装済 / 未実装) — means is
+//                         progress-bearing by construction
 //   - history (却下手段) — append-only don't-repeat ledger of rejected means
 //   - DAG (cross-edges) — `[[slug]]` dependencies on other aim nodes
 //
-// The form is STILL SETTLING (a running trial — the operator is dogfooding it),
-// so this parser is deliberately section-level + tolerant: it classifies by
-// heading keyword and never imposes a rigid grammar. Anything it does not
-// recognise falls through to `prose`, rendered verbatim — nothing is dropped.
-// (Engine-side section parsing → typed wire is the eventual home, named in the
-// corpus as a new means; left client-side for now so a settling grammar is not
-// frozen into the wire — cf. the internal-contract-principle's "leave volatile
-// seams un-contracted".)
+// The form is STILL SETTLING (a running dogfood trial), so this parser is
+// deliberately section-level + tolerant: it classifies by heading keyword and
+// never imposes a rigid grammar. Anything it does not recognise falls through
+// to `prose`, rendered verbatim — nothing is dropped. (Engine-side section
+// parsing → typed wire is the eventual home; left client-side for now so a
+// settling grammar is not frozen into the wire.)
 
-export type AimBodySectionKind = "obstacle" | "means" | "history" | "dag" | "prose";
+export type AimBodySectionKind = "is" | "obstacle" | "means" | "history" | "dag" | "prose";
 
 export interface AimBodySection {
   kind: AimBodySectionKind;
@@ -28,15 +31,14 @@ export interface AimBodySection {
   content: string;
 }
 
-// A markdown ATX heading (`#`..`###` + text). The aim form uses `#`; we accept
-// up to `###` so a deeper authoring habit still classifies rather than dropping
-// into the body of the previous section.
+// A markdown ATX heading (`#`..`###` + text).
 const HEADING = /^#{1,3}\s+(.+?)\s*$/;
 
-// Classify a heading by keyword (JP + EN variants). Order matters only in that
-// the first match wins; the buckets are disjoint in practice.
+// Classify a heading by keyword (JP + EN variants). `is` is tested first so a
+// "# is — 前提" heading reads as premises rather than falling to prose.
 function classify(heading: string): AimBodySectionKind {
   const h = heading.toLowerCase();
+  if (/前提|premise|assumption|interior|\bis\b/.test(h)) return "is";
   if (/障害|escalation|obstacle|blocker/.test(h)) return "obstacle";
   if (/手段|means/.test(h)) return "means";
   if (/history|却下|履歴|recoil/.test(h)) return "history";
@@ -76,9 +78,99 @@ export function parseAimBody(body: string): AimBodySection[] {
 
 // True when the body carries at least one RECOGNISED structured section — i.e.
 // it speaks the aim form, not just free prose. Drives whether the renderer
-// shows the canonical 障害/手段/DAG/history scaffolding (with empty slots) or
+// shows the canonical is/障害/手段/DAG/history scaffolding (with empty slots) or
 // simply renders the prose verbatim (a non-conforming body is not forced into
 // the scaffold).
 export function hasStructure(sections: readonly AimBodySection[]): boolean {
   return sections.some((s) => s.kind !== "prose");
+}
+
+// ── 手段 (means) — a progress-bearing checklist ───────────────────────────
+//
+// A means section is a (optional) lead intro + a list of implementation units,
+// each carrying an implemented / unimplemented status. The CLEAN authoring
+// convention (the Producer's, designed for easy writing) is a top-level bullet
+// prefixed with a status marker:
+//   - [実装済] existing parser already does X
+//   - [未実装] drift surfacing mechanism
+//       · sub-bullets are that item's detail
+// A bullet WITHOUT a marker is a plain (status-less) item, rendered as an
+// ordinary bullet — so a not-yet-converted body still reads correctly while
+// the section header falls back to whatever 実装済/未実装 the prose mentions.
+
+export type MeansStatus = "done" | "todo";
+
+export interface MeansItem {
+  /** done = 実装済, todo = 未実装, null = no marker (a plain bullet). */
+  status: MeansStatus | null;
+  /** The item line (markdown inline), marker stripped. */
+  text: string;
+  /** Indented continuation / sub-bullets, dedented, as markdown. */
+  detail: string;
+}
+
+export interface ParsedMeans {
+  intro: string;
+  items: MeansItem[];
+  done: number;
+  todo: number;
+}
+
+const TOP_BULLET = /^[-*]\s+(.*)$/;
+const DONE_MARK = /^\[(?:実装済|済|done|x|✓)\]\s*(.*)$/i;
+const TODO_MARK = /^\[(?:未実装|未|todo|◌)\]\s*(.*)$/i;
+
+export function parseMeans(content: string): ParsedMeans {
+  const lines = content.replace(/\r\n/g, "\n").split("\n");
+  const introLines: string[] = [];
+  const items: MeansItem[] = [];
+  let cur: MeansItem | null = null;
+  let detailLines: string[] = [];
+
+  const closeDetail = () => {
+    if (cur) cur.detail = dedent(detailLines).trim();
+    detailLines = [];
+  };
+
+  for (const line of lines) {
+    const indented = /^(?:\s\s+|\t)/.test(line);
+    const bullet = !indented ? line.match(TOP_BULLET) : null;
+    if (bullet) {
+      closeDetail();
+      let text = bullet[1];
+      let status: MeansStatus | null = null;
+      const d = text.match(DONE_MARK);
+      const t = text.match(TODO_MARK);
+      if (d) {
+        status = "done";
+        text = d[1];
+      } else if (t) {
+        status = "todo";
+        text = t[1];
+      }
+      cur = { status, text, detail: "" };
+      items.push(cur);
+    } else if (cur && (indented || line.trim() !== "")) {
+      detailLines.push(line);
+    } else if (cur === null) {
+      introLines.push(line);
+    }
+  }
+  closeDetail();
+
+  return {
+    intro: introLines.join("\n").trim(),
+    items,
+    done: items.filter((i) => i.status === "done").length,
+    todo: items.filter((i) => i.status === "todo").length,
+  };
+}
+
+// Remove the common leading whitespace from a block so nested bullets render as
+// their own list rather than an indented code block.
+function dedent(lines: readonly string[]): string {
+  const nonEmpty = lines.filter((l) => l.trim() !== "");
+  if (nonEmpty.length === 0) return "";
+  const min = Math.min(...nonEmpty.map((l) => l.match(/^\s*/)?.[0].length ?? 0));
+  return lines.map((l) => l.slice(min)).join("\n");
 }

--- a/clients/react/src/components/producer-console/r-panel/aim-body-parse.ts
+++ b/clients/react/src/components/producer-console/r-panel/aim-body-parse.ts
@@ -4,15 +4,16 @@
 //
 // The rebuilt aim form expresses a node's structured-knowing as `#`-headed
 // markdown. The body is the PRODUCER's domain (authored for write ergonomics);
-// this parser turns that into a shape the inspector renders for the operator:
-//   - is (前提)         — premises / assumptions implementation needs that the
-//                         aim (purpose) alone does not convey. Shown at the TOP.
-//   - 障害 (escalation) — the "Go だけで進めない理由" → Producer→operator escalation
-//   - 手段 (means)      — phase/condition-split implementation units, EACH
-//                         carrying progress (実装済 / 未実装) — means is
-//                         progress-bearing by construction
-//   - history (却下手段) — append-only don't-repeat ledger of rejected means
-//   - DAG (cross-edges) — `[[slug]]` dependencies on other aim nodes
+// this parser turns that into a shape the inspector renders for the operator.
+// The canonical sections (see `doc/aims/aim-body`), in reading order:
+//   - IS         — the agent's INTERPRETATION of the aim: how it read the
+//                  purpose, so the human can confirm it read it right. TOP.
+//   - ESCALATION — the "Go だけで進めない理由" → Producer→operator escalation
+//   - PROCESS    — phase/condition-split implementation steps, EACH carrying
+//                  its own progress (実装済 / 未実装) — process is
+//                  progress-bearing by construction
+//   - HISTORY    — append-only don't-repeat ledger of rejected means
+//   - DAG        — `[[slug]]` dependencies on other aim nodes
 //
 // The form is STILL SETTLING (a running dogfood trial), so this parser is
 // deliberately section-level + tolerant: it classifies by heading keyword and
@@ -34,13 +35,15 @@ export interface AimBodySection {
 // A markdown ATX heading (`#`..`###` + text).
 const HEADING = /^#{1,3}\s+(.+?)\s*$/;
 
-// Classify a heading by keyword (JP + EN variants). `is` is tested first so a
-// "# is — 前提" heading reads as premises rather than falling to prose.
+// Classify a heading by keyword. The aim form's canonical section labels are
+// IS / ESCALATION / PROCESS / HISTORY / DAG (see `doc/aims/aim-body`); JP
+// glosses + a few synonyms are accepted too. `is` is tested first so an "# IS"
+// heading reads as the agent's interpretation rather than falling to prose.
 function classify(heading: string): AimBodySectionKind {
   const h = heading.toLowerCase();
-  if (/前提|premise|assumption|interior|\bis\b/.test(h)) return "is";
-  if (/障害|escalation|obstacle|blocker/.test(h)) return "obstacle";
-  if (/手段|means/.test(h)) return "means";
+  if (/\bis\b|前提|premise|assumption|interpretation|解釈|interior/.test(h)) return "is";
+  if (/escalation|障害|obstacle|blocker/.test(h)) return "obstacle";
+  if (/process|手段|means|実装手順|実装工程/.test(h)) return "means";
   if (/history|却下|履歴|recoil/.test(h)) return "history";
   if (/dag|依存|cross.?edge/.test(h)) return "dag";
   return "prose";

--- a/clients/react/src/components/producer-console/r-panel/aim-tree.ts
+++ b/clients/react/src/components/producer-console/r-panel/aim-tree.ts
@@ -11,16 +11,23 @@
 // `isOwed` / `frontierRows` / `ledgerCounts` — not 2D layout (the prototype's
 // tidy-tree geometry retired with the canvas it served).
 //
-// Mark-only (design pin #1 / `doc/aims/README.md`): the interior `is[]` marks
-// (`confirmed` / `claimed`) are surfaced exactly as the author wrote them. This
-// module never re-judges, re-orders, or de-drifts them — it only counts and
-// filters on the kind the wire already carries.
+// Progress-driven (the formalised body model, `doc/aims/aim-body`): the owed
+// signal comes from the body's `# PROCESS` section — each implementation unit
+// carries a per-unit `[done]` / `[todo]` marker. `meansProgress` parses that
+// (client-side, via `aim-body-parse`) into done/todo counts; the ledger, the
+// Frontier worklist, the tones, and the rollups all derive owed-ness from
+// `todo` (an unfinished unit is owed). This SUPERSEDES the retired `is[]`
+// claimed/confirmed marks: the engine still ships `is[]` for any legacy node
+// that still carries marks, but the new bodies express progress in PROCESS, so
+// this module reads progress, not marks. We never re-judge — `[done]`/`[todo]`
+// are facts the author wrote.
 
 import type { AimState } from "@/types/generated/AimState";
 import type { AimsResponse } from "@/types/generated/AimsResponse";
 import type { AimWire } from "@/types/generated/AimWire";
 import type { AimWorkingDeltaWire } from "@/types/generated/AimWorkingDeltaWire";
 import type { RepoAimsWire } from "@/types/generated/RepoAimsWire";
+import { parseAimBody, parseMeans } from "./aim-body-parse";
 
 // ── Glyphs / labels ───────────────────────────────────────────────────
 //
@@ -66,24 +73,39 @@ export function isDrifted(n: AimWire): boolean {
   return n.drift !== null && n.state !== "dead";
 }
 
-// Has at least one `claimed` interior mark (unverified — an operator confirm is
-// owed). Mark-only: we read the kind the author wrote, never re-judge it.
-export function hasClaimed(n: AimWire): boolean {
-  return n.is.some((m) => m.kind === "claimed");
+// A node's PROCESS progress — the per-unit done / todo counts parsed from its
+// body's `# PROCESS` (means) section. Client-side parse (the body grammar is
+// still settling, so it is not frozen into the wire); a node with no PROCESS
+// section is {0, 0}. This is the owed-signal source that replaced `is[]`.
+export interface MeansProgress {
+  done: number;
+  todo: number;
 }
 
-// Has at least one `confirmed` interior mark (external ground-truth checked —
-// real, attention-zero).
-export function hasConfirmed(n: AimWire): boolean {
-  return n.is.some((m) => m.kind === "confirmed");
+export function meansProgress(n: AimWire): MeansProgress {
+  const section = parseAimBody(n.body).find((s) => s.kind === "means");
+  if (section === undefined) return { done: 0, todo: 0 };
+  const m = parseMeans(section.content);
+  return { done: m.done, todo: m.todo };
 }
 
-// Owed = an OPEN node that drifted or carries a `claimed` mark — the Frontier
-// worklist eligibility. `done` / `dead` are never "owed": a `done` node's drift
-// is surfaced distinctly but NOT folded into the worklist (pin #2: "not folded
-// into plain owed").
+// Has at least one unfinished (`[todo]`) PROCESS unit — an implementation step
+// still owed. Progress-driven: we read the marker the author wrote.
+export function hasTodo(n: AimWire): boolean {
+  return meansProgress(n).todo > 0;
+}
+
+// Has at least one finished (`[done]`) PROCESS unit.
+export function hasDone(n: AimWire): boolean {
+  return meansProgress(n).done > 0;
+}
+
+// Owed = an OPEN node that drifted or carries a `[todo]` PROCESS unit — the
+// Frontier worklist eligibility. `done` / `dead` are never "owed": a `done`
+// node's drift is surfaced distinctly but NOT folded into the worklist (pin #2:
+// "not folded into plain owed").
 export function isOwed(n: AimWire): boolean {
-  return n.state === "open" && (isDrifted(n) || hasClaimed(n));
+  return n.state === "open" && (isDrifted(n) || hasTodo(n));
 }
 
 // Pin #2: a `done` node that is ALSO drifted — reached against an OLD ought,
@@ -103,8 +125,8 @@ export type AimTone =
   | "done"
   | "dead"
   | "drift" // open + drifted
-  | "claimed" // open + a claimed mark
-  | "confirmed" // open + a confirmed mark (calm)
+  | "todo" // open + an unfinished PROCESS unit (owed)
+  | "progress" // open + a finished PROCESS unit, none owed (calm)
   | "root"
   | "neutral";
 
@@ -112,8 +134,8 @@ export function aimTone(n: AimWire): AimTone {
   if (n.state === "dead") return "dead";
   if (n.state === "done") return n.drift !== null ? "done-drift" : "done";
   if (isDrifted(n)) return "drift";
-  if (hasClaimed(n)) return "claimed";
-  if (hasConfirmed(n)) return "confirmed";
+  if (hasTodo(n)) return "todo";
+  if (hasDone(n)) return "progress";
   if (n.parent === null) return "root";
   return "neutral";
 }
@@ -232,13 +254,13 @@ export function breadcrumbText(slug: string, bySlug: ReadonlyMap<string, AimWire
 
 // ── Frontier worklist ─────────────────────────────────────────────────
 
-// Rank for the owed worklist: drift before claimed (the ancestor-moved verdict
-// outranks an unverified self-claim), then stable by slug.
+// Rank for the owed worklist: drift before todo (the ancestor-moved verdict
+// outranks an unfinished unit), then stable by slug.
 function owedRank(n: AimWire): number {
   return isDrifted(n) ? 0 : 1;
 }
 
-// The owed worklist for a node set — drift-first, then claimed, stable by slug.
+// The owed worklist for a node set — drift-first, then todo, stable by slug.
 // done+drift is NOT here (it is surfaced separately by `doneDriftedRows`).
 export function frontierRows(nodes: readonly AimWire[]): AimWire[] {
   return nodes
@@ -260,17 +282,18 @@ export interface RollupStats {
   count: number;
   /** Of those, how many are drifted-and-owed (open + drifted). */
   drift: number;
-  /** Of those, how many are claimed-and-owed (open + claimed, not drifted). */
-  claimed: number;
+  /** Of those, how many are todo-owed (open + an unfinished PROCESS unit, not
+   *  drifted). NODE count, not unit count — mirrors the row glyph. */
+  todo: number;
 }
 
 // Descendant rollup for a collapsed branch — total descendants + the owed
 // breakdown, so a folded branch can show `⚠N ◌M` without expanding. drift and
-// claimed are disjoint (drift wins) to mirror the row glyph.
+// todo are disjoint (drift wins) to mirror the row glyph.
 export function subtreeStats(slug: string, childrenOf: Map<string, AimWire[]>): RollupStats {
   let count = 0;
   let drift = 0;
-  let claimed = 0;
+  let todo = 0;
   const seen = new Set<string>();
   const stack = [...(childrenOf.get(slug) ?? [])];
   while (stack.length > 0) {
@@ -280,52 +303,51 @@ export function subtreeStats(slug: string, childrenOf: Map<string, AimWire[]>): 
     count++;
     if (n.state === "open") {
       if (isDrifted(n)) drift++;
-      else if (hasClaimed(n)) claimed++;
+      else if (hasTodo(n)) todo++;
     }
     for (const c of childrenOf.get(n.slug) ?? []) stack.push(c);
   }
-  return { count, drift, claimed };
+  return { count, drift, todo };
 }
 
 // Repo-wide rollup (every node in the repo) — drives the Tree repo-header
 // badge and the Frontier repo-section badge.
 export function repoStats(aims: readonly AimWire[]): RollupStats {
   let drift = 0;
-  let claimed = 0;
+  let todo = 0;
   for (const n of aims) {
     if (n.state !== "open") continue;
     if (isDrifted(n)) drift++;
-    else if (hasClaimed(n)) claimed++;
+    else if (hasTodo(n)) todo++;
   }
-  return { count: aims.length, drift, claimed };
+  return { count: aims.length, drift, todo };
 }
 
 export interface LedgerCounts {
   /** Drifted nodes across the forest (engine-honest: includes done+drift,
    *  excludes abandoned `dead` — see `isDrifted`). */
   drift: number;
-  /** Total `claimed` interior marks across the forest. */
-  claimed: number;
-  /** Total `confirmed` interior marks across the forest. */
-  confirmed: number;
+  /** Total unfinished (`[todo]`) PROCESS units across the forest. */
+  todo: number;
+  /** Total finished (`[done]`) PROCESS units across the forest. */
+  done: number;
 }
 
-// The ledger strip's three counts, straight off the forest's `drift` + `is[]`.
-// drift counts NODES (a node drifts); claimed/confirmed count MARKS (a node can
-// carry several). Engine-honest per pin #2: a done-and-drifted node still
+// The ledger strip's three counts, from the forest's `drift` + body PROCESS.
+// drift counts NODES (a node drifts); todo/done count UNITS (a node's PROCESS
+// can carry several). Engine-honest per pin #2: a done-and-drifted node still
 // counts as drift — it is surfaced, not suppressed.
 export function ledgerCounts(nodes: readonly AimWire[]): LedgerCounts {
   let drift = 0;
-  let claimed = 0;
-  let confirmed = 0;
+  let todo = 0;
+  let done = 0;
   for (const n of nodes) {
     if (n.drift !== null && n.state !== "dead") drift++;
-    for (const m of n.is) {
-      if (m.kind === "confirmed") confirmed++;
-      else if (m.kind === "claimed") claimed++;
-    }
+    const p = meansProgress(n);
+    todo += p.todo;
+    done += p.done;
   }
-  return { drift, claimed, confirmed };
+  return { drift, todo, done };
 }
 
 // ── Overview ruler ────────────────────────────────────────────────────
@@ -333,8 +355,8 @@ export function ledgerCounts(nodes: readonly AimWire[]): LedgerCounts {
 export interface RulerTick {
   slug: string;
   repoLabel: string;
-  /** `drift` / `claimed` light the tick (owed); `null` is calm forest texture. */
-  owed: "drift" | "claimed" | null;
+  /** `drift` / `todo` light the tick (owed); `null` is calm forest texture. */
+  owed: "drift" | "todo" | null;
   /** Fractional position 0..1 down the whole-forest DFS order. */
   pos: number;
   /** True at the first tick of a repo after the first — a repo boundary line. */
@@ -342,11 +364,11 @@ export interface RulerTick {
 }
 
 // The overview-ruler ticks: a repo-grouped DFS over every forest, each node a
-// tick, owed ones (drift / claimed) lit. The minimap proves "you are not
-// looking at the whole tree" while keeping the whole forest's owed density in
+// tick, owed ones (drift / todo) lit. The minimap proves "you are not looking
+// at the whole tree" while keeping the whole forest's owed density in
 // peripheral view; clicking a lit tick reveals the node in Tree mode.
 export function rulerOrder(repos: readonly RepoAimsWire[]): RulerTick[] {
-  const flat: { slug: string; repoLabel: string; owed: "drift" | "claimed" | null }[] = [];
+  const flat: { slug: string; repoLabel: string; owed: "drift" | "todo" | null }[] = [];
   for (const repo of repos) {
     const childrenOf = buildChildren(repo.aims);
     const bySlug = bySlugMap(repo.aims);
@@ -356,11 +378,7 @@ export function rulerOrder(repos: readonly RepoAimsWire[]): RulerTick[] {
       seen.add(slug);
       const n = bySlug.get(slug);
       if (!n) return;
-      const owed: "drift" | "claimed" | null = isDrifted(n)
-        ? "drift"
-        : isOwed(n)
-          ? "claimed"
-          : null;
+      const owed: "drift" | "todo" | null = isDrifted(n) ? "drift" : isOwed(n) ? "todo" : null;
       flat.push({ slug, repoLabel: repo.repo_label, owed });
       for (const c of childrenOf.get(slug) ?? []) visit(c.slug);
     };

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -1930,6 +1930,61 @@
   border-bottom: none;
   cursor: default;
 }
+/* 手段 (means) — a progress-bearing checklist. Each item carries a status
+   glyph (✓ 実装済 / ◌ 未実装 / · plain); the section header carries a done/todo
+   ratio + a thin bar. done = green (calm), todo = ochre (owed, not alarming). */
+.aim-console .ac-means-list {
+  list-style: none;
+  margin: 2px 0 0;
+  padding: 0;
+}
+.aim-console .ac-means-item {
+  margin: 3px 0;
+}
+.aim-console .ac-means-row {
+  display: flex;
+  gap: 6px;
+  align-items: baseline;
+}
+.aim-console .ac-means-g {
+  font-family: var(--mono);
+  font-size: 11px;
+  flex: none;
+  color: var(--faint);
+}
+.aim-console .ac-means-g.done {
+  color: var(--green);
+}
+.aim-console .ac-means-g.todo {
+  color: var(--ochre);
+}
+.aim-console .ac-means-detail {
+  margin: 1px 0 0 16px;
+  color: var(--faint);
+}
+.aim-console .ac-prog {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-family: var(--mono);
+  font-size: 9px;
+  letter-spacing: 0;
+  text-transform: none;
+  color: var(--dim);
+}
+.aim-console .ac-prog-bar {
+  display: inline-block;
+  width: 38px;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--ochre);
+  overflow: hidden;
+}
+.aim-console .ac-prog-bar .done {
+  display: block;
+  height: 100%;
+  background: var(--green);
+}
 
 /* ── resignation inventory (issue #811) ───────────────────────────────────
    Facts beside the done act — what this done is satisfied with vs what it

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -1860,6 +1860,77 @@
   margin-top: 12px;
 }
 
+/* ── aim node body — structured-knowing render (#824) ─────────────────────
+   The body's `#`-headed sections (障害 / 手段 / DAG / history) rendered in the
+   inspector's OWN idiom, NOT generic `prose`: section headers reuse `.ac-isec`,
+   the markdown subtree is toned to the dev-tool palette, `[[slug]]` cross-edges
+   are cyan link chips. Means-progress (実装済/未実装) rides as an `.ac-tg` chip
+   beside the section header. */
+.aim-console .ac-body-sections {
+  margin-top: 6px;
+}
+.aim-console .ac-body-sec {
+  margin-bottom: 9px;
+}
+/* the `.ac-isec` header carries an optional trailing status chip */
+.aim-console .ac-body-sec .ac-isec {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+.aim-console .ac-body {
+  font-size: 12px;
+  color: var(--dim);
+  line-height: 1.5;
+}
+.aim-console .ac-body p {
+  margin: 3px 0;
+}
+.aim-console .ac-body ul,
+.aim-console .ac-body ol {
+  margin: 3px 0;
+  padding-left: 16px;
+}
+.aim-console .ac-body li {
+  margin: 2px 0;
+}
+.aim-console .ac-body h1,
+.aim-console .ac-body h2,
+.aim-console .ac-body h3 {
+  font-family: var(--mono);
+  font-size: 10px;
+  letter-spacing: 0.5px;
+  color: var(--faint);
+  margin: 6px 0 3px;
+}
+.aim-console .ac-body strong {
+  color: #dfe9e6;
+}
+.aim-console .ac-body code {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--cyan);
+}
+/* `[[slug]]` cross-edge → an in-tree nav chip (resolved) or dim text (not). */
+.aim-console .ac-bodylink {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--cyan);
+  background: none;
+  border: none;
+  border-bottom: 1px dotted var(--cyan-d);
+  padding: 0;
+  cursor: pointer;
+}
+.aim-console .ac-bodylink:hover {
+  border-bottom-style: solid;
+}
+.aim-console .ac-bodylink.dim {
+  color: var(--faint);
+  border-bottom: none;
+  cursor: default;
+}
+
 /* ── resignation inventory (issue #811) ───────────────────────────────────
    Facts beside the done act — what this done is satisfied with vs what it
    parks. Categorical tones only (the confirmed/claimed tag tokens above plus


### PR DESCRIPTION
## Why

The rebuilt aim form expresses a node's interior as `#`-headed markdown. The **body is the Producer's domain** (authored for write ergonomics); the **render is the operator's** (readable after parse). A first cut rendered the raw body via generic `prose`, which read as foreign next to the rest of the inspector. This PR renders the body's **sections as typed blocks in each surface's own idiom**, per the operator's model.

## Body section model (canonical, top → bottom)

| section | holds |
|---|---|
| **is — 前提** | premises / assumptions implementation needs that the aim alone doesn't convey. Rendered at the **top**. |
| **障害 — escalation** | the "Go だけで進めない理由" (Producer→operator) |
| **手段 — means** | phase/condition-split units, **each carrying progress** (実装済 / 未実装) |
| **DAG — cross-edges** | `[[slug]]` dependencies on other aim nodes |
| **history — 却下手段** | append-only ledger of rejected means |

## What

- **`aim-body-parse.ts`** — pure, client-side, section-level parser (`parseAimBody`) + a means checklist parser (`parseMeans`). Tolerant — unrecognised headings → `prose`, nothing dropped. Unit-tested.
- **`AimBody`** — renders the canonical scaffold in reading order (absent sections → subtle empty slots, operator-approved); a pure-prose body verbatim. **手段 is a progress checklist**: items carry ✓ 実装済 / ◌ 未実装 from a `[実装済]` / `[未実装]` bullet marker (the Producer's authoring convention), with a done/todo ratio + bar in the header; a not-yet-converted body falls back to a section status chip. `[[slug]]` → in-tree aim-node navigation.
- **Variant-aware**: aim-console speaks `.ac-*` (new `.ac-body*` / `.ac-means*` CSS), R-panel speaks the app's prose / mark idioms.
- The legacy inspector **"interior — is" marks list now renders only when a node still carries marks** — the `is/前提` section supersedes the empty "pure ought" state. The tree-level marks machinery (frontier / ledger / resignation) is **untouched** (phased migration, per operator).

## Parse locus

Client-side on purpose: the body grammar is still settling (a running dogfood trial), so it is not frozen into the wire yet. Promote to an engine-side parser when the form stabilises.

## Gate

biome clean (changed files) · full vitest suite green (+ `parseAimBody` / `parseMeans` / `AimBody` tests) · `tsc -b && vite build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * Aim ノード本文をセクション（「is」「障害」「手段」「履歴」「dag」等）として構造化表示し、「手段」セクションの進捗（todo/done）をバッジ・進捗バーで可視化。
  * `[[slug]]` の参照をボタン化し、解決状態に応じた見た目と移動を実現。

* **UI/表示改善**
  * Inspector 側の表示を更新し、todo/done 基準で集計・ラベル・トーン表記を統一。
  * `is` が空の場合の表示挙動を調整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->