### PR TITLE
feat(webui): #540 companion — Producer-slot tabs (close + confirm) + generalize HandoffRitualOverlay to crash-respawn (#841)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -54,6 +54,7 @@ import {
   setCallerCwd,
   type UnitResponse,
 } from "@/lib/api";
+import { closeUnitSlot } from "@/lib/close-unit-slot";
 import { findProducerForUnit } from "@/lib/producer";
 import { useSSE } from "@/lib/sse-provider";
 import { ATTENTION_STRIP_WIDTH_DEFAULT, clampAttentionStripWidth } from "@/lib/ui-prefs";
@@ -579,6 +580,26 @@ export function App() {
       .catch(() => toastInfo(`Add a unit by launching a Producer: ${cmd}`));
   }, [toastSuccess, toastInfo]);
 
+  // C1 close affordance (#540 / #546 companion). The per-tab confirm gate
+  // lives in UnitTabs (close = kill, so never silent); this runs only after
+  // the operator confirms. `closeUnitSlot` POSTs the core close (Producer +
+  // dispatched workers) then kills the unit's webui-owned footer bash, which
+  // the engine can't attribute server-side. `agents` is the live roster used
+  // to resolve those hint-less footer shells.
+  const handleCloseUnit = useCallback(
+    async (unit: UnitResponse) => {
+      try {
+        await closeUnitSlot(unit, agents);
+        refresh();
+        toastSuccess(`Closed unit ${unit.name} — Producer + workers + footer bash killed`);
+      } catch (e) {
+        const reason = e instanceof Error ? e.message : String(e);
+        toastInfo(`Failed to close unit ${unit.name}: ${reason}`);
+      }
+    },
+    [agents, refresh, toastSuccess, toastInfo],
+  );
+
   // Keyboard shortcuts handlers
   useKeyboardShortcuts([
     {
@@ -666,6 +687,7 @@ export function App() {
         activeUnitName={unitName}
         onSelectUnit={handleSelectUnit}
         onAddUnit={handleAddUnit}
+        onCloseUnit={handleCloseUnit}
       />
     ) : null;
 
@@ -983,26 +1005,33 @@ export function App() {
       {/* Toast notifications */}
       <ToastContainer toasts={toast.toasts} onRemove={toast.removeToast} />
 
-      {/* Handoff-and-restart ritual UI — App-level single instance so it
+      {/* Producer slot-restart ritual UI — App-level single instance so it
           stays co-visible regardless of the active centre view (digest,
-          Producer conversation, Settings, …). The ordered phases, the
-          4-choice failure dialog, the retry budget (max 2, 3rd refused)
-          and the confirm text are the unchanged handoff-lifecycle DR §E
-          contract; this only RELOCATES the surface up from the digest. */}
-      {(ritualState.kind === "dispatching" || ritualState.kind === "in_progress") &&
-        unitName !== null && (
-          <HandoffRitualOverlay
-            unitName={unitName}
-            ritualId={ritualState.kind === "in_progress" ? ritualState.ritualId : null}
-            phases={ritualState.kind === "in_progress" ? ritualState.phases : []}
-          />
-        )}
+          Producer conversation, Settings, …). Hosts BOTH the operator
+          handoff (full 5-phase, the unchanged handoff-lifecycle DR §E
+          contract) and the supervisor crash-respawn (launching→ready, or a
+          `crash_loop_halted` escalate). The overlay/dialog read the ritual's
+          OWN `unit` (a supervisor respawn may target a non-focused unit) and
+          pick their copy off the `slot-supervisor:` id / reason. */}
+      {ritualState.kind === "dispatching" && unitName !== null && (
+        <HandoffRitualOverlay unitName={unitName} ritualId={null} phases={[]} />
+      )}
+      {ritualState.kind === "in_progress" && (
+        <HandoffRitualOverlay
+          unitName={ritualState.unit}
+          ritualId={ritualState.ritualId}
+          phases={ritualState.phases}
+        />
+      )}
 
-      {ritualState.kind === "escalated" && unitName !== null && (
+      {ritualState.kind === "escalated" && ritualState.unit !== "" && (
         <HandoffRitualFailureDialog
-          unitName={unitName}
+          unitName={ritualState.unit}
           reason={ritualState.reason}
           message={ritualState.message}
+          // The supervisor's `crash_loop_halted` halt is a different failure
+          // than an operator-rejected handoff — manual relaunch, not retry.
+          mode={ritualState.reason === "crash_loop_halted" ? "crash_loop" : "handoff"}
           producerAgentId={producerForUnit?.id ?? null}
           retryCount={handoffRetryCount}
           retryRefused={handoffRetryRefused}

--- a/clients/react/src/__tests__/App.handoff.test.tsx
+++ b/clients/react/src/__tests__/App.handoff.test.tsx
@@ -247,7 +247,7 @@ describe("App — handoff ritual wiring", () => {
     });
     useHandoffRitualMock.mockReturnValue({
       ...idleRitual(),
-      state: { kind: "in_progress", ritualId: "r-1", phases: [] },
+      state: { kind: "in_progress", ritualId: "r-1", unit: "alpha", phases: [] },
     });
 
     renderWithProviders(<App />);

--- a/clients/react/src/components/layout/UnitTabs.tsx
+++ b/clients/react/src/components/layout/UnitTabs.tsx
@@ -8,11 +8,19 @@
 // endpoint, mirroring the existing Phase-A "Open Producer terminal"
 // pattern). Mock reference: `origin/mock/aim-ui-sample` top bar.
 //
+// Each tab also carries a per-unit CLOSE affordance (×) bound to the
+// Producer-slot terminal (tmai-core #540 / #546): it kills the unit's
+// Producer + dispatched workers (and the webui's footer bash). Because
+// close is a kill — Producer + workers gone, but worktrees / uncommitted
+// work stay on disk — it is gated behind an always-on confirm dialog
+// (`useConfirm`); only on confirm does it call `onCloseUnit`.
+//
 // Built to render N units; one configured unit today collapses to a single
 // tab. The attention rollup lives in a per-unit child (`UnitTab`) so each
 // tab can call `useUnitAttention(unit)` on its own — scaling to N without a
 // rules-of-hooks violation.
 
+import { useConfirm } from "@/components/layout/ConfirmDialog";
 import { useUnitAttention } from "@/hooks/useUnitAttention";
 import type { UnitResponse } from "@/lib/api";
 import { cn } from "@/lib/utils";
@@ -30,9 +38,18 @@ interface UnitTabsProps {
   onSelectUnit: (unit: UnitResponse) => void;
   /** "Add unit = launch Producer" affordance (placeholder/clipboard). */
   onAddUnit: () => void;
+  /** Close the unit's Producer slot (kill Producer + workers + footer bash).
+   *  Called ONLY after the per-tab confirm dialog is accepted. */
+  onCloseUnit: (unit: UnitResponse) => void;
 }
 
-export function UnitTabs({ units, activeUnitName, onSelectUnit, onAddUnit }: UnitTabsProps) {
+export function UnitTabs({
+  units,
+  activeUnitName,
+  onSelectUnit,
+  onAddUnit,
+  onCloseUnit,
+}: UnitTabsProps) {
   return (
     <div data-testid="unit-tabs" className="flex flex-wrap items-center gap-1">
       {units.map((unit) => (
@@ -41,6 +58,7 @@ export function UnitTabs({ units, activeUnitName, onSelectUnit, onAddUnit }: Uni
           unit={unit}
           active={unit.name === activeUnitName}
           onSelect={() => onSelectUnit(unit)}
+          onClose={() => onCloseUnit(unit)}
         />
       ))}
       <button
@@ -60,10 +78,12 @@ function UnitTab({
   unit,
   active,
   onSelect,
+  onClose,
 }: {
   unit: UnitResponse;
   active: boolean;
   onSelect: () => void;
+  onClose: () => void;
 }) {
   // Per-unit attention rollup: count the operator-set `high` markers across
   // this unit's artifacts (the ⚠N "owed attention" badge). Reuses the
@@ -71,35 +91,67 @@ function UnitTab({
   const { data } = useUnitAttention(unit.name);
   const highCount = data?.entries.filter((e) => e.level === "high").length ?? 0;
 
+  // Always-on confirm gate (#540 companion): close = kill, so never silent.
+  const confirm = useConfirm();
+  const handleClose = async () => {
+    const ok = await confirm({
+      title: `Close unit ${unit.name}?`,
+      message:
+        "Close kills this unit's Producer, its dispatched workers, and its footer bash. " +
+        "This is a kill, not a delete — worktrees and uncommitted work stay on disk.",
+      confirmLabel: "Close unit",
+      cancelLabel: "Cancel",
+      variant: "danger",
+    });
+    if (ok) onClose();
+  };
+
   return (
-    <button
-      type="button"
-      onClick={onSelect}
-      aria-current={active ? "true" : undefined}
-      // Explicit label so the tab's accessible name is the unit (the
-      // content is just repo-basename pills + an icon badge).
-      aria-label={`unit: ${unit.name}`}
-      title={`unit: ${unit.name}`}
+    <div
+      data-testid={`unit-tab-${unit.name}`}
       className={cn(
-        "flex shrink-0 items-center gap-1.5 rounded-t border-b-2 px-2 py-1 transition-colors",
-        active
-          ? "border-primary text-foreground"
-          : "border-transparent text-muted-foreground hover:bg-surface-strong hover:text-foreground",
+        "flex shrink-0 items-center rounded-t border-b-2 transition-colors",
+        active ? "border-primary" : "border-transparent hover:bg-surface-strong",
       )}
     >
-      {unit.repos.map((repo) => (
-        <RepoPill key={repo.path} label={repoBasename(repo.path)} primary={repo.primary} />
-      ))}
-      {highCount > 0 && (
-        <span
-          data-testid="unit-attention-rollup"
-          title={`${highCount} owed attention`}
-          className="rounded bg-warning/15 px-1 font-mono text-[9px] text-warning"
-        >
-          ⚠{highCount}
-        </span>
-      )}
-    </button>
+      <button
+        type="button"
+        onClick={onSelect}
+        aria-current={active ? "true" : undefined}
+        // Explicit label so the tab's accessible name is the unit (the
+        // content is just repo-basename pills + an icon badge).
+        aria-label={`unit: ${unit.name}`}
+        title={`unit: ${unit.name}`}
+        className={cn(
+          "flex items-center gap-1.5 px-2 py-1",
+          active ? "text-foreground" : "text-muted-foreground hover:text-foreground",
+        )}
+      >
+        {unit.repos.map((repo) => (
+          <RepoPill key={repo.path} label={repoBasename(repo.path)} primary={repo.primary} />
+        ))}
+        {highCount > 0 && (
+          <span
+            data-testid="unit-attention-rollup"
+            title={`${highCount} owed attention`}
+            className="rounded bg-warning/15 px-1 font-mono text-[9px] text-warning"
+          >
+            ⚠{highCount}
+          </span>
+        )}
+      </button>
+      <button
+        type="button"
+        onClick={handleClose}
+        // No colon (avoid colliding with the select button's `unit: <name>`
+        // accessible name under a loose name matcher).
+        aria-label={`Close unit ${unit.name}`}
+        title={`Close unit ${unit.name} — kill Producer + workers + footer bash (worktrees stay)`}
+        className="mr-1 flex h-4 w-4 shrink-0 items-center justify-center rounded text-[11px] leading-none text-subtle-foreground transition-colors hover:bg-destructive/15 hover:text-destructive"
+      >
+        ×
+      </button>
+    </div>
   );
 }
 

--- a/clients/react/src/components/layout/__tests__/UnitTabs.test.tsx
+++ b/clients/react/src/components/layout/__tests__/UnitTabs.test.tsx
@@ -2,11 +2,13 @@
 //
 // UnitTabs (C1) — one tab per configured unit: repo pills (primary
 // highlighted), active highlight, ⚠N attention rollup (from the existing
-// `useUnitAttention` wire), select + add affordances.
+// `useUnitAttention` wire), select + add affordances, and the #540 / #546
+// per-unit CLOSE control (confirm-gated kill of the Producer slot).
 
-import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
+import { fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AttentionStateResponse, UnitResponse } from "@/lib/api";
+import { renderWithProviders } from "@/test/render";
 
 const unitAttentionMock = vi.fn();
 
@@ -45,12 +47,13 @@ beforeEach(() => {
 
 describe("UnitTabs", () => {
   it("renders a tab per unit with repo pills, primary highlighted", () => {
-    render(
+    renderWithProviders(
       <UnitTabs
         units={[unit()]}
         activeUnitName="tmai"
         onSelectUnit={vi.fn()}
         onAddUnit={vi.fn()}
+        onCloseUnit={vi.fn()}
       />,
     );
     const pills = screen.getAllByTestId("repo-pill");
@@ -61,12 +64,13 @@ describe("UnitTabs", () => {
   });
 
   it("marks the active unit's tab with aria-current", () => {
-    render(
+    renderWithProviders(
       <UnitTabs
         units={[unit(), unit({ name: "infra", repos: [{ path: "/p/infra", primary: true }] })]}
         activeUnitName="infra"
         onSelectUnit={vi.fn()}
         onAddUnit={vi.fn()}
+        onCloseUnit={vi.fn()}
       />,
     );
     const active = screen.getByRole("button", { name: /unit: infra/ });
@@ -77,12 +81,13 @@ describe("UnitTabs", () => {
 
   it("clicking a tab calls onSelectUnit with that unit", () => {
     const onSelectUnit = vi.fn();
-    render(
+    renderWithProviders(
       <UnitTabs
         units={[unit()]}
         activeUnitName={null}
         onSelectUnit={onSelectUnit}
         onAddUnit={vi.fn()}
+        onCloseUnit={vi.fn()}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /unit: tmai/ }));
@@ -92,12 +97,13 @@ describe("UnitTabs", () => {
 
   it("clicking + calls onAddUnit", () => {
     const onAddUnit = vi.fn();
-    render(
+    renderWithProviders(
       <UnitTabs
         units={[unit()]}
         activeUnitName="tmai"
         onSelectUnit={vi.fn()}
         onAddUnit={onAddUnit}
+        onCloseUnit={vi.fn()}
       />,
     );
     fireEvent.click(screen.getByRole("button", { name: /Add unit/ }));
@@ -112,12 +118,13 @@ describe("UnitTabs", () => {
         { repo_path: "/home/me/works/tmai", section: "pr", id: "3", level: "low" },
       ]),
     );
-    render(
+    renderWithProviders(
       <UnitTabs
         units={[unit()]}
         activeUnitName="tmai"
         onSelectUnit={vi.fn()}
         onAddUnit={vi.fn()}
+        onCloseUnit={vi.fn()}
       />,
     );
     const tab = screen.getByRole("button", { name: /unit: tmai/ });
@@ -129,16 +136,74 @@ describe("UnitTabs", () => {
 
   it("shows no rollup badge when nothing is owed attention", async () => {
     unitAttentionMock.mockResolvedValue(attention([]));
-    render(
+    renderWithProviders(
       <UnitTabs
         units={[unit()]}
         activeUnitName="tmai"
         onSelectUnit={vi.fn()}
         onAddUnit={vi.fn()}
+        onCloseUnit={vi.fn()}
       />,
     );
     // Let the (empty) attention fetch resolve, then assert no badge.
     await waitFor(() => expect(unitAttentionMock).toHaveBeenCalled());
     expect(screen.queryByTestId("unit-attention-rollup")).toBeNull();
+  });
+});
+
+describe("UnitTabs — close affordance (#540 / #546)", () => {
+  it("exposes a per-unit close control that opens a confirm dialog", async () => {
+    renderWithProviders(
+      <UnitTabs
+        units={[unit()]}
+        activeUnitName="tmai"
+        onSelectUnit={vi.fn()}
+        onAddUnit={vi.fn()}
+        onCloseUnit={vi.fn()}
+      />,
+    );
+    // No confirm dialog until the close control is clicked.
+    expect(screen.queryByRole("dialog")).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /close unit tmai/i }));
+    // The always-on confirm dialog surfaces with the kill ≠ delete caveat.
+    const dialog = await screen.findByRole("dialog");
+    expect(within(dialog).getByText(/kill, not a delete/i)).toBeTruthy();
+    expect(within(dialog).getByText(/worktrees and uncommitted work stay on disk/i)).toBeTruthy();
+  });
+
+  it("confirming the close calls onCloseUnit with the unit", async () => {
+    const onCloseUnit = vi.fn();
+    renderWithProviders(
+      <UnitTabs
+        units={[unit()]}
+        activeUnitName="tmai"
+        onSelectUnit={vi.fn()}
+        onAddUnit={vi.fn()}
+        onCloseUnit={onCloseUnit}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /close unit tmai/i }));
+    fireEvent.click(await screen.findByRole("button", { name: "Close unit" }));
+    await waitFor(() => expect(onCloseUnit).toHaveBeenCalledTimes(1));
+    expect(onCloseUnit.mock.calls[0][0].name).toBe("tmai");
+  });
+
+  it("cancelling the close does nothing", async () => {
+    const onCloseUnit = vi.fn();
+    renderWithProviders(
+      <UnitTabs
+        units={[unit()]}
+        activeUnitName="tmai"
+        onSelectUnit={vi.fn()}
+        onAddUnit={vi.fn()}
+        onCloseUnit={onCloseUnit}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: /close unit tmai/i }));
+    fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
+    // The dialog closes …
+    await waitFor(() => expect(screen.queryByRole("dialog")).toBeNull());
+    // … and the slot is never closed.
+    expect(onCloseUnit).not.toHaveBeenCalled();
   });
 });

--- a/clients/react/src/components/producer-console/HandoffRitualFailureDialog.tsx
+++ b/clients/react/src/components/producer-console/HandoffRitualFailureDialog.tsx
@@ -40,6 +40,18 @@ interface HandoffRitualFailureDialogProps {
   producerAgentId: string | null;
   retryCount: number;
   retryRefused: boolean;
+  /**
+   * Which escalation this dialog is surfacing:
+   *   - `"handoff"` (default) — an operator handoff the Producer REJECTED
+   *     (tier-1 obligation). The full 4-choice surface applies.
+   *   - `"crash_loop"` — the slot supervisor's `crash_loop_halted` escalate
+   *     (tmai-core #540 / #546): the auto-respawn budget is exhausted and
+   *     the Producer is GONE. Force-kill / Retry / Resume don't apply (no
+   *     live Producer, and re-POSTing a handoff can't help) — the copy tells
+   *     the operator to relaunch manually (a health recovery resets the
+   *     budget) and the only action is Dismiss.
+   */
+  mode?: "handoff" | "crash_loop";
   onForceKill: () => void;
   onRetry: () => void;
   onDismiss: () => void;
@@ -60,6 +72,7 @@ export function HandoffRitualFailureDialog({
   producerAgentId,
   retryCount,
   retryRefused,
+  mode = "handoff",
   onForceKill,
   onRetry,
   onDismiss,
@@ -69,18 +82,23 @@ export function HandoffRitualFailureDialog({
   const [resumeRevealed, setResumeRevealed] = useState(false);
   const resumeUuid = producerAgentId ? uuidFromAgentId(producerAgentId) : null;
 
-  const retryDisabled = retryRefused || retryCount >= 2;
+  const isCrashLoop = mode === "crash_loop";
+  // Crash-loop: re-POSTing a handoff can't help (the Producer is GONE, not
+  // refusing), so the manual relaunch — which resets the supervisor budget on
+  // a clean health recovery — is the only path forward. Retry stays disabled.
+  const retryDisabled = isCrashLoop || retryRefused || retryCount >= 2;
 
   return (
     <div
       role="dialog"
       aria-modal="true"
-      aria-label="Handoff ritual rejected"
+      aria-label={isCrashLoop ? "Producer crash-loop halted" : "Handoff ritual rejected"}
       className="fixed inset-0 z-50 flex items-center justify-center bg-background backdrop-blur-sm"
     >
       <div className="w-full max-w-lg rounded-xl border border-destructive/30 bg-surface-strong p-5 shadow-2xl">
         <h3 className="text-sm font-semibold text-destructive">
-          Handoff ritual rejected — unit <code className="text-primary">{unitName}</code>
+          {isCrashLoop ? "Producer crash-loop halted" : "Handoff ritual rejected"} — unit{" "}
+          <code className="text-primary">{unitName}</code>
         </h3>
 
         <dl className="mt-3 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-[12px]">
@@ -95,8 +113,9 @@ export function HandoffRitualFailureDialog({
         </dl>
 
         <p className="mt-3 text-[12px] leading-relaxed text-muted-foreground">
-          Producer rejected the handoff ritual (tmai tier-1: Producer's obligation to obey
-          instructions). Decide how to proceed:
+          {isCrashLoop
+            ? "The slot supervisor relaunched this unit's Producer too many times and halted. Manual relaunch required — relaunch the Producer (Open Producer terminal); a successful health recovery resets the crash-loop budget."
+            : "Producer rejected the handoff ritual (tmai tier-1: Producer's obligation to obey instructions). Decide how to proceed:"}
         </p>
 
         <div className="mt-4 grid grid-cols-2 gap-2">
@@ -120,9 +139,11 @@ export function HandoffRitualFailureDialog({
             disabled={retryDisabled}
             className="rounded-md bg-primary/15 px-3 py-2 text-xs font-medium text-primary transition-colors hover:bg-primary/25 disabled:cursor-not-allowed disabled:opacity-50"
             title={
-              retryDisabled
-                ? "DR §E: second rejection is a hard escalate — no further automatic retry"
-                : "Re-POST handoff-and-restart with the same body"
+              isCrashLoop
+                ? "Manual relaunch required — re-POSTing a handoff can't recover a crash-looped Producer"
+                : retryDisabled
+                  ? "DR §E: second rejection is a hard escalate — no further automatic retry"
+                  : "Re-POST handoff-and-restart with the same body"
             }
           >
             Retry{retryCount > 0 ? ` (${retryCount}/2)` : ""}
@@ -132,9 +153,13 @@ export function HandoffRitualFailureDialog({
             type="button"
             onClick={onDismiss}
             className="rounded-md bg-surface px-3 py-2 text-xs text-foreground transition-colors hover:bg-surface"
-            title="Producer is still alive; next manual handoff or session-end will re-surface this state"
+            title={
+              isCrashLoop
+                ? "Acknowledge — relaunch the Producer manually (Open Producer terminal) when ready"
+                : "Producer is still alive; next manual handoff or session-end will re-surface this state"
+            }
           >
-            Continue with stale
+            {isCrashLoop ? "Dismiss" : "Continue with stale"}
           </button>
 
           <button

--- a/clients/react/src/components/producer-console/HandoffRitualOverlay.tsx
+++ b/clients/react/src/components/producer-console/HandoffRitualOverlay.tsx
@@ -1,9 +1,19 @@
-// In-progress overlay for the Producer handoff-and-restart ritual.
+// In-progress overlay for the Producer slot-restart rituals.
 //
-// Shows a phase tracker per DR `2026-05-14-handoff-lifecycle-and-kill-ux.md`
-// §E (WebUI overlay). The five forward phases are pinned in their
-// canonical order (`prompted → validated → killed → launching →
-// ready`); each row carries one of four marks:
+// Hosts TWO ritual shapes over the same `HandoffRitualEvent` wire (the core
+// reused the wire deliberately — no new SSE variant):
+//
+//   • OPERATOR HANDOFF (`ritual_id` is a UUID) — the full forward sequence
+//     per DR `2026-05-14-handoff-lifecycle-and-kill-ux.md` §E:
+//       prompted → validated → killed → launching → ready
+//
+//   • SUPERVISOR CRASH-RESPAWN (`ritual_id` starts `slot-supervisor:`,
+//     tmai-core #540 / #546) — the absent Producer just VANISHED, so there
+//     is no prompted/validated/killed FRONT; the supervisor's auto-respawn
+//     begins at `launching`:
+//       launching → ready
+//
+// Each phase row carries one of four marks:
 //
 //   ✓ done    — the phase was observed
 //   ⟳ current — the most-recent observed phase (or "starting…" when
@@ -13,7 +23,7 @@
 // The terminal-failure path (`escalate`) is handled by a dedicated
 // dialog component — this overlay never renders it.
 
-import type { HandoffRitualEvent } from "@/lib/api";
+import { type HandoffRitualEvent, SUPERVISOR_RITUAL_PREFIX } from "@/lib/api";
 
 interface HandoffRitualOverlayProps {
   unitName: string;
@@ -23,25 +33,40 @@ interface HandoffRitualOverlayProps {
   phases: HandoffRitualEvent[];
 }
 
-const FORWARD_PHASES = [
+type ForwardPhaseKey = "prompted" | "validated" | "killed" | "launching" | "ready";
+
+interface PhaseRow {
+  key: ForwardPhaseKey;
+  label: string;
+  detail: string;
+}
+
+// Operator handoff — the canonical 5-phase forward sequence.
+const HANDOFF_PHASES: PhaseRow[] = [
   { key: "prompted", label: "Prompted", detail: "ritual prompt delivered" },
   { key: "validated", label: "Validated", detail: "HANDOFF READY observed + file valid" },
   { key: "killed", label: "Killed", detail: "old Producer terminated" },
   { key: "launching", label: "Launching", detail: "spawning fresh Producer..." },
   { key: "ready", label: "Ready", detail: "" },
-] as const;
+];
 
-type ForwardPhaseKey = (typeof FORWARD_PHASES)[number]["key"];
+// Supervisor crash-respawn — no FRONT (the Producer vanished, nothing to
+// prompt/validate/kill); the auto-respawn starts at `launching`.
+const RESPAWN_PHASES: PhaseRow[] = [
+  { key: "launching", label: "Launching", detail: "supervisor respawning the Producer..." },
+  { key: "ready", label: "Ready", detail: "" },
+];
 
 function phaseStatus(
+  rows: PhaseRow[],
   current: ForwardPhaseKey | null,
   rowKey: ForwardPhaseKey,
 ): "done" | "current" | "pending" {
   if (current === null) {
     return "pending";
   }
-  const currentIdx = FORWARD_PHASES.findIndex((p) => p.key === current);
-  const rowIdx = FORWARD_PHASES.findIndex((p) => p.key === rowKey);
+  const currentIdx = rows.findIndex((p) => p.key === current);
+  const rowIdx = rows.findIndex((p) => p.key === rowKey);
   if (rowIdx < currentIdx) return "done";
   if (rowIdx === currentIdx) return "current";
   return "pending";
@@ -60,39 +85,52 @@ const STATUS_CLASS = {
 } as const;
 
 export function HandoffRitualOverlay({ unitName, ritualId, phases }: HandoffRitualOverlayProps) {
-  // The most-recent forward phase observed (escalate is filtered upstream).
+  // A supervisor crash-respawn carries the synthetic `slot-supervisor:<unit>`
+  // id; an operator handoff carries a UUID. The id picks the phase set + copy.
+  const isRespawn = ritualId?.startsWith(SUPERVISOR_RITUAL_PREFIX) ?? false;
+  const phaseRows = isRespawn ? RESPAWN_PHASES : HANDOFF_PHASES;
+
+  // The most-recent forward phase observed that belongs to THIS ritual's phase
+  // set (escalate is filtered upstream; a respawn never sees prompted/validated/
+  // killed, but guard anyway against a stray FRONT event leaking into the
+  // respawn row list).
   const lastForwardPhase: ForwardPhaseKey | null = (() => {
     for (let i = phases.length - 1; i >= 0; i--) {
       const p = phases[i]?.phase;
-      if (
-        p === "prompted" ||
-        p === "validated" ||
-        p === "killed" ||
-        p === "launching" ||
-        p === "ready"
-      ) {
+      if (p !== undefined && p !== "escalate" && phaseRows.some((r) => r.key === p)) {
         return p;
       }
     }
-    // No event yet — show "prompted" as the current row so the operator
-    // sees motion immediately after clicking.
-    return phases.length === 0 ? "prompted" : null;
+    // No event yet — show the FIRST row of this ritual's set as current so the
+    // operator sees motion immediately (handoff: "prompted"; respawn:
+    // "launching").
+    return phases.length === 0 ? (phaseRows[0]?.key ?? null) : null;
   })();
+
+  const heading = isRespawn ? "Producer crash-respawn" : "Handoff & restart";
 
   return (
     <div
       role="dialog"
       aria-modal="true"
-      aria-label="Handoff and restart in progress"
+      aria-label={
+        isRespawn ? "Producer crash-respawn in progress" : "Handoff and restart in progress"
+      }
       className="fixed inset-0 z-50 flex items-center justify-center bg-background backdrop-blur-sm"
     >
       <div className="w-full max-w-lg rounded-xl border border-hairline-strong bg-surface-strong p-5 shadow-2xl">
         <h3 className="text-sm font-semibold text-foreground">
-          Handoff & restart — unit <code className="text-primary">{unitName}</code>
+          {heading} — unit <code className="text-primary">{unitName}</code>
         </h3>
+        {isRespawn && (
+          <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+            The slot supervisor detected the Producer was gone and is relaunching it automatically —
+            no operator handoff was run.
+          </p>
+        )}
         <ul className="mt-4 space-y-2">
-          {FORWARD_PHASES.map((row) => {
-            const status = phaseStatus(lastForwardPhase, row.key);
+          {phaseRows.map((row) => {
+            const status = phaseStatus(phaseRows, lastForwardPhase, row.key);
             return (
               <li
                 key={row.key}

--- a/clients/react/src/components/producer-console/__tests__/HandoffRitualFailureDialog.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/HandoffRitualFailureDialog.test.tsx
@@ -94,4 +94,62 @@ describe("HandoffRitualFailureDialog", () => {
     render(<HandoffRitualFailureDialog {...makeProps({ message: null })} />);
     expect(screen.queryByText(/detail:/)).toBeNull();
   });
+
+  // Default mode is the operator handoff — the existing copy + Retry are
+  // unchanged (regression guard for the crash-loop generalization).
+  it("uses the operator-rejected copy + enabled Retry by default", () => {
+    render(<HandoffRitualFailureDialog {...makeProps()} />);
+    expect(screen.getByRole("dialog").getAttribute("aria-label")).toBe("Handoff ritual rejected");
+    expect(screen.getByText(/Producer rejected the handoff ritual/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /Retry/ })).toHaveProperty("disabled", false);
+    expect(screen.getByRole("button", { name: /Continue with stale/ })).toBeTruthy();
+  });
+});
+
+describe("HandoffRitualFailureDialog — crash-loop (mode=crash_loop)", () => {
+  it("surfaces the manual-relaunch failure message", () => {
+    render(
+      <HandoffRitualFailureDialog
+        {...makeProps({
+          mode: "crash_loop",
+          reason: "crash_loop_halted",
+          message: null,
+          // No live Producer after a crash-loop halt.
+          producerAgentId: null,
+        })}
+      />,
+    );
+    expect(screen.getByRole("dialog").getAttribute("aria-label")).toBe(
+      "Producer crash-loop halted",
+    );
+    expect(screen.getByText(/Producer crash-loop halted/)).toBeTruthy();
+    expect(screen.getByText(/Manual relaunch required/i)).toBeTruthy();
+    expect(screen.getByText(/health recovery resets the crash-loop budget/i)).toBeTruthy();
+  });
+
+  it("disables Retry — re-POSTing a handoff can't recover a crash-loop", () => {
+    render(
+      <HandoffRitualFailureDialog
+        {...makeProps({ mode: "crash_loop", reason: "crash_loop_halted", producerAgentId: null })}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /Retry/ })).toHaveProperty("disabled", true);
+  });
+
+  it("offers Dismiss (not 'Continue with stale') since the Producer is gone", () => {
+    const onDismiss = vi.fn();
+    render(
+      <HandoffRitualFailureDialog
+        {...makeProps({
+          mode: "crash_loop",
+          reason: "crash_loop_halted",
+          producerAgentId: null,
+          onDismiss,
+        })}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: /Continue with stale/ })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Dismiss/ }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
 });

--- a/clients/react/src/components/producer-console/__tests__/HandoffRitualOverlay.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/HandoffRitualOverlay.test.tsx
@@ -66,4 +66,72 @@ describe("HandoffRitualOverlay", () => {
     render(<HandoffRitualOverlay unitName="tmai" ritualId="r-1" phases={[]} />);
     expect(screen.getByRole("dialog")).toBeTruthy();
   });
+
+  // Operator-handoff regression: a UUID ritual_id keeps the full 5-phase
+  // FRONT and the unchanged heading — the supervisor generalization must not
+  // bleed into the operator path.
+  it("keeps the operator-handoff heading + 5-phase set for a UUID ritual_id", () => {
+    render(
+      <HandoffRitualOverlay
+        unitName="tmai"
+        ritualId="3f1a2b4c-0000-4d5e-9f00-abcdef012345"
+        phases={[]}
+      />,
+    );
+    expect(screen.getByRole("dialog").getAttribute("aria-label")).toBe(
+      "Handoff and restart in progress",
+    );
+    expect(screen.getByText(/Handoff & restart/)).toBeTruthy();
+    expect(screen.getByTestId("phase-row-prompted")).toBeTruthy();
+    expect(screen.getByTestId("phase-row-validated")).toBeTruthy();
+    expect(screen.getByTestId("phase-row-killed")).toBeTruthy();
+    // No supervisor subcopy on the operator path.
+    expect(screen.queryByText(/slot supervisor/i)).toBeNull();
+  });
+});
+
+describe("HandoffRitualOverlay — supervisor crash-respawn", () => {
+  const SUP = "slot-supervisor:tmai";
+
+  function makeEvent(phase: HandoffRitualEvent["phase"]): HandoffRitualEvent {
+    if (phase === "escalate") {
+      return { unit: "tmai", ritual_id: SUP, phase: "escalate", reason: "crash_loop_halted" };
+    }
+    if (phase === "ready") {
+      return { unit: "tmai", ritual_id: SUP, phase: "ready" };
+    }
+    return { unit: "tmai", ritual_id: SUP, phase };
+  }
+
+  it("renders ONLY launching → ready (no prompted/validated/killed FRONT)", () => {
+    render(<HandoffRitualOverlay unitName="tmai" ritualId={SUP} phases={[]} />);
+    expect(screen.getByTestId("phase-row-launching")).toBeTruthy();
+    expect(screen.getByTestId("phase-row-ready")).toBeTruthy();
+    expect(screen.queryByTestId("phase-row-prompted")).toBeNull();
+    expect(screen.queryByTestId("phase-row-validated")).toBeNull();
+    expect(screen.queryByTestId("phase-row-killed")).toBeNull();
+  });
+
+  it("marks launching as the current row when no event has arrived yet", () => {
+    render(<HandoffRitualOverlay unitName="tmai" ritualId={SUP} phases={[]} />);
+    expect(screen.getByTestId("phase-row-launching").getAttribute("data-status")).toBe("current");
+    expect(screen.getByTestId("phase-row-ready").getAttribute("data-status")).toBe("pending");
+  });
+
+  it("advances launching → ready as the respawn progresses", () => {
+    render(
+      <HandoffRitualOverlay unitName="tmai" ritualId={SUP} phases={[makeEvent("launching")]} />,
+    );
+    expect(screen.getByTestId("phase-row-launching").getAttribute("data-status")).toBe("current");
+    expect(screen.getByTestId("phase-row-ready").getAttribute("data-status")).toBe("pending");
+  });
+
+  it("distinguishes the respawn in heading, copy, and dialog label", () => {
+    render(<HandoffRitualOverlay unitName="tmai" ritualId={SUP} phases={[]} />);
+    expect(screen.getByRole("dialog").getAttribute("aria-label")).toBe(
+      "Producer crash-respawn in progress",
+    );
+    expect(screen.getByText(/Producer crash-respawn/)).toBeTruthy();
+    expect(screen.getByText(/slot supervisor detected the Producer was gone/i)).toBeTruthy();
+  });
 });

--- a/clients/react/src/hooks/__tests__/useHandoffRitual.test.ts
+++ b/clients/react/src/hooks/__tests__/useHandoffRitual.test.ts
@@ -159,6 +159,21 @@ describe("useHandoffRitual — state machine", () => {
     }
   });
 
+  it("carries the dispatched unit in the in_progress state", async () => {
+    vi.mocked(api.triggerHandoffRitual).mockResolvedValue({ ritual_id: "r-1" });
+
+    const { result } = renderHook(() => useHandoffRitual());
+    await act(async () => {
+      await result.current.trigger("tmai", { trigger: "manual" });
+    });
+
+    if (result.current.state.kind === "in_progress") {
+      expect(result.current.state.unit).toBe("tmai");
+    } else {
+      throw new Error("expected in_progress state");
+    }
+  });
+
   it("transitions to ready on a `ready` phase with the new agent id surfaced", async () => {
     vi.mocked(api.triggerHandoffRitual).mockResolvedValue({ ritual_id: "r-1" });
 
@@ -321,6 +336,96 @@ describe("useHandoffRitual — retry budget (DR §E)", () => {
       await result.current.trigger("tmai", { trigger: "manual" });
     });
     expect(result.current.retryCount).toBe(0);
+  });
+});
+
+describe("useHandoffRitual — supervisor crash-respawn adoption (#540 / #546)", () => {
+  const SUP = "slot-supervisor:tmai";
+
+  it("adopts an unsolicited supervisor `launching` from idle", () => {
+    const { result } = renderHook(() => useHandoffRitual());
+    expect(result.current.state.kind).toBe("idle");
+
+    act(() => {
+      capturedSSEHandlers?.onEvent?.("handoff_ritual", phasedEvent(SUP, "launching"));
+    });
+
+    expect(result.current.state.kind).toBe("in_progress");
+    if (result.current.state.kind === "in_progress") {
+      expect(result.current.state.ritualId).toBe(SUP);
+      expect(result.current.state.unit).toBe("tmai");
+      expect(result.current.state.phases.map((p) => p.phase)).toEqual(["launching"]);
+    }
+  });
+
+  it("advances an adopted respawn launching → ready", () => {
+    const { result } = renderHook(() => useHandoffRitual());
+    act(() => {
+      capturedSSEHandlers?.onEvent?.("handoff_ritual", phasedEvent(SUP, "launching"));
+    });
+    act(() => {
+      capturedSSEHandlers?.onEvent?.(
+        "handoff_ritual",
+        phasedEvent(SUP, "ready", { new_agent_id: "claude:fresh" }),
+      );
+    });
+
+    expect(result.current.state.kind).toBe("ready");
+    if (result.current.state.kind === "ready") {
+      expect(result.current.state.unit).toBe("tmai");
+      expect(result.current.state.newAgentId).toBe("claude:fresh");
+    }
+  });
+
+  it("adopts a bare `crash_loop_halted` escalate straight from idle", () => {
+    const { result } = renderHook(() => useHandoffRitual());
+    act(() => {
+      capturedSSEHandlers?.onEvent?.(
+        "handoff_ritual",
+        phasedEvent(SUP, "escalate", { reason: "crash_loop_halted" }),
+      );
+    });
+
+    expect(result.current.state.kind).toBe("escalated");
+    if (result.current.state.kind === "escalated") {
+      expect(result.current.state.reason).toBe("crash_loop_halted");
+      expect(result.current.state.ritualId).toBe(SUP);
+      expect(result.current.state.unit).toBe("tmai");
+    }
+  });
+
+  it("does NOT adopt a non-supervisor (UUID) event from idle", () => {
+    const { result } = renderHook(() => useHandoffRitual());
+    act(() => {
+      capturedSSEHandlers?.onEvent?.("handoff_ritual", phasedEvent("uuid-r-9", "launching"));
+    });
+    // A stray operator-ritual event without a live ritual is ignored.
+    expect(result.current.state.kind).toBe("idle");
+  });
+
+  it("never lets a supervisor respawn clobber a live operator handoff", async () => {
+    vi.mocked(api.triggerHandoffRitual).mockResolvedValue({ ritual_id: "r-1" });
+    const { result } = renderHook(() => useHandoffRitual());
+    await act(async () => {
+      await result.current.trigger("tmai", { trigger: "manual" });
+    });
+    expect(result.current.state.kind).toBe("in_progress");
+
+    act(() => {
+      // A concurrent supervisor respawn for another unit must not hijack the
+      // operator's live overlay (different ritual_id, prev is in_progress).
+      capturedSSEHandlers?.onEvent?.(
+        "handoff_ritual",
+        phasedEvent("slot-supervisor:other", "launching", { unit: "other" }),
+      );
+    });
+
+    if (result.current.state.kind === "in_progress") {
+      expect(result.current.state.ritualId).toBe("r-1");
+      expect(result.current.state.phases).toHaveLength(0);
+    } else {
+      throw new Error("expected the operator ritual to stay in_progress");
+    }
   });
 });
 

--- a/clients/react/src/hooks/useHandoffRitual.ts
+++ b/clients/react/src/hooks/useHandoffRitual.ts
@@ -21,7 +21,12 @@
 // The hook ignores SSE events whose `ritual_id` does not match the
 // currently live `ritual_id` so concurrent rituals across units
 // (or operator retries against the same unit) never cross-talk into
-// the overlay.
+// the overlay — with ONE exception: an unsolicited supervisor
+// crash-respawn (synthetic `slot-supervisor:<unit>` id, tmai-core
+// #540 / #546) is ADOPTED from idle, so a Producer that the engine
+// auto-relaunches surfaces the same overlay without an operator
+// trigger. It is adopted only from idle, so it never clobbers a live
+// operator handoff or an open failure dialog.
 //
 // Retry budget (DR §E): the dialog refuses a third retry from the
 // hook side — "second rejection is a hard escalate (no further
@@ -29,11 +34,12 @@
 // retry; it surfaces a `retryRefused` flag the dialog can read so
 // the operator gets a clear reason for the disabled Retry button.
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import {
   api,
   type HandoffRitualEvent,
   HandoffRitualRequestError,
+  SUPERVISOR_RITUAL_PREFIX,
   type TriggerHandoffRitualRequest,
 } from "@/lib/api";
 import { useSSE } from "@/lib/sse-provider";
@@ -47,9 +53,9 @@ import { useSSE } from "@/lib/sse-provider";
 export type RitualUiState =
   | { kind: "idle" }
   | { kind: "dispatching" }
-  | { kind: "in_progress"; ritualId: string; phases: HandoffRitualEvent[] }
-  | { kind: "ready"; ritualId: string; newAgentId: string | null }
-  | { kind: "escalated"; ritualId: string; reason: string; message: string | null };
+  | { kind: "in_progress"; ritualId: string; unit: string; phases: HandoffRitualEvent[] }
+  | { kind: "ready"; ritualId: string; unit: string; newAgentId: string | null }
+  | { kind: "escalated"; ritualId: string; unit: string; reason: string; message: string | null };
 
 export interface UseHandoffRitualResult {
   state: RitualUiState;
@@ -81,19 +87,64 @@ export function useHandoffRitual(): UseHandoffRitualResult {
   const [retryCount, setRetryCount] = useState(0);
   const [retryRefused, setRetryRefused] = useState(false);
 
-  // Ref mirror so the SSE handler reads the current ritualId without
-  // needing to re-subscribe on every state transition.
-  const liveRitualIdRef = useRef<string | null>(null);
-
+  // Single state-driven event router (no ref mirror — matching reads `prev`
+  // inside the updater, so the SSE handler can register once and never go
+  // stale). Two routes:
+  //
+  //   1. An OPERATOR ritual that this hook dispatched: events whose
+  //      `ritual_id` matches the live `in_progress` ritual advance it.
+  //   2. An UNSOLICITED supervisor crash-respawn (synthetic
+  //      `slot-supervisor:<unit>` id, tmai-core #540 / #546): adopted ONLY
+  //      from `idle`, so it surfaces the same overlay without an operator
+  //      trigger but never clobbers a live operator handoff or an open
+  //      failure dialog. The supervisor stream begins at `launching` (no
+  //      prompted/validated/killed FRONT) and may also arrive as a bare
+  //      `escalate` (`crash_loop_halted`) if the hook attaches mid-loop —
+  //      adoption handles every phase from idle, not just `launching`.
   const applyEvent = useCallback((event: HandoffRitualEvent) => {
-    if (event.ritual_id !== liveRitualIdRef.current) return;
-
     setState((prev) => {
+      const isSupervisor = event.ritual_id.startsWith(SUPERVISOR_RITUAL_PREFIX);
+
+      // Adopt a supervisor respawn from idle, landing in whatever phase the
+      // first observed event carries.
+      if (prev.kind === "idle") {
+        if (!isSupervisor) return prev; // operator events require a live ritual
+        if (event.phase === "ready") {
+          return {
+            kind: "ready",
+            ritualId: event.ritual_id,
+            unit: event.unit,
+            newAgentId: event.new_agent_id ?? null,
+          };
+        }
+        if (event.phase === "escalate") {
+          return {
+            kind: "escalated",
+            ritualId: event.ritual_id,
+            unit: event.unit,
+            reason: event.reason,
+            message: event.message ?? null,
+          };
+        }
+        return {
+          kind: "in_progress",
+          ritualId: event.ritual_id,
+          unit: event.unit,
+          phases: [event],
+        };
+      }
+
+      // Otherwise only the live in-progress ritual's own events advance it;
+      // a mismatched `ritual_id` (a concurrent ritual / cross-unit respawn)
+      // never cross-talks into this overlay.
       if (prev.kind !== "in_progress") return prev;
+      if (event.ritual_id !== prev.ritualId) return prev;
+
       if (event.phase === "ready") {
         return {
           kind: "ready",
           ritualId: event.ritual_id,
+          unit: prev.unit,
           newAgentId: event.new_agent_id ?? null,
         };
       }
@@ -101,6 +152,7 @@ export function useHandoffRitual(): UseHandoffRitualResult {
         return {
           kind: "escalated",
           ritualId: event.ritual_id,
+          unit: prev.unit,
           reason: event.reason,
           message: event.message ?? null,
         };
@@ -125,22 +177,11 @@ export function useHandoffRitual(): UseHandoffRitualResult {
     },
   });
 
-  // Clear the live id ref whenever we leave `in_progress` so a stale
-  // event from a prior ritual can't reanimate the overlay.
-  useEffect(() => {
-    if (state.kind === "in_progress") {
-      liveRitualIdRef.current = state.ritualId;
-    } else if (state.kind === "idle" || state.kind === "dispatching") {
-      liveRitualIdRef.current = null;
-    }
-  }, [state]);
-
   const dispatchRitual = useCallback(async (unit: string, body: TriggerHandoffRitualRequest) => {
     setState({ kind: "dispatching" });
     try {
       const { ritual_id } = await api.triggerHandoffRitual(unit, body);
-      liveRitualIdRef.current = ritual_id;
-      setState({ kind: "in_progress", ritualId: ritual_id, phases: [] });
+      setState({ kind: "in_progress", ritualId: ritual_id, unit, phases: [] });
     } catch (err) {
       // Surface 400/404/etc. as an `escalated` terminal — the dialog
       // can render the reason verbatim. We use a synthetic ritualId
@@ -148,10 +189,10 @@ export function useHandoffRitual(): UseHandoffRitualResult {
       const isTyped = err instanceof HandoffRitualRequestError;
       const reason = isTyped ? `http_${err.status}` : "request_failed";
       const message = isTyped ? err.detail : err instanceof Error ? err.message : String(err);
-      liveRitualIdRef.current = null;
       setState({
         kind: "escalated",
         ritualId: "",
+        unit,
         reason,
         message,
       });
@@ -183,7 +224,6 @@ export function useHandoffRitual(): UseHandoffRitualResult {
   );
 
   const dismiss = useCallback(() => {
-    liveRitualIdRef.current = null;
     setState({ kind: "idle" });
     setRetryCount(0);
     setRetryRefused(false);

--- a/clients/react/src/lib/__tests__/close-unit-slot.test.ts
+++ b/clients/react/src/lib/__tests__/close-unit-slot.test.ts
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+//
+// close-unit-slot — the webui half of the tmai-core #540 / #546 Producer-slot
+// close: POST /api/units/{unit}/close (core kills the Producer + dispatched
+// workers), then kill the unit's webui-owned, hint-less FOOTER BASH that the
+// engine can't attribute on its own.
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { AgentSnapshot, AgentType, UnitResponse } from "@/lib/api";
+
+const closeUnitMock = vi.fn();
+const killAgentMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      closeUnit: (...args: unknown[]) => closeUnitMock(...args),
+      killAgent: (...args: unknown[]) => killAgentMock(...args),
+    },
+  };
+});
+
+import { closeUnitSlot, findFooterShells } from "@/lib/close-unit-slot";
+
+function unit(overrides: Partial<UnitResponse> = {}): UnitResponse {
+  return {
+    name: "tmai",
+    repos: [
+      { path: "/home/me/works/tmai", primary: true },
+      { path: "/home/me/works/tmai-core", primary: false },
+    ],
+    ...overrides,
+  };
+}
+
+function agent(overrides: { id: string; cwd: string; agentType?: AgentType }): AgentSnapshot {
+  return {
+    id: overrides.id,
+    target: overrides.id,
+    agent_type: overrides.agentType ?? { Custom: "bash" },
+    title: overrides.id,
+    cwd: overrides.cwd,
+    display_cwd: overrides.cwd,
+    display_name: overrides.id,
+    detection_source: "HttpHook",
+    git_branch: null,
+    git_dirty: null,
+    is_worktree: null,
+    git_common_dir: null,
+    worktree_name: null,
+    worktree_base_branch: null,
+    effort_level: null,
+    active_subagents: 0,
+    compaction_count: 0,
+    pty_session_id: null,
+    send_capability: "None",
+    is_virtual: false,
+    team_info: null,
+    attention: null,
+  } as AgentSnapshot;
+}
+
+beforeEach(() => {
+  closeUnitMock.mockReset();
+  killAgentMock.mockReset();
+  closeUnitMock.mockResolvedValue(undefined);
+  killAgentMock.mockResolvedValue(undefined);
+});
+
+describe("findFooterShells", () => {
+  it("matches plain shells whose cwd is one of the unit's repos", () => {
+    const shells = findFooterShells(unit(), [
+      agent({ id: "pty-1", cwd: "/home/me/works/tmai" }),
+      agent({ id: "pty-2", cwd: "/home/me/works/tmai-core" }),
+    ]);
+    expect(shells.map((s) => s.id).sort()).toEqual(["pty-1", "pty-2"]);
+  });
+
+  it("excludes AI agents (the bash-wrapped Producer + canonical workers)", () => {
+    // The Producer and dispatched workers carry canonical AI id schemes /
+    // ClaudeCode type — `isAiAgentLoose` excludes them; core kills those.
+    const shells = findFooterShells(unit(), [
+      agent({ id: "claude:prod", cwd: "/home/me/works/tmai" }),
+      agent({ id: "claude:work", cwd: "/home/me/works/tmai", agentType: "ClaudeCode" }),
+      agent({ id: "pty-shell", cwd: "/home/me/works/tmai" }),
+    ]);
+    expect(shells.map((s) => s.id)).toEqual(["pty-shell"]);
+  });
+
+  it("excludes shells outside the unit's repos", () => {
+    const shells = findFooterShells(unit(), [
+      agent({ id: "pty-other", cwd: "/home/me/works/somewhere-else" }),
+    ]);
+    expect(shells).toHaveLength(0);
+  });
+
+  it("normalizes trailing slashes / .git when matching cwd", () => {
+    const shells = findFooterShells(unit(), [
+      agent({ id: "pty-slash", cwd: "/home/me/works/tmai/" }),
+      agent({ id: "pty-git", cwd: "/home/me/works/tmai-core/.git" }),
+    ]);
+    expect(shells.map((s) => s.id).sort()).toEqual(["pty-git", "pty-slash"]);
+  });
+});
+
+describe("closeUnitSlot", () => {
+  it("POSTs the core close, then kills the unit's footer shells", async () => {
+    const agents = [
+      agent({ id: "claude:prod", cwd: "/home/me/works/tmai" }),
+      agent({ id: "pty-1", cwd: "/home/me/works/tmai" }),
+      agent({ id: "pty-2", cwd: "/home/me/works/tmai-core" }),
+    ];
+
+    await closeUnitSlot(unit(), agents);
+
+    expect(closeUnitMock).toHaveBeenCalledWith("tmai");
+    // Only the two footer shells are killed by the webui (not the Producer).
+    const killed = killAgentMock.mock.calls.map((c) => c[0]).sort();
+    expect(killed).toEqual(["pty-1", "pty-2"]);
+  });
+
+  it("closes before killing — never kills footer bash if the core close fails", async () => {
+    closeUnitMock.mockRejectedValue(new Error("API error 404: unknown unit"));
+    const agents = [agent({ id: "pty-1", cwd: "/home/me/works/tmai" })];
+
+    await expect(closeUnitSlot(unit(), agents)).rejects.toThrow(/unknown unit/);
+    expect(killAgentMock).not.toHaveBeenCalled();
+  });
+
+  it("tolerates a footer-kill failure (best-effort) without rejecting", async () => {
+    killAgentMock.mockRejectedValue(new Error("already dead"));
+    const agents = [agent({ id: "pty-1", cwd: "/home/me/works/tmai" })];
+
+    // A dead/unkillable footer shell must not mask a successful close.
+    await expect(closeUnitSlot(unit(), agents)).resolves.toBeUndefined();
+    expect(closeUnitMock).toHaveBeenCalledWith("tmai");
+  });
+});

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -1798,6 +1798,17 @@ export const api = {
   // as generic API errors.
   triggerHandoffRitual: (unit: string, body: TriggerHandoffRitualRequest) =>
     handoffFetch(unit, body),
+
+  // Producer-slot terminal (tmai-core #540 / #546, `post_close_unit_slot`).
+  // Closes the unit's Producer SLOT: the engine kills the live Producer + its
+  // dispatched workers and stops the auto-respawn supervisor. This is a KILL,
+  // not a delete — worktrees / uncommitted work stay on disk. Mirrors the
+  // `handoff-and-restart` POST (same X-Tmai-Origin scope, no body); resolves
+  // on 2xx regardless of the response body (the close summary, if any, isn't
+  // codegen-pinned and the UI doesn't need it). The hint-less footer bash the
+  // webui spawned is NOT attributable to the unit server-side, so the webui
+  // kills it itself after this resolves (see `closeUnitSlot`).
+  closeUnit: (unit: string) => closeUnitFetch(unit),
 };
 
 async function handoffFetch(
@@ -1826,7 +1837,43 @@ async function handoffFetch(
   return (await res.json()) as TriggerHandoffRitualResponse;
 }
 
+// Fire the slot-close POST mirroring `handoffFetch` (X-Tmai-Origin scope, no
+// body). Deliberately does NOT parse the response body — the close summary
+// shape is not codegen-pinned and the UI treats a resolved 2xx as success;
+// reading `res.json()` on a possibly-empty body would throw spuriously.
+async function closeUnitFetch(unit: string): Promise<void> {
+  const url = `${config.baseUrl}/api/units/${encodeURIComponent(unit)}/close`;
+  const origin: { kind: "Human"; interface: string; cwd?: string } = {
+    kind: "Human",
+    interface: "webui",
+    ...(callerCwd !== null ? { cwd: callerCwd } : {}),
+  };
+  const res = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${config.token}`,
+      "X-Tmai-Origin": JSON.stringify(origin),
+    },
+  });
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new Error(`API error ${res.status}: ${detail}`);
+  }
+}
+
 // ── Handoff-ritual request/response shapes ──
+
+/**
+ * Synthetic `ritual_id` prefix the core's slot supervisor stamps on an
+ * AUTO-respawn of an absent Producer (tmai-core #540 / #546): the id is
+ * `slot-supervisor:<unit>`, reusing the existing `HandoffRitualEvent` wire
+ * (no new SSE variant). It distinguishes a supervisor-driven crash-respawn
+ * from an operator-triggered handoff (whose `ritual_id` is a fresh UUID),
+ * so the overlay/dialog can vary their copy and phase set — a respawn has
+ * no prompted/validated/killed FRONT, it begins at `launching`.
+ */
+export const SUPERVISOR_RITUAL_PREFIX = "slot-supervisor:";
 
 /**
  * Body for `POST /api/units/{unit}/handoff-and-restart`.

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -322,4 +322,8 @@ export const api = {
   // ritual emits its own SSE phase events; no Tauri IPC equivalent).
   triggerHandoffRitual: (unit: string, body: TriggerHandoffRitualRequest) =>
     httpApi.triggerHandoffRitual(unit, body),
+
+  // Producer-slot close (HTTP only — engine kills the Producer + dispatched
+  // workers and stops the respawn supervisor; no Tauri IPC equivalent).
+  closeUnit: (unit: string) => httpApi.closeUnit(unit),
 };

--- a/clients/react/src/lib/close-unit-slot.ts
+++ b/clients/react/src/lib/close-unit-slot.ts
@@ -1,0 +1,40 @@
+// Close a unit's Producer slot — the webui half of the tmai-core #540 / #546
+// Producer-slot lifecycle (`post_close_unit_slot`).
+//
+// Two-step kill, because the kill targets split across the engine / webui
+// ownership boundary:
+//
+//   1. `POST /api/units/{unit}/close` — the engine kills the live Producer +
+//      its dispatched workers and stops the auto-respawn supervisor. This is a
+//      KILL, not a delete: worktrees and uncommitted work stay on disk.
+//   2. After the close returns, the webui kills the unit's FOOTER BASH itself.
+//      The footer shells (`BashFooter`) are plain, hint-less `bash` PTYs the
+//      webui spawned at the unit's repo cwds; the engine can't attribute them
+//      to the unit on close (no `unit` hint on a bare shell), so the side that
+//      OWNS the id — the webui — is responsible for killing them.
+//
+// Step 2 only runs if step 1 succeeds (the close confirms the operator intent);
+// a footer-kill failure is best-effort (`allSettled`) — a stale/dead shell that
+// can't be killed must not mask a successful close.
+
+import { type AgentSnapshot, api, isAiAgentLoose, normalizeGitDir } from "@/lib/api";
+import type { UnitResponse } from "@/types/generated/UnitResponse";
+
+// The webui-owned footer shells for a unit: plain (NON-AI) `bash` sessions
+// whose cwd is one of the unit's repos. `isAiAgentLoose` excludes the
+// bash-wrapped Producer and the workers (canonical `claude:`/`codex:`/… ids),
+// so this matches only the BashFooter's per-repo + ad-hoc shells — the same
+// normalized-cwd identity `BashFooter.findExistingBash` re-attaches on.
+export function findFooterShells(unit: UnitResponse, agents: AgentSnapshot[]): AgentSnapshot[] {
+  const repoPaths = new Set(unit.repos.map((r) => normalizeGitDir(r.path)));
+  return agents.filter((a) => !isAiAgentLoose(a) && repoPaths.has(normalizeGitDir(a.cwd)));
+}
+
+// Close the unit's Producer slot, then kill its footer bash. Throws if the
+// core close itself fails (so the caller can surface it and skip the
+// footer-kill); footer-kill failures are swallowed (best-effort).
+export async function closeUnitSlot(unit: UnitResponse, agents: AgentSnapshot[]): Promise<void> {
+  await api.closeUnit(unit.name);
+  const shells = findFooterShells(unit, agents);
+  await Promise.allSettled(shells.map((a) => api.killAgent(a.target)));
+}


### PR DESCRIPTION
Closes #841. Companion to the merged engine-side Producer-slot lifecycle (tmai-core #540 / #546). `clients/react` only — consumes the existing generated `HandoffRitualEvent` wire; **no engine/wire change** (the core reused the wire deliberately).

## What changed

### 1. Slot close on the tab
- `api-http.ts` `closeUnit(unit)` mirrors the existing `handoff-and-restart` POST (same `X-Tmai-Origin` scope, no body; resolves on 2xx without parsing the body — the close summary isn't codegen-pinned). Threaded through `api-tauri.ts` (`@/lib/api` consumers see it).
- New `src/lib/close-unit-slot.ts` (`closeUnitSlot` + `findFooterShells`): `POST /api/units/{unit}/close` (core kills the Producer + dispatched workers) **then** kills the unit's webui-owned **footer bash** via `/agents/{id}/kill`. Core can't attribute the hint-less footer shell (#546 `post_close_unit_slot`), so the side that owns it kills it. Footer shells are resolved as plain (non-AI) `bash` at the unit's repo cwds — the same identity `BashFooter` re-attaches on. Footer-kill is best-effort (`allSettled`) and only runs after a successful close.
- `UnitTabs.tsx`: each tab grows a per-unit close (×), gated behind an **always-on confirm** (`useConfirm`) spelling out **close = kill, kill ≠ delete — worktrees / uncommitted work stay on disk**. Only on confirm does it call `onCloseUnit`. App's `handleCloseUnit` runs `closeUnitSlot` + toast + refresh.

### 2. Generalize the overlay to crash-respawn
- `HandoffRitualOverlay.tsx`: when `ritual_id` starts `slot-supervisor:` it renders **`launching → ready`** (no prompted/validated/killed FRONT) with a distinct heading/copy/aria-label. The operator-handoff (UUID `ritual_id`, full 5-phase) path is **unchanged**.
- `useHandoffRitual.ts`: **adopts** an unsolicited supervisor respawn from `idle` (so an engine auto-relaunch surfaces the overlay with no operator trigger) and never clobbers a live operator handoff / open failure dialog. State now carries the ritual's own `unit` (a supervisor respawn may target a non-focused unit).
- `HandoffRitualFailureDialog.tsx`: new `mode="crash_loop"` — a `crash_loop_halted` escalate surfaces the **manual-relaunch** message (*health recovery resets the budget*); Retry is disabled (re-POSTing a handoff can't recover a crash-loop). Default `"handoff"` mode is byte-unchanged.

Left general enough to host the operator-gate of `validated` (tmai-core #547) later — not built here (out of scope; needs a core wire change first).

## Acceptance
- [x] a unit tab exposes a close control → confirm dialog → confirm calls `POST /close` then kills the footer bash; cancel does nothing
- [x] after a confirmed close, Producer + dispatched workers are gone (kill ≠ delete — worktrees remain)
- [x] a `slot-supervisor:<unit>` respawn renders `launching → ready` without the handoff FRONT phases
- [x] a `crash_loop_halted` escalate surfaces the manual-relaunch failure message
- [x] operator-handoff overlay behaviour (UUID `ritual_id`, full 5-phase) unchanged — regression tested

## Gate (clients/react, from `clients/react/`)
`tsc --noEmit` ✓ · `pnpm lint` (biome) ✓ · `pnpm build` ✓ · `pnpm test` (vitest) ✓ — 1070 passed / 2 skipped. New tests cover close confirm/cancel + footer-bash kill (incl. AI-agent exclusion + close-before-kill ordering), supervisor-respawn overlay (launching→ready, no FRONT), `crash_loop_halted` message + disabled Retry, hook adoption (launching/ready/escalate from idle; no clobber of a live operator handoff), and the operator-handoff regression.

## Refs
- engine half: tmai-core #540 (#546 merged)
- lockstep follow-on: tmai-core #547 (operator-gate — not in scope)
- epic: tmai-core #542

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ユニットをクローズ/停止する機能を追加しました。確認ダイアログで承認後に実行されます。

* **Bug Fixes**
  * ハンドオフ儀式とProducerクラッシュ復旧のフロー表示を改善しました。オペレーター/スーパーバイザーシナリオに対応し、各フェーズの進捗状況をより明確に表示します。

* **Tests**
  * ユニットクローズ、ハンドオフ儀式、クラッシュ復旧フローの包括的なテストを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->