### PR TITLE
fix(webui): cancel pending resize-notify rAF on unmount (deterministic jsdom teardown crash)

### DIFF
--- a/clients/react/src/hooks/__tests__/useResponsiveLayout.test.ts
+++ b/clients/react/src/hooks/__tests__/useResponsiveLayout.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+//
+// The resize-notify rAF lifecycle. A sidebar / action-panel toggle schedules a
+// `window.dispatchEvent(new Event("resize"))` one frame later. The regression
+// these tests pin (#852 fallout): that deferred callback was never cancelled,
+// so when a test unmounted (or the jsdom env was torn down) before the frame
+// fired, it ran against a gone `window` and threw `ReferenceError: window is
+// not defined` — an unhandled error Vitest attributes to whichever test is
+// mid-flight (Gutters / RPanel in CI), failing the whole run.
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { useResponsiveLayout } from "../useResponsiveLayout";
+
+// jsdom doesn't ship matchMedia; the hook reads it on mount to seed the
+// narrow/mobile flags. A minimal always-matching stub is sufficient — we don't
+// exercise the breakpoint flags here.
+beforeAll(() => {
+  if (!window.matchMedia) {
+    Object.defineProperty(window, "matchMedia", {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: true,
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+        onchange: null,
+      })),
+    });
+  }
+});
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("useResponsiveLayout resize-notify rAF lifecycle", () => {
+  it("cancels a still-pending resize-notify rAF on unmount", () => {
+    // Capture the scheduled frame callback instead of running it, so we can
+    // assert what happens to a notification that is still in flight at unmount.
+    let nextId = 1;
+    const rafSpy = vi
+      .spyOn(window, "requestAnimationFrame")
+      .mockImplementation((_cb: FrameRequestCallback) => nextId++);
+    const cancelSpy = vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+
+    const { result, unmount } = renderHook(() => useResponsiveLayout());
+
+    // A toggle schedules exactly one one-frame-later resize notification.
+    act(() => result.current.toggleSidebar());
+    expect(rafSpy).toHaveBeenCalledTimes(1);
+
+    // Unmount before the frame fires: the pending rAF (id 1) must be cancelled
+    // so it can never run against a torn-down window. This is the fix — pre-fix
+    // the id was untracked and the callback fired post-teardown.
+    unmount();
+    expect(cancelSpy).toHaveBeenCalledWith(1);
+  });
+
+  it("dispatches a single resize when the scheduled frame fires while mounted", () => {
+    let scheduled: FrameRequestCallback | null = null;
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb: FrameRequestCallback) => {
+      scheduled = cb;
+      return 1;
+    });
+    const dispatchSpy = vi.spyOn(window, "dispatchEvent");
+
+    const { result } = renderHook(() => useResponsiveLayout());
+    act(() => result.current.toggleActionPanel());
+    expect(scheduled).not.toBeNull();
+
+    // Fire the captured frame: a single `resize` reaches resize-aware listeners.
+    act(() => (scheduled as FrameRequestCallback)(0));
+    const resizeDispatched = dispatchSpy.mock.calls.some(
+      ([e]) => e instanceof Event && e.type === "resize",
+    );
+    expect(resizeDispatched).toBe(true);
+  });
+
+  it("re-arming the toggle cancels the prior pending frame (no double resize)", () => {
+    // Two rapid toggles must coalesce to one pending frame — the second cancels
+    // the first so resize-aware components are nudged once, not twice.
+    let nextId = 1;
+    const cancelSpy = vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation(
+      (_cb: FrameRequestCallback) => nextId++,
+    );
+
+    const { result } = renderHook(() => useResponsiveLayout());
+    act(() => result.current.toggleSidebar());
+    act(() => result.current.toggleSidebar());
+
+    // The second schedule cancelled the first (id 1).
+    expect(cancelSpy).toHaveBeenCalledWith(1);
+  });
+});

--- a/clients/react/src/hooks/useResponsiveLayout.ts
+++ b/clients/react/src/hooks/useResponsiveLayout.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 const STORAGE_KEY_SIDEBAR = "tmai:sidebar-collapsed";
 const STORAGE_KEY_ACTION_PANEL = "tmai:action-panel-collapsed";
@@ -94,6 +94,35 @@ export function useResponsiveLayout(): UseResponsiveLayoutResult {
     return () => mql.removeEventListener("change", handler);
   }, []);
 
+  // A sidebar / action-panel toggle nudges resize-aware components (xterm.js,
+  // the gutter re-clamp) one frame later, once the layout has settled. The rAF
+  // id is tracked in a ref so a still-pending notification is cancelled on
+  // unmount — otherwise the deferred callback can fire AFTER its environment is
+  // gone (the jsdom test teardown, or a fast unmount) and throw
+  // `ReferenceError: window is not defined`, which Vitest surfaces as an
+  // unhandled error that fails the whole run, landing on whichever test is
+  // mid-flight. The `typeof window` guards are belt-and-suspenders for the same
+  // teardown race.
+  const resizeRaf = useRef<number | null>(null);
+  const notifyResize = useCallback(() => {
+    if (typeof window === "undefined") return;
+    if (resizeRaf.current !== null) cancelAnimationFrame(resizeRaf.current);
+    resizeRaf.current = requestAnimationFrame(() => {
+      resizeRaf.current = null;
+      if (typeof window !== "undefined") {
+        window.dispatchEvent(new Event("resize"));
+      }
+    });
+  }, []);
+  useEffect(() => {
+    return () => {
+      if (resizeRaf.current !== null) {
+        cancelAnimationFrame(resizeRaf.current);
+        resizeRaf.current = null;
+      }
+    };
+  }, []);
+
   // Toggle sidebar with localStorage persistence
   const toggleSidebar = useCallback(() => {
     setSidebarCollapsed((prev) => {
@@ -103,11 +132,10 @@ export function useResponsiveLayout(): UseResponsiveLayoutResult {
       } catch {
         // ignore
       }
-      // Notify xterm.js and other resize-aware components
-      requestAnimationFrame(() => window.dispatchEvent(new Event("resize")));
       return next;
     });
-  }, []);
+    notifyResize();
+  }, [notifyResize]);
 
   // Toggle action panel with localStorage persistence
   const toggleActionPanel = useCallback(() => {
@@ -118,10 +146,10 @@ export function useResponsiveLayout(): UseResponsiveLayoutResult {
       } catch {
         // ignore
       }
-      requestAnimationFrame(() => window.dispatchEvent(new Event("resize")));
       return next;
     });
-  }, []);
+    notifyResize();
+  }, [notifyResize]);
 
   const toggleMobileDrawer = useCallback(() => {
     setMobileDrawerOpen((prev) => !prev);


### PR DESCRIPTION
## What
`useResponsiveLayout`'s sidebar / action-panel toggles scheduled a one-frame-later `requestAnimationFrame(() => window.dispatchEvent(new Event("resize")))` whose id was never tracked, so the pending frame could not be cancelled.

## Why it broke main
In the Vitest (jsdom) suite, a toggle scheduled on the **default aim-console render path** — surfaced when #852 made the aim console the primary surface — fired **after** its environment was torn down, throwing `ReferenceError: window is not defined`. Vitest reports that as an *unhandled error* and fails the **whole run**, attributing it to whichever test is mid-flight (`Gutters.test.tsx` on `main`, `RPanel.test.tsx` on the bot PR run). So hub `main`'s **Build React WebUI** went red deterministically from the #852 merge, and every subsequent PR's React build (including the gen-spec bot PR **#853**) inherited the red — masking the bot PR's own validity.

## Fix
- Track the pending rAF id in a ref; **cancel it on unmount** so it can never run against a gone `window`.
- Coalesce rapid toggles (the second cancels the first) → one resize nudge, not two.
- `typeof window` guards as belt-and-suspenders for the same teardown race.
- Behaviour while mounted is unchanged: one `resize` event one frame after a toggle.

## Tests
New `useResponsiveLayout.test.ts` pins cancel-on-unmount, single-dispatch-while-mounted, and toggle-coalesce.

## Local verification (mirrors CI)
- `biome check src/` → exit 0 (pre-existing unrelated warning only)
- `tsc -b` → clean
- `vitest run` → **120 files, 1086 passed / 2 skipped** (the previously-failing suite is green)
- `vite build` → clean

Unblocks #853 (its React build re-runs green once this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)