### PR TITLE
fix(aim-console): resolve the unit Producer launched at the wrapper dir

### DIFF
--- a/clients/react/src/lib/__tests__/find-producer-for-unit.test.ts
+++ b/clients/react/src/lib/__tests__/find-producer-for-unit.test.ts
@@ -38,7 +38,9 @@ function stubAgent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnaps
     git_branch: partial.git_branch ?? "main",
     git_dirty: partial.git_dirty ?? false,
     is_worktree: partial.is_worktree ?? false,
-    git_common_dir: partial.git_common_dir ?? "/repo/.git",
+    // Honour an explicit `null` (a wrapper-dir Producer's cwd has no
+    // `git_common_dir`); only a wholly-omitted key gets the repo default.
+    git_common_dir: partial.git_common_dir === undefined ? "/repo/.git" : partial.git_common_dir,
     worktree_name: partial.worktree_name ?? null,
     worktree_base_branch: partial.worktree_base_branch ?? null,
     effort_level: partial.effort_level ?? null,
@@ -210,5 +212,67 @@ describe("findProducerForUnit — cross-repo (UnitRepoWire[]) overload", () => {
       is_worktree: false,
     });
     expect(findProducerForUnit([a, b], multiRepoUnit)).toBeNull();
+  });
+});
+
+describe("findProducerForUnit — wrapper-dir project model (tmai-core #529/#530)", () => {
+  // The wrapper-dir model launches the unit's Producer at the WRAPPER
+  // directory — the parent that holds the unit's auto-discovered member
+  // repos — not at a repo root. The wrapper is not itself a git repo, so
+  // the Producer's `git_common_dir` is null and the resolver falls back to
+  // its cwd, which sits one level ABOVE the primary repo path.
+  const multiRepoUnit: Array<UnitRepoWire> = [
+    { path: "/works/u/primary", primary: true },
+    { path: "/works/u/secondary", primary: false },
+  ];
+
+  it("resolves a Producer launched at the unit wrapper dir (cross-repo overload)", () => {
+    const producer = stubAgent({
+      id: "claude:prod-1",
+      cwd: "/works/u",
+      git_common_dir: null, // wrapper is not a git repo
+      is_worktree: false,
+    });
+    expect(findProducerForUnit([producer], multiRepoUnit)).toBe(producer);
+  });
+
+  it("resolves a wrapper-dir Producer via the back-compat single-path overload", () => {
+    const producer = stubAgent({
+      id: "claude:prod-1",
+      cwd: "/works/u",
+      git_common_dir: null,
+      is_worktree: false,
+    });
+    // The single-path overload receives the unit's primary repo path; the
+    // wrapper one level up still resolves.
+    expect(findProducerForUnit([producer], "/works/u/primary")).toBe(producer);
+  });
+
+  it("does NOT mis-classify a Claude session sitting AT a member repo as the wrapper Producer", () => {
+    // A session at the secondary repo is at neither the primary repo nor the
+    // wrapper — the wrapper-position widening must not pull it in.
+    const atSecondary = stubAgent({
+      id: "claude:sibling-1",
+      cwd: "/works/u/secondary",
+      git_common_dir: "/works/u/secondary/.git",
+      is_worktree: false,
+    });
+    expect(findProducerForUnit([atSecondary], multiRepoUnit)).toBeNull();
+  });
+
+  it("preserves the single-Producer invariant — a wrapper agent and a primary-repo agent are ambiguous", () => {
+    const atWrapper = stubAgent({
+      id: "claude:prod-a",
+      cwd: "/works/u",
+      git_common_dir: null,
+      is_worktree: false,
+    });
+    const atPrimary = stubAgent({
+      id: "claude:prod-b",
+      cwd: "/works/u/primary",
+      git_common_dir: "/works/u/primary/.git",
+      is_worktree: false,
+    });
+    expect(findProducerForUnit([atWrapper, atPrimary], multiRepoUnit)).toBeNull();
   });
 });

--- a/clients/react/src/lib/producer.ts
+++ b/clients/react/src/lib/producer.ts
@@ -18,15 +18,30 @@ import { type AgentSnapshot, normalizeGitDir, type UnitRepoWire } from "@/lib/ap
 // `useHandover` does.
 export const PRODUCER_ID_SCHEME = "claude:";
 
+/** The parent directory of an absolute path, or `null` when it has no
+ *  proper parent (root, or a single leading-slash segment). Used to
+ *  recognize a Producer launched at the unit's WRAPPER directory — the
+ *  parent that holds the unit's member repos — under the wrapper-dir
+ *  project model (tmai-core #529/#530). */
+function parentDir(path: string): string | null {
+  const i = path.lastIndexOf("/");
+  if (i <= 0) return null;
+  return path.slice(0, i);
+}
+
 /** Find the single live Producer for this unit, if any.
  *
  *  Filter rules (DR §E + scoping pattern from `useHandover`):
  *   1. `id` starts with `claude:` (canonical scheme)
- *   2. `!is_worktree` — Producer runs at the repo root, not in a
- *      worktree clone (worktree Producers would be Worker agents)
+ *   2. `!is_worktree` — Producer runs at the repo root (or the unit
+ *      wrapper), not in a worktree clone (worktree Producers would be
+ *      Worker agents)
  *   3. cwd / `git_common_dir` resolves to the unit's **primary** repo
- *      path — per `UnitRepoWire.primary`, the one repo a unit's
- *      Producer is launched at, even when the unit spans multiple repos
+ *      path (per `UnitRepoWire.primary`) — OR to the unit's WRAPPER dir,
+ *      the parent of that repo. The wrapper-dir project model (tmai-core
+ *      #529/#530) launches the Producer at the wrapper (which is not
+ *      itself a git repo), so its resolved dir sits one level above the
+ *      primary repo path; both positions count.
  *
  *  Cross-repo signature (tmai-core #439, wire #460, public types #741):
  *  callers on the units wire pass the unit's full `UnitRepoWire[]`
@@ -63,6 +78,15 @@ export function findProducerForUnit(
     primaryPath = primary.path;
   }
   const targetPath = normalizeGitDir(primaryPath);
+  // Wrapper-dir project model (tmai-core #529/#530): a unit's Producer is
+  // launched at the unit's WRAPPER directory — the parent that holds the
+  // auto-discovered member repos — not at a repo root. That Producer's cwd
+  // is the wrapper, which is not itself a git repo (no `git_common_dir`),
+  // so its resolved `agentRepo` is one level ABOVE the primary repo path.
+  // Accept that position as well; otherwise a wrapper-launched Producer
+  // never resolves and every "talk to the Producer" surface (the aim-console
+  // session pane included) shows "no active session".
+  const wrapperPath = parentDir(targetPath);
   const candidates = agents.filter((a) => {
     if (!a.id.startsWith(PRODUCER_ID_SCHEME)) return false;
     if (a.is_worktree === true) return false;
@@ -70,7 +94,7 @@ export function findProducerForUnit(
     // compared against an already-normalized `targetPath` and could miss
     // (trailing slash / `.git` suffix).
     const agentRepo = normalizeGitDir(a.git_common_dir ?? a.cwd);
-    return agentRepo === targetPath;
+    return agentRepo === targetPath || (wrapperPath !== null && agentRepo === wrapperPath);
   });
   return candidates.length === 1 ? (candidates[0] ?? null) : null;
 }


### PR DESCRIPTION
## Symptom

The aim-console SessionPane shows **"No active session for this unit — launch a Producer or dispatch a worker."** even when a live Producer is running for the unit (the legacy console renders the same Producer fine). Reported in dogfood, 2026-06-16.

## Root cause

`findProducerForUnit` (`clients/react/src/lib/producer.ts`) — the shared resolver behind every "talk to the Producer" surface — matches a unit's Producer only when its `cwd` / `git_common_dir` equals the unit's **primary repo** path.

The **wrapper-dir project model** (tmai-core #529/#530) launches the Producer at the unit's **wrapper directory** — the parent that holds the unit's auto-discovered member repos — not at a repo root. That wrapper is not itself a git repo, so the Producer's `git_common_dir` is null and its resolved dir falls back to the wrapper `cwd`, which sits **one level above** the primary repo path. The exact-path comparison therefore never matches → resolver returns `null` → `selectedAgent` is null → the empty-state message.

Confirmed against the live agent: Producer `cwd` = `…/works/<unit>` (wrapper); resolver target = `…/works/<unit>/<primary-repo>`.

## Fix

Accept the **wrapper position** (parent of the primary repo) in addition to the existing repo-root position. The single-Producer invariant (`candidates.length === 1`) and the non-primary-repo guard (an opportunistic Claude session sitting *at* a member repo is still not mis-classified) are both preserved.

## Tests

- New `wrapper-dir project model` describe block: wrapper Producer resolves via both the `UnitRepoWire[]` and back-compat single-path overloads; a session at a member repo is **not** mis-classified as the wrapper Producer; the single-Producer invariant holds when a wrapper agent and a primary-repo agent are both present (ambiguous → null).
- `stubAgent` now honours an explicit `null` `git_common_dir` (a wrapper Producer's cwd has none); a wholly-omitted key still gets the repo default, so existing cases are unchanged.

## Gate (CI parity, all green locally)

`pnpm tsc --noEmit` ✓ · `pnpm lint` ✓ · `pnpm test` (113 files, 1014 passed / 2 skipped) ✓ · `pnpm build` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * 複数のリポジトリレイアウトでのProducer検出ロジックを改善し、より正確な検出を実現しました。
  * 設定値の`null`指定時の既定値処理を改善しました。

* **テスト**
  * 新しいプロジェクトレイアウトに対応したテストケースを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->