### PR TITLE
feat(aim-console): wire the "+" add-unit affordance to a real Producer launch

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -26,6 +26,7 @@ import {
   selectedRecordKey,
 } from "@/components/producer-console/r-panel/r-viewer/RRecordViewer";
 import { ProducerFeedChip } from "@/components/producer-feed/ProducerFeedChip";
+import { ProducerLaunchPicker } from "@/components/project/ProducerLaunchPicker";
 import { SecurityPanel } from "@/components/settings/SecurityPanel";
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import { TerminalList } from "@/components/terminal/TerminalList";
@@ -580,6 +581,18 @@ export function App() {
       .catch(() => toastInfo(`Add a unit by launching a Producer: ${cmd}`));
   }, [toastSuccess, toastInfo]);
 
+  // Aim-console "+" = the REAL "add unit = launch a Producer" path (the
+  // bootstrap the `producer-slot-invariant` safety-net presupposes — it only
+  // re-spawns slots that already hold a live Producer, so the FIRST occupant
+  // must come from an explicit launch act). Opens a repo-root picker and
+  // launches a Producer there via the existing `/api/spawn` path
+  // (`launchProducerAt` → derives the unit from the basename); the launch cwd
+  // DEFINES the unit (aim `producer-cwd`). No new endpoint (#788). The legacy
+  // UnitTabs "+" keeps the clipboard placeholder above; only the aim console
+  // gets the live launcher.
+  const [launchPickerOpen, setLaunchPickerOpen] = useState(false);
+  const openLaunchPicker = useCallback(() => setLaunchPickerOpen(true), []);
+
   // C1 close affordance (#540 / #546 companion). The per-tab confirm gate
   // lives in UnitTabs (close = kill, so never silent); this runs only after
   // the operator confirms. `closeUnitSlot` POSTs the core close (Producer +
@@ -719,17 +732,24 @@ export function App() {
   // is not rendered in this mode).
   if (consoleMode === "aim") {
     return (
-      <AimConsole
-        units={unitsData?.units ?? []}
-        activeUnitName={unitName}
-        onSelectUnit={handleSelectUnit}
-        onAddUnit={handleAddUnit}
-        onExit={toggleConsoleMode}
-        agents={agents}
-        currentProjectPath={currentProject}
-        trigger={triggerHandoff}
-        onOpenSettings={openSettingsFromOverride}
-      />
+      <>
+        <AimConsole
+          units={unitsData?.units ?? []}
+          activeUnitName={unitName}
+          onSelectUnit={handleSelectUnit}
+          onAddUnit={openLaunchPicker}
+          onExit={toggleConsoleMode}
+          agents={agents}
+          currentProjectPath={currentProject}
+          trigger={triggerHandoff}
+          onOpenSettings={openSettingsFromOverride}
+        />
+        <ProducerLaunchPicker
+          open={launchPickerOpen}
+          onClose={() => setLaunchPickerOpen(false)}
+          onLaunchProducerAt={launchProducerAt}
+        />
+      </>
     );
   }
 

--- a/clients/react/src/components/project/ProducerLaunchPicker.tsx
+++ b/clients/react/src/components/project/ProducerLaunchPicker.tsx
@@ -1,0 +1,81 @@
+import { useEffect, useState } from "react";
+import { DirBrowser } from "@/components/project/DirBrowser";
+import { api } from "@/lib/api";
+
+interface ProducerLaunchPickerProps {
+  /** Whether the directory picker is open. */
+  open: boolean;
+  /** Close the picker without launching (backdrop / cancel / post-launch). */
+  onClose: () => void;
+  /** Launch a Producer at the picked repo root — App's `launchProducerAt`,
+   *  which derives the unit name from the path basename and spawns via the
+   *  existing `/api/spawn` (no new launch endpoint — #788). */
+  onLaunchProducerAt: (path: string) => void;
+}
+
+// Modal repo-root picker that LAUNCHES a Producer at the chosen directory —
+// the aim-console's "add unit = launch a Producer" path. The launch DEFINES
+// the unit: the launch cwd becomes the project (aim `producer-cwd`), which is
+// the bootstrap the `producer-slot-invariant` safety-net presupposes (it only
+// re-spawns slots that already have a live Producer; the FIRST occupant must
+// come from an explicit launch act like this one).
+//
+// Reuses `DirBrowser` and the `actionSlot` "Launch Producer here" affordance
+// exactly as `ProducerConsoleActions` does for the legacy console, so both
+// surfaces drive the same `/api/spawn` launch path.
+export function ProducerLaunchPicker({
+  open,
+  onClose,
+  onLaunchProducerAt,
+}: ProducerLaunchPickerProps) {
+  const [defaultRoot, setDefaultRoot] = useState<string | null>(null);
+
+  // Pull `[general] default_project_root` lazily on open so an edit in
+  // GeneralSection flips the picker's start dir on the next open without a
+  // reload. A transient fetch failure just leaves `defaultRoot = null` and
+  // `DirBrowser` falls back to `~`. (Mirrors `ProducerConsoleActions`.)
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const g = await api.getGeneralSettings();
+        if (!cancelled) setDefaultRoot(g.default_project_root);
+      } catch {
+        // intentional no-op — see comment above.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [open]);
+
+  if (!open) return null;
+
+  return (
+    <DirBrowser
+      startPath={defaultRoot ?? undefined}
+      onCancel={onClose}
+      actionSlot={(currentPath) => (
+        <div className="flex w-full flex-col gap-1.5">
+          <button
+            type="button"
+            onClick={() => {
+              onClose();
+              onLaunchProducerAt(currentPath);
+            }}
+            disabled={!currentPath}
+            className="w-full rounded bg-primary/10 px-3 py-1.5 text-center text-xs text-primary transition-colors hover:bg-primary/20 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            Launch Producer here ▸
+          </button>
+          <p className="text-[10px] text-subtle-foreground">
+            tmai will spawn{" "}
+            <code className="text-muted-foreground">tmai producer &lt;basename&gt;</code> in the
+            chosen repo — the launch cwd defines the unit.
+          </p>
+        </div>
+      )}
+    />
+  );
+}

--- a/clients/react/src/components/project/__tests__/ProducerLaunchPicker.test.tsx
+++ b/clients/react/src/components/project/__tests__/ProducerLaunchPicker.test.tsx
@@ -1,0 +1,56 @@
+// @vitest-environment jsdom
+//
+// ProducerLaunchPicker — the aim-console "add unit = launch a Producer" path.
+// The picker reuses DirBrowser; on "Launch Producer here" it forwards the
+// browsed repo root to `onLaunchProducerAt` (App's `launchProducerAt`, the
+// existing /api/spawn launch — no new endpoint, #788) and closes.
+//
+// `api.getGeneralSettings` (start-dir default) and `api.listDirectories`
+// (DirBrowser's tree) are mocked so the picker never hits the network.
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { DirEntry } from "@/lib/api";
+import { ProducerLaunchPicker } from "../ProducerLaunchPicker";
+
+vi.mock("@/lib/api", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
+  return {
+    ...actual,
+    api: {
+      ...actual.api,
+      getGeneralSettings: vi.fn(async () => ({ default_project_root: "/home/u" })),
+      listDirectories: vi.fn(
+        async (_path?: string): Promise<DirEntry[]> => [
+          { path: "/home/u/proj", name: "proj", is_git: true },
+        ],
+      ),
+    },
+  };
+});
+
+describe("ProducerLaunchPicker", () => {
+  it("renders nothing when closed", () => {
+    const { container } = render(
+      <ProducerLaunchPicker open={false} onClose={vi.fn()} onLaunchProducerAt={vi.fn()} />,
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("launches a Producer at the browsed repo root and closes", async () => {
+    const onClose = vi.fn();
+    const onLaunchProducerAt = vi.fn();
+    render(<ProducerLaunchPicker open onClose={onClose} onLaunchProducerAt={onLaunchProducerAt} />);
+
+    // DirBrowser loads the default root → currentPath is set → the
+    // "Launch Producer here" action enables.
+    const launchBtn = (await screen.findByRole("button", {
+      name: /Launch Producer here/,
+    })) as HTMLButtonElement;
+    await waitFor(() => expect(launchBtn.disabled).toBe(false));
+
+    fireEvent.click(launchBtn);
+    expect(onLaunchProducerAt).toHaveBeenCalledWith("/home/u");
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary
The aim-console's top-bar `+` ("Add unit — launch Producer") was a **clipboard placeholder** (#788 C1's deliberate v1 — copy `tmai producer <path>` and toast). So a unit with no live Producer had **no way to start one from the aim-console**.

This matters because `producer-slot-invariant` (tmai-core `doc/aims/producer-slot-invariant.md`) is implemented as a **homeostatic respawn safety-net for slots derived from a LIVE Producer** (`register_live_producer_slots`, no durable state) — it does **not** cold-bootstrap a configured-but-never-launched unit. The first occupant must come from an **explicit launch act**, and that path was missing from the aim-console.

## What changed
- **New `ProducerLaunchPicker`** (`clients/react/src/components/project/ProducerLaunchPicker.tsx`): a modal repo-root picker that reuses `DirBrowser` + the "Launch Producer here" `actionSlot`, exactly mirroring `ProducerConsoleActions` for the legacy console. On pick it forwards the repo root to `onLaunchProducerAt`.
- **`App.tsx`**: render `ProducerLaunchPicker` in the aim-mode return and point the aim-console `+` (`onAddUnit`) at it. Launch goes through the existing `launchProducerAt` → `/api/spawn` (**no new launch endpoint** — within #788's constraint). The launch cwd **defines the unit** (aim `producer-cwd`).
- The legacy `UnitTabs` `+` keeps its clipboard placeholder (minimal blast radius); only the aim console gets the live launcher.

## Why this shape
`AimConsole` itself is unchanged — its `+` already calls `onAddUnit`; only what that handler *does* changed. App owns the picker so the shell stays presentational.

## Testing
- `pnpm lint` ✓ · `pnpm build` ✓ · `pnpm test` ✓ (119 files, 1082 passed)
- New `ProducerLaunchPicker.test.tsx`: closed → renders nothing; open → "Launch Producer here" forwards the browsed repo root to `onLaunchProducerAt` and closes.

## Related
- Implements the bootstrap-path PROCESS `[todo]` recorded on tmai-core `doc/aims/producer-slot-invariant.md` (operator-decided bearing: launch-first).
- Follow-up candidate: unify the duplicated `DirBrowser`+launch `actionSlot` between `ProducerLaunchPicker` and `ProducerConsoleActions`; and decide whether the legacy `UnitTabs` `+` should adopt the live launcher too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * Aim コンソール内の「＋（ユニット追加）」から、ディレクトリブラウザを使用して任意のリポジトリルートを選択し、そこから直接 Producer を起動できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->