### PR TITLE
feat(aim-console): make the aim console the default (primary) surface

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -80,7 +80,11 @@ function rPanelRatioToWidth(ratio: number): number {
   return (1 - ratio) * rPanelViewportWidth();
 }
 
-export function App() {
+export function App({
+  initialConsoleMode = DEFAULT_CONSOLE_MODE,
+}: {
+  initialConsoleMode?: ConsoleMode;
+} = {}) {
   // Apply the active WebUI theme's css vars to <html> and keep them in
   // sync when the user switches themes in Settings — re-skins the whole
   // UI live, no reload.
@@ -126,15 +130,14 @@ export function App() {
     "agents",
   );
   // Coexist console-mode toggle (aim node `tmai-core:doc/aims/aim-ui.md`).
-  // A sibling of `mainPanel`: which TOP-LEVEL console is shown. `producer`
-  // (default) keeps the entire existing shell (sidebar + digest/conversation
-  // + R panel); `aim` swaps the whole window for the new full-screen
-  // <AimConsole>. Aim-ui is opt-in via the StatusBar button and stays opt-in
-  // until the aim mechanism matures — the existing console is never ripped
-  // out. Deliberately NOT persisted to ui-prefs in S1: the aim panes are
-  // stubs, so a reload should land back on the working Producer console
-  // rather than a stub-only screen.
-  const [consoleMode, setConsoleMode] = useState<ConsoleMode>(DEFAULT_CONSOLE_MODE);
+  // A sibling of `mainPanel`: which TOP-LEVEL console is shown. `aim` (now the
+  // DEFAULT — see `console-mode.ts`, hub #850/#851 made it self-sufficient)
+  // swaps the whole window for the full-screen <AimConsole>; `producer` keeps
+  // the legacy shell (sidebar + digest/conversation + R panel) and is the
+  // opt-OUT via the aim console's EXIT toggle. Not persisted to ui-prefs: the
+  // default IS the landing mode on every load (tests pin the legacy console
+  // via the `initialConsoleMode` prop).
+  const [consoleMode, setConsoleMode] = useState<ConsoleMode>(initialConsoleMode);
   const toggleConsoleMode = useCallback(
     () => setConsoleMode((m) => (m === "aim" ? "producer" : "aim")),
     [],

--- a/clients/react/src/__tests__/App.console-mode.test.tsx
+++ b/clients/react/src/__tests__/App.console-mode.test.tsx
@@ -4,10 +4,10 @@
 // `tmai-core:doc/aims/aim-ui.md`, S1). The StatusBar hosts a console-mode
 // toggle; App holds the `consoleMode` sibling state. The contract:
 //
-//   1. DEFAULT is the existing ProducerConsole — aim-ui is opt-in;
-//   2. the StatusBar toggle switches the WHOLE shell to the full-window
-//      <AimConsole> (the sidebar / digest / R panel are replaced);
-//   3. the aim console's own EXIT toggle returns to the Producer console.
+//   1. DEFAULT is the full-window <AimConsole> — it is now the primary surface;
+//   2. the aim console's own EXIT toggle returns to the legacy ProducerConsole
+//      (the sidebar / digest / R panel reappear);
+//   3. in producer mode the StatusBar toggle switches back to the aim console.
 //
 // The real <AimConsole> is covered by its own test; here it's stubbed so we
 // observe WHICH top-level view App renders, plus the exit seam.
@@ -179,25 +179,29 @@ beforeEach(() => {
 });
 
 describe("App — console-mode coexist toggle", () => {
-  it("defaults to the Producer console (aim-ui is opt-in)", () => {
+  it("defaults to the aim console (now the primary surface)", () => {
     renderWithProviders(<App />);
-    expect(screen.getByTestId("producer-console-stub")).toBeTruthy();
-    expect(screen.queryByTestId("aim-console-stub")).toBeNull();
+    expect(screen.getByTestId("aim-console-stub")).toBeTruthy();
+    expect(screen.queryByTestId("producer-console-stub")).toBeNull();
   });
 
-  it("switches the whole shell to the aim console and back", () => {
+  it("exits the aim console to the Producer console and back", () => {
     renderWithProviders(<App />);
 
-    // Enter aim-ui via the StatusBar toggle.
-    fireEvent.click(screen.getByLabelText("Switch to the aim console (preview)"));
+    // Default is the full-window aim console — the existing shell (digest +
+    // R panel) is replaced.
     expect(screen.getByTestId("aim-console-stub")).toBeTruthy();
-    // The existing shell is replaced — digest AND R panel are gone.
     expect(screen.queryByTestId("producer-console-stub")).toBeNull();
     expect(screen.queryByTestId("r-panel-stub")).toBeNull();
 
-    // Exit via the aim console's own toggle → back to the Producer console.
+    // Exit via the aim console's own toggle → the legacy Producer console.
     fireEvent.click(screen.getByText("exit-aim"));
     expect(screen.getByTestId("producer-console-stub")).toBeTruthy();
     expect(screen.queryByTestId("aim-console-stub")).toBeNull();
+
+    // Re-enter via the StatusBar toggle → back to the aim console.
+    fireEvent.click(screen.getByLabelText("Switch to the aim console (preview)"));
+    expect(screen.getByTestId("aim-console-stub")).toBeTruthy();
+    expect(screen.queryByTestId("producer-console-stub")).toBeNull();
   });
 });

--- a/clients/react/src/__tests__/App.handoff.test.tsx
+++ b/clients/react/src/__tests__/App.handoff.test.tsx
@@ -199,7 +199,7 @@ describe("App — handoff ritual wiring", () => {
       refresh: vi.fn(),
     });
 
-    renderWithProviders(<App />);
+    renderWithProviders(<App initialConsoleMode="producer" />);
 
     // No selection yet → digest, no conversation header.
     expect(screen.queryByTestId("conversation-header-stub")).toBeNull();
@@ -228,7 +228,7 @@ describe("App — handoff ritual wiring", () => {
       refresh: vi.fn(),
     });
 
-    renderWithProviders(<App />);
+    renderWithProviders(<App initialConsoleMode="producer" />);
 
     fireEvent.click(screen.getByTitle("claude:work"));
 
@@ -250,7 +250,7 @@ describe("App — handoff ritual wiring", () => {
       state: { kind: "in_progress", ritualId: "r-1", unit: "alpha", phases: [] },
     });
 
-    renderWithProviders(<App />);
+    renderWithProviders(<App initialConsoleMode="producer" />);
 
     // Overlay is present in the digest view …
     expect(screen.getByTestId("phase-row-prompted")).toBeTruthy();

--- a/clients/react/src/__tests__/App.r-panel.test.tsx
+++ b/clients/react/src/__tests__/App.r-panel.test.tsx
@@ -228,13 +228,13 @@ beforeEach(() => {
 
 describe("App — persistent R panel layout", () => {
   it("shows the digest in the centre AND the R panel on the right with no selection", () => {
-    renderWithProviders(<App />);
+    renderWithProviders(<App initialConsoleMode="producer" />);
     expect(screen.getByTestId("producer-console-stub")).toBeTruthy();
     expect(screen.getByTestId("r-panel-stub")).toBeTruthy();
   });
 
   it("keeps the R panel co-visible after an agent is selected (centre swaps, R stays)", () => {
-    renderWithProviders(<App />);
+    renderWithProviders(<App initialConsoleMode="producer" />);
 
     const agentBtn = screen.getByTitle("claude:abc");
     fireEvent.click(agentBtn);
@@ -248,7 +248,7 @@ describe("App — persistent R panel layout", () => {
     useResponsiveLayoutMock.mockReturnValue(responsive({ isNarrowScreen: true }));
     useSplitPaneMock.mockReturnValue(splitPane(true));
 
-    renderWithProviders(<App />);
+    renderWithProviders(<App initialConsoleMode="producer" />);
 
     expect(screen.queryByTestId("r-panel-stub")).toBeNull();
   });
@@ -256,7 +256,7 @@ describe("App — persistent R panel layout", () => {
   it("hides the R panel on mobile", () => {
     useResponsiveLayoutMock.mockReturnValue(responsive({ isMobileScreen: true }));
 
-    renderWithProviders(<App />);
+    renderWithProviders(<App initialConsoleMode="producer" />);
 
     expect(screen.queryByTestId("r-panel-stub")).toBeNull();
   });
@@ -269,7 +269,7 @@ describe("App — persistent R panel layout", () => {
       refresh: vi.fn(),
     });
 
-    renderWithProviders(<App />);
+    renderWithProviders(<App initialConsoleMode="producer" />);
 
     expect(screen.getByTestId("console-current-project").textContent).toBe("/p/alpha");
 
@@ -280,7 +280,7 @@ describe("App — persistent R panel layout", () => {
   });
 
   it("focus mode: a focus renders the viewer INSIDE the single R panel column (no additive sibling)", () => {
-    renderWithProviders(<App />);
+    renderWithProviders(<App initialConsoleMode="producer" />);
 
     // No focus yet → no viewer anywhere.
     expect(screen.queryByTestId("r-pr-viewer-stub")).toBeNull();
@@ -299,7 +299,7 @@ describe("App — persistent R panel layout", () => {
   });
 
   it("focus mode: the ‹ Inventory back affordance clears the focus (returns to inventory)", () => {
-    renderWithProviders(<App />);
+    renderWithProviders(<App initialConsoleMode="producer" />);
 
     fireEvent.click(screen.getByText("focus-pr"));
     expect(screen.getByTestId("r-pr-viewer-stub")).toBeTruthy();

--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -7,10 +7,11 @@
 // node `aim-ui` (`tmai-core:doc/aims/aim-ui.md`), part of the aim-model
 // dogfood.
 //
-// COEXIST, DO NOT RIP: this is opt-in behind a StatusBar toggle; the
-// existing ProducerConsole stays the default (see `console-mode.ts`). The
-// dev-tool tokens are scoped to `.aim-console` in `styles/aim-console.css`
-// so they never bleed into the existing console.
+// COEXIST, DO NOT RIP: this is now the DEFAULT surface (see `console-mode.ts`,
+// hub #850 / #851 made it self-sufficient: open + close units); the legacy
+// ProducerConsole is the opt-OUT via this console's EXIT toggle. The dev-tool
+// tokens are scoped to `.aim-console` in `styles/aim-console.css` so they
+// never bleed into the existing console.
 //
 // SCOPE so far: the TOKEN LAYER + the SHELL (S1), the Aim pane (S2), the
 // Session pane (S3), its docked bash footer (S4), and the PR-rail lists (S5).

--- a/clients/react/src/components/aim-console/console-mode.ts
+++ b/clients/react/src/components/aim-console/console-mode.ts
@@ -1,14 +1,16 @@
 // The two top-level console views the operator can switch between.
 //
-// COEXIST, DO NOT RIP (aim node `tmai-core:doc/aims/aim-ui.md`): `producer`
-// is the existing hand-over digest console — the DEFAULT, and it stays the
-// default until the aim mechanism matures. `aim` is the new full-window
-// 3-pane aim console (S1 shell + S2–S4 fill).
-//
-// The toggle to ENTER aim-ui lives in StatusBar (the existing top chrome);
-// the toggle to EXIT lives in the aim console's own top bar, because the
-// aim console is a full-screen takeover that replaces the existing shell —
-// StatusBar included — while it is shown.
+// COEXIST, DO NOT RIP (aim node `tmai-core:doc/aims/aim-ui.md`): `aim` is the
+// full-window 3-pane aim console and is now the DEFAULT — the aim mechanism
+// matured enough to be the primary surface: it can open AND close units
+// (launch + per-tab close, hub #850 / #851), so it is self-sufficient as the
+// landing view. `producer` is the legacy hand-over digest console, kept as the
+// opt-OUT (reached via the aim console's own EXIT toggle; in `producer` mode
+// the StatusBar then hosts the toggle BACK to `aim`). The aim console is a
+// full-screen takeover that replaces the existing shell — StatusBar included —
+// while it is shown.
 export type ConsoleMode = "producer" | "aim";
 
-export const DEFAULT_CONSOLE_MODE: ConsoleMode = "producer";
+// `consoleMode` is App `useState` only (not persisted), so this default IS the
+// landing mode on every load. Set to "producer" to revert the primary surface.
+export const DEFAULT_CONSOLE_MODE: ConsoleMode = "aim";


### PR DESCRIPTION
## Summary
Make the **aim console the default landing surface**. It's now self-sufficient — open units (launch, #850) + close them (per-tab × + confirm, #851) — so it graduates from opt-in preview to primary.

- Flip `DEFAULT_CONSOLE_MODE` `producer` → `aim` (`console-mode.ts`).
- The legacy **ProducerConsole stays reachable** as the opt-OUT via the aim console's EXIT toggle (and, in producer mode, the StatusBar toggle back to aim). Nothing is ripped out.

## Why a prop, not just the const
`consoleMode` is App `useState` seeded from `DEFAULT_CONSOLE_MODE` and **not persisted**, so flipping the const alone changes the landing mode on every load — that's the whole change in production. But the producer-mode App suites (`App.handoff`, `App.r-panel`) render `<App />` and assert producer-console UI, which would now never mount. Added an **`initialConsoleMode` prop** to `App` (defaults to `DEFAULT_CONSOLE_MODE`) as a test seam: those suites pin `initialConsoleMode="producer"`; production `main.tsx` renders `<App />` (no prop) → aim.

## What changed
- `console-mode.ts`: `DEFAULT_CONSOLE_MODE = "aim"` + comments.
- `App.tsx`: `initialConsoleMode` prop seeds `consoleMode`; comments updated.
- `AimConsole.tsx`: COEXIST comment updated (now default, ProducerConsole is opt-out).
- Tests: `App.console-mode` inverted (asserts aim default + exit→producer→re-enter); `App.handoff` / `App.r-panel` pin `initialConsoleMode="producer"`.

## Testing
- `pnpm lint` ✓ · `pnpm build` ✓ · `pnpm test` ✓ (119 files, 1083 passed)

## Follow-up candidates
- Persist the operator's console-mode choice in `ui-prefs` (so an explicit switch survives reload), if wanted — currently the default is the landing mode every load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)