### PR TITLE
feat(aim-console): offline file-backed aim mode for design-machine authoring

### DIFF
--- a/clients/react/.gitignore
+++ b/clients/react/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 dist/
+dist-aim-offline/
 *.tsbuildinfo
 
 # Claude Code local state (per-collaborator notes, skill logs, etc.)

--- a/clients/react/aim-offline.html
+++ b/clients/react/aim-offline.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="ja">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>tmai · aim offline</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/aim-offline.tsx"></script>
+  </body>
+</html>

--- a/clients/react/package.json
+++ b/clients/react/package.json
@@ -5,7 +5,9 @@
   "type": "module",
   "scripts": {
     "dev": "vite",
+    "dev:aim-offline": "vite --config vite.aim-offline.config.ts",
     "build": "tsc -b && vite build",
+    "build:aim-offline": "tsc -b && vite build --config vite.aim-offline.config.ts",
     "preview": "vite preview",
     "lint": "biome check src/",
     "lint:fix": "biome check --write src/",

--- a/clients/react/src/aim-offline.tsx
+++ b/clients/react/src/aim-offline.tsx
@@ -1,0 +1,105 @@
+// Offline aim mode entry — the design-machine authoring surface.
+//
+// Mounts the UNCHANGED `AimFace` (the aim-console's worklist) against a locally
+// picked `doc/aims/` directory via the File System Access API. The vite build
+// (`vite.aim-offline.config.ts`) aliases `@/lib/api` → `@/lib/api-files`, so the
+// reuse is total: `AimFace` + `useUnitAims` + the aim-tree / aim-body-parse
+// logic run as-is, only the read/write transport is file-backed. No engine, no
+// Rust, no HTTP. Drift is absent (git-derived, engine-only) — this is the
+// static design-phase view.
+
+import { type ReactElement, StrictMode, useCallback, useState } from "react";
+import { createRoot } from "react-dom/client";
+import { AimFace } from "@/components/aim-console/AimPane";
+import { setAimsDirectory } from "@/lib/api-files";
+import { applyThemeToDocument, resolveTheme } from "@/lib/theme";
+import { loadUIPrefs } from "@/lib/ui-prefs";
+import { UIPrefsProvider } from "@/lib/ui-prefs-provider";
+import "@fontsource/ibm-plex-mono/400.css";
+import "@fontsource/ibm-plex-mono/500.css";
+import "@fontsource/ibm-plex-mono/600.css";
+import "@fontsource/inter-tight/400.css";
+import "@fontsource/inter-tight/500.css";
+import "@fontsource/inter-tight/600.css";
+import "@fontsource/noto-sans-jp/400.css";
+import "@fontsource/noto-sans-jp/500.css";
+import "./styles/globals.css";
+import "@/styles/aim-console.css";
+import "./styles/aim-offline.css";
+
+// The File System Access API picker (Chromium). Accessed structurally rather
+// than via a global augmentation so it never conflicts with a lib.dom
+// declaration across TS versions.
+interface DirectoryPickerWindow {
+  showDirectoryPicker(options?: {
+    mode?: "read" | "readwrite";
+  }): Promise<FileSystemDirectoryHandle>;
+}
+
+function pickAimsDirectory(): Promise<FileSystemDirectoryHandle> {
+  const picker = window as unknown as Partial<DirectoryPickerWindow>;
+  if (typeof picker.showDirectoryPicker !== "function") {
+    return Promise.reject(
+      new Error("File System Access API がありません — Chrome / Edge で開いてください。"),
+    );
+  }
+  return picker.showDirectoryPicker({ mode: "readwrite" });
+}
+
+function AimOffline(): ReactElement {
+  const [label, setLabel] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const onPick = useCallback(async (): Promise<void> => {
+    setError(null);
+    try {
+      const handle = await pickAimsDirectory();
+      setAimsDirectory(handle, handle.name);
+      setLabel(handle.name);
+    } catch (e) {
+      // Dismissing the native picker rejects with AbortError — not an error.
+      if (e instanceof DOMException && e.name === "AbortError") return;
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  if (label === null) {
+    return (
+      <div className="aim-offline-gate">
+        <div className="aim-offline-gate-card">
+          <h1>aim offline</h1>
+          <p>
+            doc/aims ディレクトリを選ぶと、ローカルのファイルを直接読み書きします（engine
+            不要）。anchor はあなたが直接書き、body はエージェントが書きます。
+          </p>
+          <button type="button" className="aim-offline-pick" onClick={onPick}>
+            doc/aims を選ぶ
+          </button>
+          {error !== null ? <p className="aim-offline-error">{error}</p> : null}
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="aim-console aim-offline-root">
+      <section className="ac-col ac-aim" aria-label="Aim">
+        <AimFace unitName={label} />
+      </section>
+    </div>
+  );
+}
+
+applyThemeToDocument(resolveTheme(loadUIPrefs().theme));
+
+const rootEl = document.getElementById("root");
+if (rootEl === null) {
+  throw new Error("aim-offline: #root element missing");
+}
+createRoot(rootEl).render(
+  <StrictMode>
+    <UIPrefsProvider>
+      <AimOffline />
+    </UIPrefsProvider>
+  </StrictMode>,
+);

--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -157,7 +157,7 @@ export function AimPane({ unitName }: { unitName: string | null }) {
 
 // ── AIM face orchestrator (the pre-#809 pane, behaviour unchanged) ────
 
-function AimFace({ unitName }: { unitName: string | null }) {
+export function AimFace({ unitName }: { unitName: string | null }) {
   const { data, loading, error, refresh } = useUnitAims(unitName);
   const repos = useMemo(() => repoForests(data), [data]);
   const allNodes = useMemo(() => flattenRepos(data), [data]);

--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -413,13 +413,18 @@ function resolveSelection(slug: string | null, repos: readonly RepoAimsWire[]): 
   return null;
 }
 
-// Default branch-expansion: every repo group + every root open (the mock's
-// default — deeper branches collapse behind a rollup).
+// Default branch-expansion: FULLY EXPANDED — every repo group + every node.
+// Tree is the opt-in structure view (the operator deliberately switches to it
+// FROM the Frontier premise to see the shape), so it opens fully; a roots-only
+// default would defeat the reason for choosing Tree. Frontier stays the
+// attention-economical default view; the data scan + the aim-tree compute are
+// identical either way, so this is purely a render-side default the operator
+// can still collapse per-branch (the rollup badges return on manual collapse).
 function seedExpanded(repos: readonly RepoAimsWire[]): Set<string> {
   const s = new Set<string>();
   for (const r of repos) {
     s.add(repoKey(r));
-    for (const root of findRoots(r.aims)) s.add(root.slug);
+    for (const node of r.aims) s.add(node.slug);
   }
   return s;
 }

--- a/clients/react/src/lib/__tests__/aim-file-format.test.ts
+++ b/clients/react/src/lib/__tests__/aim-file-format.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it } from "vitest";
+import {
+  editAimFrontmatter,
+  fileToAimWire,
+  serializeNewAim,
+  splitFrontmatter,
+  unquoteYamlScalar,
+  validateAimSlug,
+  yamlInlineScalar,
+} from "../aim-file-format";
+
+describe("splitFrontmatter", () => {
+  it("splits leading frontmatter from the body", () => {
+    const r = splitFrontmatter("---\naim: x\nstate: open\n---\n\n# IS\n\nbody.\n");
+    expect(r).not.toBeNull();
+    expect(r?.front).toBe("aim: x\nstate: open");
+    expect(r?.body).toBe("\n# IS\n\nbody.\n");
+  });
+
+  it("handles CRLF endings (mirror of the Rust — the pre-close CR stays in front, frontLines strips it)", () => {
+    const r = splitFrontmatter("---\r\naim: x\r\nstate: open\r\n---\r\nbody\r\n");
+    expect(r?.front).toBe("aim: x\r\nstate: open\r");
+    expect(r?.body).toBe("body\r\n");
+    // downstream: fileToAimWire normalizes the CR away
+    const w = fileToAimWire("x", "---\r\naim: hi\r\nstate: open\r\n---\r\nbody\r\n");
+    expect(w.aim).toBe("hi");
+    expect(w.state).toBe("open");
+  });
+
+  it("returns null for a file with no frontmatter", () => {
+    expect(splitFrontmatter("# just a markdown file\n")).toBeNull();
+    expect(splitFrontmatter("---\naim: unterminated\n")).toBeNull();
+  });
+});
+
+describe("yaml scalar round-trip", () => {
+  const cases = [
+    "tmai はバイブコーディングの個人開発を支援する",
+    "unit を組んでいれば同じ権限で動いて然るべき",
+    "a value: with a colon",
+    "has \"double\" and 'single' quotes",
+    "- leading dash looks like a sequence",
+    "trailing colon:",
+    "true",
+    "42",
+    "café — em dash and unicode ✓",
+    "#hash-leading",
+  ];
+  for (const v of cases) {
+    it(`round-trips ${JSON.stringify(v)}`, () => {
+      expect(unquoteYamlScalar(yamlInlineScalar(v))).toBe(v);
+    });
+  }
+
+  it("emits a plain scalar for a safe value (corpus style)", () => {
+    expect(yamlInlineScalar("a plain anchor sentence")).toBe("a plain anchor sentence");
+  });
+
+  it("double-quotes a value carrying a colon", () => {
+    expect(yamlInlineScalar("a: b")).toBe('"a: b"');
+  });
+
+  it("reads the engine's single-quoted output", () => {
+    expect(unquoteYamlScalar("'it''s quoted'")).toBe("it's quoted");
+  });
+});
+
+describe("fileToAimWire", () => {
+  it("parses a root node", () => {
+    const w = fileToAimWire(
+      "aim-system",
+      "---\naim: the root bearing\nstate: open\n---\n\n# IS\n\nx\n",
+    );
+    expect(w.slug).toBe("aim-system");
+    expect(w.aim).toBe("the root bearing");
+    expect(w.parent).toBeNull();
+    expect(w.state).toBe("open");
+    expect(w.body).toBe("\n# IS\n\nx\n");
+    expect(w.drift).toBeNull();
+    expect(w.working_delta).toBeNull();
+    expect(w.is).toEqual([]);
+  });
+
+  it("parses a child node with a quoted anchor and a parent", () => {
+    const w = fileToAimWire(
+      "drift-git",
+      '---\naim: "drift: a colon anchor"\nparent: new-aim\nstate: done\n---\nbody\n',
+    );
+    expect(w.aim).toBe("drift: a colon anchor");
+    expect(w.parent).toBe("new-aim");
+    expect(w.state).toBe("done");
+  });
+
+  it("ignores look-alike keys and preserves the body", () => {
+    const w = fileToAimWire("x", "---\naim: real\naim_note: not a key\nstate: dead\n---\nB\n");
+    expect(w.aim).toBe("real");
+    expect(w.state).toBe("dead");
+  });
+
+  it("throws on a missing anchor or state", () => {
+    expect(() => fileToAimWire("x", "---\nstate: open\n---\n")).toThrow(/aim:/);
+    expect(() => fileToAimWire("x", "---\naim: y\n---\n")).toThrow(/state/);
+    expect(() => fileToAimWire("x", "no frontmatter")).toThrow(/frontmatter/);
+  });
+});
+
+describe("serializeNewAim", () => {
+  it("emits a frontmatter-only root, no parent line", () => {
+    expect(serializeNewAim("hello", null, "open")).toBe("---\naim: hello\nstate: open\n---\n");
+  });
+
+  it("emits parent between aim and state when present", () => {
+    expect(serializeNewAim("child goal", "parent-slug", "open")).toBe(
+      "---\naim: child goal\nparent: parent-slug\nstate: open\n---\n",
+    );
+  });
+
+  it("round-trips through the parser", () => {
+    const raw = serializeNewAim("a: colon anchor", "p", "done");
+    const w = fileToAimWire("s", raw);
+    expect(w.aim).toBe("a: colon anchor");
+    expect(w.parent).toBe("p");
+    expect(w.state).toBe("done");
+    expect(w.body).toBe("");
+  });
+});
+
+describe("editAimFrontmatter", () => {
+  const record = [
+    "---",
+    "aim: old anchor",
+    "parent: old-parent",
+    "depends_on: [a, b]",
+    "state: open",
+    "---",
+    "",
+    "# IS",
+    "",
+    "the body is preserved.",
+    "",
+  ].join("\n");
+
+  it("rewrites only aim/parent/state, preserving cross-edges and body byte-for-byte", () => {
+    const out = editAimFrontmatter(record, "new anchor", "new-parent", "done");
+    expect(out).toBe(
+      [
+        "---",
+        "aim: new anchor",
+        "parent: new-parent",
+        "depends_on: [a, b]",
+        "state: done",
+        "---",
+        "",
+        "# IS",
+        "",
+        "the body is preserved.",
+        "",
+      ].join("\n"),
+    );
+  });
+
+  it("re-roots by dropping the parent line when parent is null", () => {
+    const out = editAimFrontmatter(record, "old anchor", null, "open");
+    expect(out).not.toContain("parent:");
+    expect(out).toContain("depends_on: [a, b]");
+    expect(out).toContain("the body is preserved.");
+  });
+
+  it("inserts a new parent line right after aim when none existed", () => {
+    const rootRecord = "---\naim: a root\nstate: open\n---\nBODY\n";
+    const out = editAimFrontmatter(rootRecord, "a root", "now-a-child", "open");
+    expect(out).toBe("---\naim: a root\nparent: now-a-child\nstate: open\n---\nBODY\n");
+  });
+
+  it("preserves the body exactly across an edit", () => {
+    const out = editAimFrontmatter(record, "x", "old-parent", "open");
+    const body = splitFrontmatter(out)?.body;
+    expect(body).toBe("\n# IS\n\nthe body is preserved.\n");
+  });
+});
+
+describe("validateAimSlug", () => {
+  it("accepts a valid kebab slug", () => {
+    expect(validateAimSlug("aim-system")).toBeNull();
+    expect(validateAimSlug("drift-git")).toBeNull();
+  });
+
+  it("rejects empty / uppercase / bad dashes / dated slugs", () => {
+    expect(validateAimSlug("")).toMatch(/empty/);
+    expect(validateAimSlug("Aim-System")).toMatch(/kebab/);
+    expect(validateAimSlug("under_score")).toMatch(/kebab/);
+    expect(validateAimSlug("-leading")).toMatch(/start\/end/);
+    expect(validateAimSlug("double--dash")).toMatch(/start\/end/);
+    expect(validateAimSlug("2026-06-15-dated")).toMatch(/NON-dated/);
+  });
+});

--- a/clients/react/src/lib/aim-file-format.ts
+++ b/clients/react/src/lib/aim-file-format.ts
@@ -1,0 +1,255 @@
+// Pure aim-record file format — parse a `doc/aims/<slug>.md` file into the wire
+// shape the aim-console renders, and serialize the operator's frontmatter edits
+// back. A faithful TS mirror of tmai-core's `workbench::aim` write surface
+// (`split_frontmatter` / `serialize_new_aim` / `edit_aim_frontmatter` /
+// `yaml_inline_scalar` / `validate_new_aim_slug`), so the offline (file-backed)
+// aim mode produces records the engine parses identically and edits records
+// byte-for-byte the way the engine does. No DOM, no FS — fully unit-testable.
+//
+// Scope mirrors the engine's: the frontmatter carries the operator's bearing
+// (`aim` / `parent` / `state`) only; the agent-authored body and any other
+// frontmatter line (cross-edges) are preserved verbatim on edit. The body's
+// `[[slug]]` DAG and `# PROCESS` progress are read from `body` downstream
+// (`aim-body-parse` / `aim-tree`), so this module leaves the cross-edge wire
+// fields empty — they are vestigial for the new body-section form.
+
+import type { AimState } from "@/types/generated/AimState";
+import type { AimWire } from "@/types/generated/AimWire";
+
+const AIM_STATES: readonly AimState[] = ["open", "done", "dead"];
+
+export interface SplitResult {
+  /** The YAML frontmatter block, trailing newline excluded. */
+  front: string;
+  /** Everything after the closing `---` line, verbatim. */
+  body: string;
+}
+
+// Mirror of `decision::split_frontmatter`: require a leading `---` line, find
+// the closing `---` line, return the block between and the body after. Handles
+// both `\n` and `\r\n` line endings, same as the Rust.
+export function splitFrontmatter(raw: string): SplitResult | null {
+  let rest: string | null = null;
+  if (raw.startsWith("---\n")) rest = raw.slice(4);
+  else if (raw.startsWith("---\r\n")) rest = raw.slice(5);
+  if (rest === null) return null;
+
+  let end = rest.indexOf("\n---\n");
+  let closeLen = 5;
+  if (end === -1) {
+    end = rest.indexOf("\n---\r\n");
+    closeLen = 6;
+  }
+  if (end === -1) return null;
+
+  return { front: rest.slice(0, end), body: rest.slice(end + closeLen) };
+}
+
+// A top-level frontmatter line declaring `key` — begins `key:` with no leading
+// indentation, so a block-sequence item or a `aim_foo:` look-alike never
+// matches. Mirror of `aim::is_frontmatter_key`.
+function isFrontmatterKey(line: string, key: string): boolean {
+  return line.startsWith(key) && line.slice(key.length).startsWith(":");
+}
+
+// Split front into its lines, normalizing CRLF (mirrors Rust `str::lines`).
+function frontLines(front: string): string[] {
+  return front.split("\n").map((l) => (l.endsWith("\r") ? l.slice(0, -1) : l));
+}
+
+// ── YAML single-line scalar (de)serialization ─────────────────────────
+//
+// The corpus frontmatter values (`aim` / `parent` / `state`) are always a
+// single line. We only need single-line scalar round-trip, not a full YAML
+// emitter: emit a plain scalar when it is unambiguous, otherwise a
+// double-quoted scalar (`JSON.stringify` is a valid YAML double-quoted scalar:
+// YAML's double-quoted escapes are a superset of JSON's). The engine parses
+// either form back to the same value; we are not required to be byte-identical
+// to serde_yaml's emitter, only to round-trip the value.
+
+const YAML_INDICATOR_START = /^[-?:,[\]{}#&*!|>'"%@`]/;
+const YAML_RESERVED = /^(?:true|false|null|~|yes|no|on|off)$/i;
+const YAML_NUMBER_LIKE = /^[+-]?(?:\d|\.\d)/;
+
+function isPlainSafe(v: string): boolean {
+  if (v.length === 0) return false;
+  if (v !== v.trim()) return false;
+  if (v.includes("\n")) return false;
+  if (YAML_INDICATOR_START.test(v)) return false;
+  if (v.includes(": ") || v.endsWith(":")) return false;
+  if (v.includes(" #")) return false;
+  if (YAML_RESERVED.test(v)) return false;
+  if (YAML_NUMBER_LIKE.test(v)) return false;
+  return true;
+}
+
+// Mirror of `aim::yaml_inline_scalar` (role-equivalent — plain when safe, else
+// a quoted form the YAML parser round-trips).
+export function yamlInlineScalar(value: string): string {
+  return isPlainSafe(value) ? value : JSON.stringify(value);
+}
+
+// Unescape the common YAML double-quoted escapes JSON.parse does not cover
+// (used only as a fallback when the value is not valid JSON).
+function unescapeDoubleQuoted(inner: string): string {
+  return inner.replace(/\\(u[0-9a-fA-F]{4}|.)/g, (_m, esc: string) => {
+    if (esc.startsWith("u")) return String.fromCharCode(Number.parseInt(esc.slice(1), 16));
+    const map: Record<string, string> = {
+      n: "\n",
+      t: "\t",
+      r: "\r",
+      "\\": "\\",
+      '"': '"',
+      "/": "/",
+      "0": "\0",
+    };
+    return map[esc] ?? esc;
+  });
+}
+
+// Invert `yamlInlineScalar`, and also accept the engine's single-quoted output.
+// Single-line scalars only (the corpus invariant): plain, double-quoted, or
+// single-quoted (`''` → `'`).
+export function unquoteYamlScalar(raw: string): string {
+  const t = raw.trim();
+  if (t.length >= 2 && t.startsWith('"') && t.endsWith('"')) {
+    try {
+      const parsed: unknown = JSON.parse(t);
+      if (typeof parsed === "string") return parsed;
+    } catch {
+      // fall through to the YAML-double-quote unescape
+    }
+    return unescapeDoubleQuoted(t.slice(1, -1));
+  }
+  if (t.length >= 2 && t.startsWith("'") && t.endsWith("'")) {
+    return t.slice(1, -1).replace(/''/g, "'");
+  }
+  return t;
+}
+
+// ── Frontmatter → AimWire ─────────────────────────────────────────────
+
+function fieldValue(lines: readonly string[], key: string): string | null {
+  const line = lines.find((l) => isFrontmatterKey(l, key));
+  if (line === undefined) return null;
+  return unquoteYamlScalar(line.slice(key.length + 1));
+}
+
+function parseState(token: string | null): AimState {
+  const found = AIM_STATES.find((s) => s === token);
+  if (found === undefined) {
+    throw new Error(`aim record has an unknown or missing state: ${token ?? "<none>"}`);
+  }
+  return found;
+}
+
+// Parse one `doc/aims/<slug>.md` file's raw text into an `AimWire`. The
+// git-derived fields (`drift` / `working_delta`) are `null` (no engine /
+// git analysis offline) and `is` is empty (progress is read from the body's
+// `# PROCESS` downstream, not the wire `is[]`). Throws on a malformed record.
+export function fileToAimWire(slug: string, raw: string): AimWire {
+  const split = splitFrontmatter(raw);
+  if (split === null) {
+    throw new Error(`aim record ${slug} has no \`---\` YAML frontmatter`);
+  }
+  const lines = frontLines(split.front);
+  const aim = fieldValue(lines, "aim");
+  if (aim === null) {
+    throw new Error(`aim record ${slug} frontmatter has no \`aim:\` line`);
+  }
+  const parent = fieldValue(lines, "parent");
+  const state = parseState(fieldValue(lines, "state"));
+
+  return {
+    slug,
+    aim,
+    parent: parent === null ? null : parent,
+    state,
+    depends_on: [],
+    serves: [],
+    related: [],
+    body: split.body,
+    drift: null,
+    working_delta: null,
+    is: [],
+  };
+}
+
+// ── AimWire frontmatter → file text ───────────────────────────────────
+
+// Mirror of `aim::serialize_new_aim`: a `---`-delimited frontmatter (`aim`,
+// then `parent` only when present, then `state`) followed by an empty body.
+export function serializeNewAim(aim: string, parent: string | null, state: AimState): string {
+  let front = `aim: ${yamlInlineScalar(aim)}\n`;
+  if (parent !== null) front += `parent: ${yamlInlineScalar(parent)}\n`;
+  front += `state: ${state}\n`;
+  return `---\n${front}---\n`;
+}
+
+// Mirror of `aim::edit_aim_frontmatter`: rewrite ONLY `aim` / `parent` /
+// `state`, preserving every other frontmatter line and the entire body
+// byte-for-byte. `parent === null` drops any `parent:` line (re-rooting);
+// a newly-set parent with no line to replace goes right after `aim:`.
+export function editAimFrontmatter(
+  raw: string,
+  aim: string,
+  parent: string | null,
+  state: AimState,
+): string {
+  const split = splitFrontmatter(raw);
+  if (split === null) {
+    throw new Error("aim record has no `---` YAML frontmatter");
+  }
+
+  const aimLine = `aim: ${yamlInlineScalar(aim)}`;
+  const stateLine = `state: ${state}`;
+  const parentLine = parent === null ? null : `parent: ${yamlInlineScalar(parent)}`;
+
+  const lines = frontLines(split.front);
+  const hasParentLine = lines.some((l) => isFrontmatterKey(l, "parent"));
+
+  const out: string[] = [];
+  let seenAim = false;
+  let seenState = false;
+  for (const line of lines) {
+    if (isFrontmatterKey(line, "aim")) {
+      out.push(aimLine);
+      seenAim = true;
+      if (!hasParentLine && parentLine !== null) out.push(parentLine);
+    } else if (isFrontmatterKey(line, "parent")) {
+      if (parentLine !== null) out.push(parentLine);
+    } else if (isFrontmatterKey(line, "state")) {
+      out.push(stateLine);
+      seenState = true;
+    } else {
+      out.push(line);
+    }
+  }
+
+  if (!seenAim) throw new Error("aim record frontmatter has no `aim:` line");
+  if (!seenState) throw new Error("aim record frontmatter has no `state:` line");
+
+  return `---\n${out.join("\n")}\n---\n${split.body}`;
+}
+
+// ── Slug validation (mirror of `aim::validate_new_aim_slug`) ──────────
+
+const DATE_PREFIX = /^\d{4}-\d{2}-\d{2}-/;
+
+// Returns the reason the slug is invalid, or `null` if valid. Non-empty,
+// lowercase kebab (`[a-z0-9-]`, no leading/trailing/doubled `-`), and NON-dated
+// (a `YYYY-MM-DD-` prefix is the decision/approach convention; aim slugs are
+// dateless stable identities).
+export function validateAimSlug(slug: string): string | null {
+  if (slug.length === 0) return "slug must not be empty";
+  if (!/^[a-z0-9-]+$/.test(slug)) {
+    return `slug '${slug}' must be lowercase kebab-case (only [a-z0-9-] allowed)`;
+  }
+  if (slug.startsWith("-") || slug.endsWith("-") || slug.includes("--")) {
+    return `slug '${slug}' must not start/end with '-' or contain '--'`;
+  }
+  if (DATE_PREFIX.test(slug)) {
+    return `slug '${slug}' must be NON-dated (aim slugs are dateless stable identities)`;
+  }
+  return null;
+}

--- a/clients/react/src/lib/api-files.ts
+++ b/clients/react/src/lib/api-files.ts
@@ -1,0 +1,153 @@
+// File-backed API for the OFFLINE aim mode (design-machine authoring).
+//
+// The aim-console reads its tree from `api.aims(unit)` and writes via
+// `api.createAim` / `api.editAim`, all through `@/lib/api`. The offline build
+// aliases `@/lib/api` to THIS module (see `vite.aim-offline.config.ts`), so the
+// UNCHANGED `AimFace` + `useUnitAims` operate on a locally-picked `doc/aims/`
+// directory via the File System Access API instead of the HTTP engine.
+//
+// Scope = the design phase: the static corpus (tree / neighborhood / progress
+// from the body), NOT the live engine. `drift` / `working_delta` are `null`
+// (git-derived, engine-only); `aimTone` handles that. Writes mirror the engine
+// byte discipline through `aim-file-format` (frontmatter only — the agent
+// authors the body; cross-edge lines and the body are preserved on edit).
+//
+// Every non-aim `api` method is inherited from the HTTP layer (spread below) so
+// any transitive import resolves; `AimFace` only ever calls the three aim
+// methods, so those engine-only paths are never reached offline.
+
+export * from "./api-http";
+
+import type { AimCreateRequest } from "@/types/generated/AimCreateRequest";
+import type { AimEditRequest } from "@/types/generated/AimEditRequest";
+import type { AimsResponse } from "@/types/generated/AimsResponse";
+import type { AimWire } from "@/types/generated/AimWire";
+import {
+  editAimFrontmatter,
+  fileToAimWire,
+  serializeNewAim,
+  validateAimSlug,
+} from "./aim-file-format";
+import { api as httpApi } from "./api-http";
+
+// The operator-picked `doc/aims/` directory (set once by the offline entry's
+// directory picker). All three aim methods read/write through it; `null` until
+// a directory is chosen.
+let aimsDir: FileSystemDirectoryHandle | null = null;
+let aimsLabel = "doc/aims";
+
+export function setAimsDirectory(handle: FileSystemDirectoryHandle, label?: string): void {
+  aimsDir = handle;
+  if (label !== undefined) aimsLabel = label;
+}
+
+export function aimsDirectoryName(): string {
+  return aimsDir?.name ?? aimsLabel;
+}
+
+function requireDir(): FileSystemDirectoryHandle {
+  if (aimsDir === null) {
+    throw new Error("no doc/aims directory picked yet");
+  }
+  return aimsDir;
+}
+
+const AIM_FILE = /\.md$/;
+
+async function readText(dir: FileSystemDirectoryHandle, name: string): Promise<string> {
+  const fh = await dir.getFileHandle(name);
+  const file = await fh.getFile();
+  return file.text();
+}
+
+async function writeText(
+  dir: FileSystemDirectoryHandle,
+  name: string,
+  content: string,
+): Promise<void> {
+  const fh = await dir.getFileHandle(name, { create: true });
+  const writable = await fh.createWritable();
+  await writable.write(content);
+  await writable.close();
+}
+
+async function fileExists(dir: FileSystemDirectoryHandle, name: string): Promise<boolean> {
+  try {
+    await dir.getFileHandle(name);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+// Read every top-level `*.md` (single-level scan, mirroring tmai-core's
+// `read_aims_dir` — so an `_archive/` or `_incubator/` subdir is excluded), and
+// parse each into an `AimWire`. A malformed record is skipped (a console.warn,
+// never a crash) so one bad file does not blank the whole tree.
+async function readAims(dir: FileSystemDirectoryHandle): Promise<AimWire[]> {
+  const aims: AimWire[] = [];
+  for await (const [name, handle] of dir.entries()) {
+    if (handle.kind !== "file" || !AIM_FILE.test(name)) continue;
+    const slug = name.replace(AIM_FILE, "");
+    try {
+      aims.push(fileToAimWire(slug, await readText(dir, name)));
+    } catch (e) {
+      console.warn(`skipping unparseable aim record ${name}:`, e);
+    }
+  }
+  return aims.sort((a, b) => a.slug.localeCompare(b.slug));
+}
+
+async function aims(unit: string): Promise<AimsResponse> {
+  const dir = requireDir();
+  const repoAims = await readAims(dir);
+  return {
+    unit,
+    composed_at: new Date().toISOString(),
+    repos: [
+      {
+        repo_label: dir.name,
+        repo_root: dir.name,
+        primary: true,
+        repo_head: null,
+        aims: repoAims,
+      },
+    ],
+  };
+}
+
+async function createAim(_unit: string, body: AimCreateRequest): Promise<AimWire> {
+  const dir = requireDir();
+  const reason = validateAimSlug(body.slug);
+  if (reason !== null) throw new Error(reason);
+
+  const name = `${body.slug}.md`;
+  if (await fileExists(dir, name)) {
+    throw new Error(`an aim node '${body.slug}' already exists`);
+  }
+  // `state` defaults to `open` server-side; the offline create mirrors that.
+  const content = serializeNewAim(body.aim, body.parent, "open");
+  await writeText(dir, name, content);
+  return fileToAimWire(body.slug, content);
+}
+
+async function editAim(_unit: string, slug: string, body: AimEditRequest): Promise<AimWire> {
+  const dir = requireDir();
+  const name = `${slug}.md`;
+  if (!(await fileExists(dir, name))) {
+    throw new Error(`no aim node '${slug}'`);
+  }
+  const edited = editAimFrontmatter(await readText(dir, name), body.aim, body.parent, body.state);
+  await writeText(dir, name, edited);
+  return fileToAimWire(slug, edited);
+}
+
+// The file-backed `api`: every HTTP method inherited, the three aim methods
+// overridden. The local `api` export shadows the `export *`-re-exported one
+// (same pattern as `api-tauri.ts`).
+export const api = {
+  ...httpApi,
+  aims,
+  createAim,
+  editAim,
+};

--- a/clients/react/src/lib/api-files.ts
+++ b/clients/react/src/lib/api-files.ts
@@ -67,16 +67,28 @@ async function writeText(
 ): Promise<void> {
   const fh = await dir.getFileHandle(name, { create: true });
   const writable = await fh.createWritable();
-  await writable.write(content);
-  await writable.close();
+  try {
+    await writable.write(content);
+    await writable.close();
+  } catch (e) {
+    // Release the file lock on failure — otherwise the writable stays locked
+    // and blocks subsequent writes until reload. abort() rejects if the stream
+    // is already closed, so swallow that (best-effort release).
+    await writable.abort().catch(() => {});
+    throw e;
+  }
 }
 
 async function fileExists(dir: FileSystemDirectoryHandle, name: string): Promise<boolean> {
   try {
     await dir.getFileHandle(name);
     return true;
-  } catch {
-    return false;
+  } catch (e) {
+    // Only a missing file means "does not exist"; surface permission
+    // (NotAllowedError) / name-is-a-directory (TypeMismatchError) rather than
+    // masking them as not-found.
+    if (e instanceof DOMException && e.name === "NotFoundError") return false;
+    throw e;
   }
 }
 

--- a/clients/react/src/styles/aim-offline.css
+++ b/clients/react/src/styles/aim-offline.css
@@ -1,0 +1,59 @@
+/* Offline aim mode — full-window single (aim) pane + the directory-pick gate.
+ * Reuses the `.aim-console` dev-tool token scope (aim-console.css) but replaces
+ * its 3-pane grid with a single full-height column. The double-class selector
+ * (`.aim-offline-root.aim-console`) outranks `.aim-console` so the layout is
+ * overridden while the custom-property tokens still apply. */
+
+.aim-offline-root.aim-console {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  overflow: hidden;
+}
+
+.aim-offline-root .ac-aim {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Pick gate — shown until a doc/aims directory is chosen. */
+.aim-offline-gate {
+  height: 100vh;
+  display: grid;
+  place-items: center;
+  background: var(--background, #111);
+  color: var(--foreground, #eee);
+}
+
+.aim-offline-gate-card {
+  max-width: 32rem;
+  padding: 2rem;
+  text-align: center;
+  font-family: var(--sans, system-ui, sans-serif);
+  line-height: 1.6;
+}
+
+.aim-offline-gate-card h1 {
+  margin: 0 0 0.75rem;
+  font-size: 1.5rem;
+}
+
+.aim-offline-pick {
+  margin-top: 1.25rem;
+  padding: 0.55rem 1.2rem;
+  font: inherit;
+  cursor: pointer;
+  border: 1px solid currentColor;
+  border-radius: 0.375rem;
+  background: transparent;
+  color: inherit;
+}
+
+.aim-offline-pick:hover {
+  background: rgb(255 255 255 / 0.08);
+}
+
+.aim-offline-error {
+  margin-top: 0.9rem;
+  color: #e06c75;
+}

--- a/clients/react/src/styles/aim-offline.css
+++ b/clients/react/src/styles/aim-offline.css
@@ -43,7 +43,7 @@
   padding: 0.55rem 1.2rem;
   font: inherit;
   cursor: pointer;
-  border: 1px solid currentColor;
+  border: 1px solid currentcolor;
   border-radius: 0.375rem;
   background: transparent;
   color: inherit;

--- a/clients/react/src/types/file-system-access.d.ts
+++ b/clients/react/src/types/file-system-access.d.ts
@@ -1,0 +1,12 @@
+// The File System Access API directory async-iteration is not in this TS
+// version's lib.dom. Declaration-merge the one method the offline aim mode uses
+// (`api-files.ts`) onto the existing `FileSystemDirectoryHandle` — additive, so
+// it composes with the lib.dom definition rather than conflicting.
+
+declare global {
+  interface FileSystemDirectoryHandle {
+    entries(): AsyncIterableIterator<[string, FileSystemHandle]>;
+  }
+}
+
+export {};

--- a/clients/react/vite.aim-offline.config.ts
+++ b/clients/react/vite.aim-offline.config.ts
@@ -34,5 +34,9 @@ export default defineConfig({
   server: {
     port: 1421,
     strictPort: true,
+    // The dev server serves `index.html` (the engine app) at `/`; the offline
+    // tool is the `aim-offline.html` page. Auto-open it so `dev:aim-offline`
+    // lands on the file-backed entry, not the engine app's empty unit tabs.
+    open: "/aim-offline.html",
   },
 });

--- a/clients/react/vite.aim-offline.config.ts
+++ b/clients/react/vite.aim-offline.config.ts
@@ -1,0 +1,38 @@
+// Build config for the OFFLINE aim mode (design-machine authoring).
+//
+// Identical to `vite.config.ts` except: the entry is `aim-offline.html`, and
+// `@/lib/api` is aliased to the file-backed `api-files` so the unchanged
+// aim-console components read/write a locally-picked `doc/aims/` directory
+// instead of the HTTP engine. The exact-match regex alias is FIRST so it wins
+// over the broad `@` prefix alias (a plain `@/lib/api` string alias would also
+// rewrite `@/lib/api-http`, which `api-files` itself imports — the regex avoids
+// that). Production's `vite.config.ts` is untouched.
+
+import path from "path";
+import tailwindcss from "@tailwindcss/vite";
+import react from "@vitejs/plugin-react";
+import { defineConfig } from "vite";
+
+export default defineConfig({
+  plugins: [react(), tailwindcss()],
+  resolve: {
+    alias: [
+      {
+        find: /^@\/lib\/api$/,
+        replacement: path.resolve(__dirname, "./src/lib/api-files.ts"),
+      },
+      { find: "@", replacement: path.resolve(__dirname, "./src") },
+    ],
+  },
+  build: {
+    outDir: "dist-aim-offline",
+    emptyOutDir: true,
+    rollupOptions: {
+      input: path.resolve(__dirname, "aim-offline.html"),
+    },
+  },
+  server: {
+    port: 1421,
+    strictPort: true,
+  },
+});


### PR DESCRIPTION
## What

An engine-less **offline aim mode**: a standalone aim-console entry that reads/writes a locally-picked `doc/aims/` directory via the **File System Access API**. It lets aims be authored on a machine where the Rust engine does not run (the design machine), with the result pushed via git — git-equivalent to authoring in the live UI.

The operator types the **anchor** directly (the bearing act — cheap, in their words); the agent drafts the **body**, which the operator reviews rendered. This mirrors the engine's write surface exactly (frontmatter `aim`/`parent`/`state` only).

## How — total reuse, transport swap

The offline vite build (`vite.aim-offline.config.ts`) aliases `@/lib/api` → a file-backed `api-files`. So the **unchanged** `AimFace` + `useUnitAims` + `aim-tree` / `aim-body-parse` run as-is; only the read/write transport is swapped. `drift` / `working_delta` are `null` (git-derived, engine-only) — this is the static design-phase view. Production `vite.config.ts` is untouched; `AimFace` is exported (1-word change) so the worklist mounts without the slack tab.

- **`src/lib/aim-file-format.ts`** — pure TS mirror of tmai-core `workbench::aim` (`split_frontmatter` / `serialize_new_aim` / `edit_aim_frontmatter` / `yaml_inline_scalar` / `validate_new_aim_slug`). Frontmatter-only writes; the body + any cross-edge line are preserved byte-for-byte on edit. 29 unit tests cover scalar round-trip, body preservation, slug rules.
- **`src/lib/api-files.ts`** — FS-API `aims` / `createAim` / `editAim`; every other `api` method is inherited from the HTTP layer (`AimFace` only ever calls the three). Top-level `*.md` scan (mirrors `read_aims_dir`, so `_archive/` / `_incubator/` are excluded); a malformed record is skipped (a `console.warn`), never a crash.
- **`src/aim-offline.{tsx,html}` + `vite.aim-offline.config.ts`** — standalone entry + directory picker. `pnpm build:aim-offline` / `pnpm dev:aim-offline` (Node-only, **no cargo**).

## Scope boundaries (by design)

- The tool writes **frontmatter only** (anchor create + `aim`/`parent`/`state` edit) — identical to the engine's write surface. The body is authored separately by the agent.
- **drift disabled** offline (no git analysis) — the static corpus view; `aimTone` handles `drift: null`.
- The picked directory is the unit; one repo per session (`AimsResponse.repos.len() == 1`).

## Test

`tsc -b` · `biome check` · `vitest run` (**250 passed**, +29 new) · `vite build:aim-offline` — all green. FS Access API is Chromium-only (Chrome/Edge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * オフラインモード対応：ローカルの作業ディレクトリを選択して、aimの表示・編集を直接実行
  * オフライン専用画面を追加（選択前は案内表示）／起動時にUIテーマを自動適用
  * ツリーモードの初期表示を全体展開に変更
* **テスト**
  * aimファイル形式の仕様検証テストを追加
* **スタイル**
  * オフライン用UIスタイルを追加
* **改善**
  * オフライン用ビルド/開発コマンドを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->