### PR TITLE
chore(gen): sync generated spec + types from tmai-core@59ebcaa63b

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -1797,7 +1797,7 @@
       "description": "SSE payload emitted at each transition of the\n`POST /api/units/{unit}/handoff-and-restart` ritual.\n\nWired into [`CoreEvent::HandoffRitual`]; surfaces on `/api/events` as event\nkind `handoff_ritual`. `ritual_id` is a fresh UUID minted at ritual start\nso concurrent rituals across units (or operator retries) don't alias."
     },
     "HandoffRitualPhase": {
-      "description": "Phase of the Producer handoff-and-restart ritual (DR\n`2026-05-14-handoff-lifecycle-and-kill-ux.md` §C).\n\nPhases progress strictly in the order `Prompted → Validated → Killed →\nLaunching → Ready`; any step can short-circuit to `Escalate` with a\nmachine-readable `reason` (§D — uniform tier-1 escalation, no per-mode\npolicy). Consumers driving the WebUI overlay (`§E`) treat all `Escalate`\nvariants as the terminal failure state regardless of reason.",
+      "description": "Phase of the Producer handoff-and-restart ritual (DR\n`2026-05-14-handoff-lifecycle-and-kill-ux.md` §C; operator review gate\n`2026-06-19` aim `handoff-review-gate`, #547).\n\nPhases progress strictly in the order `Prompted → Validated →\nAwaitingReview → Killed → Launching → Ready`; any step can short-circuit to\n`Escalate` with a machine-readable `reason` (§D — uniform tier-1\nescalation, no per-mode policy). A `request-rewrite` decision at the\n`AwaitingReview` gate loops back to a fresh `Prompted → Validated →\nAwaitingReview` round (the old Producer is re-prompted, never killed until\nthe operator approves). Consumers driving the WebUI overlay (`§E`) treat all\n`Escalate` variants as the terminal failure state regardless of reason.",
       "oneOf": [
         {
           "description": "Ritual prompt was delivered to the active Producer (§C step 2).",
@@ -1820,6 +1820,21 @@
             "phase": {
               "enum": [
                 "validated"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "phase"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Baton validated; the ritual is PAUSED at the operator review gate\nbefore the irreversible kill (#547 / aim `handoff-review-gate`). The\noperator either approves (→ `Killed`) or requests a rewrite (→ the old\nProducer is re-prompted and a fresh `Prompted → Validated →\nAwaitingReview` round runs; the kill is never reached until approval).\nThe baton body is fetched out-of-band by the overlay\n(`GET /api/units/{unit}/handoffs/active`), so this phase carries no\npayload beyond the shared event envelope.",
+          "properties": {
+            "phase": {
+              "enum": [
+                "awaiting_review"
               ],
               "type": "string"
             }
@@ -1875,7 +1890,7 @@
           "type": "object"
         },
         {
-          "description": "Failure path; `reason` is a machine-readable code per DR §D failure\ninventory (`no_active_producer`, `multiple_producers`,\n`prompt_send_failed`, `timeout`, `malformed_handoff`, `kill_failed`,\n`spawn_failed`). Consumers route every variant to the same operator\ndialog (§E).",
+          "description": "Failure path; `reason` is a machine-readable code per DR §D failure\ninventory (`no_active_producer`, `multiple_producers`,\n`prompt_send_failed`, `no_baton`, `malformed_handoff`, `kill_failed`,\n`spawn_failed`, `review_abandoned`). Consumers route every variant to\nthe same operator dialog (§E).",
           "properties": {
             "phase": {
               "enum": [

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -4097,6 +4097,21 @@
           },
           {
             "type": "object",
+            "description": "Baton validated; the ritual is PAUSED at the operator review gate\nbefore the irreversible kill (#547 / aim `handoff-review-gate`). The\noperator either approves (→ `Killed`) or requests a rewrite (→ the old\nProducer is re-prompted and a fresh `Prompted → Validated →\nAwaitingReview` round runs; the kill is never reached until approval).\nThe baton body is fetched out-of-band by the overlay\n(`GET /api/units/{unit}/handoffs/active`), so this phase carries no\npayload beyond the shared event envelope.",
+            "required": [
+              "phase"
+            ],
+            "properties": {
+              "phase": {
+                "type": "string",
+                "enum": [
+                  "awaiting_review"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
             "description": "Old Producer was killed via PTY-server `kill_agent` (§C step 5).",
             "required": [
               "phase"
@@ -4142,7 +4157,7 @@
           },
           {
             "type": "object",
-            "description": "Failure path; `reason` is a machine-readable code per DR §D failure\ninventory (`no_active_producer`, `multiple_producers`,\n`prompt_send_failed`, `timeout`, `malformed_handoff`, `kill_failed`,\n`spawn_failed`). Consumers route every variant to the same operator\ndialog (§E).",
+            "description": "Failure path; `reason` is a machine-readable code per DR §D failure\ninventory (`no_active_producer`, `multiple_producers`,\n`prompt_send_failed`, `no_baton`, `malformed_handoff`, `kill_failed`,\n`spawn_failed`, `review_abandoned`). Consumers route every variant to\nthe same operator dialog (§E).",
             "required": [
               "reason",
               "phase"
@@ -4161,7 +4176,7 @@
             }
           }
         ],
-        "description": "Phase of the Producer handoff-and-restart ritual (DR\n`2026-05-14-handoff-lifecycle-and-kill-ux.md` §C).\n\nPhases progress strictly in the order `Prompted → Validated → Killed →\nLaunching → Ready`; any step can short-circuit to `Escalate` with a\nmachine-readable `reason` (§D — uniform tier-1 escalation, no per-mode\npolicy). Consumers driving the WebUI overlay (`§E`) treat all `Escalate`\nvariants as the terminal failure state regardless of reason."
+        "description": "Phase of the Producer handoff-and-restart ritual (DR\n`2026-05-14-handoff-lifecycle-and-kill-ux.md` §C; operator review gate\n`2026-06-19` aim `handoff-review-gate`, #547).\n\nPhases progress strictly in the order `Prompted → Validated →\nAwaitingReview → Killed → Launching → Ready`; any step can short-circuit to\n`Escalate` with a machine-readable `reason` (§D — uniform tier-1\nescalation, no per-mode policy). A `request-rewrite` decision at the\n`AwaitingReview` gate loops back to a fresh `Prompted → Validated →\nAwaitingReview` round (the old Producer is re-prompted, never killed until\nthe operator approves). Consumers driving the WebUI overlay (`§E`) treat all\n`Escalate` variants as the terminal failure state regardless of reason."
       },
       "HandoffsResponse": {
         "type": "object",

--- a/clients/react/src/components/producer-console/HandoffRitualOverlay.tsx
+++ b/clients/react/src/components/producer-console/HandoffRitualOverlay.tsx
@@ -4,8 +4,12 @@
 // reused the wire deliberately — no new SSE variant):
 //
 //   • OPERATOR HANDOFF (`ritual_id` is a UUID) — the full forward sequence
-//     per DR `2026-05-14-handoff-lifecycle-and-kill-ux.md` §E:
-//       prompted → validated → killed → launching → ready
+//     per DR `2026-05-14-handoff-lifecycle-and-kill-ux.md` §E + the #547
+//     operator review gate (tmai-core #549):
+//       prompted → validated → awaiting_review → killed → launching → ready
+//     At `awaiting_review` the ritual PAUSES for the operator's decision —
+//     Approve (→ kill + respawn) or Request rewrite (→ re-prompt the
+//     still-alive old Producer; the gate re-opens on the regenerated baton).
 //
 //   • SUPERVISOR CRASH-RESPAWN (`ritual_id` starts `slot-supervisor:`,
 //     tmai-core #540 / #546) — the absent Producer just VANISHED, so there
@@ -23,7 +27,13 @@
 // The terminal-failure path (`escalate`) is handled by a dedicated
 // dialog component — this overlay never renders it.
 
-import { type HandoffRitualEvent, SUPERVISOR_RITUAL_PREFIX } from "@/lib/api";
+import { useEffect, useState } from "react";
+import {
+  api,
+  HandoffReviewError,
+  type HandoffRitualEvent,
+  SUPERVISOR_RITUAL_PREFIX,
+} from "@/lib/api";
 
 interface HandoffRitualOverlayProps {
   unitName: string;
@@ -33,7 +43,13 @@ interface HandoffRitualOverlayProps {
   phases: HandoffRitualEvent[];
 }
 
-type ForwardPhaseKey = "prompted" | "validated" | "killed" | "launching" | "ready";
+type ForwardPhaseKey =
+  | "prompted"
+  | "validated"
+  | "awaiting_review"
+  | "killed"
+  | "launching"
+  | "ready";
 
 interface PhaseRow {
   key: ForwardPhaseKey;
@@ -41,10 +57,19 @@ interface PhaseRow {
   detail: string;
 }
 
-// Operator handoff — the canonical 5-phase forward sequence.
+// Operator handoff — the canonical forward sequence. The `awaiting_review`
+// row (tmai-core #547 / #549) sits between `validated` and `killed`: the
+// ritual PAUSES there for the operator review gate before the irreversible
+// kill (Approve → kill + respawn; Request rewrite → re-prompt the still-alive
+// old Producer, gate re-opens on the regenerated baton).
 const HANDOFF_PHASES: PhaseRow[] = [
   { key: "prompted", label: "Prompted", detail: "ritual prompt delivered" },
   { key: "validated", label: "Validated", detail: "HANDOFF READY observed + file valid" },
+  {
+    key: "awaiting_review",
+    label: "Awaiting review",
+    detail: "operator review gate — approve or request a rewrite",
+  },
   { key: "killed", label: "Killed", detail: "old Producer terminated" },
   { key: "launching", label: "Launching", detail: "spawning fresh Producer..." },
   { key: "ready", label: "Ready", detail: "" },
@@ -84,6 +109,19 @@ const STATUS_CLASS = {
   pending: "text-subtle-foreground",
 } as const;
 
+// Render an operator-review-gate decision failure as a short, non-fatal
+// message. A 409 is the expected race (the gate already advanced / the
+// ritual_id is stale), so it gets friendly copy rather than the raw body.
+function reviewErrorMessage(err: unknown): string {
+  if (err instanceof HandoffReviewError) {
+    if (err.status === 409) {
+      return "No review gate is armed — the ritual may have already advanced or this decision is stale.";
+    }
+    return err.detail || err.message;
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
 export function HandoffRitualOverlay({ unitName, ritualId, phases }: HandoffRitualOverlayProps) {
   // A supervisor crash-respawn carries the synthetic `slot-supervisor:<unit>`
   // id; an operator handoff carries a UUID. The id picks the phase set + copy.
@@ -108,6 +146,76 @@ export function HandoffRitualOverlay({ unitName, ritualId, phases }: HandoffRitu
   })();
 
   const heading = isRespawn ? "Producer crash-respawn" : "Handoff & restart";
+
+  // Operator review gate (#547). Only an operator handoff (UUID ritual) ever
+  // pauses at `awaiting_review`; a supervisor respawn has no FRONT and never
+  // reaches it. The decision endpoints need a real `ritual_id`.
+  const atReviewGate = !isRespawn && lastForwardPhase === "awaiting_review" && ritualId !== null;
+
+  const [feedback, setFeedback] = useState("");
+  // A single in-flight flag for either decision — the operator acts once.
+  const [busy, setBusy] = useState(false);
+  const [actionError, setActionError] = useState<string | null>(null);
+  // The proposed (just-validated) baton, fetched out-of-band so the operator
+  // can review it before deciding. `null` until loaded; `batonError` flags a
+  // fetch failure (non-fatal — the decision controls still work).
+  const [baton, setBaton] = useState<string | null>(null);
+  const [batonError, setBatonError] = useState(false);
+
+  useEffect(() => {
+    if (!atReviewGate) return;
+    let cancelled = false;
+    setBaton(null);
+    setBatonError(false);
+    // The validated baton is the unit's ACTIVE hand-over file at this point
+    // (`validated` means HANDOFF READY observed + file valid).
+    api
+      .unitHandoff(unitName, "active")
+      .then((res) => {
+        if (!cancelled) setBaton(res.content);
+      })
+      .catch(() => {
+        if (!cancelled) setBatonError(true);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [atReviewGate, unitName]);
+
+  const handleApprove = async () => {
+    if (ritualId === null) return;
+    setActionError(null);
+    setBusy(true);
+    try {
+      await api.approveHandoff(unitName, ritualId);
+      // No client-side phase bookkeeping — the SSE stream advances the overlay
+      // (killed → launching → ready) and unmounts these controls.
+    } catch (err) {
+      setActionError(reviewErrorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleRequestRewrite = async () => {
+    if (ritualId === null) return;
+    const trimmed = feedback.trim();
+    if (trimmed === "") return;
+    setActionError(null);
+    setBusy(true);
+    try {
+      await api.requestHandoffRewrite(unitName, ritualId, trimmed);
+      // Clear so the textarea can't be re-submitted with stale feedback; the
+      // empty-feedback disable then blocks a no-op resubmit until the operator
+      // types again. The SSE stream re-opens the gate on the regenerated baton
+      // (a fresh prompted → validated → awaiting_review round).
+      setFeedback("");
+    } catch (err) {
+      setActionError(reviewErrorMessage(err));
+    } finally {
+      setBusy(false);
+    }
+  };
 
   return (
     <div
@@ -159,6 +267,81 @@ export function HandoffRitualOverlay({ unitName, ritualId, phases }: HandoffRitu
             );
           })}
         </ul>
+        {atReviewGate && (
+          <div
+            data-testid="awaiting-review-controls"
+            className="mt-4 border-t border-hairline-strong pt-4"
+          >
+            <p className="text-[12px] font-medium text-foreground">Operator review gate</p>
+            <p className="mt-1 text-[11px] leading-relaxed text-muted-foreground">
+              The regenerated baton is validated, but the old Producer is still alive. Approve to
+              kill it and launch the fresh Producer, or request a rewrite to re-prompt the current
+              Producer with your feedback.
+            </p>
+
+            <div className="mt-3">
+              <p className="text-[11px] font-medium text-muted-foreground">Proposed baton</p>
+              {baton !== null ? (
+                <pre
+                  data-testid="awaiting-review-baton"
+                  className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap rounded border border-hairline-strong bg-background p-2 font-mono text-[10px] leading-relaxed text-muted-foreground"
+                >
+                  {baton}
+                </pre>
+              ) : batonError ? (
+                <p className="mt-1 text-[10px] text-subtle-foreground">
+                  (could not load the baton preview — review it from the hand-over view before
+                  deciding)
+                </p>
+              ) : (
+                <p className="mt-1 text-[10px] text-subtle-foreground">Loading baton…</p>
+              )}
+            </div>
+
+            {actionError !== null && (
+              <p
+                role="alert"
+                data-testid="awaiting-review-error"
+                className="mt-3 text-[11px] text-destructive"
+              >
+                {actionError}
+              </p>
+            )}
+
+            <div className="mt-3 flex flex-col gap-2">
+              <textarea
+                aria-label="Rewrite feedback"
+                data-testid="awaiting-review-feedback"
+                value={feedback}
+                onChange={(e) => setFeedback(e.target.value)}
+                disabled={busy}
+                rows={3}
+                placeholder="Feedback for the rewrite (what to change before approving)…"
+                className="w-full resize-y rounded border border-hairline-strong bg-background p-2 text-[12px] text-foreground placeholder:text-subtle-foreground focus:border-primary focus:outline-none disabled:opacity-50"
+              />
+              <div className="flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  data-testid="awaiting-review-request-rewrite"
+                  onClick={() => void handleRequestRewrite()}
+                  disabled={busy || feedback.trim() === ""}
+                  className="rounded-md bg-surface px-3 py-1.5 text-[12px] font-medium text-foreground transition-colors hover:bg-surface-strong disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Request rewrite
+                </button>
+                <button
+                  type="button"
+                  data-testid="awaiting-review-approve"
+                  onClick={() => void handleApprove()}
+                  disabled={busy}
+                  className="rounded-md bg-primary/15 px-3 py-1.5 text-[12px] font-medium text-primary transition-colors hover:bg-primary/25 disabled:cursor-not-allowed disabled:opacity-50"
+                >
+                  Approve
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
         {ritualId !== null && (
           <p className="mt-4 font-mono text-[10px] text-subtle-foreground">ritual_id: {ritualId}</p>
         )}

--- a/clients/react/src/components/producer-console/__tests__/HandoffRitualOverlay.review-gate.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/HandoffRitualOverlay.review-gate.test.tsx
@@ -1,0 +1,184 @@
+// @vitest-environment jsdom
+//
+// Operator review-gate (#547 / tmai-core #549) tests for the
+// HandoffRitualOverlay. The `awaiting_review` phase PAUSES the ritual before
+// the irreversible kill: the operator must Approve (→ kill + respawn) or
+// Request a rewrite (→ the still-alive old Producer is re-prompted, the gate
+// re-opens on the regenerated baton).
+//
+// We mock `@/lib/api` (partial — keep the real `HandoffReviewError` /
+// `SUPERVISOR_RITUAL_PREFIX`) so we can assert the exact POSTs the controls
+// fire and drive a 409 race deterministically.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { HandoffRitualEvent } from "@/lib/api";
+
+const unitHandoffMock = vi.fn();
+const approveHandoffMock = vi.fn();
+const requestHandoffRewriteMock = vi.fn();
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      unitHandoff: (...args: unknown[]) => unitHandoffMock(...args),
+      approveHandoff: (...args: unknown[]) => approveHandoffMock(...args),
+      requestHandoffRewrite: (...args: unknown[]) => requestHandoffRewriteMock(...args),
+    },
+  };
+});
+
+import { HandoffReviewError } from "@/lib/api";
+import { HandoffRitualOverlay } from "../HandoffRitualOverlay";
+
+const RITUAL = "3f1a2b4c-0000-4d5e-9f00-abcdef012345";
+
+function ev(phase: HandoffRitualEvent["phase"], ritualId = RITUAL): HandoffRitualEvent {
+  if (phase === "escalate") {
+    return { unit: "tmai", ritual_id: ritualId, phase: "escalate", reason: "timeout" };
+  }
+  if (phase === "ready") {
+    return { unit: "tmai", ritual_id: ritualId, phase: "ready" };
+  }
+  return { unit: "tmai", ritual_id: ritualId, phase };
+}
+
+// phases that land the overlay at the awaiting_review gate.
+const AT_GATE = [ev("prompted"), ev("validated"), ev("awaiting_review")];
+
+beforeEach(() => {
+  unitHandoffMock.mockReset();
+  approveHandoffMock.mockReset();
+  requestHandoffRewriteMock.mockReset();
+  // Default: baton fetch + decisions resolve cleanly.
+  unitHandoffMock.mockResolvedValue({ unit: "tmai", name: "active", content: "baton body" });
+  approveHandoffMock.mockResolvedValue(undefined);
+  requestHandoffRewriteMock.mockResolvedValue(undefined);
+});
+
+describe("HandoffRitualOverlay — operator review gate", () => {
+  it("renders an Awaiting-review phase row in the operator handoff set", () => {
+    render(<HandoffRitualOverlay unitName="tmai" ritualId={RITUAL} phases={[]} />);
+    expect(screen.getByTestId("phase-row-awaiting_review")).toBeTruthy();
+  });
+
+  it("renders the Approve + Request-rewrite controls ONLY at awaiting_review", () => {
+    const { rerender } = render(
+      <HandoffRitualOverlay unitName="tmai" ritualId={RITUAL} phases={[ev("validated")]} />,
+    );
+    // Earlier phase — no controls.
+    expect(screen.queryByTestId("awaiting-review-controls")).toBeNull();
+
+    rerender(<HandoffRitualOverlay unitName="tmai" ritualId={RITUAL} phases={AT_GATE} />);
+    expect(screen.getByTestId("awaiting-review-controls")).toBeTruthy();
+    expect(screen.getByTestId("awaiting-review-approve")).toBeTruthy();
+    expect(screen.getByTestId("awaiting-review-request-rewrite")).toBeTruthy();
+
+    // Past the gate (killed) — controls gone again.
+    rerender(
+      <HandoffRitualOverlay
+        unitName="tmai"
+        ritualId={RITUAL}
+        phases={[...AT_GATE, ev("killed")]}
+      />,
+    );
+    expect(screen.queryByTestId("awaiting-review-controls")).toBeNull();
+  });
+
+  it("surfaces the proposed baton out-of-band for review", async () => {
+    render(<HandoffRitualOverlay unitName="tmai" ritualId={RITUAL} phases={AT_GATE} />);
+    await waitFor(() => expect(unitHandoffMock).toHaveBeenCalledWith("tmai", "active"));
+    expect((await screen.findByTestId("awaiting-review-baton")).textContent).toContain(
+      "baton body",
+    );
+  });
+
+  it("Approve fires POST .../handoff/approve with the current ritual_id", async () => {
+    render(<HandoffRitualOverlay unitName="tmai" ritualId={RITUAL} phases={AT_GATE} />);
+    fireEvent.click(screen.getByTestId("awaiting-review-approve"));
+    await waitFor(() => expect(approveHandoffMock).toHaveBeenCalledWith("tmai", RITUAL));
+    expect(requestHandoffRewriteMock).not.toHaveBeenCalled();
+  });
+
+  it("Request-rewrite fires POST .../handoff/request-rewrite with { ritual_id, feedback }", async () => {
+    render(<HandoffRitualOverlay unitName="tmai" ritualId={RITUAL} phases={AT_GATE} />);
+    const textarea = screen.getByTestId("awaiting-review-feedback") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "tighten the scope section" } });
+    fireEvent.click(screen.getByTestId("awaiting-review-request-rewrite"));
+    await waitFor(() =>
+      expect(requestHandoffRewriteMock).toHaveBeenCalledWith(
+        "tmai",
+        RITUAL,
+        "tighten the scope section",
+      ),
+    );
+    expect(approveHandoffMock).not.toHaveBeenCalled();
+  });
+
+  it("blocks an empty-feedback rewrite and clears the textarea after a submit", async () => {
+    render(<HandoffRitualOverlay unitName="tmai" ritualId={RITUAL} phases={AT_GATE} />);
+    const submit = screen.getByTestId("awaiting-review-request-rewrite") as HTMLButtonElement;
+    // Empty feedback — submit is disabled and firing it is a no-op.
+    expect(submit.disabled).toBe(true);
+    fireEvent.click(submit);
+    expect(requestHandoffRewriteMock).not.toHaveBeenCalled();
+
+    const textarea = screen.getByTestId("awaiting-review-feedback") as HTMLTextAreaElement;
+    fireEvent.change(textarea, { target: { value: "  needs more detail  " } });
+    expect(submit.disabled).toBe(false);
+    fireEvent.click(submit);
+    // Trimmed feedback on the wire…
+    await waitFor(() =>
+      expect(requestHandoffRewriteMock).toHaveBeenCalledWith("tmai", RITUAL, "needs more detail"),
+    );
+    // …and the textarea is cleared (re-disabling the submit) after success.
+    await waitFor(() => expect(textarea.value).toBe(""));
+    expect(submit.disabled).toBe(true);
+  });
+
+  it("surfaces a 409 as a non-fatal error rather than crashing", async () => {
+    approveHandoffMock.mockRejectedValueOnce(new HandoffReviewError(409, "no armed gate"));
+    render(<HandoffRitualOverlay unitName="tmai" ritualId={RITUAL} phases={AT_GATE} />);
+    fireEvent.click(screen.getByTestId("awaiting-review-approve"));
+    const alert = await screen.findByTestId("awaiting-review-error");
+    expect(alert.textContent ?? "").toMatch(/no review gate is armed/i);
+    // The overlay is still mounted (no crash) — controls remain.
+    expect(screen.getByTestId("awaiting-review-controls")).toBeTruthy();
+    expect(screen.getByTestId("awaiting-review-approve")).toBeTruthy();
+  });
+
+  it("falls back gracefully when the baton preview fails to load", async () => {
+    unitHandoffMock.mockRejectedValueOnce(new Error("not found"));
+    render(<HandoffRitualOverlay unitName="tmai" ritualId={RITUAL} phases={AT_GATE} />);
+    expect(await screen.findByText(/could not load the baton preview/i)).toBeTruthy();
+    // Decision controls still work despite the missing preview.
+    fireEvent.click(screen.getByTestId("awaiting-review-approve"));
+    await waitFor(() => expect(approveHandoffMock).toHaveBeenCalledWith("tmai", RITUAL));
+  });
+});
+
+describe("HandoffRitualOverlay — review gate regressions", () => {
+  it("never shows the review controls for a supervisor crash-respawn", () => {
+    const SUP = "slot-supervisor:tmai";
+    render(
+      <HandoffRitualOverlay
+        unitName="tmai"
+        ritualId={SUP}
+        // Even if an awaiting_review event leaked onto a respawn stream, the
+        // respawn phase set has no such row and the gate stays closed.
+        phases={[ev("launching", SUP), ev("awaiting_review", SUP)]}
+      />,
+    );
+    expect(screen.queryByTestId("awaiting-review-controls")).toBeNull();
+    expect(approveHandoffMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fetch the baton or render controls before the gate", () => {
+    render(<HandoffRitualOverlay unitName="tmai" ritualId={RITUAL} phases={[ev("prompted")]} />);
+    expect(screen.queryByTestId("awaiting-review-controls")).toBeNull();
+    expect(unitHandoffMock).not.toHaveBeenCalled();
+  });
+});

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -1809,6 +1809,23 @@ export const api = {
   // webui spawned is NOT attributable to the unit server-side, so the webui
   // kills it itself after this resolves (see `closeUnitSlot`).
   closeUnit: (unit: string) => closeUnitFetch(unit),
+
+  // Operator review gate (tmai-core #547 / #549, DR
+  // `2026-05-14-handoff-lifecycle-and-kill-ux.md` + aim `handoff-review-gate`).
+  // At the `awaiting_review` phase the ritual PAUSES before the irreversible
+  // kill: the old Producer is still alive and the operator must decide.
+  //   - `approveHandoff` → `POST .../handoff/approve` (body `{ ritual_id }`):
+  //     proceed with kill + respawn (the SSE stream resumes killed→…→ready).
+  //   - `requestHandoffRewrite` → `POST .../handoff/request-rewrite` (body
+  //     `{ ritual_id, feedback }`): re-prompt the still-alive old Producer with
+  //     the feedback; the gate re-opens on the regenerated baton (a fresh
+  //     prompted→validated→awaiting_review round over SSE).
+  // Both resolve on 2xx; a 409 (no armed gate / stale ritual_id) surfaces as a
+  // typed `HandoffReviewError` callers render as a non-fatal error.
+  approveHandoff: (unit: string, ritualId: string) =>
+    handoffReviewFetch(unit, "approve", { ritual_id: ritualId }),
+  requestHandoffRewrite: (unit: string, ritualId: string, feedback: string) =>
+    handoffReviewFetch(unit, "request-rewrite", { ritual_id: ritualId, feedback }),
 };
 
 async function handoffFetch(
@@ -1859,6 +1876,59 @@ async function closeUnitFetch(unit: string): Promise<void> {
   if (!res.ok) {
     const detail = await res.text();
     throw new Error(`API error ${res.status}: ${detail}`);
+  }
+}
+
+// Fire an operator review-gate decision (#547 / tmai-core #549), mirroring
+// `closeUnitFetch`'s X-Tmai-Origin scope. The decision endpoints return no
+// body the UI needs (the SSE phase stream advances the overlay), so resolve on
+// 2xx without parsing; a non-2xx becomes a typed `HandoffReviewError` so the
+// overlay can distinguish a 409 (no armed gate / stale ritual_id) from a
+// transport failure and surface it non-fatally.
+async function handoffReviewFetch(
+  unit: string,
+  decision: "approve" | "request-rewrite",
+  body: { ritual_id: string; feedback?: string },
+): Promise<void> {
+  const url = `${config.baseUrl}/api/units/${encodeURIComponent(unit)}/handoff/${decision}`;
+  const origin: { kind: "Human"; interface: string; cwd?: string } = {
+    kind: "Human",
+    interface: "webui",
+    ...(callerCwd !== null ? { cwd: callerCwd } : {}),
+  };
+  const res = await fetch(url, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${config.token}`,
+      "X-Tmai-Origin": JSON.stringify(origin),
+    },
+  });
+  if (!res.ok) {
+    const detail = await res.text();
+    throw new HandoffReviewError(res.status, detail);
+  }
+}
+
+/**
+ * Typed error raised by `approveHandoff` / `requestHandoffRewrite`. Surfaces
+ * the HTTP status so the overlay can give the operator a clear, non-fatal
+ * message for the expected race:
+ *   - 409 — no review gate is armed / the `ritual_id` is stale (the ritual
+ *     already advanced past `awaiting_review`, or another operator acted)
+ *   - other — transport / server-side rejection
+ *
+ * The unwrapped raw body lives on `.detail`.
+ */
+export class HandoffReviewError extends Error {
+  readonly status: number;
+  readonly detail: string;
+  constructor(status: number, detail: string) {
+    super(`handoff review failed: ${status} ${detail}`);
+    this.name = "HandoffReviewError";
+    this.status = status;
+    this.detail = detail;
   }
 }
 

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -326,4 +326,11 @@ export const api = {
   // Producer-slot close (HTTP only — engine kills the Producer + dispatched
   // workers and stops the respawn supervisor; no Tauri IPC equivalent).
   closeUnit: (unit: string) => httpApi.closeUnit(unit),
+
+  // Operator review-gate decisions (#547 / tmai-core #549; HTTP only —
+  // server-driven ritual that emits its own SSE phase events, like
+  // triggerHandoffRitual; no Tauri IPC equivalent).
+  approveHandoff: (unit: string, ritualId: string) => httpApi.approveHandoff(unit, ritualId),
+  requestHandoffRewrite: (unit: string, ritualId: string, feedback: string) =>
+    httpApi.requestHandoffRewrite(unit, ritualId, feedback),
 };

--- a/clients/react/src/types/generated/HandoffRitualEvent.ts
+++ b/clients/react/src/types/generated/HandoffRitualEvent.ts
@@ -24,7 +24,7 @@ message?: string,
 /**
  * Canonical AgentId of the newly spawned Producer. Set only on `Ready`.
  */
-new_agent_id?: string, } & ({ "phase": "prompted" } | { "phase": "validated" } | { "phase": "killed" } | { "phase": "launching" } | { "phase": "ready" } | { "phase": "escalate", 
+new_agent_id?: string, } & ({ "phase": "prompted" } | { "phase": "validated" } | { "phase": "awaiting_review" } | { "phase": "killed" } | { "phase": "launching" } | { "phase": "ready" } | { "phase": "escalate", 
 /**
  * Machine-readable failure reason (see variant doc).
  */

--- a/clients/react/src/types/generated/HandoffRitualPhase.ts
+++ b/clients/react/src/types/generated/HandoffRitualPhase.ts
@@ -2,15 +2,19 @@
 
 /**
  * Phase of the Producer handoff-and-restart ritual (DR
- * `2026-05-14-handoff-lifecycle-and-kill-ux.md` §C).
+ * `2026-05-14-handoff-lifecycle-and-kill-ux.md` §C; operator review gate
+ * `2026-06-19` aim `handoff-review-gate`, #547).
  *
- * Phases progress strictly in the order `Prompted → Validated → Killed →
- * Launching → Ready`; any step can short-circuit to `Escalate` with a
- * machine-readable `reason` (§D — uniform tier-1 escalation, no per-mode
- * policy). Consumers driving the WebUI overlay (`§E`) treat all `Escalate`
- * variants as the terminal failure state regardless of reason.
+ * Phases progress strictly in the order `Prompted → Validated →
+ * AwaitingReview → Killed → Launching → Ready`; any step can short-circuit to
+ * `Escalate` with a machine-readable `reason` (§D — uniform tier-1
+ * escalation, no per-mode policy). A `request-rewrite` decision at the
+ * `AwaitingReview` gate loops back to a fresh `Prompted → Validated →
+ * AwaitingReview` round (the old Producer is re-prompted, never killed until
+ * the operator approves). Consumers driving the WebUI overlay (`§E`) treat all
+ * `Escalate` variants as the terminal failure state regardless of reason.
  */
-export type HandoffRitualPhase = { "phase": "prompted" } | { "phase": "validated" } | { "phase": "killed" } | { "phase": "launching" } | { "phase": "ready" } | { "phase": "escalate", 
+export type HandoffRitualPhase = { "phase": "prompted" } | { "phase": "validated" } | { "phase": "awaiting_review" } | { "phase": "killed" } | { "phase": "launching" } | { "phase": "ready" } | { "phase": "escalate", 
 /**
  * Machine-readable failure reason (see variant doc).
  */


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@59ebcaa63bd609f62c5afcde8b73d0415853f011

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/corevents.schema.json                        | 19 +++++++++++++++++--
 api-spec/openapi.json                                 | 19 +++++++++++++++++--
 .../react/src/types/generated/HandoffRitualEvent.ts   |  2 +-
 .../react/src/types/generated/HandoffRitualPhase.ts   | 18 +++++++++++-------
 4 files changed, 46 insertions(+), 12 deletions(-)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * ハンドオフ進行に「レビュー待ち」フェーズを追加し、オペレーター承認が必要なゲート処理を反映しました。
  * 承認・書き換えの操作用APIを追加し、UIで提案バトンのプレビューと操作手順を提供しました。

* **Bug Fixes**
  * 失敗理由の内訳を見直し、「レビュー放棄」を追加しました。

* **Tests**
  * レビューゲートの表示・送信・エラー表示・回帰を検証するテストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->