### PR TITLE
feat(webui): resolveRepoDir deepest-match — fix wrapper vs nested same-named repo mis-resolution (#538 companion) (#839)

### DIFF
--- a/clients/react/src/lib/__tests__/resolve-repo-dir.test.ts
+++ b/clients/react/src/lib/__tests__/resolve-repo-dir.test.ts
@@ -1,0 +1,160 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { type AgentSnapshot, resolveRepoDir } from "../api-http";
+
+// Minimal AgentSnapshot stub — `resolveRepoDir` only reads `git_common_dir`
+// and `cwd`; the rest are inert but required by the type.
+function stubAgent(overrides: Partial<AgentSnapshot> = {}): AgentSnapshot {
+  return {
+    id: "claude:agent",
+    target: "claude:agent",
+    agent_type: "ClaudeCode",
+    title: "",
+    cwd: "/home/u/works/tmai",
+    display_cwd: "/home/u/works/tmai",
+    display_name: "claude:agent",
+    detection_source: "HttpHook",
+    git_branch: null,
+    git_dirty: false,
+    is_worktree: false,
+    git_common_dir: null,
+    worktree_name: null,
+    worktree_base_branch: null,
+    effort_level: null,
+    active_subagents: 0,
+    compaction_count: 0,
+    pty_session_id: null,
+    send_capability: "PtyInject",
+    is_virtual: false,
+    team_info: null,
+    attention: null,
+    ...overrides,
+  };
+}
+
+describe("resolveRepoDir — deepest-match prefix resolution (#839)", () => {
+  it("prefers git_common_dir over any cwd prefix match", () => {
+    const agent = stubAgent({
+      git_common_dir: "/home/u/works/tmai/.git",
+      cwd: "/home/u/works/tmai/tmai/src",
+    });
+    const cwdToGitDir = new Map([["/home/u/works/tmai/tmai", "/home/u/works/tmai/tmai"]]);
+
+    // git_common_dir short-circuits the prefix scan entirely.
+    expect(resolveRepoDir(agent, cwdToGitDir)).toBe("/home/u/works/tmai");
+  });
+
+  it("returns the exact cwd→git-dir hit when present", () => {
+    const agent = stubAgent({ git_common_dir: null, cwd: "/home/u/works/tmai/tmai" });
+    const cwdToGitDir = new Map([
+      ["/home/u/works/tmai", "/home/u/works/tmai"],
+      ["/home/u/works/tmai/tmai", "/home/u/works/tmai/tmai"],
+    ]);
+
+    expect(resolveRepoDir(agent, cwdToGitDir)).toBe("/home/u/works/tmai/tmai");
+  });
+
+  it("resolves an agent inside the DEEPER of two prefix-sharing repos to the deeper repo", () => {
+    // Wrapper `.../tmai` and nested `.../tmai/tmai` are both repos; the agent
+    // sits inside the nested one. Deepest (longest) matching prefix must win,
+    // regardless of insertion order — here the SHALLOWER key is inserted first.
+    const agent = stubAgent({ git_common_dir: null, cwd: "/home/u/works/tmai/tmai/src/lib" });
+    const cwdToGitDir = new Map([
+      ["/home/u/works/tmai", "/home/u/works/tmai"],
+      ["/home/u/works/tmai/tmai", "/home/u/works/tmai/tmai"],
+    ]);
+
+    expect(resolveRepoDir(agent, cwdToGitDir)).toBe("/home/u/works/tmai/tmai");
+  });
+
+  it("is independent of Map iteration order (deeper wins even when inserted last)", () => {
+    const agent = stubAgent({ git_common_dir: null, cwd: "/home/u/works/tmai/tmai/src/lib" });
+    const cwdToGitDir = new Map([
+      ["/home/u/works/tmai/tmai", "/home/u/works/tmai/tmai"],
+      ["/home/u/works/tmai", "/home/u/works/tmai"],
+    ]);
+
+    expect(resolveRepoDir(agent, cwdToGitDir)).toBe("/home/u/works/tmai/tmai");
+  });
+
+  it("resolves the tmai/tmai case (wrapper name == nested same-named repo)", () => {
+    // The nested repo shares the wrapper's basename (`tmai`). An agent inside
+    // the nested `tmai/tmai` must bind to it, NOT the shallower wrapper `tmai`
+    // and NOT the prefix-sharing sibling `tmai/tmai-core`.
+    const agent = stubAgent({ git_common_dir: null, cwd: "/home/u/works/tmai/tmai/api-spec" });
+    const cwdToGitDir = new Map([
+      ["/home/u/works/tmai", "/home/u/works/tmai"],
+      ["/home/u/works/tmai/tmai-core", "/home/u/works/tmai/tmai-core"],
+      ["/home/u/works/tmai/tmai", "/home/u/works/tmai/tmai"],
+    ]);
+
+    expect(resolveRepoDir(agent, cwdToGitDir)).toBe("/home/u/works/tmai/tmai");
+  });
+
+  it("does NOT bind a sibling whose name shares a prefix (tmai vs tmai-core)", () => {
+    // `agent.cwd.startsWith(cwd)` without a `/` boundary would have let the
+    // `.../tmai` key match a `.../tmai-core` cwd. The `/`-boundary check stops
+    // that: the agent inside `tmai-core` resolves to `tmai-core`, not `tmai`.
+    const agent = stubAgent({ git_common_dir: null, cwd: "/home/u/works/tmai-core/src" });
+    const cwdToGitDir = new Map([
+      ["/home/u/works/tmai", "/home/u/works/tmai"],
+      ["/home/u/works/tmai-core", "/home/u/works/tmai-core"],
+    ]);
+
+    expect(resolveRepoDir(agent, cwdToGitDir)).toBe("/home/u/works/tmai-core");
+  });
+
+  it("falls back to the deepest repo nested under a wrapper cwd", () => {
+    // The agent sits AT the wrapper dir with no inside-repo match; the wrapper
+    // fallback picks the deepest repo nested beneath it. With two siblings at
+    // equal depth the lexicographically smaller key wins (order-independent).
+    const agent = stubAgent({ git_common_dir: null, cwd: "/home/u/works/tmai" });
+    const cwdToGitDir = new Map([
+      ["/home/u/works/tmai/tmai-core", "/home/u/works/tmai/tmai-core"],
+      ["/home/u/works/tmai/tmai", "/home/u/works/tmai/tmai"],
+    ]);
+
+    expect(resolveRepoDir(agent, cwdToGitDir)).toBe("/home/u/works/tmai/tmai");
+  });
+
+  it("prefers an inside-repo match over the wrapper fallback", () => {
+    // Both an inside-repo match (`.../tmai` contains the agent) and a wrapper
+    // candidate (`.../tmai/tmai` nested under… no — only inside applies here)
+    // — the inside match must win. Agent is inside `.../tmai`, and a deeper
+    // repo `.../tmai/tmai` is NOT under the agent's cwd's parent, so only the
+    // inside branch fires.
+    const agent = stubAgent({ git_common_dir: null, cwd: "/home/u/works/tmai/docs" });
+    const cwdToGitDir = new Map([
+      ["/home/u/works/tmai", "/home/u/works/tmai"],
+      ["/home/u/works/tmai/tmai", "/home/u/works/tmai/tmai"],
+    ]);
+
+    // `/home/u/works/tmai/docs` is inside `/home/u/works/tmai` (inside match),
+    // while `/home/u/works/tmai/tmai` is neither a parent nor a child of it.
+    expect(resolveRepoDir(agent, cwdToGitDir)).toBe("/home/u/works/tmai");
+  });
+
+  it("leaves single-repo resolution unchanged", () => {
+    const agent = stubAgent({ git_common_dir: null, cwd: "/home/u/works/solo/src" });
+    const cwdToGitDir = new Map([["/home/u/works/solo", "/home/u/works/solo"]]);
+
+    expect(resolveRepoDir(agent, cwdToGitDir)).toBe("/home/u/works/solo");
+  });
+
+  it("leaves distinct-name resolution unchanged", () => {
+    const agent = stubAgent({ git_common_dir: null, cwd: "/home/u/works/backend/api" });
+    const cwdToGitDir = new Map([
+      ["/home/u/works/frontend", "/home/u/works/frontend"],
+      ["/home/u/works/backend", "/home/u/works/backend"],
+    ]);
+
+    expect(resolveRepoDir(agent, cwdToGitDir)).toBe("/home/u/works/backend");
+  });
+
+  it("falls back to the agent's own cwd when nothing matches", () => {
+    const agent = stubAgent({ git_common_dir: null, cwd: "/home/u/works/unknown" });
+    const cwdToGitDir = new Map([["/home/u/works/other", "/home/u/works/other"]]);
+
+    expect(resolveRepoDir(agent, cwdToGitDir)).toBe("/home/u/works/unknown");
+  });
+});

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -454,23 +454,74 @@ export function resolveUnitName(
   return owning ? owning.name : projectName(currentProject);
 }
 
+// Number of path segments (`/`-separated). Depth, not string length, is the
+// "deepest" metric: two prefix-sharing siblings (`.../tmai`, `.../tmai-core`)
+// sit at the SAME depth even though their names differ in length, so ranking
+// by raw length would wrongly favour the longer-named sibling.
+function pathDepth(p: string): number {
+  let n = 0;
+  for (const ch of p) if (ch === "/") n++;
+  return n;
+}
+
+// Find the DEEPEST `cwd` in `cwdToGitDir` whose key satisfies `pred`, returning
+// its git dir. "Deepest" = most path segments; a depth tie breaks toward the
+// lexicographically smaller path so the result NEVER depends on Map iteration
+// order — that order-dependence is the exact bug being fixed (a loose
+// first-match could bind a wrapper-cwd agent to the wrong prefix-sharing child
+// repo). For the inside-repo case every candidate is a prefix of the same cwd,
+// so depth strictly orders them and no tie can arise; the tie-break only bites
+// for the wrapper fallback's same-depth siblings.
+function deepestMatch(
+  cwdToGitDir: Map<string, string>,
+  pred: (cwd: string) => boolean,
+): string | undefined {
+  let bestCwd: string | null = null;
+  let bestDir: string | undefined;
+  for (const [cwd, gitDir] of cwdToGitDir) {
+    if (!pred(cwd)) continue;
+    if (bestCwd === null) {
+      bestCwd = cwd;
+      bestDir = gitDir;
+      continue;
+    }
+    const depth = pathDepth(cwd);
+    const bestDepth = pathDepth(bestCwd);
+    if (depth > bestDepth || (depth === bestDepth && cwd < bestCwd)) {
+      bestCwd = cwd;
+      bestDir = gitDir;
+    }
+  }
+  return bestDir;
+}
+
 // Resolve an agent's normalized repo directory: prefer `git_common_dir`,
 // then a cwd→git_common_dir prefix match, then the cwd itself. Factored
 // out of the grouping loop so unit-grouping (for the representative repo
 // path) and the back-compat git_common_dir grouping share one resolver.
-function resolveRepoDir(agent: AgentSnapshot, cwdToGitDir: Map<string, string>): string {
+//
+// The prefix match is **deepest-wins**, not first-match (#839, companion to
+// tmai-core #538 `pick_primary_by_name`). Under a wrapper dir (`.../tmai`)
+// containing prefix-sharing repos (`.../tmai/tmai`, `.../tmai/tmai-core`), the
+// old loose first-match (`startsWith` either direction, no `/` boundary) could
+// bind the agent to the wrong child depending on Map order. Resolution order:
+//   1. an EXACT `agent.cwd === cwd` hit (the agent IS at a known repo root);
+//   2. else the DEEPEST repo the agent sits inside (`agent.cwd` under `cwd/`);
+//   3. else (wrapper fallback) the DEEPEST repo nested under the agent's cwd
+//      (`cwd` under `agent.cwd/`) — only when no inside-repo match exists.
+// The `/` boundary also stops sibling prefixes from colliding (`.../tmai` no
+// longer matches `.../tmai-core`).
+export function resolveRepoDir(agent: AgentSnapshot, cwdToGitDir: Map<string, string>): string {
   if (agent.git_common_dir) return normalizeGitDir(agent.git_common_dir);
-  // Try to match this cwd to a known git dir via prefix
-  let matched = cwdToGitDir.get(agent.cwd);
-  if (!matched) {
-    for (const [cwd, gitDir] of cwdToGitDir) {
-      if (agent.cwd.startsWith(cwd) || cwd.startsWith(agent.cwd)) {
-        matched = gitDir;
-        break;
-      }
-    }
-  }
-  return matched || agent.cwd;
+  // 1. Exact cwd hit.
+  const exact = cwdToGitDir.get(agent.cwd);
+  if (exact !== undefined) return exact;
+  // 2. Deepest repo the agent sits INSIDE wins over…
+  const inside = deepestMatch(cwdToGitDir, (cwd) => agent.cwd.startsWith(`${cwd}/`));
+  if (inside !== undefined) return inside;
+  // 3. …the deepest repo nested under the agent's cwd (wrapper fallback).
+  const wrapper = deepestMatch(cwdToGitDir, (cwd) => cwd.startsWith(`${agent.cwd}/`));
+  return wrapper ?? agent.cwd;
 }
 
 // Group agents into the left-panel unit groups and their worktree


### PR DESCRIPTION
## Why

Companion to the engine-side unit-resolution rework **trust-delta/tmai-core#538** (filesystem-driven walk-with-prune; part of the agent-primacy unit-model epic **trust-delta/tmai-core#542**). The engine now resolves a wrapper unit whose name equals a nested same-named repo (`tmai/tmai`) via deepest-match. The webui's `resolveRepoDir` still used a **loose first-match prefix scan** that could bind a wrapper-cwd agent to the wrong child repo — the residue called out in trust-delta/tmai-core#838's hand-off (wrapper-cwd Producer mis-resolving to a child repo).

Closes #839.

## The bug (`clients/react/src/lib/api-http.ts`)

`resolveRepoDir`'s cwd→git-dir loop took the **first** loose prefix match (`agent.cwd.startsWith(cwd) || cwd.startsWith(agent.cwd)`, no `/` boundary), not the deepest. Under a wrapper (`.../tmai`) containing prefix-sharing repos (`.../tmai/tmai`, `.../tmai/tmai-core`), the bound repo depended on `Map` iteration order.

## Change (clients/react only)

`resolveRepoDir` — replace first-match with **deepest-wins**, mirroring the engine's deepest-match (tmai-core #538 `pick_primary_by_name`):

1. exact `agent.cwd === cwd`;
2. else the **deepest** repo the agent sits inside (`agent.cwd` under `cwd/`);
3. else (wrapper fallback) the **deepest** repo nested under the agent's cwd (`cwd` under `agent.cwd/`) — only when no inside-repo match exists.

Two correctness details:

- **Depth is measured by path-segment count, not raw string length.** Prefix-sharing siblings (`.../tmai`, `.../tmai-core`) sit at the same depth despite different name lengths; ranking by length would wrongly favour the longer-named sibling (`tmai-core`) for a wrapper-cwd `tmai` Producer.
- **Depth ties break lexicographically**, so the result is independent of `Map` insertion order — the root cause of the bug. For the inside-repo case every candidate is a prefix of the same cwd, so depth strictly orders them and no tie can arise.
- The `/` boundary also stops sibling prefixes from colliding (`.../tmai` no longer matches `.../tmai-core`).

`resolveUnitName` (~:440) is **left unchanged** (per #538) — it already uses owning-unit prefix membership.

## Acceptance

- [x] an agent whose cwd is inside the deeper of two prefix-sharing repos resolves to the **deeper** repo (not the shallower / first-iterated)
- [x] `tmai/tmai` (wrapper name == nested same-named repo) resolves correctly
- [x] existing single-repo / distinct-name resolution unchanged (regression test)
- [x] `resolveUnitName` behavior unchanged

## Tests

New `clients/react/src/lib/__tests__/resolve-repo-dir.test.ts` (11 cases): `git_common_dir` short-circuit, exact hit, deeper-prefix-sharing-repo wins (both insertion orders), `tmai/tmai` same-named resolution, sibling-prefix non-collision (`tmai` vs `tmai-core`), wrapper fallback (deepest + deterministic tie-break), inside-repo preferred over wrapper, single-repo / distinct-name regression, and own-cwd fallback.

## Gate

Locally green (mirrors the clients/react CI job): `pnpm lint` (biome), `pnpm exec tsc -b` (types), `pnpm build`, `pnpm test` (1045 passed, 2 pre-existing skips). No `any`. `types/generated/` untouched.

## Refs

- epic: trust-delta/tmai-core#542
- engine half: trust-delta/tmai-core#538 (merged)
- residue noted in: trust-delta/tmai-core#838 hand-off

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * リポジトリディレクトリの解決ロジックを改善し、ネストされたリポジトリやパス共有のある複数リポジトリ環境でも正しいリポジトリを確実に選択できるようになりました。

* **Tests**
  * リポジトリディレクトリ解決機能の包括的なテストスイートを追加し、様々なリポジトリ構成に対する動作を検証しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->