### PR TITLE
chore(gen): sync generated spec + types from tmai-core@3c2f6801e9

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -1797,7 +1797,7 @@
       "description": "SSE payload emitted at each transition of the\n`POST /api/units/{unit}/handoff-and-restart` ritual.\n\nWired into [`CoreEvent::HandoffRitual`]; surfaces on `/api/events` as event\nkind `handoff_ritual`. `ritual_id` is a fresh UUID minted at ritual start\nso concurrent rituals across units (or operator retries) don't alias."
     },
     "HandoffRitualPhase": {
-      "description": "Phase of the Producer handoff-and-restart ritual (DR\n`2026-05-14-handoff-lifecycle-and-kill-ux.md` §C).\n\nPhases progress strictly in the order `Prompted → Validated → Killed →\nLaunching → Ready`; any step can short-circuit to `Escalate` with a\nmachine-readable `reason` (§D — uniform tier-1 escalation, no per-mode\npolicy). Consumers driving the WebUI overlay (`§E`) treat all `Escalate`\nvariants as the terminal failure state regardless of reason.",
+      "description": "Phase of the Producer handoff-and-restart ritual (DR\n`2026-05-14-handoff-lifecycle-and-kill-ux.md` §C; operator review gate\n`2026-06-19` aim `handoff-review-gate`, #547).\n\nPhases progress strictly in the order `Prompted → Validated →\nAwaitingReview → Killed → Launching → Ready`; any step can short-circuit to\n`Escalate` with a machine-readable `reason` (§D — uniform tier-1\nescalation, no per-mode policy). A `request-rewrite` decision at the\n`AwaitingReview` gate loops back to a fresh `Prompted → Validated →\nAwaitingReview` round (the old Producer is re-prompted, never killed until\nthe operator approves). Consumers driving the WebUI overlay (`§E`) treat all\n`Escalate` variants as the terminal failure state regardless of reason.",
       "oneOf": [
         {
           "description": "Ritual prompt was delivered to the active Producer (§C step 2).",
@@ -1820,6 +1820,21 @@
             "phase": {
               "enum": [
                 "validated"
+              ],
+              "type": "string"
+            }
+          },
+          "required": [
+            "phase"
+          ],
+          "type": "object"
+        },
+        {
+          "description": "Baton validated; the ritual is PAUSED at the operator review gate\nbefore the irreversible kill (#547 / aim `handoff-review-gate`). The\noperator either approves (→ `Killed`) or requests a rewrite (→ the old\nProducer is re-prompted and a fresh `Prompted → Validated →\nAwaitingReview` round runs; the kill is never reached until approval).\nThe baton body is fetched out-of-band by the overlay\n(`GET /api/units/{unit}/handoffs/active`), so this phase carries no\npayload beyond the shared event envelope.",
+          "properties": {
+            "phase": {
+              "enum": [
+                "awaiting_review"
               ],
               "type": "string"
             }
@@ -1875,7 +1890,7 @@
           "type": "object"
         },
         {
-          "description": "Failure path; `reason` is a machine-readable code per DR §D failure\ninventory (`no_active_producer`, `multiple_producers`,\n`prompt_send_failed`, `timeout`, `malformed_handoff`, `kill_failed`,\n`spawn_failed`). Consumers route every variant to the same operator\ndialog (§E).",
+          "description": "Failure path; `reason` is a machine-readable code per DR §D failure\ninventory (`no_active_producer`, `multiple_producers`,\n`prompt_send_failed`, `no_baton`, `malformed_handoff`, `kill_failed`,\n`spawn_failed`, `review_abandoned`). Consumers route every variant to\nthe same operator dialog (§E).",
           "properties": {
             "phase": {
               "enum": [

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -4097,6 +4097,21 @@
           },
           {
             "type": "object",
+            "description": "Baton validated; the ritual is PAUSED at the operator review gate\nbefore the irreversible kill (#547 / aim `handoff-review-gate`). The\noperator either approves (→ `Killed`) or requests a rewrite (→ the old\nProducer is re-prompted and a fresh `Prompted → Validated →\nAwaitingReview` round runs; the kill is never reached until approval).\nThe baton body is fetched out-of-band by the overlay\n(`GET /api/units/{unit}/handoffs/active`), so this phase carries no\npayload beyond the shared event envelope.",
+            "required": [
+              "phase"
+            ],
+            "properties": {
+              "phase": {
+                "type": "string",
+                "enum": [
+                  "awaiting_review"
+                ]
+              }
+            }
+          },
+          {
+            "type": "object",
             "description": "Old Producer was killed via PTY-server `kill_agent` (§C step 5).",
             "required": [
               "phase"
@@ -4142,7 +4157,7 @@
           },
           {
             "type": "object",
-            "description": "Failure path; `reason` is a machine-readable code per DR §D failure\ninventory (`no_active_producer`, `multiple_producers`,\n`prompt_send_failed`, `timeout`, `malformed_handoff`, `kill_failed`,\n`spawn_failed`). Consumers route every variant to the same operator\ndialog (§E).",
+            "description": "Failure path; `reason` is a machine-readable code per DR §D failure\ninventory (`no_active_producer`, `multiple_producers`,\n`prompt_send_failed`, `no_baton`, `malformed_handoff`, `kill_failed`,\n`spawn_failed`, `review_abandoned`). Consumers route every variant to\nthe same operator dialog (§E).",
             "required": [
               "reason",
               "phase"
@@ -4161,7 +4176,7 @@
             }
           }
         ],
-        "description": "Phase of the Producer handoff-and-restart ritual (DR\n`2026-05-14-handoff-lifecycle-and-kill-ux.md` §C).\n\nPhases progress strictly in the order `Prompted → Validated → Killed →\nLaunching → Ready`; any step can short-circuit to `Escalate` with a\nmachine-readable `reason` (§D — uniform tier-1 escalation, no per-mode\npolicy). Consumers driving the WebUI overlay (`§E`) treat all `Escalate`\nvariants as the terminal failure state regardless of reason."
+        "description": "Phase of the Producer handoff-and-restart ritual (DR\n`2026-05-14-handoff-lifecycle-and-kill-ux.md` §C; operator review gate\n`2026-06-19` aim `handoff-review-gate`, #547).\n\nPhases progress strictly in the order `Prompted → Validated →\nAwaitingReview → Killed → Launching → Ready`; any step can short-circuit to\n`Escalate` with a machine-readable `reason` (§D — uniform tier-1\nescalation, no per-mode policy). A `request-rewrite` decision at the\n`AwaitingReview` gate loops back to a fresh `Prompted → Validated →\nAwaitingReview` round (the old Producer is re-prompted, never killed until\nthe operator approves). Consumers driving the WebUI overlay (`§E`) treat all\n`Escalate` variants as the terminal failure state regardless of reason."
       },
       "HandoffsResponse": {
         "type": "object",

--- a/clients/react/src/types/generated/HandoffRitualEvent.ts
+++ b/clients/react/src/types/generated/HandoffRitualEvent.ts
@@ -24,7 +24,7 @@ message?: string,
 /**
  * Canonical AgentId of the newly spawned Producer. Set only on `Ready`.
  */
-new_agent_id?: string, } & ({ "phase": "prompted" } | { "phase": "validated" } | { "phase": "killed" } | { "phase": "launching" } | { "phase": "ready" } | { "phase": "escalate", 
+new_agent_id?: string, } & ({ "phase": "prompted" } | { "phase": "validated" } | { "phase": "awaiting_review" } | { "phase": "killed" } | { "phase": "launching" } | { "phase": "ready" } | { "phase": "escalate", 
 /**
  * Machine-readable failure reason (see variant doc).
  */

--- a/clients/react/src/types/generated/HandoffRitualPhase.ts
+++ b/clients/react/src/types/generated/HandoffRitualPhase.ts
@@ -2,15 +2,19 @@
 
 /**
  * Phase of the Producer handoff-and-restart ritual (DR
- * `2026-05-14-handoff-lifecycle-and-kill-ux.md` §C).
+ * `2026-05-14-handoff-lifecycle-and-kill-ux.md` §C; operator review gate
+ * `2026-06-19` aim `handoff-review-gate`, #547).
  *
- * Phases progress strictly in the order `Prompted → Validated → Killed →
- * Launching → Ready`; any step can short-circuit to `Escalate` with a
- * machine-readable `reason` (§D — uniform tier-1 escalation, no per-mode
- * policy). Consumers driving the WebUI overlay (`§E`) treat all `Escalate`
- * variants as the terminal failure state regardless of reason.
+ * Phases progress strictly in the order `Prompted → Validated →
+ * AwaitingReview → Killed → Launching → Ready`; any step can short-circuit to
+ * `Escalate` with a machine-readable `reason` (§D — uniform tier-1
+ * escalation, no per-mode policy). A `request-rewrite` decision at the
+ * `AwaitingReview` gate loops back to a fresh `Prompted → Validated →
+ * AwaitingReview` round (the old Producer is re-prompted, never killed until
+ * the operator approves). Consumers driving the WebUI overlay (`§E`) treat all
+ * `Escalate` variants as the terminal failure state regardless of reason.
  */
-export type HandoffRitualPhase = { "phase": "prompted" } | { "phase": "validated" } | { "phase": "killed" } | { "phase": "launching" } | { "phase": "ready" } | { "phase": "escalate", 
+export type HandoffRitualPhase = { "phase": "prompted" } | { "phase": "validated" } | { "phase": "awaiting_review" } | { "phase": "killed" } | { "phase": "launching" } | { "phase": "ready" } | { "phase": "escalate", 
 /**
  * Machine-readable failure reason (see variant doc).
  */


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@3c2f6801e97f887eef3935a51d7563abd02967da

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/corevents.schema.json                        | 19 +++++++++++++++++--
 api-spec/openapi.json                                 | 19 +++++++++++++++++--
 .../react/src/types/generated/HandoffRitualEvent.ts   |  2 +-
 .../react/src/types/generated/HandoffRitualPhase.ts   | 18 +++++++++++-------
 4 files changed, 46 insertions(+), 12 deletions(-)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ハンドオフ儀式プロセスにオペレータレビューゲート段階を追加しました。フェーズ進行が「Prompted → Validated → AwaitingReview → Killed → Launching → Ready」に更新されます。

* **ドキュメント**
  * エスカレーション（失敗）時のエラーコード仕様を更新しました。レビュー関連の失敗パターンを明確化しています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->