### PR TITLE
fix(webui): drop post-unmount setState in R-panel data hooks (shared usePolledResource)

### DIFF
--- a/clients/react/src/hooks/__tests__/usePolledResource.test.ts
+++ b/clients/react/src/hooks/__tests__/usePolledResource.test.ts
@@ -1,0 +1,150 @@
+// @vitest-environment jsdom
+//
+// The shared R-panel resource hook. The regression these tests pin: an
+// in-flight fetch that resolves after the consumer unmounts (or after the
+// depKey moves on) must be DROPPED, never stamped via setState. A
+// post-unmount setState is what made the whole Vitest suite fail
+// nondeterministically — React 19's resolveUpdatePriority reads `window`
+// during the update, and the jsdom teardown has already removed it
+// (`ReferenceError: window is not defined`). A single test can't reproduce
+// that crash (window is present during the test), so the generation guard is
+// proven via the observable depKey-change path; the deterministic full-suite
+// green run is the teardown proof.
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { usePolledResource } from "../usePolledResource";
+
+function deferred<T>() {
+  let resolve!: (v: T) => void;
+  let reject!: (e: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe("usePolledResource", () => {
+  it("fetches once and stamps data/loading on a non-null depKey", async () => {
+    const fetcher = vi.fn(() => Promise.resolve("hello"));
+    const { result } = renderHook(() => usePolledResource("u", fetcher));
+    expect(result.current.loading).toBe(true);
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    expect(result.current.data).toBe("hello");
+    expect(result.current.loading).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+
+  it("parks on a null depKey (no fetch, not loading)", () => {
+    const fetcher = vi.fn(() => Promise.resolve("z"));
+    const { result } = renderHook(() => usePolledResource(null, fetcher));
+    expect(fetcher).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(false);
+    expect(result.current.data).toBeNull();
+  });
+
+  it("drops a response from a previous depKey (generation guard)", async () => {
+    const dA = deferred<string>();
+    const dB = deferred<string>();
+    const queue = [dA, dB];
+    let i = 0;
+    const fetcher = vi.fn(() => queue[i++].promise);
+
+    const { result, rerender } = renderHook(
+      ({ k }: { k: string }) => usePolledResource(k, fetcher),
+      { initialProps: { k: "a" } },
+    );
+    // Switch selection before "a" resolves — the effect re-runs and fires the
+    // second fetch (dB) under a new generation.
+    rerender({ k: "b" });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    // The fresh (b) response stamps.
+    await act(async () => {
+      dB.resolve("B");
+      await Promise.resolve();
+    });
+    expect(result.current.data).toBe("B");
+
+    // The stale (a) response resolves last and must be dropped.
+    await act(async () => {
+      dA.resolve("A-stale");
+      await Promise.resolve();
+    });
+    expect(result.current.data).toBe("B");
+  });
+
+  it("drops an in-flight response that resolves after unmount (no throw)", async () => {
+    const d = deferred<string>();
+    const fetcher = vi.fn(() => d.promise);
+    const { result, unmount } = renderHook(() => usePolledResource("u", fetcher));
+    unmount();
+    // The cleanup bumped the generation, so resolving now is a dropped no-op
+    // rather than a setState on a gone component.
+    await act(async () => {
+      d.resolve("late");
+      await d.promise;
+    });
+    expect(result.current.data).toBeNull();
+  });
+
+  it("polls every intervalMs and stops polling on unmount", async () => {
+    vi.useFakeTimers();
+    const fetcher = vi.fn(() => Promise.resolve("x"));
+    const { unmount } = renderHook(() => usePolledResource("u", fetcher, { intervalMs: 1000 }));
+    expect(fetcher).toHaveBeenCalledTimes(1); // initial fetch
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2); // one poll tick
+    unmount();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5000);
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2); // interval cleared on unmount
+  });
+
+  it("one-shot (no intervalMs) fetches once and never polls", async () => {
+    vi.useFakeTimers();
+    const fetcher = vi.fn(() => Promise.resolve("y"));
+    renderHook(() => usePolledResource("u", fetcher));
+    expect(fetcher).toHaveBeenCalledTimes(1);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(120_000);
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it("refresh re-fetches under the current generation; no-op while parked", async () => {
+    const fetcher = vi.fn(() => Promise.resolve("a"));
+    const { result, rerender } = renderHook(
+      ({ k }: { k: string | null }) => usePolledResource(k, fetcher),
+      { initialProps: { k: "u" as string | null } },
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+    expect(fetcher).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      result.current.refresh();
+      await Promise.resolve();
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+
+    // Park, then refresh must be a no-op.
+    rerender({ k: null });
+    act(() => {
+      result.current.refresh();
+    });
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+});

--- a/clients/react/src/hooks/useApproaches.ts
+++ b/clients/react/src/hooks/useApproaches.ts
@@ -4,16 +4,16 @@
 // Approaches change on the timescale a Producer raises/closes an
 // experiment — rare, human-paced. A 60-second poll (same cadence as
 // `useCalibration`) is ample; no SSE here yet (the next session-start
-// compose cleans up any tail). Mirrors `useCalibration`'s shape: keeps
-// the previous response visible while a re-fetch is in flight so the
-// inbox does not flicker; `loading` reflects only the initial fetch.
+// compose cleans up any tail). Keeps the previous response visible while a
+// re-fetch is in flight so the inbox does not flicker; `loading` reflects
+// only the initial fetch.
 //
 // `unit = null` parks the hook (no fetch, no interval) — used when no
 // project is selected so the section can render a placeholder rather
 // than poll a non-existent unit.
 
-import { useEffect, useRef, useState } from "react";
 import { type ApproachesResponse, api } from "@/lib/api";
+import { usePolledResource } from "./usePolledResource";
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -24,56 +24,11 @@ export interface UseApproachesResult {
 }
 
 export function useApproaches(unit: string | null): UseApproachesResult {
-  const [data, setData] = useState<ApproachesResponse | null>(null);
-  const [loading, setLoading] = useState(unit !== null);
-  const [error, setError] = useState<Error | null>(null);
-  // An in-flight response from a previous unit must not stamp over a
-  // newer unit's data (same guard as useCalibration).
-  const generationRef = useRef(0);
-
-  useEffect(() => {
-    if (!unit) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    // Clear on unit *change* (this effect's only re-trigger — deps are
-    // [unit]) so the previous unit's inbox is never shown under the new
-    // unit's header. The 60s same-unit re-poll goes through fetchOnce,
-    // which intentionally keeps the last response visible (anti-flicker);
-    // that path is untouched. Transparency-over-completeness:
-    // doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md.
-    setData(null);
-    setError(null);
-    setLoading(true);
-
-    const fetchOnce = async () => {
-      try {
-        const res = await api.approaches(unit);
-        if (myGen !== generationRef.current) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (myGen !== generationRef.current) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (myGen === generationRef.current) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void fetchOnce();
-    const id = window.setInterval(() => {
-      void fetchOnce();
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(id);
-    };
-  }, [unit]);
-
-  return { data, loading, error };
+  // Shared poll resource: the generation guard drops a stale-unit response
+  // AND a response that resolves after unmount (no setState on a gone
+  // component). See usePolledResource. `unit` is the depKey, so the fetcher
+  // only runs while it is non-null.
+  return usePolledResource(unit, () => api.approaches(unit as string), {
+    intervalMs: POLL_INTERVAL_MS,
+  });
 }

--- a/clients/react/src/hooks/useCalibration.ts
+++ b/clients/react/src/hooks/useCalibration.ts
@@ -27,7 +27,7 @@ export function useCalibration(unit: string | null, days = 90): UseCalibrationRe
   // `days` is part of the request identity, so it joins the depKey — a days
   // change re-fetches just like a unit change. The generation guard drops a
   // stale response (prior unit/days) AND a response resolving after unmount.
-  const depKey = unit !== null ? `${unit}#${days}` : null;
+  const depKey = unit !== null ? JSON.stringify([unit, days]) : null;
   return usePolledResource(depKey, () => api.calibration(unit as string, days), {
     intervalMs: POLL_INTERVAL_MS,
   });

--- a/clients/react/src/hooks/useCalibration.ts
+++ b/clients/react/src/hooks/useCalibration.ts
@@ -3,17 +3,17 @@
 // Per `doc/decisions/2026-05-13-synthesis-processing-and-calibration-schema.md`
 // §B.3 / §B.4, calibration data changes on the timescale of a synthesis
 // pass — minutes at the fastest, hours typically. A 60-second poll is
-// plenty for the WebUI top-bar tripwire indicator and the drill-down
-// panel; we deliberately do not wire SSE here yet (the indicator does
-// not need real-time precision, the cache miss on the next session
-// start cleans up any tail).
+// plenty for the WebUI top-bar tripwire indicator and the drill-down panel;
+// we deliberately do not wire SSE here yet.
 //
-// The hook keeps the previous response visible while a re-fetch is in
-// flight (`loading` reflects only the initial fetch) so the tripwire
-// chip does not flicker between renders.
+// Keeps the previous response visible while a re-fetch is in flight
+// (`loading` reflects only the initial fetch) so the tripwire chip does not
+// flicker between renders.
+//
+// `unit = null` parks the hook: no fetch, no interval, no data.
 
-import { useEffect, useRef, useState } from "react";
 import { api, type CalibrationResponse } from "@/lib/api";
+import { usePolledResource } from "./usePolledResource";
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -23,67 +23,12 @@ export interface UseCalibrationResult {
   error: Error | null;
 }
 
-/**
- * Poll the unit's calibration view at `POLL_INTERVAL_MS`. Returns the
- * latest response, an initial-load `loading` flag, and the most recent
- * error (cleared on a successful fetch).
- *
- * `unit = null` parks the hook: no fetch, no interval, no data. Useful
- * when the UI has no project selected and we want the chip / banner to
- * sit dormant rather than poll a non-existent unit.
- */
 export function useCalibration(unit: string | null, days = 90): UseCalibrationResult {
-  const [data, setData] = useState<CalibrationResponse | null>(null);
-  const [loading, setLoading] = useState(unit !== null);
-  const [error, setError] = useState<Error | null>(null);
-  // Track the latest fetch so an in-flight response from a previous unit
-  // cannot stamp over a newer unit's data.
-  const generationRef = useRef(0);
-
-  useEffect(() => {
-    if (!unit) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    // Clear on unit/days *change* (this effect's only re-triggers — deps
-    // are [unit, days]) so a previous query's tripwire/chip is never
-    // shown under a new unit's context. The 60s same-query re-poll goes
-    // through fetchOnce, which intentionally keeps the last response
-    // visible (anti-flicker); that path is untouched. Mirrors the same
-    // guard in useApproaches; transparency-over-completeness per
-    // doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md.
-    setData(null);
-    setError(null);
-    setLoading(true);
-
-    const fetchOnce = async () => {
-      try {
-        const res = await api.calibration(unit, days);
-        if (myGen !== generationRef.current) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (myGen !== generationRef.current) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (myGen === generationRef.current) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void fetchOnce();
-    const id = window.setInterval(() => {
-      void fetchOnce();
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(id);
-    };
-  }, [unit, days]);
-
-  return { data, loading, error };
+  // `days` is part of the request identity, so it joins the depKey — a days
+  // change re-fetches just like a unit change. The generation guard drops a
+  // stale response (prior unit/days) AND a response resolving after unmount.
+  const depKey = unit !== null ? `${unit}#${days}` : null;
+  return usePolledResource(depKey, () => api.calibration(unit as string, days), {
+    intervalMs: POLL_INTERVAL_MS,
+  });
 }

--- a/clients/react/src/hooks/useDecisions.ts
+++ b/clients/react/src/hooks/useDecisions.ts
@@ -7,12 +7,14 @@
 // tmai-core side) but the polling shape lets us land the UX without
 // blocking on that wire-side work.
 //
-// The hook keeps the previous response visible while a re-fetch is in
-// flight (`loading` reflects only the initial fetch) so the bucketed
-// render does not flash empty between renders.
+// Keeps the previous response visible while a re-fetch is in flight
+// (`loading` reflects only the initial fetch) so the bucketed render does
+// not flash empty between renders.
+//
+// `unit = null` parks the hook: no fetch, no interval, no data.
 
-import { useEffect, useRef, useState } from "react";
 import { api, type DecisionsResponse } from "@/lib/api";
+import { usePolledResource } from "./usePolledResource";
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -22,58 +24,10 @@ export interface UseDecisionsResult {
   error: Error | null;
 }
 
-/**
- * Poll the unit's settled-decisions view at `POLL_INTERVAL_MS`. Returns
- * the latest response, an initial-load `loading` flag, and the most
- * recent error (cleared on a successful fetch).
- *
- * `unit = null` parks the hook: no fetch, no interval, no data. Useful
- * when the UI has no project selected and we want the section to render
- * its "no unit yet" placeholder rather than poll a non-existent unit.
- */
 export function useDecisions(unit: string | null): UseDecisionsResult {
-  const [data, setData] = useState<DecisionsResponse | null>(null);
-  const [loading, setLoading] = useState(unit !== null);
-  const [error, setError] = useState<Error | null>(null);
-  // Track the latest fetch so an in-flight response from a previous unit
-  // cannot stamp over a newer unit's data.
-  const generationRef = useRef(0);
-
-  useEffect(() => {
-    if (!unit) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    setLoading(true);
-
-    const fetchOnce = async () => {
-      try {
-        const res = await api.decisions(unit);
-        if (myGen !== generationRef.current) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (myGen !== generationRef.current) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (myGen === generationRef.current) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void fetchOnce();
-    const id = window.setInterval(() => {
-      void fetchOnce();
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(id);
-    };
-  }, [unit]);
-
-  return { data, loading, error };
+  // Shared poll resource: the generation guard drops a stale-unit response
+  // AND a response that resolves after unmount. See usePolledResource.
+  return usePolledResource(unit, () => api.decisions(unit as string), {
+    intervalMs: POLL_INTERVAL_MS,
+  });
 }

--- a/clients/react/src/hooks/useHandoffs.ts
+++ b/clients/react/src/hooks/useHandoffs.ts
@@ -53,6 +53,8 @@ export function useHandoffContent(
   name: string | null,
 ): UseHandoffContentResult {
   // depKey is non-null exactly when both args are, which parks otherwise.
-  const depKey = unit !== null && name !== null ? `${unit}/${name}` : null;
+  // JSON-encode the pair so a `/` inside `unit`/`name` can't collide two
+  // distinct selections onto the same key.
+  const depKey = unit !== null && name !== null ? JSON.stringify([unit, name]) : null;
   return usePolledResource(depKey, () => api.unitHandoff(unit as string, name as string));
 }

--- a/clients/react/src/hooks/useHandoffs.ts
+++ b/clients/react/src/hooks/useHandoffs.ts
@@ -1,22 +1,20 @@
 // Fetch hooks for the R₂ in-tmai Hand-over viewer — the operator-side half
 // of tmai-core PR #473's handoffs endpoint.
 //
-// `useHandoffs(unit)` is the LIST hook (mirrors `useDecisions` /
-// `useCalibration`): a 60-second poll over the unit's baton inventory
-// (active first, then archived newest-first — the wire order). Batons
-// change only when a hand-over ritual completes (minutes to hours), so a
-// 60s poll is plenty; SSE is a deferred follow-up like the other R₁
-// sections. A `null` unit parks the hook (no fetch, no interval).
+// `useHandoffs(unit)` is the LIST hook (mirrors `useDecisions`): a 60-second
+// poll over the unit's baton inventory (active first, then archived
+// newest-first — the wire order). Batons change only when a hand-over ritual
+// completes (minutes to hours), so a 60s poll is plenty; SSE is a deferred
+// follow-up. A `null` unit parks the hook (no fetch, no interval).
 //
-// `useHandoffContent(unit, name)` is the one-shot CONTENT hook (mirrors
-// `usePrDetail`'s `usePrResource`): it fetches a single baton's raw
-// markdown only after an explicit operator click on a row, with a
-// generation guard so a stale in-flight response from a previously selected
-// baton never stamps over the current one. It parks when EITHER arg is
-// null.
+// `useHandoffContent(unit, name)` is the one-shot CONTENT hook: it fetches a
+// single baton's raw markdown only after an explicit operator click on a
+// row, with a generation guard so a stale in-flight response from a
+// previously selected baton never stamps over the current one. It parks when
+// EITHER arg is null.
 
-import { useEffect, useRef, useState } from "react";
 import { api, type HandoffContentResponse, type HandoffsResponse } from "@/lib/api";
+import { usePolledResource } from "./usePolledResource";
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -27,64 +25,14 @@ export interface UseHandoffsResult {
 }
 
 /**
- * Poll the unit's hand-over baton list at `POLL_INTERVAL_MS`. Returns the
- * latest response, an initial-load `loading` flag, and the most recent
- * error (cleared on a successful fetch).
- *
- * `unit = null` parks the hook: no fetch, no interval, no data — the R₁
- * section renders its "pick a project" placeholder rather than poll a
- * non-existent unit.
+ * Poll the unit's hand-over baton list at `POLL_INTERVAL_MS`. `unit = null`
+ * parks the hook (no fetch, no interval). The generation guard drops a
+ * stale-unit response AND a response that resolves after unmount.
  */
 export function useHandoffs(unit: string | null): UseHandoffsResult {
-  const [data, setData] = useState<HandoffsResponse | null>(null);
-  const [loading, setLoading] = useState(unit !== null);
-  const [error, setError] = useState<Error | null>(null);
-  // Track the latest fetch so an in-flight response from a previous unit
-  // cannot stamp over a newer unit's data.
-  const generationRef = useRef(0);
-
-  useEffect(() => {
-    if (!unit) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    // Clear on unit *change* so a previous unit's batons are never shown
-    // under a new unit; the 60s same-unit re-poll keeps the last response
-    // visible (anti-flicker) through fetchOnce below.
-    setData(null);
-    setError(null);
-    setLoading(true);
-
-    const fetchOnce = async () => {
-      try {
-        const res = await api.unitHandoffs(unit);
-        if (myGen !== generationRef.current) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (myGen !== generationRef.current) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (myGen === generationRef.current) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void fetchOnce();
-    const id = window.setInterval(() => {
-      void fetchOnce();
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(id);
-    };
-  }, [unit]);
-
-  return { data, loading, error };
+  return usePolledResource(unit, () => api.unitHandoffs(unit as string), {
+    intervalMs: POLL_INTERVAL_MS,
+  });
 }
 
 export interface UseHandoffContentResult {
@@ -97,53 +45,14 @@ export interface UseHandoffContentResult {
  * One-shot fetch of a single baton's raw markdown. Fetches once when both
  * `unit` and `name` are non-null (an explicit row click drives the
  * selection — the viewer never auto-opens), re-fetches on a baton change,
- * and parks (no fetch) when EITHER arg is null.
- *
- * Mirrors `usePrDetail`'s `usePrResource`: a generation guard so a stale
- * in-flight response from a previously selected baton never stamps over the
- * current one, and the previous payload is cleared synchronously on change
- * so a stale baton is never shown.
+ * and parks (no fetch) when EITHER arg is null. The generation guard drops a
+ * stale selection's response AND a response that resolves after unmount.
  */
 export function useHandoffContent(
   unit: string | null,
   name: string | null,
 ): UseHandoffContentResult {
-  const [data, setData] = useState<HandoffContentResponse | null>(null);
-  const [loading, setLoading] = useState(unit !== null && name !== null);
-  const [error, setError] = useState<Error | null>(null);
-  const generationRef = useRef(0);
-
-  // The stable identity of the request; the effect re-runs only when it
-  // changes. `null` exactly when either arg is null, which parks the hook.
+  // depKey is non-null exactly when both args are, which parks otherwise.
   const depKey = unit !== null && name !== null ? `${unit}/${name}` : null;
-
-  useEffect(() => {
-    if (depKey === null) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    setData(null);
-    setError(null);
-    setLoading(true);
-    void (async () => {
-      try {
-        // depKey is non-null exactly when both args are, so they are
-        // concrete here.
-        const res = await api.unitHandoff(unit as string, name as string);
-        if (myGen !== generationRef.current) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (myGen !== generationRef.current) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (myGen === generationRef.current) setLoading(false);
-      }
-    })();
-  }, [depKey, unit, name]);
-
-  return { data, loading, error };
+  return usePolledResource(depKey, () => api.unitHandoff(unit as string, name as string));
 }

--- a/clients/react/src/hooks/useIssueDetail.ts
+++ b/clients/react/src/hooks/useIssueDetail.ts
@@ -29,7 +29,10 @@ export function useIssueDetail(
   // One-shot shared resource (no intervalMs): keyed on (repo, issue). The
   // generation guard drops a stale selection's response AND a response that
   // resolves after unmount. depKey is non-null exactly when both args are.
-  const depKey = repoPath !== null && issueNumber !== null ? `${repoPath}#${issueNumber}` : null;
+  // JSON-encode the pair so an arbitrary char in `repoPath` can't collide two
+  // distinct (repo, issue) selections onto the same key.
+  const depKey =
+    repoPath !== null && issueNumber !== null ? JSON.stringify([repoPath, issueNumber]) : null;
   return usePolledResource(depKey, () =>
     api.getIssueDetail(repoPath as string, issueNumber as number),
   );

--- a/clients/react/src/hooks/useIssueDetail.ts
+++ b/clients/react/src/hooks/useIssueDetail.ts
@@ -8,14 +8,13 @@
 // assignees / timestamps / comments), so the viewer needs only this one
 // fetch rather than the PR viewer's per-section fan-out.
 //
-// WHY one-shot, not the 60s poll `useIssues` runs: the viewer only mounts
-// after an explicit operator click on an issue row (no auto-open on focus
-// — viewer-approach negative space), and an issue's body / comments are
-// stable across a single review pass. Re-selecting the issue (or
-// switching units, which clears the selection) re-fetches.
+// WHY one-shot, not the 60s poll `useUnitIssues` runs: the viewer only
+// mounts after an explicit operator click on an issue row, and an issue's
+// body / comments are stable across a single review pass. Re-selecting the
+// issue (or switching units, which clears the selection) re-fetches.
 
-import { useEffect, useRef, useState } from "react";
 import { api, type IssueDetail } from "@/lib/api";
+import { usePolledResource } from "./usePolledResource";
 
 export interface UseIssueDetailResult {
   data: IssueDetail | null;
@@ -27,39 +26,11 @@ export function useIssueDetail(
   repoPath: string | null,
   issueNumber: number | null,
 ): UseIssueDetailResult {
-  const [data, setData] = useState<IssueDetail | null>(null);
-  const [loading, setLoading] = useState(repoPath !== null && issueNumber !== null);
-  const [error, setError] = useState<Error | null>(null);
-  // Gates against stale responses across (repo, issue) changes — a slow
-  // fetch from a previously selected issue returning after a newer
-  // selection must not stamp over the current data.
-  const generationRef = useRef(0);
-
-  useEffect(() => {
-    if (repoPath === null || issueNumber === null) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    setData(null);
-    setError(null);
-    setLoading(true);
-    void (async () => {
-      try {
-        const res = await api.getIssueDetail(repoPath, issueNumber);
-        if (myGen !== generationRef.current) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (myGen !== generationRef.current) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (myGen === generationRef.current) setLoading(false);
-      }
-    })();
-  }, [repoPath, issueNumber]);
-
-  return { data, loading, error };
+  // One-shot shared resource (no intervalMs): keyed on (repo, issue). The
+  // generation guard drops a stale selection's response AND a response that
+  // resolves after unmount. depKey is non-null exactly when both args are.
+  const depKey = repoPath !== null && issueNumber !== null ? `${repoPath}#${issueNumber}` : null;
+  return usePolledResource(depKey, () =>
+    api.getIssueDetail(repoPath as string, issueNumber as number),
+  );
 }

--- a/clients/react/src/hooks/usePolledResource.ts
+++ b/clients/react/src/hooks/usePolledResource.ts
@@ -1,0 +1,136 @@
+// Shared fetch/poll resource for the R-panel data hooks.
+//
+// Every R-panel data hook (`useUnitInventory`, `useDecisions`, `usePrBody`,
+// `useIssueDetail`, …) was a hand-duplicated copy of the same shape: a
+// `{ data, loading, error }` triple, a `generationRef` guard so a stale
+// in-flight response from a previously selected unit/PR never stamps over the
+// current one, a `null` dep that parks the hook, and (for the list hooks) a
+// 60s poll. This consolidates that shape into one place and — critically —
+// closes the bug every copy shared: the cleanup never invalidated the
+// in-flight fetch, so a response that resolved AFTER unmount called `setState`
+// on a gone component. React 19's `resolveUpdatePriority` reads `window`
+// during that update; under the jsdom test teardown `window` is already gone,
+// so it threw `ReferenceError: window is not defined` — an unhandled error
+// Vitest attributes to whichever test was mid-flight, failing the whole suite
+// nondeterministically. Bumping the generation in the cleanup drops the late
+// response on every path (depKey change, park, and unmount).
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export interface PolledResource<T> {
+  data: T | null;
+  loading: boolean;
+  error: Error | null;
+  /**
+   * Imperatively re-fetch under the CURRENT generation, keeping the previous
+   * response visible while in flight (anti-flicker, same as the poll tick). A
+   * no-op while parked (`depKey === null`). Consumers that mutate server state
+   * (a capture / create / edit POST) call this so the persisted record shows
+   * immediately instead of waiting on the next poll tick.
+   */
+  refresh: () => void;
+}
+
+export interface PolledResourceOptions {
+  /**
+   * When set, re-fetch every `intervalMs` after the initial load (the R₁ list
+   * hooks' 60s poll). Omit for a one-shot resource (the R₂ detail hooks):
+   * fetch once per `depKey` change, no interval.
+   */
+  intervalMs?: number;
+}
+
+/**
+ * Own the `{ data, loading, error }` triple for a fetched (optionally polled)
+ * resource, with a generation guard that drops:
+ *   - a response from a previous `depKey` (a stale unit / selection), and
+ *   - a response that resolves AFTER unmount or park — the cleanup bumps the
+ *     generation, so the late `setState` is skipped (see the file header for
+ *     why a post-unmount `setState` is fatal under the jsdom test teardown).
+ *
+ * `depKey` is the stable request identity (e.g. the unit, or `${repo}#${n}`);
+ * the effect re-runs only when it changes, and `depKey === null` parks the
+ * hook (no fetch, no interval, cleared state). `fetcher` is read through a ref
+ * so a fresh closure each render does not retrigger the effect — the effect's
+ * only trigger is a `depKey` change, which is exactly when the fetcher's
+ * captured args change too.
+ */
+export function usePolledResource<T>(
+  depKey: string | null,
+  fetcher: () => Promise<T>,
+  options: PolledResourceOptions = {},
+): PolledResource<T> {
+  const { intervalMs } = options;
+  const [data, setData] = useState<T | null>(null);
+  const [loading, setLoading] = useState(depKey !== null);
+  const [error, setError] = useState<Error | null>(null);
+  const generationRef = useRef(0);
+  const fetcherRef = useRef(fetcher);
+  fetcherRef.current = fetcher;
+  // The live depKey, so the stable `refresh` callback can no-op while parked
+  // without being re-created on every depKey change.
+  const depKeyRef = useRef(depKey);
+  depKeyRef.current = depKey;
+
+  // One generation-guarded fetch, keeping the previous response visible
+  // (anti-flicker). `gen` is captured by the caller so the response is dropped
+  // once the generation has moved on (depKey change, park, or unmount).
+  const runFetch = useCallback(async (gen: number) => {
+    try {
+      const res = await fetcherRef.current();
+      if (gen !== generationRef.current) return;
+      setData(res);
+      setError(null);
+    } catch (e) {
+      if (gen !== generationRef.current) return;
+      setError(e instanceof Error ? e : new Error(String(e)));
+    } finally {
+      if (gen === generationRef.current) setLoading(false);
+    }
+  }, []);
+
+  const refresh = useCallback(() => {
+    if (depKeyRef.current === null) return;
+    // Re-fetch under the CURRENT generation, no data clear — the poll path's
+    // anti-flicker behaviour, triggered on demand after an operator write.
+    void runFetch(generationRef.current);
+  }, [runFetch]);
+
+  useEffect(() => {
+    if (depKey === null) {
+      // Park: invalidate any in-flight fetch from the previous depKey so a
+      // late response can't stamp data after we have cleared it.
+      generationRef.current += 1;
+      setData(null);
+      setLoading(false);
+      setError(null);
+      return;
+    }
+    const myGen = ++generationRef.current;
+    // Clear on depKey *change* so a previous selection's data is never shown
+    // under the new one. The interval re-poll / `refresh` keep the last
+    // response visible (anti-flicker) — only this change-driven path clears.
+    setData(null);
+    setError(null);
+    setLoading(true);
+
+    void runFetch(myGen);
+
+    if (intervalMs === undefined) {
+      // One-shot: still invalidate this generation on unmount so a late
+      // response is dropped rather than setState-ing a gone component.
+      return () => {
+        generationRef.current += 1;
+      };
+    }
+    const id = window.setInterval(() => {
+      void runFetch(myGen);
+    }, intervalMs);
+    return () => {
+      generationRef.current += 1;
+      window.clearInterval(id);
+    };
+  }, [depKey, intervalMs, runFetch]);
+
+  return { data, loading, error, refresh };
+}

--- a/clients/react/src/hooks/usePolledResource.ts
+++ b/clients/react/src/hooks/usePolledResource.ts
@@ -76,6 +76,10 @@ export function usePolledResource<T>(
   // (anti-flicker). `gen` is captured by the caller so the response is dropped
   // once the generation has moved on (depKey change, park, or unmount).
   const runFetch = useCallback(async (gen: number) => {
+    // Skip entirely if this call is already stale (the depKey moved on, parked,
+    // or unmounted) — don't even invoke the fetcher. The post-await guard below
+    // then catches a generation that moves WHILE the fetch is in flight.
+    if (gen !== generationRef.current) return;
     try {
       const res = await fetcherRef.current();
       if (gen !== generationRef.current) return;

--- a/clients/react/src/hooks/usePrDetail.ts
+++ b/clients/react/src/hooks/usePrDetail.ts
@@ -1,72 +1,26 @@
 // PR-detail fetch hooks for the R₂ in-tmai PR viewer (#749).
 //
-// One generic one-shot resource hook (`usePrResource`) plus thin named
-// wrappers (body / labels / comments / merge-status / diff / checks),
-// mirroring the `useUnitPrs` contract shape: `{ data, loading, error }`,
-// a generation guard so a stale in-flight response from a previously
-// selected PR never stamps over the current one, and a `null` dep that
-// parks the hook (no fetch).
+// Thin named wrappers (body / labels / comments / merge-status / diff /
+// checks) over the shared one-shot resource (`usePolledResource` with no
+// interval), mirroring the `useUnitPrs` contract shape: `{ data, loading,
+// error }`, a generation guard so a stale in-flight response from a
+// previously selected PR never stamps over the current one (and one that
+// resolves after unmount is dropped too), and a `null` dep that parks the
+// hook (no fetch).
 //
-// WHY one-shot, not the 60s poll `useUnitPrs` runs: the viewer only
-// mounts after an explicit operator click on a PR row (no auto-open on
-// focus — viewer approach negative space), and a PR's body / diff /
-// comments are stable across a single review pass. Re-selecting the PR
-// (or switching units, which clears the selection) re-fetches. Keeping
-// it poll-free also avoids piling N background intervals (one per
-// detail section) onto the existing `useUnitPrs` poll.
+// WHY one-shot, not the 60s poll `useUnitPrs` runs: the viewer only mounts
+// after an explicit operator click on a PR row, and a PR's body / diff /
+// comments are stable across a single review pass. Re-selecting the PR (or
+// switching units, which clears the selection) re-fetches. Keeping it
+// poll-free also avoids piling N background intervals (one per detail
+// section) onto the existing `useUnitPrs` poll.
 
-import { useEffect, useRef, useState } from "react";
 import { api, type CiSummary, type PrComment, type PrMergeStatus } from "@/lib/api";
+import { type PolledResource, usePolledResource } from "./usePolledResource";
 
-export interface UsePrResourceResult<T> {
-  data: T | null;
-  loading: boolean;
-  error: Error | null;
-}
-
-// `depKey` is the stable identity of the request (e.g. `${repo}#${n}`);
-// the effect re-runs only when it changes. `fetcher` is read through a
-// ref so a fresh closure each render does not retrigger the effect — the
-// same anti-churn discipline as `useUnitPrs`, expressed for a one-shot.
-function usePrResource<T>(
-  depKey: string | null,
-  fetcher: () => Promise<T>,
-): UsePrResourceResult<T> {
-  const [data, setData] = useState<T | null>(null);
-  const [loading, setLoading] = useState(depKey !== null);
-  const [error, setError] = useState<Error | null>(null);
-  const generationRef = useRef(0);
-  const fetcherRef = useRef(fetcher);
-  fetcherRef.current = fetcher;
-
-  useEffect(() => {
-    if (depKey === null) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    setData(null);
-    setError(null);
-    setLoading(true);
-    void (async () => {
-      try {
-        const res = await fetcherRef.current();
-        if (myGen !== generationRef.current) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (myGen !== generationRef.current) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (myGen === generationRef.current) setLoading(false);
-      }
-    })();
-  }, [depKey]);
-
-  return { data, loading, error };
-}
+// The one-shot detail hooks expose the read-only triple; `refresh` from the
+// shared resource is unused here (a detail pane re-fetches by re-selection).
+export type UsePrResourceResult<T> = Pick<PolledResource<T>, "data" | "loading" | "error">;
 
 function prKey(repoPath: string | null, prNumber: number | null): string | null {
   return repoPath !== null && prNumber !== null ? `${repoPath}#${prNumber}` : null;
@@ -76,7 +30,7 @@ export function usePrBody(
   repoPath: string | null,
   prNumber: number | null,
 ): UsePrResourceResult<string> {
-  return usePrResource(prKey(repoPath, prNumber), () =>
+  return usePolledResource(prKey(repoPath, prNumber), () =>
     // The dep key is non-null exactly when both args are non-null, so the
     // fetcher only ever runs with concrete values.
     api.prBody(repoPath as string, prNumber as number),
@@ -87,7 +41,7 @@ export function usePrLabels(
   repoPath: string | null,
   prNumber: number | null,
 ): UsePrResourceResult<string[]> {
-  return usePrResource(prKey(repoPath, prNumber), () =>
+  return usePolledResource(prKey(repoPath, prNumber), () =>
     api.prLabels(repoPath as string, prNumber as number),
   );
 }
@@ -96,7 +50,7 @@ export function usePrComments(
   repoPath: string | null,
   prNumber: number | null,
 ): UsePrResourceResult<PrComment[]> {
-  return usePrResource(prKey(repoPath, prNumber), () =>
+  return usePolledResource(prKey(repoPath, prNumber), () =>
     api.getPrComments(repoPath as string, prNumber as number),
   );
 }
@@ -105,7 +59,7 @@ export function usePrMergeStatus(
   repoPath: string | null,
   prNumber: number | null,
 ): UsePrResourceResult<PrMergeStatus> {
-  return usePrResource(prKey(repoPath, prNumber), () =>
+  return usePolledResource(prKey(repoPath, prNumber), () =>
     api.getPrMergeStatus(repoPath as string, prNumber as number),
   );
 }
@@ -114,7 +68,7 @@ export function usePrDiff(
   repoPath: string | null,
   prNumber: number | null,
 ): UsePrResourceResult<string> {
-  return usePrResource(prKey(repoPath, prNumber), async () => {
+  return usePolledResource(prKey(repoPath, prNumber), async () => {
     const res = await api.prDiff(repoPath as string, prNumber as number);
     return res.patch;
   });
@@ -128,5 +82,5 @@ export function usePrChecks(
   branch: string | null,
 ): UsePrResourceResult<CiSummary> {
   const key = repoPath !== null && branch !== null ? `${repoPath}@${branch}` : null;
-  return usePrResource(key, () => api.listChecks(repoPath as string, branch as string));
+  return usePolledResource(key, () => api.listChecks(repoPath as string, branch as string));
 }

--- a/clients/react/src/hooks/usePrDetail.ts
+++ b/clients/react/src/hooks/usePrDetail.ts
@@ -23,7 +23,9 @@ import { type PolledResource, usePolledResource } from "./usePolledResource";
 export type UsePrResourceResult<T> = Pick<PolledResource<T>, "data" | "loading" | "error">;
 
 function prKey(repoPath: string | null, prNumber: number | null): string | null {
-  return repoPath !== null && prNumber !== null ? `${repoPath}#${prNumber}` : null;
+  // JSON-encode the pair so an arbitrary char in `repoPath` can't collide two
+  // distinct (repo, pr) selections onto the same key.
+  return repoPath !== null && prNumber !== null ? JSON.stringify([repoPath, prNumber]) : null;
 }
 
 export function usePrBody(
@@ -81,6 +83,8 @@ export function usePrChecks(
   repoPath: string | null,
   branch: string | null,
 ): UsePrResourceResult<CiSummary> {
-  const key = repoPath !== null && branch !== null ? `${repoPath}@${branch}` : null;
+  // JSON-encode the pair so an `@` in `repoPath`/`branch` can't collide two
+  // distinct (repo, branch) selections onto the same key.
+  const key = repoPath !== null && branch !== null ? JSON.stringify([repoPath, branch]) : null;
   return usePolledResource(key, () => api.listChecks(repoPath as string, branch as string));
 }

--- a/clients/react/src/hooks/useProducerFeed.ts
+++ b/clients/react/src/hooks/useProducerFeed.ts
@@ -5,16 +5,16 @@
 // (`has_pending_delta = tip > last_served_cursor`) moves on the
 // timescale of worker activity landing on the unit's feed. A 60-second
 // poll matches the calibration sibling and is plenty for a manual
-// operator affordance; we deliberately do not wire SSE here yet (the
-// button does not need real-time precision, the cache miss on the next
-// session start cleans up any tail).
+// operator affordance; we deliberately do not wire SSE here yet.
 //
-// The hook keeps the previous response visible while a re-fetch is in
-// flight (`loading` reflects only the initial fetch) so the button's
-// pending-state badge does not flicker between renders.
+// Keeps the previous response visible while a re-fetch is in flight
+// (`loading` reflects only the initial fetch) so the button's pending-state
+// badge does not flicker between renders.
+//
+// `unit = null` parks the hook: no fetch, no interval, no data.
 
-import { useEffect, useRef, useState } from "react";
 import { api, type ProducerFeedStatus } from "@/lib/api";
+import { usePolledResource } from "./usePolledResource";
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -24,66 +24,10 @@ export interface UseProducerFeedResult {
   error: Error | null;
 }
 
-/**
- * Poll the unit's producer-feed status at `POLL_INTERVAL_MS`. Returns
- * the latest response, an initial-load `loading` flag, and the most
- * recent error (cleared on a successful fetch).
- *
- * `unit = null` parks the hook: no fetch, no interval, no data. Useful
- * when the UI has no project selected and we want the delta-check
- * button to sit dormant rather than poll a non-existent unit.
- */
 export function useProducerFeed(unit: string | null): UseProducerFeedResult {
-  const [data, setData] = useState<ProducerFeedStatus | null>(null);
-  const [loading, setLoading] = useState(unit !== null);
-  const [error, setError] = useState<Error | null>(null);
-  // Track the latest fetch so an in-flight response from a previous unit
-  // cannot stamp over a newer unit's data.
-  const generationRef = useRef(0);
-
-  useEffect(() => {
-    if (!unit) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    // Clear on unit *change* (this effect's only re-trigger — dep is
-    // [unit]) so a previous query's pending-badge is never shown under a
-    // new unit's context. The 60s same-query re-poll goes through
-    // fetchOnce, which intentionally keeps the last response visible
-    // (anti-flicker); that path is untouched. Mirrors the same guard in
-    // useCalibration / useApproaches.
-    setData(null);
-    setError(null);
-    setLoading(true);
-
-    const fetchOnce = async () => {
-      try {
-        const res = await api.producerFeed(unit);
-        if (myGen !== generationRef.current) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (myGen !== generationRef.current) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (myGen === generationRef.current) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void fetchOnce();
-    const id = window.setInterval(() => {
-      void fetchOnce();
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(id);
-    };
-  }, [unit]);
-
-  return { data, loading, error };
+  // Shared poll resource: the generation guard drops a stale-unit response
+  // AND a response that resolves after unmount. See usePolledResource.
+  return usePolledResource(unit, () => api.producerFeed(unit as string), {
+    intervalMs: POLL_INTERVAL_MS,
+  });
 }

--- a/clients/react/src/hooks/useUnitAims.ts
+++ b/clients/react/src/hooks/useUnitAims.ts
@@ -4,19 +4,17 @@
 // `parent` / `state` / `depends_on` / `serves` / `related` / `body`).
 //
 // The aim-tree twin of `useUnitObservations` / `useApproaches` — same shape,
-// same cadence. Aims change on the timescale an operator edits an anchor or a
-// Producer files a node — rare, human-paced. A 60-second poll (same cadence as
-// the siblings) is ample for an operator-scan surface; no SSE here yet. Mirrors
-// the siblings' shape exactly: keeps the previous response visible while a
-// re-fetch is in flight so the tree does not flicker; `loading` reflects only
-// the initial fetch.
+// same cadence. Aims change on the timescale an operator edits an anchor or
+// a Producer files a node — rare, human-paced. A 60-second poll is ample for
+// an operator-scan surface; no SSE here yet. Keeps the previous response
+// visible while a re-fetch is in flight so the tree does not flicker;
+// `loading` reflects only the initial fetch. `refresh` reflects an operator
+// write (create / edit) immediately instead of waiting on the next tick.
 //
-// `unit = null` parks the hook (no fetch, no interval) — used when no project
-// is selected so the section can render a placeholder rather than poll a
-// non-existent unit.
+// `unit = null` parks the hook (no fetch, no interval).
 
-import { useCallback, useEffect, useRef, useState } from "react";
 import { type AimsResponse, api } from "@/lib/api";
+import { usePolledResource } from "./usePolledResource";
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -35,70 +33,9 @@ export interface UseUnitAimsResult {
 }
 
 export function useUnitAims(unit: string | null): UseUnitAimsResult {
-  const [data, setData] = useState<AimsResponse | null>(null);
-  const [loading, setLoading] = useState(unit !== null);
-  const [error, setError] = useState<Error | null>(null);
-  // An in-flight response from a previous unit must not stamp over a
-  // newer unit's data (same guard as useUnitObservations / useApproaches).
-  const generationRef = useRef(0);
-  // The live unit, so the stable `refresh` callback re-fetches the *current*
-  // unit without being re-created on every unit change.
-  const unitRef = useRef(unit);
-  unitRef.current = unit;
-
-  // One gen-guarded fetch against `targetUnit`, keeping the previous response
-  // visible (anti-flicker). Shared by the initial fetch, the 60s poll, and
-  // `refresh`. Stable identity (no deps) so it doesn't re-trigger the effect.
-  const fetchFor = useCallback(async (targetUnit: string, gen: number) => {
-    try {
-      const res = await api.aims(targetUnit);
-      if (gen !== generationRef.current) return;
-      setData(res);
-      setError(null);
-    } catch (e) {
-      if (gen !== generationRef.current) return;
-      setError(e instanceof Error ? e : new Error(String(e)));
-    } finally {
-      if (gen === generationRef.current) {
-        setLoading(false);
-      }
-    }
-  }, []);
-
-  const refresh = useCallback(() => {
-    const u = unitRef.current;
-    if (!u) return;
-    // Re-fetch under the CURRENT generation, no data clear — the poll path's
-    // anti-flicker behaviour, triggered on demand after an operator write.
-    void fetchFor(u, generationRef.current);
-  }, [fetchFor]);
-
-  useEffect(() => {
-    if (!unit) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    // Clear on unit *change* (this effect's only re-trigger — deps are
-    // [unit]) so the previous unit's aims are never shown under the new
-    // unit's header. The 60s same-unit re-poll and `refresh` go through
-    // fetchFor, which intentionally keeps the last response visible
-    // (anti-flicker); those paths are untouched. Mirrors useUnitObservations.
-    setData(null);
-    setError(null);
-    setLoading(true);
-
-    void fetchFor(unit, myGen);
-    const id = window.setInterval(() => {
-      void fetchFor(unit, myGen);
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(id);
-    };
-  }, [unit, fetchFor]);
-
-  return { data, loading, error, refresh };
+  // Shared poll resource (exposes `refresh`): the generation guard drops a
+  // stale-unit response AND a response that resolves after unmount.
+  return usePolledResource(unit, () => api.aims(unit as string), {
+    intervalMs: POLL_INTERVAL_MS,
+  });
 }

--- a/clients/react/src/hooks/useUnitAttention.ts
+++ b/clients/react/src/hooks/useUnitAttention.ts
@@ -133,6 +133,15 @@ export function useUnitAttention(unit: string | null): UseUnitAttentionResult {
     }, POLL_INTERVAL_MS);
 
     return () => {
+      // Bump the generation so this effect's in-flight GET *and* any in-flight
+      // setAttention POST (both gate on `generationRef`) are dropped after
+      // unmount. Without it a response resolving post-unmount calls setState on
+      // a gone component, and React 19's resolveUpdatePriority reads `window` —
+      // which the jsdom test teardown has removed (`ReferenceError: window is
+      // not defined`, failing the whole suite). This hook keeps its bespoke
+      // shape (POST write-back + writeSeq) rather than usePolledResource, so it
+      // carries the same guard inline.
+      ++generationRef.current;
       window.clearInterval(id);
     };
   }, [unit]);

--- a/clients/react/src/hooks/useUnitInventory.ts
+++ b/clients/react/src/hooks/useUnitInventory.ts
@@ -6,20 +6,15 @@
 // its fact-projected status / work-residual / liveness.
 //
 // The inventory twin of `useUnitIssues` / `useApproaches` — same shape,
-// same cadence. The inventory tracks records + their fact-logs, which move
-// on the timescale a Producer raises/closes an approach or files a fact —
-// human-paced. A 60-second poll (same cadence as the siblings) is ample
-// for an operator-review surface; no SSE here yet. Mirrors the siblings'
-// shape exactly: keeps the previous response visible while a re-fetch is in
-// flight so the list does not flicker; `loading` reflects only the initial
-// fetch.
+// same cadence. A 60-second poll is ample for an operator-review surface;
+// no SSE here yet. Keeps the previous response visible while a re-fetch is
+// in flight so the list does not flicker; `loading` reflects only the
+// initial fetch.
 //
-// `unit = null` parks the hook (no fetch, no interval) — used when no
-// project is selected so the section can render a placeholder rather than
-// poll a non-existent unit.
+// `unit = null` parks the hook (no fetch, no interval).
 
-import { useEffect, useRef, useState } from "react";
 import { api, type UnitInventoryResponse } from "@/lib/api";
+import { usePolledResource } from "./usePolledResource";
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -30,55 +25,9 @@ export interface UseUnitInventoryResult {
 }
 
 export function useUnitInventory(unit: string | null): UseUnitInventoryResult {
-  const [data, setData] = useState<UnitInventoryResponse | null>(null);
-  const [loading, setLoading] = useState(unit !== null);
-  const [error, setError] = useState<Error | null>(null);
-  // An in-flight response from a previous unit must not stamp over a
-  // newer unit's data (same guard as useUnitIssues / useApproaches).
-  const generationRef = useRef(0);
-
-  useEffect(() => {
-    if (!unit) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    // Clear on unit *change* (this effect's only re-trigger — deps are
-    // [unit]) so the previous unit's inventory is never shown under the new
-    // unit's header. The 60s same-unit re-poll goes through fetchOnce,
-    // which intentionally keeps the last response visible (anti-flicker);
-    // that path is untouched. Mirrors the same guard in useUnitIssues.
-    setData(null);
-    setError(null);
-    setLoading(true);
-
-    const fetchOnce = async () => {
-      try {
-        const res = await api.unitInventory(unit);
-        if (myGen !== generationRef.current) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (myGen !== generationRef.current) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (myGen === generationRef.current) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void fetchOnce();
-    const id = window.setInterval(() => {
-      void fetchOnce();
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(id);
-    };
-  }, [unit]);
-
-  return { data, loading, error };
+  // Shared poll resource: the generation guard drops a stale-unit response
+  // AND a response that resolves after unmount. See usePolledResource.
+  return usePolledResource(unit, () => api.unitInventory(unit as string), {
+    intervalMs: POLL_INTERVAL_MS,
+  });
 }

--- a/clients/react/src/hooks/useUnitIssues.ts
+++ b/clients/react/src/hooks/useUnitIssues.ts
@@ -1,26 +1,19 @@
 // Polling hook for the unit's `📋 Issues` view — the unified cross-repo
 // open-issue list behind the Producer console's R panel (approach
-// `2026-05-29-r-panel-as-project-artifact-inventory.md`, which closes
-// its "no unit-scoped issues endpoint exists yet" defer item now that
-// tmai-core serves `GET /api/units/{unit}/issues`). One unit-scoped list
-// across every repo in the unit; the section renders it grouped by repo,
-// not as a per-repo switcher.
+// `2026-05-29-r-panel-as-project-artifact-inventory.md`, served by
+// tmai-core `GET /api/units/{unit}/issues`). One unit-scoped list across
+// every repo in the unit; the section renders it grouped by repo, not as a
+// per-repo switcher.
 //
-// The issues twin of `useUnitPrs` — same shape, same cadence. Issues
-// change on the timescale a worker files / closes one — minutes
-// typically. A 60-second poll (same cadence as `useUnitPrs` /
-// `useApproaches` / `useCalibration`) is ample for an operator-review
-// surface; no SSE here yet (the next session-start compose cleans up any
-// tail). Mirrors the siblings' shape exactly: keeps the previous response
-// visible while a re-fetch is in flight so the list does not flicker;
-// `loading` reflects only the initial fetch.
+// The issues twin of `useUnitPrs` — same shape, same cadence. A 60-second
+// poll is ample for an operator-review surface; no SSE here yet. Keeps the
+// previous response visible while a re-fetch is in flight so the list does
+// not flicker; `loading` reflects only the initial fetch.
 //
-// `unit = null` parks the hook (no fetch, no interval) — used when no
-// project is selected so the section can render a placeholder rather
-// than poll a non-existent unit.
+// `unit = null` parks the hook (no fetch, no interval).
 
-import { useEffect, useRef, useState } from "react";
 import { api, type UnitIssuesResponse } from "@/lib/api";
+import { usePolledResource } from "./usePolledResource";
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -31,57 +24,9 @@ export interface UseUnitIssuesResult {
 }
 
 export function useUnitIssues(unit: string | null): UseUnitIssuesResult {
-  const [data, setData] = useState<UnitIssuesResponse | null>(null);
-  const [loading, setLoading] = useState(unit !== null);
-  const [error, setError] = useState<Error | null>(null);
-  // An in-flight response from a previous unit must not stamp over a
-  // newer unit's data (same guard as useUnitPrs / useApproaches).
-  const generationRef = useRef(0);
-
-  useEffect(() => {
-    if (!unit) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    // Clear on unit *change* (this effect's only re-trigger — deps are
-    // [unit]) so the previous unit's issue list is never shown under the
-    // new unit's header. The 60s same-unit re-poll goes through
-    // fetchOnce, which intentionally keeps the last response visible
-    // (anti-flicker); that path is untouched. Mirrors the same guard in
-    // useUnitPrs; transparency-over-completeness per
-    // doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md.
-    setData(null);
-    setError(null);
-    setLoading(true);
-
-    const fetchOnce = async () => {
-      try {
-        const res = await api.unitIssues(unit);
-        if (myGen !== generationRef.current) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (myGen !== generationRef.current) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (myGen === generationRef.current) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void fetchOnce();
-    const id = window.setInterval(() => {
-      void fetchOnce();
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(id);
-    };
-  }, [unit]);
-
-  return { data, loading, error };
+  // Shared poll resource: the generation guard drops a stale-unit response
+  // AND a response that resolves after unmount. See usePolledResource.
+  return usePolledResource(unit, () => api.unitIssues(unit as string), {
+    intervalMs: POLL_INTERVAL_MS,
+  });
 }

--- a/clients/react/src/hooks/useUnitObservations.ts
+++ b/clients/react/src/hooks/useUnitObservations.ts
@@ -4,20 +4,16 @@
 // record in each repo's `doc/observations/`, carrying only the row fields
 // (`slug` / `summary` / `status`).
 //
-// The observations twin of `useApproaches` / `useUnitInventory` — same shape,
-// same cadence. Observations change on the timescale a Producer files a note
-// — rare, human-paced. A 60-second poll (same cadence as the siblings) is
-// ample for an operator-scan surface; no SSE here yet. Mirrors the siblings'
-// shape exactly: keeps the previous response visible while a re-fetch is in
-// flight so the list does not flicker; `loading` reflects only the initial
-// fetch.
+// The observations twin of `useApproaches` / `useUnitInventory` — same
+// shape, same cadence. A 60-second poll is ample for an operator-scan
+// surface; no SSE here yet. Keeps the previous response visible while a
+// re-fetch is in flight so the list does not flicker; `loading` reflects
+// only the initial fetch.
 //
-// `unit = null` parks the hook (no fetch, no interval) — used when no project
-// is selected so the section can render a placeholder rather than poll a
-// non-existent unit.
+// `unit = null` parks the hook (no fetch, no interval).
 
-import { useEffect, useRef, useState } from "react";
 import { api, type ObservationsResponse } from "@/lib/api";
+import { usePolledResource } from "./usePolledResource";
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -28,55 +24,9 @@ export interface UseUnitObservationsResult {
 }
 
 export function useUnitObservations(unit: string | null): UseUnitObservationsResult {
-  const [data, setData] = useState<ObservationsResponse | null>(null);
-  const [loading, setLoading] = useState(unit !== null);
-  const [error, setError] = useState<Error | null>(null);
-  // An in-flight response from a previous unit must not stamp over a
-  // newer unit's data (same guard as useApproaches / useUnitInventory).
-  const generationRef = useRef(0);
-
-  useEffect(() => {
-    if (!unit) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    // Clear on unit *change* (this effect's only re-trigger — deps are
-    // [unit]) so the previous unit's observations are never shown under the
-    // new unit's header. The 60s same-unit re-poll goes through fetchOnce,
-    // which intentionally keeps the last response visible (anti-flicker);
-    // that path is untouched. Mirrors the guard in useApproaches.
-    setData(null);
-    setError(null);
-    setLoading(true);
-
-    const fetchOnce = async () => {
-      try {
-        const res = await api.observations(unit);
-        if (myGen !== generationRef.current) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (myGen !== generationRef.current) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (myGen === generationRef.current) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void fetchOnce();
-    const id = window.setInterval(() => {
-      void fetchOnce();
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(id);
-    };
-  }, [unit]);
-
-  return { data, loading, error };
+  // Shared poll resource: the generation guard drops a stale-unit response
+  // AND a response that resolves after unmount. See usePolledResource.
+  return usePolledResource(unit, () => api.observations(unit as string), {
+    intervalMs: POLL_INTERVAL_MS,
+  });
 }

--- a/clients/react/src/hooks/useUnitPrs.ts
+++ b/clients/react/src/hooks/useUnitPrs.ts
@@ -4,20 +4,15 @@
 // PR #389). One unit-scoped list across every repo in the unit; the
 // section renders it flat, not a per-repo switcher.
 //
-// PRs change on the timescale a worker pushes / a review lands —
-// minutes typically. A 60-second poll (same cadence as `useApproaches`
-// / `useCalibration`) is ample for an operator-review surface; no SSE
-// here yet (the next session-start compose cleans up any tail). Mirrors
-// the siblings' shape exactly: keeps the previous response visible
-// while a re-fetch is in flight so the list does not flicker; `loading`
-// reflects only the initial fetch.
+// A 60-second poll is ample for an operator-review surface; no SSE here yet
+// (the next session-start compose cleans up any tail). Keeps the previous
+// response visible while a re-fetch is in flight so the list does not
+// flicker; `loading` reflects only the initial fetch.
 //
-// `unit = null` parks the hook (no fetch, no interval) — used when no
-// project is selected so the section can render a placeholder rather
-// than poll a non-existent unit.
+// `unit = null` parks the hook (no fetch, no interval).
 
-import { useEffect, useRef, useState } from "react";
 import { api, type UnitPrsResponse } from "@/lib/api";
+import { usePolledResource } from "./usePolledResource";
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -28,57 +23,9 @@ export interface UseUnitPrsResult {
 }
 
 export function useUnitPrs(unit: string | null): UseUnitPrsResult {
-  const [data, setData] = useState<UnitPrsResponse | null>(null);
-  const [loading, setLoading] = useState(unit !== null);
-  const [error, setError] = useState<Error | null>(null);
-  // An in-flight response from a previous unit must not stamp over a
-  // newer unit's data (same guard as useApproaches / useCalibration).
-  const generationRef = useRef(0);
-
-  useEffect(() => {
-    if (!unit) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    // Clear on unit *change* (this effect's only re-trigger — deps are
-    // [unit]) so the previous unit's PR list is never shown under the
-    // new unit's header. The 60s same-unit re-poll goes through
-    // fetchOnce, which intentionally keeps the last response visible
-    // (anti-flicker); that path is untouched. Mirrors the same guard in
-    // useApproaches; transparency-over-completeness per
-    // doc/decisions/2026-05-14-webui-simulated-onboarded-posture.md.
-    setData(null);
-    setError(null);
-    setLoading(true);
-
-    const fetchOnce = async () => {
-      try {
-        const res = await api.unitPrs(unit);
-        if (myGen !== generationRef.current) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (myGen !== generationRef.current) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (myGen === generationRef.current) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void fetchOnce();
-    const id = window.setInterval(() => {
-      void fetchOnce();
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(id);
-    };
-  }, [unit]);
-
-  return { data, loading, error };
+  // Shared poll resource: the generation guard drops a stale-unit response
+  // AND a response that resolves after unmount. See usePolledResource.
+  return usePolledResource(unit, () => api.unitPrs(unit as string), {
+    intervalMs: POLL_INTERVAL_MS,
+  });
 }

--- a/clients/react/src/hooks/useUnitSlack.ts
+++ b/clients/react/src/hooks/useUnitSlack.ts
@@ -7,18 +7,15 @@
 //
 // Ores change on the timescale the operator captures one — human-paced. A
 // 60-second poll (same cadence as `useUnitPrs` / `useUnitAims`) is ample for
-// a terrain surface; no SSE here. Mirrors the siblings' shape exactly: keeps
-// the previous response visible while a re-fetch is in flight so the terrain
-// does not flicker; `loading` reflects only the initial fetch. `refresh`
-// follows `useUnitAims` — the capture box re-fetches the persisted state
-// after a successful POST instead of waiting on the next poll tick.
+// a terrain surface; no SSE here. Keeps the previous response visible while
+// a re-fetch is in flight so the terrain does not flicker; `loading`
+// reflects only the initial fetch. `refresh` re-fetches the persisted state
+// after a successful capture POST instead of waiting on the next poll tick.
 //
-// `unit = null` parks the hook (no fetch, no interval) — used when no
-// project is selected so the face can render a placeholder rather than poll
-// a non-existent unit.
+// `unit = null` parks the hook (no fetch, no interval).
 
-import { useCallback, useEffect, useRef, useState } from "react";
 import { api, type UnitSlackResponse } from "@/lib/api";
+import { usePolledResource } from "./usePolledResource";
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -36,70 +33,9 @@ export interface UseUnitSlackResult {
 }
 
 export function useUnitSlack(unit: string | null): UseUnitSlackResult {
-  const [data, setData] = useState<UnitSlackResponse | null>(null);
-  const [loading, setLoading] = useState(unit !== null);
-  const [error, setError] = useState<Error | null>(null);
-  // An in-flight response from a previous unit must not stamp over a
-  // newer unit's data (same guard as useUnitPrs / useUnitAims).
-  const generationRef = useRef(0);
-  // The live unit, so the stable `refresh` callback re-fetches the *current*
-  // unit without being re-created on every unit change.
-  const unitRef = useRef(unit);
-  unitRef.current = unit;
-
-  // One gen-guarded fetch against `targetUnit`, keeping the previous response
-  // visible (anti-flicker). Shared by the initial fetch, the 60s poll, and
-  // `refresh`. Stable identity (no deps) so it doesn't re-trigger the effect.
-  const fetchFor = useCallback(async (targetUnit: string, gen: number) => {
-    try {
-      const res = await api.unitSlack(targetUnit);
-      if (gen !== generationRef.current) return;
-      setData(res);
-      setError(null);
-    } catch (e) {
-      if (gen !== generationRef.current) return;
-      setError(e instanceof Error ? e : new Error(String(e)));
-    } finally {
-      if (gen === generationRef.current) {
-        setLoading(false);
-      }
-    }
-  }, []);
-
-  const refresh = useCallback(() => {
-    const u = unitRef.current;
-    if (!u) return;
-    // Re-fetch under the CURRENT generation, no data clear — the poll path's
-    // anti-flicker behaviour, triggered on demand after an operator capture.
-    void fetchFor(u, generationRef.current);
-  }, [fetchFor]);
-
-  useEffect(() => {
-    if (!unit) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    // Clear on unit *change* (this effect's only re-trigger — deps are
-    // [unit]) so the previous unit's ores are never shown under the new
-    // unit's header. The 60s same-unit re-poll and `refresh` go through
-    // fetchFor, which intentionally keeps the last response visible
-    // (anti-flicker); those paths are untouched. Mirrors useUnitPrs.
-    setData(null);
-    setError(null);
-    setLoading(true);
-
-    void fetchFor(unit, myGen);
-    const id = window.setInterval(() => {
-      void fetchFor(unit, myGen);
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(id);
-    };
-  }, [unit, fetchFor]);
-
-  return { data, loading, error, refresh };
+  // Shared poll resource (exposes `refresh`): the generation guard drops a
+  // stale-unit response AND a response that resolves after unmount.
+  return usePolledResource(unit, () => api.unitSlack(unit as string), {
+    intervalMs: POLL_INTERVAL_MS,
+  });
 }

--- a/clients/react/src/hooks/useWorkingWithHuman.ts
+++ b/clients/react/src/hooks/useWorkingWithHuman.ts
@@ -1,13 +1,13 @@
 // Polling hook for the unit's `◐ Working with this human` view.
 //
-// Mirrors `useDecisions` / `useCalibration`: 60s poll, parked when
-// `unit` is null, generation guard against in-flight stamping. The
-// memory directory + `MEMORY.md` change on human timescales (operators
-// editing memory entries occasionally); polling is fine. SSE follow-up
+// Mirrors `useDecisions` / `useCalibration`: 60s poll, parked when `unit`
+// is null, generation guard against in-flight stamping. The memory
+// directory + `MEMORY.md` change on human timescales (operators editing
+// memory entries occasionally); polling is fine. SSE follow-up
 // (`CoreEvent::MemoryChanged`) would be the natural next step.
 
-import { useEffect, useRef, useState } from "react";
 import { api, type WorkingWithHumanResponse } from "@/lib/api";
+import { usePolledResource } from "./usePolledResource";
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -17,56 +17,10 @@ export interface UseWorkingWithHumanResult {
   error: Error | null;
 }
 
-/**
- * Poll the unit's working-with-human view at `POLL_INTERVAL_MS`.
- * Returns the latest response, an initial-load `loading` flag, and the
- * most recent error (cleared on a successful fetch).
- *
- * `unit = null` parks the hook: no fetch, no interval. The section
- * then renders a "pick a project" notice rather than thrashing the
- * server on a non-existent unit.
- */
 export function useWorkingWithHuman(unit: string | null): UseWorkingWithHumanResult {
-  const [data, setData] = useState<WorkingWithHumanResponse | null>(null);
-  const [loading, setLoading] = useState(unit !== null);
-  const [error, setError] = useState<Error | null>(null);
-  const generationRef = useRef(0);
-
-  useEffect(() => {
-    if (!unit) {
-      setData(null);
-      setLoading(false);
-      setError(null);
-      return;
-    }
-    const myGen = ++generationRef.current;
-    setLoading(true);
-
-    const fetchOnce = async () => {
-      try {
-        const res = await api.workingWithHuman(unit);
-        if (myGen !== generationRef.current) return;
-        setData(res);
-        setError(null);
-      } catch (e) {
-        if (myGen !== generationRef.current) return;
-        setError(e instanceof Error ? e : new Error(String(e)));
-      } finally {
-        if (myGen === generationRef.current) {
-          setLoading(false);
-        }
-      }
-    };
-
-    void fetchOnce();
-    const id = window.setInterval(() => {
-      void fetchOnce();
-    }, POLL_INTERVAL_MS);
-
-    return () => {
-      window.clearInterval(id);
-    };
-  }, [unit]);
-
-  return { data, loading, error };
+  // Shared poll resource: the generation guard drops a stale-unit response
+  // AND a response that resolves after unmount. See usePolledResource.
+  return usePolledResource(unit, () => api.workingWithHuman(unit as string), {
+    intervalMs: POLL_INTERVAL_MS,
+  });
 }


### PR DESCRIPTION
## Root cause (completes #854)
Every R-panel data hook (`useUnitInventory` / `useDecisions` / `usePrBody` / …) was a hand-duplicated copy of the same fetch + poll + generation-guard shape. Every copy cleared its interval on unmount but **never invalidated the in-flight fetch** — a response that resolved *after* unmount called `setState` on a gone component. React 19's `resolveUpdatePriority` reads `window` during that update, and the jsdom test teardown has already removed it → `ReferenceError: window is not defined`, which Vitest reports as an *unhandled error* failing the **whole run**, attributed nondeterministically to whichever test is mid-flight (`Gutters` / `RPanel` in CI).

This is why hub `main`'s **Build React WebUI** went flaky-red after #852 put the R panel on the default render path. The rAF half was #854; **this is the dominant source** (the repeated `fetchOnce → dispatchSetState` errors in the failing logs).

## Fix
Consolidate the shape into a shared `usePolledResource(depKey, fetcher, { intervalMs? })` whose generation guard now also **bumps on cleanup**, so a late response is dropped on every path (depKey change, park, unmount):
- ~14 list/detail hooks become thin wrappers (the local `usePrResource` in `usePrDetail` is replaced too — same latent bug).
- `useUnitAttention` keeps its bespoke POST-write-back shape (settingKey / writeSeq) and carries the same cleanup bump inline (which fixes both its GET and its setAttention POST, since both gate on `generationRef`).

**Net −455 lines.**

## Tests / verification (mirrors CI)
- New `usePolledResource.test.ts` (7 tests): unmount-drop, stale-depKey-drop, poll-vs-one-shot, park, refresh.
- All existing per-hook tests preserved.
- `biome check` exit 0 (pre-existing unrelated warning only), `tsc -b` clean, `vite build` clean.
- **Full `vitest run` green across 3 consecutive runs** — the flaky `window is not defined` teardown error is gone (121 files, 1093 passed / 2 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Refactor**
  * アプリケーション内の複数のポーリング機能を共通フックに統一し、実装を整理しました。遅延応答やアンマウント後の状態更新に関する処理の一貫性と堅牢性が向上しています。

* **Tests**
  * 共有フックの動作を検証するテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->