### PR TITLE
chore(gen): sync generated spec + types from tmai-core@534d092f76

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -1108,9 +1108,8 @@
       "description": "Source of agent state detection\n\nWire format is `snake_case` to match the contract-layer enums\n(`VendorAvailabilityState`, `CapacityCauseSummary`, `BundleStatus`). The\nPascalCase names (e.g. `\"HttpHook\"`) shipped prior to #7 are still\naccepted on deserialization via `#[serde(alias = ...)]` so that\npreviously-persisted `MonitoredAgent.detection_source` payloads continue\nto round-trip.",
       "enum": [
         "http_hook",
-        "ipc_socket",
         "web_socket",
-        "capture_pane"
+        "pty_server"
       ],
       "type": "string"
     },

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -3376,9 +3376,8 @@
         "description": "Source of agent state detection\n\nWire format is `snake_case` to match the contract-layer enums\n(`VendorAvailabilityState`, `CapacityCauseSummary`, `BundleStatus`). The\nPascalCase names (e.g. `\"HttpHook\"`) shipped prior to #7 are still\naccepted on deserialization via `#[serde(alias = ...)]` so that\npreviously-persisted `MonitoredAgent.detection_source` payloads continue\nto round-trip.",
         "enum": [
           "http_hook",
-          "ipc_socket",
           "web_socket",
-          "capture_pane"
+          "pty_server"
         ]
       },
       "DiffSummarySnapshot": {

--- a/clients/ratatui/src/types/generated/detection_source.rs
+++ b/clients/ratatui/src/types/generated/detection_source.rs
@@ -11,7 +11,6 @@ use std::collections::HashMap;
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum DetectionSource {
     http_hook,
-    ipc_socket,
     web_socket,
-    capture_pane,
+    pty_server,
 }

--- a/clients/react/src/types/generated/DetectionSource.ts
+++ b/clients/react/src/types/generated/DetectionSource.ts
@@ -10,4 +10,4 @@
  * previously-persisted `MonitoredAgent.detection_source` payloads continue
  * to round-trip.
  */
-export type DetectionSource = "http_hook" | "ipc_socket" | "web_socket" | "capture_pane";
+export type DetectionSource = "http_hook" | "web_socket" | "pty_server";


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@534d092f76ecc131cbc79d8fe23077a01c0e52cd

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/corevents.schema.json                          | 3 +--
 api-spec/openapi.json                                   | 3 +--
 clients/ratatui/src/types/generated/detection_source.rs | 3 +--
 clients/react/src/types/generated/DetectionSource.ts    | 2 +-
 4 files changed, 4 insertions(+), 7 deletions(-)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * API仕様を更新しました。検出元を表す設定値が変更され、新しい検出方式に対応しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->