### PR TITLE
WebUI reads stale is_orchestrator off AgentSnapshot in 4 surfaces — engine serves is_producer (silently broken) (#836)

### DIFF
--- a/clients/react/src/__tests__/App.console-mode.test.tsx
+++ b/clients/react/src/__tests__/App.console-mode.test.tsx
@@ -131,7 +131,7 @@ function agent(target: string, cwd: string): AgentSnapshot {
     send_capability: "None",
     is_virtual: false,
     team_info: null,
-    is_orchestrator: false,
+    is_producer: false,
     attention: null,
   } as AgentSnapshot;
 }

--- a/clients/react/src/__tests__/App.handoff.test.tsx
+++ b/clients/react/src/__tests__/App.handoff.test.tsx
@@ -130,7 +130,7 @@ function agent(overrides: {
     send_capability: "None",
     is_virtual: false,
     team_info: null,
-    is_orchestrator: false,
+    is_producer: false,
     attention: null,
   } as AgentSnapshot;
 }

--- a/clients/react/src/__tests__/App.r-panel.test.tsx
+++ b/clients/react/src/__tests__/App.r-panel.test.tsx
@@ -180,7 +180,7 @@ function agent(target: string, cwd: string): AgentSnapshot {
     send_capability: "None",
     is_virtual: false,
     team_info: null,
-    is_orchestrator: false,
+    is_producer: false,
     attention: null,
   } as AgentSnapshot;
 }

--- a/clients/react/src/components/agent/AgentCard.tsx
+++ b/clients/react/src/components/agent/AgentCard.tsx
@@ -251,7 +251,7 @@ export function AgentCard({ agent, selected, onClick, variant = "default" }: Age
       className={cn(
         "glass-card group w-full rounded-xl px-3 py-2 text-left transition-subtle",
         "hover:bg-surface hover:border-hairline-strong",
-        agent.is_orchestrator && "!border-primary/20 bg-primary/[0.04]",
+        agent.is_producer && "!border-primary/20 bg-primary/[0.04]",
         // Producer headline: accent the unit's "who am I talking to" row so
         // it reads as first-class above its subordinate worker roster.
         variant === "headline" && "!border-primary/25 bg-primary/[0.05]",
@@ -268,9 +268,9 @@ export function AgentCard({ agent, selected, onClick, variant = "default" }: Age
               Producer
             </span>
           )}
-          {agent.is_orchestrator && (
+          {agent.is_producer && (
             <span className="shrink-0 rounded border border-primary/30 bg-primary/10 px-1 py-px text-[9px] font-semibold text-primary">
-              ORCH
+              PROD
             </span>
           )}
           <span className="truncate text-sm font-medium text-foreground group-hover:text-foreground transition-subtle">

--- a/clients/react/src/components/agent/__tests__/AgentCard.test.tsx
+++ b/clients/react/src/components/agent/__tests__/AgentCard.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { AgentCard } from "@/components/agent/AgentCard";
+import type { AgentSnapshot } from "@/lib/api";
+
+// Producer detection rides the `is_producer` wire field (DR
+// `2026-05-16-producer-identity-and-operator-addressing` §B). Before #836
+// this card read the stale `is_orchestrator`, which the engine never
+// serves, so the badge + accent highlight never rendered for the Producer.
+function stubAgent(overrides: Partial<AgentSnapshot> = {}): AgentSnapshot {
+  return {
+    id: "claude:prod-1",
+    target: "claude:prod-1",
+    agent_type: "ClaudeCode",
+    title: "",
+    cwd: "/repo",
+    display_cwd: "/repo",
+    display_name: "claude:prod-1",
+    detection_source: "HttpHook",
+    git_branch: null,
+    git_dirty: false,
+    is_worktree: false,
+    git_common_dir: "/repo/.git",
+    worktree_name: null,
+    worktree_base_branch: null,
+    effort_level: null,
+    active_subagents: 0,
+    compaction_count: 0,
+    pty_session_id: null,
+    send_capability: "PtyInject",
+    is_virtual: false,
+    team_info: null,
+    attention: null,
+    ...overrides,
+  };
+}
+
+describe("AgentCard — Producer badge + accent", () => {
+  it("renders the PROD badge and accent highlight for the Producer (is_producer: true)", () => {
+    const { container } = render(<AgentCard agent={stubAgent({ is_producer: true })} />);
+
+    expect(screen.getByText("PROD")).toBeTruthy();
+    // The accent highlight is applied to the outer card button.
+    const button = container.querySelector("button");
+    expect(button?.className).toContain("bg-primary/[0.04]");
+  });
+
+  it("omits the badge and accent for a same-unit worker (is_producer: false)", () => {
+    const { container } = render(<AgentCard agent={stubAgent({ is_producer: false })} />);
+
+    expect(screen.queryByText("PROD")).toBeNull();
+    const button = container.querySelector("button");
+    expect(button?.className).not.toContain("bg-primary/[0.04]");
+  });
+});

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsole.test.tsx
@@ -147,7 +147,7 @@ describe("ProducerConsole", () => {
               displayName: "halted-agent",
               attention: "halted",
               cwd: "/p/a",
-              isOrchestrator: false,
+              isProducer: false,
             },
           ],
         },

--- a/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConsoleActions.test.tsx
@@ -98,7 +98,7 @@ function agent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot 
     is_virtual: partial.is_virtual ?? false,
     team_info: partial.team_info ?? null,
     attention: partial.attention ?? null,
-    is_orchestrator: partial.is_orchestrator,
+    is_producer: partial.is_producer,
   };
 }
 

--- a/clients/react/src/components/producer-console/__tests__/ProducerConversationHeader.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConversationHeader.test.tsx
@@ -58,7 +58,7 @@ function agent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot 
     is_virtual: partial.is_virtual ?? false,
     team_info: partial.team_info ?? null,
     attention: partial.attention ?? null,
-    is_orchestrator: partial.is_orchestrator,
+    is_producer: partial.is_producer,
     ctx_usage: partial.ctx_usage,
   };
 }

--- a/clients/react/src/components/producer-console/__tests__/ProducerCtxHeader.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerCtxHeader.test.tsx
@@ -53,7 +53,7 @@ function agent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot 
     is_virtual: partial.is_virtual ?? false,
     team_info: partial.team_info ?? null,
     attention: partial.attention ?? null,
-    is_orchestrator: partial.is_orchestrator,
+    is_producer: partial.is_producer,
     ctx_usage: partial.ctx_usage,
   };
 }

--- a/clients/react/src/components/producer-console/sections/WhereYouLeftOffSection.tsx
+++ b/clients/react/src/components/producer-console/sections/WhereYouLeftOffSection.tsx
@@ -112,8 +112,8 @@ function AttentionAgentsList({ agents }: { agents: AttentionAgentBrief[] }) {
           <li key={a.target} className="flex items-baseline gap-2">
             <AttentionGlyph kind={a.attention} />
             <code className="text-foreground">{a.displayName}</code>
-            {a.isOrchestrator && (
-              <span className="rounded bg-primary/10 px-1 text-[10px] text-primary">orch</span>
+            {a.isProducer && (
+              <span className="rounded bg-primary/10 px-1 text-[10px] text-primary">prod</span>
             )}
             <span className="text-subtle-foreground">{a.cwd}</span>
           </li>

--- a/clients/react/src/components/project/ProjectGroup.tsx
+++ b/clients/react/src/components/project/ProjectGroup.tsx
@@ -121,9 +121,12 @@ export function ProjectGroup({ project, selection, onSelectAgent, onSpawned }: P
   const hasMultipleTargets =
     spawnTargets.length > 1 || (spawnTargets.length === 1 && spawnTargets[0].isWorktree);
 
-  // Check if an orchestrator agent is already running in this project
+  // Check if a Producer agent is already running in this project. Keys on
+  // `is_producer` — the wire field (DR `2026-05-16-producer-identity-and-
+  // operator-addressing` §B); the stale `is_orchestrator` read never
+  // fired, so the spawn gate below was always open (#836).
   const hasRunningOrchestrator = project.worktrees.some((wt) =>
-    wt.agents.some((a) => a.is_orchestrator),
+    wt.agents.some((a) => a.is_producer),
   );
 
   const isEmpty = project.totalAgents === 0;

--- a/clients/react/src/components/project/__tests__/orchestrator-ux.test.ts
+++ b/clients/react/src/components/project/__tests__/orchestrator-ux.test.ts
@@ -1,18 +1,21 @@
 import { describe, expect, it } from "vitest";
 import type { AgentSnapshot, WorktreeGroup } from "@/lib/api-http";
 
-// ---- Helper: sort agents with orchestrator pinned to top (mirrors WorktreeSection) ----
-function sortAgentsOrchestratorFirst(agents: AgentSnapshot[]): AgentSnapshot[] {
+// ---- Helper: sort agents with the Producer pinned to top (mirrors WorktreeSection) ----
+// Keys on the `is_producer` wire field (DR `2026-05-16-producer-identity-
+// and-operator-addressing` §B); the pre-#836 `is_orchestrator` read was
+// silently absent and pinned nothing.
+function sortAgentsProducerFirst(agents: AgentSnapshot[]): AgentSnapshot[] {
   return [...agents].sort((a, b) => {
-    if (a.is_orchestrator && !b.is_orchestrator) return -1;
-    if (!a.is_orchestrator && b.is_orchestrator) return 1;
+    if (a.is_producer && !b.is_producer) return -1;
+    if (!a.is_producer && b.is_producer) return 1;
     return 0;
   });
 }
 
-// ---- Helper: check if orchestrator is already running in project (mirrors ProjectGroup) ----
-function hasRunningOrchestrator(worktrees: WorktreeGroup[]): boolean {
-  return worktrees.some((wt) => wt.agents.some((a) => a.is_orchestrator));
+// ---- Helper: check if a Producer is already running in project (mirrors ProjectGroup) ----
+function hasRunningProducer(worktrees: WorktreeGroup[]): boolean {
+  return worktrees.some((wt) => wt.agents.some((a) => a.is_producer));
 }
 
 // Minimal AgentSnapshot stub for testing
@@ -48,37 +51,37 @@ function stubAgent(overrides: Partial<AgentSnapshot> = {}): AgentSnapshot {
     effort_level: null,
     team_info: null,
     pty_session_id: null,
-    is_orchestrator: false,
+    is_producer: false,
     ...overrides,
   } as AgentSnapshot;
 }
 
-describe("orchestrator agent sorting", () => {
-  it("pins orchestrator agent to the top of the list", () => {
+describe("Producer agent sorting", () => {
+  it("pins the Producer agent to the top of the list", () => {
     const agents = [
-      stubAgent({ id: "worker-1" }),
-      stubAgent({ id: "orch", is_orchestrator: true }),
-      stubAgent({ id: "worker-2" }),
+      stubAgent({ id: "worker-1", is_producer: false }),
+      stubAgent({ id: "producer", is_producer: true }),
+      stubAgent({ id: "worker-2", is_producer: false }),
     ];
-    const sorted = sortAgentsOrchestratorFirst(agents);
-    expect(sorted[0].id).toBe("orch");
+    const sorted = sortAgentsProducerFirst(agents);
+    expect(sorted[0].id).toBe("producer");
     expect(sorted[1].id).toBe("worker-1");
     expect(sorted[2].id).toBe("worker-2");
   });
 
-  it("preserves order when no orchestrator present", () => {
+  it("preserves order when no Producer present", () => {
     const agents = [stubAgent({ id: "a" }), stubAgent({ id: "b" }), stubAgent({ id: "c" })];
-    const sorted = sortAgentsOrchestratorFirst(agents);
+    const sorted = sortAgentsProducerFirst(agents);
     expect(sorted.map((a) => a.id)).toEqual(["a", "b", "c"]);
   });
 
   it("handles empty agent list", () => {
-    expect(sortAgentsOrchestratorFirst([])).toEqual([]);
+    expect(sortAgentsProducerFirst([])).toEqual([]);
   });
 });
 
-describe("hasRunningOrchestrator", () => {
-  it("returns true when orchestrator exists in a worktree", () => {
+describe("hasRunningProducer", () => {
+  it("returns true when the Producer exists in a worktree", () => {
     const worktrees: WorktreeGroup[] = [
       {
         name: "main",
@@ -86,13 +89,13 @@ describe("hasRunningOrchestrator", () => {
         branch: "main",
         isWorktree: false,
         dirty: false,
-        agents: [stubAgent({ is_orchestrator: true })],
+        agents: [stubAgent({ is_producer: true })],
       },
     ];
-    expect(hasRunningOrchestrator(worktrees)).toBe(true);
+    expect(hasRunningProducer(worktrees)).toBe(true);
   });
 
-  it("returns false when no orchestrator exists", () => {
+  it("returns false when only same-unit workers exist", () => {
     const worktrees: WorktreeGroup[] = [
       {
         name: "main",
@@ -100,17 +103,17 @@ describe("hasRunningOrchestrator", () => {
         branch: "main",
         isWorktree: false,
         dirty: false,
-        agents: [stubAgent(), stubAgent()],
+        agents: [stubAgent({ is_producer: false }), stubAgent({ is_producer: false })],
       },
     ];
-    expect(hasRunningOrchestrator(worktrees)).toBe(false);
+    expect(hasRunningProducer(worktrees)).toBe(false);
   });
 
   it("returns false for empty worktrees", () => {
-    expect(hasRunningOrchestrator([])).toBe(false);
+    expect(hasRunningProducer([])).toBe(false);
   });
 
-  it("detects orchestrator across multiple worktrees", () => {
+  it("detects the Producer across multiple worktrees", () => {
     const worktrees: WorktreeGroup[] = [
       {
         name: "main",
@@ -118,7 +121,7 @@ describe("hasRunningOrchestrator", () => {
         branch: "main",
         isWorktree: false,
         dirty: false,
-        agents: [stubAgent()],
+        agents: [stubAgent({ is_producer: false })],
       },
       {
         name: "feature",
@@ -126,9 +129,9 @@ describe("hasRunningOrchestrator", () => {
         branch: "feature",
         isWorktree: true,
         dirty: false,
-        agents: [stubAgent({ is_orchestrator: true })],
+        agents: [stubAgent({ is_producer: true })],
       },
     ];
-    expect(hasRunningOrchestrator(worktrees)).toBe(true);
+    expect(hasRunningProducer(worktrees)).toBe(true);
   });
 });

--- a/clients/react/src/hooks/__tests__/useAgentSelectionFallback.test.ts
+++ b/clients/react/src/hooks/__tests__/useAgentSelectionFallback.test.ts
@@ -41,7 +41,7 @@ function agent(
     send_capability: "Unknown",
     is_virtual: false,
     team_info: null,
-    is_orchestrator: false,
+    is_producer: false,
     attention: null,
     ...rest,
   } as AgentSnapshot;
@@ -84,14 +84,17 @@ describe("useAgentSelectionFallback", () => {
     expect(setSelection).toHaveBeenCalledWith({ type: "agent", id: "b" });
   });
 
-  it("prefers orchestrator within the same cwd group", () => {
-    // Mirrors the sidebar's "orchestrator on top" sort — the killed
-    // agent's neighbour is the orchestrator if one is present, even when
-    // a non-orchestrator was inserted earlier.
+  it("prefers the Producer within the same cwd group", () => {
+    // Mirrors the sidebar's "Producer on top" sort — the killed agent's
+    // neighbour is the Producer if one is present, even when a same-unit
+    // worker (`is_producer: false`) was inserted earlier. Keys on the
+    // `is_producer` wire field; the pre-#836 `is_orchestrator` read
+    // silently sorted nothing, so the worker would have won by insertion
+    // order.
     const setSelection = vi.fn();
     const a = agent({ target: "a", cwd: "/foo" });
-    const worker = agent({ target: "worker", cwd: "/foo" });
-    const orch = agent({ target: "orch", cwd: "/foo", is_orchestrator: true });
+    const worker = agent({ target: "worker", cwd: "/foo", is_producer: false });
+    const producer = agent({ target: "producer", cwd: "/foo", is_producer: true });
     const { rerender } = renderHook(
       ({ selectedAgent, agents }: FallbackProps) =>
         useAgentSelectionFallback({
@@ -100,12 +103,12 @@ describe("useAgentSelectionFallback", () => {
           agents,
           setSelection,
         }),
-      { initialProps: { selectedAgent: a, agents: [a, worker, orch] } as FallbackProps },
+      { initialProps: { selectedAgent: a, agents: [a, worker, producer] } as FallbackProps },
     );
 
-    rerender({ selectedAgent: undefined, agents: [worker, orch] });
+    rerender({ selectedAgent: undefined, agents: [worker, producer] });
 
-    expect(setSelection).toHaveBeenCalledWith({ type: "agent", id: "orch" });
+    expect(setSelection).toHaveBeenCalledWith({ type: "agent", id: "producer" });
   });
 
   it("falls back to any agent when no same-cwd sibling exists", () => {

--- a/clients/react/src/hooks/__tests__/useHandover.test.ts
+++ b/clients/react/src/hooks/__tests__/useHandover.test.ts
@@ -52,7 +52,7 @@ function agent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot 
     is_virtual: partial.is_virtual ?? false,
     team_info: partial.team_info ?? null,
     attention: partial.attention ?? null,
-    is_orchestrator: partial.is_orchestrator,
+    is_producer: partial.is_producer,
   };
 }
 
@@ -160,6 +160,45 @@ describe("useHandover — WhereYouLeftOff scoping", () => {
     const names = result.current.whereYouLeftOff.attentionAgents.map((a) => a.displayName);
     expect(names).toContain("needs-attention");
     expect(names).not.toContain("other-needs");
+  });
+
+  it("flags the Producer attention agent via is_producer, not the same-unit worker", () => {
+    // Both agents are blocked (non-null attention) and share the scoped
+    // project, so both surface in `attentionAgents`. The brief's
+    // `isProducer` must come off the `is_producer` wire field: the
+    // Producer (`is_producer: true`) flags true, a same-unit worker
+    // (`is_producer: false`) flags false. Pre-#836 this read the stale
+    // `is_orchestrator` and every brief flagged false.
+    useAgentsMock.mockReturnValue({
+      agents: [
+        agent({
+          id: "claude:producer",
+          cwd: "/home/u/proj-a",
+          git_common_dir: "/home/u/proj-a/.git",
+          attention: "halted",
+          display_name: "producer-agent",
+          is_producer: true,
+        }),
+        agent({
+          id: "claude:worker",
+          cwd: "/home/u/proj-a",
+          git_common_dir: "/home/u/proj-a/.git",
+          attention: "halted",
+          display_name: "worker-agent",
+          is_producer: false,
+        }),
+      ],
+      attentionCount: 2,
+      loading: false,
+      refresh: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useHandover("/home/u/proj-a"));
+    const briefs = result.current.whereYouLeftOff.attentionAgents;
+    const producer = briefs.find((a) => a.displayName === "producer-agent");
+    const worker = briefs.find((a) => a.displayName === "worker-agent");
+    expect(producer?.isProducer).toBe(true);
+    expect(worker?.isProducer).toBe(false);
   });
 
   it("falls back to all attention agents when no project is scoped", () => {

--- a/clients/react/src/hooks/useAgentSelectionFallback.ts
+++ b/clients/react/src/hooks/useAgentSelectionFallback.ts
@@ -8,14 +8,16 @@ interface UseAgentSelectionFallbackArgs {
   setSelection: (next: Selection | null) => void;
 }
 
-// Sort key for "first agent in this group": orchestrator wins, then
+// Sort key for "first agent in this group": the Producer wins, then
 // insertion order. Mirrors `WorktreeSection` in ProjectGroup so the
 // fallback target matches what the sidebar renders at the top of the
-// group the user was already looking at.
-function sortByOrchestratorFirst(agents: AgentSnapshot[]): AgentSnapshot[] {
+// group the user was already looking at. Keys on `is_producer` — the
+// wire field (DR `2026-05-16-producer-identity-and-operator-addressing`
+// §B); the stale `is_orchestrator` read silently sorted nothing (#836).
+function sortByProducerFirst(agents: AgentSnapshot[]): AgentSnapshot[] {
   return [...agents].sort((a, b) => {
-    if (a.is_orchestrator && !b.is_orchestrator) return -1;
-    if (!a.is_orchestrator && b.is_orchestrator) return 1;
+    if (a.is_producer && !b.is_producer) return -1;
+    if (!a.is_producer && b.is_producer) return 1;
     return 0;
   });
 }
@@ -23,16 +25,16 @@ function sortByOrchestratorFirst(agents: AgentSnapshot[]): AgentSnapshot[] {
 function pickSibling(agents: AgentSnapshot[], prevCwd: string | null): AgentSnapshot | undefined {
   if (prevCwd) {
     const sameCwd = agents.filter((a) => a.cwd === prevCwd);
-    const pick = sortByOrchestratorFirst(sameCwd)[0];
+    const pick = sortByProducerFirst(sameCwd)[0];
     if (pick) return pick;
   }
-  return sortByOrchestratorFirst(agents)[0];
+  return sortByProducerFirst(agents)[0];
 }
 
 /**
  * Move selection to a sibling agent when the previously-resolved one
  * disappears from `agents` (kill button, CC quit, dispatch unwind, …).
- * Prefers "same cwd, orchestrator first" so the user lands in the same
+ * Prefers "same cwd, Producer first" so the user lands in the same
  * project group; falls back to any first agent; clears selection only
  * when the entity list is empty.
  *

--- a/clients/react/src/hooks/useHandover.ts
+++ b/clients/react/src/hooks/useHandover.ts
@@ -69,7 +69,7 @@ export interface AttentionAgentBrief {
   displayName: string;
   attention: AgentAttention;
   cwd: string;
-  isOrchestrator: boolean;
+  isProducer: boolean;
 }
 
 export interface WhereYouLeftOff {
@@ -180,7 +180,10 @@ export function useHandover(currentProjectPath: string | null): HandoverDigest {
         displayName: a.display_name,
         attention: a.attention,
         cwd: a.cwd,
-        isOrchestrator: a.is_orchestrator === true,
+        // Keys on `is_producer` — the wire field (DR `2026-05-16-producer-
+        // identity-and-operator-addressing` §B). The stale `is_orchestrator`
+        // read always yielded `false`, misclassifying the Producer (#836).
+        isProducer: a.is_producer === true,
       })),
     };
   }, [currentProjectPath, projectGroups, aiAgents]);

--- a/clients/react/src/lib/__tests__/find-producer-for-unit.test.ts
+++ b/clients/react/src/lib/__tests__/find-producer-for-unit.test.ts
@@ -51,7 +51,7 @@ function stubAgent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnaps
     is_virtual: partial.is_virtual ?? false,
     team_info: partial.team_info ?? null,
     attention: partial.attention ?? null,
-    is_orchestrator: partial.is_orchestrator,
+    is_producer: partial.is_producer,
   };
 }
 

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -299,7 +299,16 @@ export interface AgentSnapshot {
   connection_channels?: ConnectionChannels;
   model_id?: string | null;
   model_display_name?: string | null;
-  is_orchestrator?: boolean;
+  /** Whether this agent is the unit's Producer. Wire field name
+   *  `is_producer` (tmai-core `crates/tmai-core/src/api/types.rs`,
+   *  serde `is_producer` with `skip_serializing_if` so it is absent on
+   *  the wire — and reads as `undefined`/falsy — when not the Producer),
+   *  per DR `2026-05-16-producer-identity-and-operator-addressing` §B:
+   *  the deliberate contract-surface rename the neutral
+   *  `is_orchestrator` name (#402) was holding back. The stale
+   *  `is_orchestrator?` mirror was removed (#836) so any read of the
+   *  absent field is now a tsc error, not a silent `false`. */
+  is_producer?: boolean;
   /** Attention axis introduced by Step 4 of the agent-state attention
    *  rebuild (decision tmai-core@2026-05-07). `null` / absent on the
    *  wire encodes "unknown" — the sampler bootstrap window per Δ6.


### PR DESCRIPTION
## Problem

Four WebUI surfaces read `a.is_orchestrator` off `AgentSnapshot`, but the engine does **not** serve `is_orchestrator` on the agents wire — it serves **`is_producer`** (tmai-core `crates/tmai-core/src/api/types.rs`, serde field `is_producer` with `skip_serializing_if`, per DR `2026-05-16-producer-identity-and-operator-addressing` §B). The hand-written `AgentSnapshot` interface (`clients/react/src/lib/api-http.ts`) still carried a stale `is_orchestrator?` field left over from before the orchestrator→producer rename, so these reads silently evaluated to `false` — the Producer was never identified. Shape-invisible hand-mirror failure: tsc passed, behavior silently wrong.

Closes #836. Follows PR #835 (which fixed `findProducerForUnit` and flagged these four remaining sites).

## Fix (clients/react only — no tmai-core change)

Switched the four reads from `a.is_orchestrator` to `a.is_producer`:

- **`hooks/useAgentSelectionFallback.ts`** — `sortByOrchestratorFirst` → `sortByProducerFirst`; producer-first fallback ordering restored so the fallback target matches what the sidebar renders.
- **`components/project/ProjectGroup.tsx`** — project-group Producer detection (`hasRunningOrchestrator` spawn gate) now fires.
- **`components/agent/AgentCard.tsx`** — the Producer badge/highlight now shows (stale `ORCH` badge label → `PROD`).
- **`hooks/useHandover.ts`** — `AttentionAgentBrief.isOrchestrator` → `isProducer`; hand-over no longer misclassifies the Producer (consumed at `producer-console/sections/WhereYouLeftOffSection.tsx`, stale `orch` pill → `prod`).

Replaced the stale `is_orchestrator?: boolean` on the `AgentSnapshot` interface with `is_producer?: boolean` (+ a DR-referencing doc comment), so any future read of the absent field is a **tsc compile error**, not a silent `false`. Migrated all remaining `is_orchestrator` references (including test stubs) to `is_producer`. Zero `is_orchestrator` reads on `AgentSnapshot` remain (only history-explaining comments + the `hasRunningOrchestrator` local identifier, kept to stay consistent with the surrounding orchestrator-spawn UI vocabulary).

## Tests

Each of the four surfaces is now exercised with a Producer (`is_producer: true`, detected) **and** a same-unit worker (`is_producer: false`, NOT detected):
- `useAgentSelectionFallback.test.ts` — Producer wins the same-cwd sort over an earlier-inserted worker.
- `orchestrator-ux.test.ts` — sort + `hasRunningProducer` detection migrated to `is_producer`.
- **new** `AgentCard.test.tsx` — badge + accent render for the Producer, absent for a worker (no AgentCard test existed before).
- `useHandover.test.ts` — new assertion that the Producer attention brief flags `isProducer: true` while the worker flags `false`.

## Gate (CI parity, run under `clients/react/`) — all green

- `tsc --noEmit` ✓
- `pnpm lint` ✓ (remaining warning is a pre-existing unrelated `ProducerFeedChip.tsx` suggestion)
- `pnpm test` ✓ (1017 passed, 2 skipped)
- `pnpm build` ✓

## Out of scope

Retiring the hand-mirror entirely / adding a generated `AgentSnapshot` ts-rs export — there is no generated `AgentSnapshot` today (hand-written in `api-http.ts`); that is a separate cross-repo tmai-core task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * エージェントの識別方式をプロデューサーベースに更新しました。

* **Bug Fixes**
  * エージェント表示でプロデューサーバッジを正しく表示するよう修正しました。
  * エージェント選択時の優先順位をプロデューサー優先に変更しました。

* **Tests**
  * テストデータをプロデューサー属性に対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->