### PR TITLE
fix(webui): resolve active unit by [[unit]] membership, not project-path basename

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -49,6 +49,7 @@ import {
   api,
   groupByProject,
   isAiAgentLoose,
+  resolveUnitName,
   type Selection,
   setCallerCwd,
   type UnitResponse,
@@ -216,18 +217,30 @@ export function App() {
   );
   const openCalibration = useCallback(() => setMainPanel("calibration"), []);
 
-  // Unit name for the calibration view. The wire endpoint (`GET
-  // /api/units/{unit}/calibration`) takes a unit *name* (a configured
-  // `[[unit]]` table key or a cwd-synthesized basename) — the WebUI does
-  // not know which `[[unit]]` tables the operator has configured, so we
-  // pass the basename of the currently-selected project path. The
-  // backend's `resolve_unit_or_cwd` falls back to the basename when no
-  // matching `[[unit]]` exists, which matches what the CLI does for the
-  // same input.
-  const unitName = useMemo(() => {
-    if (!currentProject) return null;
-    return currentProject.split("/").filter(Boolean).pop() ?? null;
-  }, [currentProject]);
+  // Configured-unit membership (tmai-core #460 — wire half of #439). Read
+  // BEFORE `unitName` because the active unit is resolved by membership (see
+  // `resolveUnitName`), not the project-path basename. Also threaded into
+  // `findProducerForUnit` below so multi-repo units resolve their Producer
+  // against the primary repo specifically, not against whichever repo
+  // `currentProject` happens to point at. `useHandover` consumes the same wire
+  // for cross-unit reconciliation.
+  const { data: unitsData } = useUnits();
+
+  // The active unit NAME, fed to the unit-scoped wires (`GET
+  // /api/units/{unit}/…`). Anchored to the unit that OWNS `currentProject` in
+  // the configured `[[unit]]` membership — NOT the basename of the project
+  // path. A multi-repo unit's `currentProject` can resolve to a SECONDARY repo
+  // (e.g. `…/tmai-core`, basename "tmai-core") while the unit — and every
+  // agent's wire `unit` — is "tmai"; a basename derivation then mismatched the
+  // SessionPane `agent.unit === unitName` filter and hid the unit's own agents
+  // (the aim-console worker-invisibility bug). `resolveUnitName` falls back to
+  // the basename when no configured unit matches — the same cwd-synthesized-
+  // unit behaviour the backend's `resolve_unit_or_cwd` and the CLI give for an
+  // unconfigured cwd.
+  const unitName = useMemo(
+    () => resolveUnitName(currentProject, unitsData?.units ?? []),
+    [currentProject, unitsData],
+  );
   const { data: calibrationData } = useCalibration(unitName);
   const { data: producerFeedData } = useProducerFeed(unitName);
 
@@ -240,12 +253,6 @@ export function App() {
   useEffect(() => {
     clearFocusedArtifact();
   }, [unitName]);
-  // Configured-unit membership (tmai-core #460 — wire half of #439).
-  // Threaded into `findProducerForUnit` below so multi-repo units
-  // resolve their Producer against the primary repo specifically,
-  // not against whichever repo `currentProject` happens to point at.
-  // `useHandover` consumes the same wire for cross-unit reconciliation.
-  const { data: unitsData } = useUnits();
   const unitReposForCurrent = useMemo(() => {
     if (unitName === null) return null;
     return unitsData?.units.find((u) => u.name === unitName)?.repos ?? null;

--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -224,7 +224,7 @@ export function App() {
   // against the primary repo specifically, not against whichever repo
   // `currentProject` happens to point at. `useHandover` consumes the same wire
   // for cross-unit reconciliation.
-  const { data: unitsData } = useUnits();
+  const { data: unitsData, loading: unitsLoading } = useUnits();
 
   // The active unit NAME, fed to the unit-scoped wires (`GET
   // /api/units/{unit}/…`). Anchored to the unit that OWNS `currentProject` in
@@ -237,10 +237,16 @@ export function App() {
   // the basename when no configured unit matches — the same cwd-synthesized-
   // unit behaviour the backend's `resolve_unit_or_cwd` and the CLI give for an
   // unconfigured cwd.
-  const unitName = useMemo(
-    () => resolveUnitName(currentProject, unitsData?.units ?? []),
-    [currentProject, unitsData],
-  );
+  const unitName = useMemo(() => {
+    // Hold while the membership wire is still loading: until it arrives we
+    // cannot tell which unit owns `currentProject`, and resolving by basename
+    // in the meantime would briefly mis-scope a multi-repo unit to its
+    // SECONDARY repo before units land. Once loading clears — even on fetch
+    // failure (`data` stays null) — we fall through to the basename, the same
+    // as an unconfigured cwd.
+    if (unitsLoading) return null;
+    return resolveUnitName(currentProject, unitsData?.units ?? []);
+  }, [currentProject, unitsData, unitsLoading]);
   const { data: calibrationData } = useCalibration(unitName);
   const { data: producerFeedData } = useProducerFeed(unitName);
 

--- a/clients/react/src/__tests__/App.handoff.test.tsx
+++ b/clients/react/src/__tests__/App.handoff.test.tsx
@@ -44,6 +44,13 @@ vi.mock("@/hooks/useWorktrees", () => ({
 vi.mock("@/hooks/useCalibration", () => ({
   useCalibration: () => ({ data: null, loading: false, error: null }),
 }));
+// Loaded-empty membership: `unitName` then resolves by basename of the
+// synthetic `/p/...` paths these tests use (no configured `[[unit]]`). Must be
+// `loading: false` so App's units-load gate releases `unitName` (otherwise it
+// holds `null` while the real hook reports its initial `loading: true`).
+vi.mock("@/hooks/useUnits", () => ({
+  useUnits: () => ({ data: { units: [] }, loading: false, error: null }),
+}));
 vi.mock("@/hooks/useNotificationConfig", () => ({ useNotificationConfig: () => ({}) }));
 vi.mock("@/hooks/useIdleNotification", () => ({
   useIdleNotification: () => ({ handleAgentStopped: vi.fn() }),

--- a/clients/react/src/lib/__tests__/resolve-unit-name.test.ts
+++ b/clients/react/src/lib/__tests__/resolve-unit-name.test.ts
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import type { UnitResponse } from "@/types/generated/UnitResponse";
+import { resolveUnitName } from "../api-http";
+
+// The real multi-repo unit at the heart of the aim-console worker-
+// invisibility bug: the Producer runs at the wrapper `…/tmai`, the unit
+// "tmai" spans a primary repo (`…/tmai/tmai`, basename matches the unit name)
+// and a SECONDARY repo (`…/tmai/tmai-core`, basename "tmai-core" does NOT).
+const TMAI_UNIT: UnitResponse = {
+  name: "tmai",
+  repos: [
+    { path: "/home/u/works/tmai/tmai", primary: true },
+    { path: "/home/u/works/tmai/tmai-core", primary: false },
+  ],
+};
+
+describe("resolveUnitName", () => {
+  it("returns null for a null currentProject", () => {
+    expect(resolveUnitName(null, [TMAI_UNIT])).toBeNull();
+  });
+
+  // The regression: a worktree worker's git_common_dir lands `currentProject`
+  // on the SECONDARY repo. A basename derivation would yield "tmai-core",
+  // mismatching every agent's wire `unit` ("tmai") and emptying the
+  // SessionPane. Membership resolution returns the OWNING unit instead.
+  it("resolves a SECONDARY repo path to the owning unit name (the bug)", () => {
+    expect(resolveUnitName("/home/u/works/tmai/tmai-core", [TMAI_UNIT])).toBe("tmai");
+  });
+
+  it("resolves the primary repo path to the unit name", () => {
+    expect(resolveUnitName("/home/u/works/tmai/tmai", [TMAI_UNIT])).toBe("tmai");
+  });
+
+  it("resolves the wrapper dir (which contains the repos) to the unit name", () => {
+    expect(resolveUnitName("/home/u/works/tmai", [TMAI_UNIT])).toBe("tmai");
+  });
+
+  it("resolves a path INSIDE a repo (a worktree cwd) to the owning unit", () => {
+    expect(
+      resolveUnitName("/home/u/works/tmai/tmai-core/.claude/worktrees/probe", [TMAI_UNIT]),
+    ).toBe("tmai");
+  });
+
+  it("normalizes a trailing /.git and slashes before matching", () => {
+    expect(resolveUnitName("/home/u/works/tmai/tmai-core/.git", [TMAI_UNIT])).toBe("tmai");
+    expect(resolveUnitName("/home/u/works/tmai/tmai-core///", [TMAI_UNIT])).toBe("tmai");
+  });
+
+  it("falls back to the path basename when no configured unit matches", () => {
+    expect(resolveUnitName("/home/u/works/other-proj", [TMAI_UNIT])).toBe("other-proj");
+  });
+
+  it("falls back to the basename when the units list is empty (cwd-synthesized unit)", () => {
+    expect(resolveUnitName("/home/u/works/standalone", [])).toBe("standalone");
+  });
+
+  it("does not match a sibling repo that merely shares a path prefix", () => {
+    // `…/tmai-core-extra` must NOT match the `…/tmai-core` repo — the boundary
+    // check is on a full path segment (`norm === repo` or a `/`-delimited
+    // prefix), not a bare string prefix.
+    const units: UnitResponse[] = [
+      { name: "tmai", repos: [{ path: "/home/u/works/tmai/tmai-core", primary: true }] },
+    ];
+    expect(resolveUnitName("/home/u/works/tmai/tmai-core-extra", units)).toBe("tmai-core-extra");
+  });
+});

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -420,6 +420,40 @@ export function normalizeGitDir(dir: string): string {
   return cleaned.slice(0, end);
 }
 
+// Resolve the active unit's NAME from the currently-focused project path.
+//
+// The unit identity is anchored to the Producer's launch cwd and its
+// constituent repos (the engine's `[[unit]]` model: one unit = the wrapper
+// dir the Producer runs in, its repos = the git dirs under it). It is NOT the
+// basename of whatever repo dir `currentProject` happens to point at. A
+// multi-repo unit's `currentProject` can land on a SECONDARY repo (e.g. a
+// worktree worker's `git_common_dir`, whose basename differs from the unit
+// name); deriving the active unit by basename then yields the secondary repo's
+// name, and every agent — whose wire `unit` carries the REAL unit name — fails
+// the `agent.unit === unitName` filter and drops out of its own unit's
+// SessionPane (the aim-console worker-invisibility bug).
+//
+// So match `currentProject` against the configured unit membership and return
+// the OWNING unit's name. Fall back to the path basename only when no
+// configured unit matches (a cwd-synthesized unit — the same behaviour the
+// engine/CLI give for an unconfigured cwd).
+export function resolveUnitName(
+  currentProject: string | null,
+  units: UnitResponse[],
+): string | null {
+  if (!currentProject) return null;
+  const norm = normalizeGitDir(currentProject);
+  const owning = units.find((u) =>
+    u.repos.some((r) => {
+      const repo = normalizeGitDir(r.path);
+      // `currentProject` belongs to the unit when it is AT a repo, INSIDE a
+      // repo, or IS the wrapper dir that contains the repo.
+      return norm === repo || norm.startsWith(`${repo}/`) || repo.startsWith(`${norm}/`);
+    }),
+  );
+  return owning ? owning.name : projectName(currentProject);
+}
+
 // Resolve an agent's normalized repo directory: prefer `git_common_dir`,
 // then a cwd→git_common_dir prefix match, then the cwd itself. Factored
 // out of the grouping loop so unit-grouping (for the representative repo


### PR DESCRIPTION
## What
Fixes the aim-console **worker-invisibility** bug (operator-reported, dogfood): a dispatched worker in a multi-repo unit's *secondary* repo (e.g. `tmai-core` under unit "tmai") does not appear in the aim-console `SessionPane`, even though it shows in the legacy console and a hard reload does not help.

## Root cause (UI-only — the backend is correct)
`SessionPane` filters agents with `agentInUnit`: `agent.unit === unitName`. The wire serves the worker correctly with `unit="tmai"` (verified on both `/api/agents` and `/api/bootstrap`). But `unitName` was derived as `basename(currentProject)`. For a multi-repo unit, `currentProject` can resolve to a **secondary repo** (`…/tmai-core`) whose basename is `"tmai-core"`, so `agent.unit ("tmai") === unitName ("tmai-core")` is false and every agent (Producer + workers) is filtered out of its own unit's pane. A hard reload does not fix it because the derivation is deterministic.

First exercised by the wrapper-dir project model (#529/#530): the Producer runs at the wrapper `…/tmai` (a path prefix of every child repo), so `resolveRepoDir`'s loose prefix match resolves the Producer's repo dir to a child repo, and `groupByProject` then falls back to the secondary repo dir as the unit group's representative path → `currentProject = …/tmai-core`.

## Fix
Anchor the active unit to the configured `[[unit]]` membership instead of the project-path basename:
- New pure helper `resolveUnitName(currentProject, units)` (`api-http.ts`): returns the name of the unit whose `repos[]` own `currentProject` (at / inside / containing it), falling back to the path basename only when no configured unit matches (cwd-synthesized unit — same as the backend's `resolve_unit_or_cwd` / the CLI).
- `App.tsx`: read `useUnits()` before `unitName`; derive `unitName` via the helper.

Minimal by design (per operator steer): `resolveRepoDir`'s prefix match is left as-is — the membership resolution makes its mis-resolution harmless for `unitName`.

## Test
New `resolve-unit-name.test.ts` (9 cases incl. the regression: a secondary-repo path → owning unit name; path-segment-boundary safety; cwd-synthesized fallback). Full suite green (1034 passed / 2 skipped); `tsc -b` + `vite build` + `biome check` all clean.

## Verify
A probe worker (`aim-console-probe`, a `tmai-core` worktree) is running for live verification; once this lands and vite dev reloads, it should appear in the aim-console SessionPane under unit "tmai".


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * ユニットメンバーシップに基づいて正しいユニット名が選択されるようになりました。

* **Tests**
  * ユニット名解決ロジックの包括的なテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->