### PR TITLE
aim-console: Producer session unresolved at restart-adopt — findProducerForUnit keys on hook-derived cwd, not the hint-resilient is_producer/unit (blocker for legacy-console retirement) (#834)

### DIFF
--- a/clients/react/src/lib/__tests__/find-producer-for-unit.test.ts
+++ b/clients/react/src/lib/__tests__/find-producer-for-unit.test.ts
@@ -54,7 +54,7 @@ function stubAgent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnaps
     is_virtual: partial.is_virtual ?? false,
     team_info: partial.team_info ?? null,
     attention: partial.attention ?? null,
-    is_orchestrator: partial.is_orchestrator,
+    is_producer: partial.is_producer,
   };
 }
 
@@ -280,9 +280,9 @@ describe("findProducerForUnit — wrapper-dir project model (tmai-core #529/#530
   });
 });
 
-describe("findProducerForUnit — restart-adopt (adopt-resilient is_orchestrator + unit)", () => {
+describe("findProducerForUnit — restart-adopt (adopt-resilient is_producer + unit)", () => {
   // After an engine restart the Producer is re-adopted by the PTY server
-  // with its `is_orchestrator` flag (auto-restored across restart) and its
+  // with its `is_producer` flag (auto-restored across restart) and its
   // `unit` field set — but its `cwd` / `git_common_dir` stay stale until
   // the first conversation turn re-fires the statusline hook. A cwd-only
   // resolver returns null in that window ("no active session"), which is a
@@ -306,7 +306,7 @@ describe("findProducerForUnit — restart-adopt (adopt-resilient is_orchestrator
       cwd: "/var/stale", // hook not yet re-derived → no cwd match
       git_common_dir: null,
       is_worktree: false,
-      is_orchestrator: true,
+      is_producer: true,
       unit: "acme",
     });
   }
@@ -321,9 +321,9 @@ describe("findProducerForUnit — restart-adopt (adopt-resilient is_orchestrator
     expect(findProducerForUnit([producer], "/works/acme/acme")).toBe(producer);
   });
 
-  it("does NOT classify a same-unit WORKER (unit matches but not is_orchestrator) as the Producer", () => {
+  it("does NOT classify a same-unit WORKER (unit matches but not is_producer) as the Producer", () => {
     // The non-primary-repo guard, re-expressed for the identity key: a
-    // worker shares the unit's `unit` field but is not `is_orchestrator`,
+    // worker shares the unit's `unit` field but is not `is_producer`,
     // so it must never be mistaken for the Producer even before its own
     // cwd resolves.
     const worker = stubAgent({
@@ -331,7 +331,7 @@ describe("findProducerForUnit — restart-adopt (adopt-resilient is_orchestrator
       cwd: "/var/stale",
       git_common_dir: null,
       is_worktree: false,
-      is_orchestrator: false,
+      is_producer: false,
       unit: "acme",
     });
     expect(findProducerForUnit([worker], unit)).toBeNull();
@@ -344,43 +344,43 @@ describe("findProducerForUnit — restart-adopt (adopt-resilient is_orchestrator
       cwd: "/works/acme/lib",
       git_common_dir: "/works/acme/lib/.git",
       is_worktree: false,
-      is_orchestrator: false,
+      is_producer: false,
       unit: "acme",
     });
     expect(findProducerForUnit([producer, worker], unit)).toBe(producer);
   });
 
-  it("does NOT match an is_orchestrator agent of a DIFFERENT unit", () => {
+  it("does NOT match an is_producer agent of a DIFFERENT unit", () => {
     const otherProducer = stubAgent({
       id: "claude:prod-x",
       cwd: "/var/stale",
       git_common_dir: null,
       is_worktree: false,
-      is_orchestrator: true,
+      is_producer: true,
       unit: "other",
     });
     expect(findProducerForUnit([otherProducer], unit)).toBeNull();
   });
 
-  it("preserves the single-Producer invariant — two is_orchestrator agents for the unit are ambiguous", () => {
+  it("preserves the single-Producer invariant — two is_producer agents for the unit are ambiguous", () => {
     const a = restartAdoptProducer("claude:prod-a");
     const b = restartAdoptProducer("claude:prod-b");
     expect(findProducerForUnit([a, b], unit)).toBeNull();
   });
 
-  it("excludes a worktree agent even with is_orchestrator + unit (worktrees host workers, not Producers)", () => {
+  it("excludes a worktree agent even with is_producer + unit (worktrees host workers, not Producers)", () => {
     const wt = stubAgent({
       id: "claude:wt-1",
       cwd: "/var/stale",
       git_common_dir: null,
       is_worktree: true,
-      is_orchestrator: true,
+      is_producer: true,
       unit: "acme",
     });
     expect(findProducerForUnit([wt], unit)).toBeNull();
   });
 
-  it("still degrades to cwd-keying when is_orchestrator/unit are absent (old engine)", () => {
+  it("still degrades to cwd-keying when is_producer/unit are absent (old engine)", () => {
     // No identity fields on the wire (engine not rebuilt). The cwd key must
     // still resolve a Producer sitting at the primary repo — proving rule
     // 3a is additive, never a regression for the transition window.
@@ -389,7 +389,7 @@ describe("findProducerForUnit — restart-adopt (adopt-resilient is_orchestrator
       cwd: "/works/acme/acme",
       git_common_dir: "/works/acme/acme/.git",
       is_worktree: false,
-      // is_orchestrator + unit deliberately omitted
+      // is_producer + unit deliberately omitted
     });
     expect(findProducerForUnit([producer], unit)).toBe(producer);
   });

--- a/clients/react/src/lib/__tests__/find-producer-for-unit.test.ts
+++ b/clients/react/src/lib/__tests__/find-producer-for-unit.test.ts
@@ -41,6 +41,9 @@ function stubAgent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnaps
     // Honour an explicit `null` (a wrapper-dir Producer's cwd has no
     // `git_common_dir`); only a wholly-omitted key gets the repo default.
     git_common_dir: partial.git_common_dir === undefined ? "/repo/.git" : partial.git_common_dir,
+    // Adopt-resilient wire fields (#834). Optional on the snapshot; omitted
+    // here unless a test sets them, mirroring an engine not serving them.
+    unit: partial.unit,
     worktree_name: partial.worktree_name ?? null,
     worktree_base_branch: partial.worktree_base_branch ?? null,
     effort_level: partial.effort_level ?? null,
@@ -274,5 +277,120 @@ describe("findProducerForUnit — wrapper-dir project model (tmai-core #529/#530
       is_worktree: false,
     });
     expect(findProducerForUnit([atWrapper, atPrimary], multiRepoUnit)).toBeNull();
+  });
+});
+
+describe("findProducerForUnit — restart-adopt (adopt-resilient is_orchestrator + unit)", () => {
+  // After an engine restart the Producer is re-adopted by the PTY server
+  // with its `is_orchestrator` flag (auto-restored across restart) and its
+  // `unit` field set — but its `cwd` / `git_common_dir` stay stale until
+  // the first conversation turn re-fires the statusline hook. A cwd-only
+  // resolver returns null in that window ("no active session"), which is a
+  // bootstrap deadlock once the aim-console is the sole surface (no legacy
+  // terminal left to fire that first hook — issue #834). The identity key
+  // resolves the Producer immediately, with NO cwd/git_common_dir match.
+  //
+  // The unit's primary repo basename IS the unit name by tmai's project
+  // model, so `findProducerForUnit` derives the key `unit` ("acme") from
+  // the primary path — the Producer's `unit` field must equal it.
+  const unit: Array<UnitRepoWire> = [
+    { path: "/works/acme/acme", primary: true },
+    { path: "/works/acme/lib", primary: false },
+  ];
+
+  // A Producer freshly re-adopted: identity fields set, cwd NOT yet the
+  // wrapper/primary (the hook has not re-derived it).
+  function restartAdoptProducer(id: string): AgentSnapshot {
+    return stubAgent({
+      id,
+      cwd: "/var/stale", // hook not yet re-derived → no cwd match
+      git_common_dir: null,
+      is_worktree: false,
+      is_orchestrator: true,
+      unit: "acme",
+    });
+  }
+
+  it("resolves the Producer with NO cwd/git_common_dir match (cross-repo overload)", () => {
+    const producer = restartAdoptProducer("claude:prod-1");
+    expect(findProducerForUnit([producer], unit)).toBe(producer);
+  });
+
+  it("resolves via the back-compat single-path overload (no cwd match)", () => {
+    const producer = restartAdoptProducer("claude:prod-1");
+    expect(findProducerForUnit([producer], "/works/acme/acme")).toBe(producer);
+  });
+
+  it("does NOT classify a same-unit WORKER (unit matches but not is_orchestrator) as the Producer", () => {
+    // The non-primary-repo guard, re-expressed for the identity key: a
+    // worker shares the unit's `unit` field but is not `is_orchestrator`,
+    // so it must never be mistaken for the Producer even before its own
+    // cwd resolves.
+    const worker = stubAgent({
+      id: "claude:worker-1",
+      cwd: "/var/stale",
+      git_common_dir: null,
+      is_worktree: false,
+      is_orchestrator: false,
+      unit: "acme",
+    });
+    expect(findProducerForUnit([worker], unit)).toBeNull();
+  });
+
+  it("keeps the Producer when a same-unit worker is also present (worker filtered out)", () => {
+    const producer = restartAdoptProducer("claude:prod-1");
+    const worker = stubAgent({
+      id: "claude:worker-1",
+      cwd: "/works/acme/lib",
+      git_common_dir: "/works/acme/lib/.git",
+      is_worktree: false,
+      is_orchestrator: false,
+      unit: "acme",
+    });
+    expect(findProducerForUnit([producer, worker], unit)).toBe(producer);
+  });
+
+  it("does NOT match an is_orchestrator agent of a DIFFERENT unit", () => {
+    const otherProducer = stubAgent({
+      id: "claude:prod-x",
+      cwd: "/var/stale",
+      git_common_dir: null,
+      is_worktree: false,
+      is_orchestrator: true,
+      unit: "other",
+    });
+    expect(findProducerForUnit([otherProducer], unit)).toBeNull();
+  });
+
+  it("preserves the single-Producer invariant — two is_orchestrator agents for the unit are ambiguous", () => {
+    const a = restartAdoptProducer("claude:prod-a");
+    const b = restartAdoptProducer("claude:prod-b");
+    expect(findProducerForUnit([a, b], unit)).toBeNull();
+  });
+
+  it("excludes a worktree agent even with is_orchestrator + unit (worktrees host workers, not Producers)", () => {
+    const wt = stubAgent({
+      id: "claude:wt-1",
+      cwd: "/var/stale",
+      git_common_dir: null,
+      is_worktree: true,
+      is_orchestrator: true,
+      unit: "acme",
+    });
+    expect(findProducerForUnit([wt], unit)).toBeNull();
+  });
+
+  it("still degrades to cwd-keying when is_orchestrator/unit are absent (old engine)", () => {
+    // No identity fields on the wire (engine not rebuilt). The cwd key must
+    // still resolve a Producer sitting at the primary repo — proving rule
+    // 3a is additive, never a regression for the transition window.
+    const producer = stubAgent({
+      id: "claude:prod-1",
+      cwd: "/works/acme/acme",
+      git_common_dir: "/works/acme/acme/.git",
+      is_worktree: false,
+      // is_orchestrator + unit deliberately omitted
+    });
+    expect(findProducerForUnit([producer], unit)).toBe(producer);
   });
 });

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -299,6 +299,16 @@ export interface AgentSnapshot {
   connection_channels?: ConnectionChannels;
   model_id?: string | null;
   model_display_name?: string | null;
+  /** Producer-identity flag — **this is the field the engine actually
+   *  serves** (derived from the `role` spawn hint, tmai-core #527; verified
+   *  against the live `GET /api/agents` payload). It is adopt-resilient, so
+   *  it identifies the Producer at restart-adopt before any hook fires
+   *  (`findProducerForUnit` rule 3a, #834). NB the sibling `is_orchestrator`
+   *  below is a STALE hand-mirror field — left over from before the
+   *  orchestrator→producer rename and NOT served by the engine; reads of it
+   *  (AgentCard / useHandover / useAgentSelectionFallback / ProjectGroup)
+   *  are silently broken and want correcting to `is_producer` (see #834). */
+  is_producer?: boolean;
   is_orchestrator?: boolean;
   /** Attention axis introduced by Step 4 of the agent-state attention
    *  rebuild (decision tmai-core@2026-05-07). `null` / absent on the

--- a/clients/react/src/lib/producer.ts
+++ b/clients/react/src/lib/producer.ts
@@ -36,12 +36,32 @@ function parentDir(path: string): string | null {
  *   2. `!is_worktree` — Producer runs at the repo root (or the unit
  *      wrapper), not in a worktree clone (worktree Producers would be
  *      Worker agents)
- *   3. cwd / `git_common_dir` resolves to the unit's **primary** repo
- *      path (per `UnitRepoWire.primary`) — OR to the unit's WRAPPER dir,
- *      the parent of that repo. The wrapper-dir project model (tmai-core
- *      #529/#530) launches the Producer at the wrapper (which is not
- *      itself a git repo), so its resolved dir sits one level above the
- *      primary repo path; both positions count.
+ *   3. EITHER of:
+ *      a. **Adopt-resilient identity** (#834): `is_orchestrator === true`
+ *         AND `unit` equals this unit's name. Both fields are set at
+ *         PTY-server **adopt** (the Producer-identity flag is auto-restored
+ *         across restart — tmai-core #380/#527; `unit` is the #443/#533
+ *         hook-resilient wire field), so they resolve the Producer the
+ *         instant the engine comes back — BEFORE any conversation turn
+ *         re-fires the statusline hook. The cwd key below cannot: cwd /
+ *         `git_common_dir` are hook-derived and stale at restart-adopt, so
+ *         a cwd-only resolver shows "no active session" until the operator
+ *         types — a bootstrap deadlock once the aim-console is the sole
+ *         surface (there is no legacy terminal left to fire that first
+ *         hook). NB the wire field is `is_orchestrator`, not `is_producer`:
+ *         the orchestrator→producer rename landed on `ActionOrigin` only;
+ *         `AgentSnapshot` keeps `is_orchestrator` as the Producer-identity
+ *         flag.
+ *      b. cwd / `git_common_dir` resolves to the unit's **primary** repo
+ *         path (per `UnitRepoWire.primary`) — OR to the unit's WRAPPER dir,
+ *         the parent of that repo. The wrapper-dir project model (tmai-core
+ *         #529/#530) launches the Producer at the wrapper (which is not
+ *         itself a git repo), so its resolved dir sits one level above the
+ *         primary repo path; both positions count. This is the steady
+ *         state once the hook has fired, AND the back-compat path for an
+ *         engine not yet serving `is_orchestrator` / `unit`: those are
+ *         absent on the wire then, rule 3a never fires, and the resolver
+ *         degrades to exactly the prior cwd-keying.
  *
  *  Cross-repo signature (tmai-core #439, wire #460, public types #741):
  *  callers on the units wire pass the unit's full `UnitRepoWire[]`
@@ -87,12 +107,28 @@ export function findProducerForUnit(
   // never resolves and every "talk to the Producer" surface (the aim-console
   // session pane included) shows "no active session".
   const wrapperPath = parentDir(targetPath);
+  // The unit name, derived from the primary repo's basename. By tmai's
+  // project model the primary repo's basename IS the unit name — the same
+  // derivation App uses for its `unitName` and `groupByProject` for its
+  // path pick — so a Producer whose adopt-resilient `unit` field equals it
+  // is this unit's Producer. `null` when the path has no basename (we then
+  // never identity-match, falling through to the cwd key).
+  const unitName = targetPath.split("/").filter(Boolean).pop() ?? null;
   const candidates = agents.filter((a) => {
     if (!a.id.startsWith(PRODUCER_ID_SCHEME)) return false;
     if (a.is_worktree === true) return false;
-    // Normalize both branches: a raw `cwd` fallback would otherwise be
-    // compared against an already-normalized `targetPath` and could miss
-    // (trailing slash / `.git` suffix).
+    // Rule 3a — adopt-resilient identity. Resolves the Producer at
+    // restart-adopt, before the hook re-derives cwd. `is_orchestrator`
+    // narrows `unit` (which a worker shares) down to the single Producer,
+    // preserving the non-primary-repo guard: a same-unit worker sitting at
+    // a secondary repo is `is_orchestrator !== true`, so it never matches.
+    if (a.is_orchestrator === true && unitName !== null && a.unit === unitName) {
+      return true;
+    }
+    // Rule 3b — cwd / `git_common_dir` position. Normalize both branches:
+    // a raw `cwd` fallback would otherwise be compared against an
+    // already-normalized `targetPath` and could miss (trailing slash /
+    // `.git` suffix).
     const agentRepo = normalizeGitDir(a.git_common_dir ?? a.cwd);
     return agentRepo === targetPath || (wrapperPath !== null && agentRepo === wrapperPath);
   });

--- a/clients/react/src/lib/producer.ts
+++ b/clients/react/src/lib/producer.ts
@@ -37,10 +37,10 @@ function parentDir(path: string): string | null {
  *      wrapper), not in a worktree clone (worktree Producers would be
  *      Worker agents)
  *   3. EITHER of:
- *      a. **Adopt-resilient identity** (#834): `is_orchestrator === true`
+ *      a. **Adopt-resilient identity** (#834): `is_producer === true`
  *         AND `unit` equals this unit's name. Both fields are set at
- *         PTY-server **adopt** (the Producer-identity flag is auto-restored
- *         across restart — tmai-core #380/#527; `unit` is the #443/#533
+ *         PTY-server **adopt** (`is_producer` is derived from the `role`
+ *         spawn hint — tmai-core #527; `unit` is the #443/#533
  *         hook-resilient wire field), so they resolve the Producer the
  *         instant the engine comes back — BEFORE any conversation turn
  *         re-fires the statusline hook. The cwd key below cannot: cwd /
@@ -48,10 +48,11 @@ function parentDir(path: string): string | null {
  *         a cwd-only resolver shows "no active session" until the operator
  *         types — a bootstrap deadlock once the aim-console is the sole
  *         surface (there is no legacy terminal left to fire that first
- *         hook). NB the wire field is `is_orchestrator`, not `is_producer`:
- *         the orchestrator→producer rename landed on `ActionOrigin` only;
- *         `AgentSnapshot` keeps `is_orchestrator` as the Producer-identity
- *         flag.
+ *         hook). NB the live wire field on `AgentSnapshot` is `is_producer`
+ *         (verified against the running `GET /api/agents` payload). The
+ *         hand-written `AgentSnapshot` type ALSO declares a stale
+ *         `is_orchestrator` from before the orchestrator→producer rename,
+ *         but the engine does not serve it — keying on it is a no-op (#834).
  *      b. cwd / `git_common_dir` resolves to the unit's **primary** repo
  *         path (per `UnitRepoWire.primary`) — OR to the unit's WRAPPER dir,
  *         the parent of that repo. The wrapper-dir project model (tmai-core
@@ -59,7 +60,7 @@ function parentDir(path: string): string | null {
  *         itself a git repo), so its resolved dir sits one level above the
  *         primary repo path; both positions count. This is the steady
  *         state once the hook has fired, AND the back-compat path for an
- *         engine not yet serving `is_orchestrator` / `unit`: those are
+ *         engine not yet serving `is_producer` / `unit`: those are
  *         absent on the wire then, rule 3a never fires, and the resolver
  *         degrades to exactly the prior cwd-keying.
  *
@@ -118,11 +119,11 @@ export function findProducerForUnit(
     if (!a.id.startsWith(PRODUCER_ID_SCHEME)) return false;
     if (a.is_worktree === true) return false;
     // Rule 3a — adopt-resilient identity. Resolves the Producer at
-    // restart-adopt, before the hook re-derives cwd. `is_orchestrator`
+    // restart-adopt, before the hook re-derives cwd. `is_producer`
     // narrows `unit` (which a worker shares) down to the single Producer,
     // preserving the non-primary-repo guard: a same-unit worker sitting at
-    // a secondary repo is `is_orchestrator !== true`, so it never matches.
-    if (a.is_orchestrator === true && unitName !== null && a.unit === unitName) {
+    // a secondary repo is `is_producer !== true`, so it never matches.
+    if (a.is_producer === true && unitName !== null && a.unit === unitName) {
       return true;
     }
     // Rule 3b — cwd / `git_common_dir` position. Normalize both branches:


### PR DESCRIPTION
## Summary

`findProducerForUnit` (`clients/react/src/lib/producer.ts`) keyed **solely** on the Producer's `cwd` / `git_common_dir` position (the unit's primary-repo path or wrapper dir, per #829). Those are **hook-derived** and stay stale after an engine restart until the first conversation turn re-fires the statusline hook — so the aim-console SessionPane showed *"No active session for this unit"* post-restart. Once the legacy Producer console is retired and the aim-console is the **sole** surface, that is a **bootstrap deadlock**: an empty aim-console offers no terminal to fire the first hook (the "retire 前に必須" concern of tmai-core#531).

This adds an **adopt-resilient identity key** to the resolver.

## Investigation conclusion (adopt-resilience of the lead's fields)

The lead said to key on **`is_producer`/`unit`**. Confirmed against the wire types + data flow (engine not runnable — reasoned from the contract):

- **`unit`** — present on `AgentSnapshot` (`api-http.ts`), the #443/#533 hook-resilient wire field. ✅
- **`is_producer`** — **NOT on `AgentSnapshot`**. It lives on `ActionOrigin` (action provenance). The orchestrator→producer rename (#715) landed on **`ActionOrigin` only**; `AgentSnapshot` retains **`is_orchestrator`** as the Producer-identity flag — and every other surface (`AgentCard`, `ProjectGroup`, `useHandover`, `useAgentSelectionFallback`) reads `is_orchestrator`. In-repo evidence it is **adopt-resilient**: commit `50e0f20 feat: auto-restore is_orchestrator flag across tmai restart and /resume`, corroborated by the lead's tmai-core #527 (spawn `role` hint). 

So the lead is **correct in substance**; the concrete frontend field is **`is_orchestrator`**, not `is_producer`. The fix stays in `clients/react` — no tmai-core change needed.

## Change

`findProducerForUnit` now matches a candidate on **either**:

- **3a (new, adopt-resilient):** `is_orchestrator === true` **AND** `unit === <unit name>`. Resolves the Producer the instant the engine restarts, before any hook.
- **3b (existing):** cwd / `git_common_dir` at the primary-repo path or wrapper dir. The hook-resolved steady state **and** the back-compat path — when an engine doesn't serve `is_orchestrator`/`unit` those are absent, 3a never fires, and the resolver degrades to **exactly** the prior cwd-keying (no transition-window regression).

The unit name is derived from the **primary repo basename** (tmai's project model: primary basename IS the unit name — the same derivation App's `unitName` and `groupByProject`'s path-pick use), so the **signature is unchanged** and all callers (`SessionPane`, `ProducerConsoleActions`, `ProducerCtxHeader`, `ProducerConversationHeader`, `ProducerRoster`, App) keep working untouched.

## Contracts preserved

- **Non-primary-repo guard:** `is_orchestrator` narrows the unit-shared `unit` down to the single Producer — a same-unit **worker** at a secondary repo is `is_orchestrator !== true` and is never matched. New test proves this.
- **Single-Producer invariant:** `candidates.length === 1 ? … : null` untouched. New test: two `is_orchestrator` agents for the unit → null.

## Tests

`find-producer-for-unit.test.ts`: all existing cases kept; **8 new** cases added — resolution **with no cwd/git_common_dir match** (the restart-adopt case, both overloads), the same-unit-worker guard, cross-unit isolation, worktree exclusion, the single-Producer invariant under the new key, and old-engine degradation to cwd-keying. **24 passed.**

## Gate (CI parity — all green)

- `pnpm tsc --noEmit` ✅
- `pnpm lint` ✅ (1 pre-existing warning in unrelated `ProducerFeedChip.tsx`)
- `pnpm test` ✅ (1022 passed, 2 skipped / 113 files)
- `pnpm build` ✅

## Acceptance

After an engine restart with no conversation turn, `findProducerForUnit` resolves the Producer from `is_orchestrator` + `unit` alone (validated by the new no-cwd-match tests). Validate end-to-end against an engine rebuilt from current `main` (carries #533) — the running engine may predate it.

Closes #834.

🤖 Generated with [Claude Code](https://claude.com/claude-code)