### PR TITLE
feat(aim-console): per-unit close (×) affordance — surface the producer-kill teardown

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -738,6 +738,7 @@ export function App() {
           activeUnitName={unitName}
           onSelectUnit={handleSelectUnit}
           onAddUnit={openLaunchPicker}
+          onCloseUnit={handleCloseUnit}
           onExit={toggleConsoleMode}
           agents={agents}
           currentProjectPath={currentProject}

--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -30,6 +30,7 @@
 // writes it back.
 
 import { type CSSProperties, useCallback, useState } from "react";
+import { useConfirm } from "@/components/layout/ConfirmDialog";
 import { useUnitAttention } from "@/hooks/useUnitAttention";
 import type { AgentSnapshot, TriggerHandoffRitualRequest, UnitResponse } from "@/lib/api";
 import {
@@ -74,8 +75,14 @@ interface AimConsoleProps {
   activeUnitName: string | null;
   /** Re-scope the focused unit to the clicked tab. */
   onSelectUnit: (unit: UnitResponse) => void;
-  /** "Add unit = launch Producer" affordance (App's clipboard placeholder). */
+  /** "Add unit = launch Producer" affordance — opens App's repo-root launch
+   *  picker (the launch cwd defines the unit; aim `producer-cwd`). */
   onAddUnit: () => void;
+  /** Close the unit's Producer slot — kill Producer + dispatched workers +
+   *  footer bash (the `producer-kill` teardown, the sole `producer-slot-
+   *  invariant` carve-out: close does NOT respawn). Gated behind an always-on
+   *  confirm in the tab; called ONLY after that confirm is accepted. */
+  onCloseUnit: (unit: UnitResponse) => void;
   /** Switch back to the existing ProducerConsole (the default view). The
    *  ENTER toggle lives in StatusBar; this is its EXIT pair, since the
    *  full-window aim console replaces the existing chrome incl. StatusBar. */
@@ -100,6 +107,7 @@ export function AimConsole({
   activeUnitName,
   onSelectUnit,
   onAddUnit,
+  onCloseUnit,
   onExit,
   agents,
   currentProjectPath,
@@ -186,6 +194,7 @@ export function AimConsole({
             unit={unit}
             active={unit.name === activeUnitName}
             onSelect={() => onSelectUnit(unit)}
+            onClose={() => onCloseUnit(unit)}
           />
         ))}
         <button
@@ -270,39 +279,70 @@ function AimUnitTab({
   unit,
   active,
   onSelect,
+  onClose,
 }: {
   unit: UnitResponse;
   active: boolean;
   onSelect: () => void;
+  onClose: () => void;
 }) {
   const { data } = useUnitAttention(unit.name);
   const highCount = data?.entries.filter((e) => e.level === "high").length ?? 0;
 
+  // Always-on confirm gate (mirrors the legacy UnitTabs, same copy): close =
+  // kill (Producer + workers + footer bash), so it is never silent. Nesting a
+  // <button> inside the tab <button> is invalid, so the close × is a sibling
+  // under a wrapper, exactly as UnitTabs does it.
+  const confirm = useConfirm();
+  const handleClose = async () => {
+    const ok = await confirm({
+      title: `Close unit ${unit.name}?`,
+      message:
+        "Close kills this unit's Producer, its dispatched workers, and its footer bash. " +
+        "This is a kill, not a delete — worktrees and uncommitted work stay on disk.",
+      confirmLabel: "Close unit",
+      cancelLabel: "Cancel",
+      variant: "danger",
+    });
+    if (ok) onClose();
+  };
+
   return (
-    <button
-      type="button"
-      className={cn("ac-utab", active && "on")}
-      onClick={onSelect}
-      aria-current={active ? "true" : undefined}
-      aria-label={`unit: ${unit.name}`}
-      title={`unit: ${unit.name}`}
-    >
-      <span className="ac-d" />
-      {unit.repos.map((repo) => (
-        <span
-          key={repo.path}
-          className={cn("ac-rp", repo.primary && "pri")}
-          data-testid="aim-repo-pill"
-          data-primary={repo.primary ? "true" : "false"}
-        >
-          {repoBasename(repo.path)}
-        </span>
-      ))}
-      {highCount > 0 && (
-        <span className="ac-um" title={`${highCount} owed attention`}>
-          ⚠{highCount}
-        </span>
-      )}
-    </button>
+    <div className="ac-utab-wrap">
+      <button
+        type="button"
+        className={cn("ac-utab", active && "on")}
+        onClick={onSelect}
+        aria-current={active ? "true" : undefined}
+        aria-label={`unit: ${unit.name}`}
+        title={`unit: ${unit.name}`}
+      >
+        <span className="ac-d" />
+        {unit.repos.map((repo) => (
+          <span
+            key={repo.path}
+            className={cn("ac-rp", repo.primary && "pri")}
+            data-testid="aim-repo-pill"
+            data-primary={repo.primary ? "true" : "false"}
+          >
+            {repoBasename(repo.path)}
+          </span>
+        ))}
+        {highCount > 0 && (
+          <span className="ac-um" title={`${highCount} owed attention`}>
+            ⚠{highCount}
+          </span>
+        )}
+      </button>
+      <button
+        type="button"
+        className="ac-uclose"
+        onClick={handleClose}
+        aria-label={`Close unit ${unit.name}`}
+        title={`Close unit ${unit.name} — kill Producer + workers + footer bash (worktrees stay)`}
+      >
+        ×
+      </button>
+    </div>
   );
 }

--- a/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
@@ -15,8 +15,9 @@
 // network, no act-warning churn) — the shell assertions don't depend on the
 // data.
 
-import { fireEvent, render, screen, within } from "@testing-library/react";
+import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
+import { ConfirmProvider } from "@/components/layout/ConfirmDialog";
 import type { AimsResponse, UnitIssuesResponse, UnitPrsResponse, UnitResponse } from "@/lib/api";
 import { UIPrefsProvider } from "@/lib/ui-prefs-provider";
 import { AimConsole } from "../AimConsole";
@@ -56,6 +57,7 @@ function renderConsole(overrides: Partial<Parameters<typeof AimConsole>[0]> = {}
     activeUnitName: "tmai" as string | null,
     onSelectUnit: vi.fn(),
     onAddUnit: vi.fn(),
+    onCloseUnit: vi.fn(),
     onExit: vi.fn(),
     // S3 Session-pane wiring — empty here so the shell tests stay
     // data-agnostic (no live sessions → the pane parks in its empty state,
@@ -69,7 +71,9 @@ function renderConsole(overrides: Partial<Parameters<typeof AimConsole>[0]> = {}
   };
   render(
     <UIPrefsProvider>
-      <AimConsole {...props} />
+      <ConfirmProvider>
+        <AimConsole {...props} />
+      </ConfirmProvider>
     </UIPrefsProvider>,
   );
   return props;
@@ -141,6 +145,14 @@ describe("AimConsole — S1 shell", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Return to the Producer console" }));
     expect(props.onExit).toHaveBeenCalledTimes(1);
+  });
+
+  it("closes a unit only after the confirm gate (× → confirm → onCloseUnit)", async () => {
+    const props = renderConsole();
+    // The per-tab × opens an always-on confirm; onCloseUnit fires only on accept.
+    fireEvent.click(screen.getByRole("button", { name: "Close unit tmai" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Close unit" }));
+    await waitFor(() => expect(props.onCloseUnit).toHaveBeenCalledWith(UNITS[0]));
   });
 
   it("falls back the meta readout to the first unit when none is focused", () => {

--- a/clients/react/src/components/aim-console/__tests__/Gutters.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/Gutters.test.tsx
@@ -13,6 +13,7 @@
 
 import { fireEvent, render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ConfirmProvider } from "@/components/layout/ConfirmDialog";
 import type {
   AgentSnapshot,
   AimsResponse,
@@ -62,17 +63,20 @@ const UNITS: UnitResponse[] = [
 function renderConsole() {
   render(
     <UIPrefsProvider>
-      <AimConsole
-        units={UNITS}
-        activeUnitName="tmai"
-        onSelectUnit={vi.fn()}
-        onAddUnit={vi.fn()}
-        onExit={vi.fn()}
-        agents={[] as AgentSnapshot[]}
-        currentProjectPath="/home/u/tmai"
-        trigger={vi.fn()}
-        onOpenSettings={vi.fn()}
-      />
+      <ConfirmProvider>
+        <AimConsole
+          units={UNITS}
+          activeUnitName="tmai"
+          onSelectUnit={vi.fn()}
+          onAddUnit={vi.fn()}
+          onCloseUnit={vi.fn()}
+          onExit={vi.fn()}
+          agents={[] as AgentSnapshot[]}
+          currentProjectPath="/home/u/tmai"
+          trigger={vi.fn()}
+          onOpenSettings={vi.fn()}
+        />
+      </ConfirmProvider>
     </UIPrefsProvider>,
   );
 }

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -189,6 +189,32 @@
 .aim-console .ac-uadd:hover {
   color: var(--cyan);
 }
+/* per-tab close (×) — the producer-kill teardown affordance, a sibling to the
+   tab button (a nested <button> is invalid). Mirrors the legacy UnitTabs ×:
+   quiet by default, danger on hover. */
+.aim-console .ac-utab-wrap {
+  display: inline-flex;
+  align-items: center;
+}
+.aim-console .ac-uclose {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 16px;
+  height: 16px;
+  margin: 0 6px 0 -2px;
+  border: none;
+  background: transparent;
+  color: var(--faint);
+  cursor: pointer;
+  font-size: 13px;
+  line-height: 1;
+  border-radius: 3px;
+}
+.aim-console .ac-uclose:hover {
+  color: var(--danger);
+  background: #221111;
+}
 .aim-console .ac-sp {
   flex: 1;
 }


### PR DESCRIPTION
## Summary
The aim-console could **open** units (#850 — `+` launches a Producer) but had **no way to close** one. Because `producer-slot-invariant` respawns any open slot whose Producer dies, killing a Producer alone just respawns it — the **only terminal** is closing the unit. That's the `producer-kill` aim: close = kill Producer + dispatched workers + footer bash together (the sole slot-invariant carve-out — close does **not** respawn), **kill ≠ delete** (worktrees / uncommitted work stay on disk).

That teardown **already exists** (backend `POST /api/units/{unit}/close` + `closeUnitSlot`) and is wired in the legacy `UnitTabs`, but the aim-console never surfaced it. This PR adds the symmetric counterpart to #850's launch.

## What changed
- **`AimUnitTab`** (`AimConsole.tsx`): a per-tab close `×` rendered as a **sibling** of the tab button (nested `<button>` is invalid HTML), behind an **always-on confirm** (`useConfirm`, identical copy to `UnitTabs`). On accept it calls the new `onCloseUnit`.
- **`AimConsole`**: new `onCloseUnit` prop; **`App.tsx`** aim-mode return passes the existing `handleCloseUnit` (→ `closeUnitSlot`). No new backend.
- **`aim-console.css`**: `.ac-utab-wrap` + `.ac-uclose` tokens (quiet by default, danger on hover).

## Why this shape
Mirrors the launch path (#850) and the legacy `UnitTabs` close exactly — same teardown, same confirm copy — so both consoles read identically and there's one close mechanism, not two.

## Testing
- `pnpm lint` ✓ · `pnpm build` ✓ · `pnpm test` ✓ (119 files, 1083 passed)
- `AimConsole.test`: new close test (`×` → confirm → `onCloseUnit`) + `ConfirmProvider` wrapper.
- `Gutters.test`: updated for the new required prop + `ConfirmProvider`.

## Related
- Symmetric to #850 (aim-console launch). Together they make the aim-console self-sufficient (open + close) — the precondition for making it primary.
- Realizes the UI face of tmai-core `doc/aims/producer-kill.md`; I'll reconcile that aim's PROCESS marks to reality in a separate doc commit (core close + this surface done; remaining = #532 quit-dialog semantics).
- Follow-up candidate: unify the duplicated `useConfirm` close block between `AimUnitTab` and `UnitTabs`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)