### PR TITLE
feat(webui): cut Producer launch over to engine-direct endpoint ((B) Phase 2)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -394,26 +394,19 @@ export function App({
         return;
       }
       try {
-        // tmai-core's `/api/spawn` only allows a tight set of commands
-        // (`claude / codex / gemini / bash / sh / zsh`) — see
-        // `tmai-core/src/server/spawn.rs`. `tmai` itself isn't on the
-        // allow-list, so we wrap the launch in a `bash -c "exec …"`.
+        // (B) Phase 2 — the engine composes + spawns the Producer directly via
+        // `POST /api/units/{unit}/producer/launch` (#566), so the launched
+        // process IS `claude` (`agent_type=claude` + `is_producer` set at the
+        // spawn act), with no bash / tmai shim on the process tree. The engine
+        // resolves the unit from the derived basename — a configured `[[unit]]`,
+        // or a repo/worktree basename that reduces to its owning unit
+        // (`resolve_unit_or_cwd`). An unresolvable name returns 404 and surfaces
+        // as the failure toast below.
         //
-        // The unit name flows through `$0` so shell metacharacters in
-        // the basename (a real concern: it's a user-picked directory)
-        // can't break out of the argument. `exec` collapses the bash
-        // wrapper into the tmai process; `tmai producer` itself execs
-        // into the Claude session — net result is a clean PTY with no
-        // bash / tmai shim left on the process tree.
-        //
-        // The right long-term fix is a Producer-specific spawn
-        // endpoint (or extending the allow-list) on the tmai-core
-        // side; tracked as Phase C / D work.
-        const res = await api.spawnPty({
-          command: "bash",
-          args: ["-c", 'exec tmai producer "$0"', derivedUnit],
-          cwd: path,
-        });
+        // The bash-wrap `/api/spawn` path (`exec tmai producer "$0"`) stays as a
+        // live fallback in tmai-core until this engine-direct launch is proven
+        // in dogfood; it is retired separately, not in this cut-over.
+        const res = await api.launchProducer(derivedUnit);
         setSelection({ type: "agent", id: res.session_id });
         setCurrentProject(path);
         closeMainPanelOverlay();

--- a/clients/react/src/lib/__tests__/api-launch-producer.test.ts
+++ b/clients/react/src/lib/__tests__/api-launch-producer.test.ts
@@ -1,0 +1,60 @@
+// @vitest-environment jsdom
+//
+// api.launchProducer — (B) Phase 2 engine-composed Producer launch (#566).
+// Asserts the wire contract: POST /units/{unit}/producer/launch (unit
+// URL-encoded), no request body (the unit in the path is the only input),
+// returns the SpawnResponse, and a backend rejection (404 unresolvable unit)
+// propagates as an Error. Mirrors the fetch-mock shape of api-aim-write.test.ts.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// Stub window.location before module import so getConfig() resolves correctly.
+Object.defineProperty(window, "location", {
+  value: { origin: "http://localhost", search: "?token=tok" },
+  writable: true,
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+import { api, type SpawnResponse } from "../api-http";
+
+const SPAWN: SpawnResponse = { session_id: "claude:abc123", pid: 0, command: "claude" };
+
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+describe("api.launchProducer", () => {
+  beforeEach(() => {
+    mockFetch.mockResolvedValue(jsonResponse(SPAWN));
+  });
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("POSTs to /units/{unit}/producer/launch and returns the spawn response", async () => {
+    const result = await api.launchProducer("tmai");
+    expect(result).toEqual(SPAWN);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+    const [url, init] = mockFetch.mock.calls[0];
+    expect(url).toMatch(/\/api\/units\/tmai\/producer\/launch$/);
+    expect((init as RequestInit).method).toBe("POST");
+    // No request body — the unit (in the path) is the only input.
+    expect((init as RequestInit).body).toBeUndefined();
+  });
+
+  it("URL-encodes the unit name", async () => {
+    await api.launchProducer("a/b");
+    const [url] = mockFetch.mock.calls[0];
+    expect(url).toMatch(/\/units\/a%2Fb\/producer\/launch$/);
+  });
+
+  it("propagates an unresolvable unit (404) as Error", async () => {
+    mockFetch.mockResolvedValueOnce(new Response("no [[unit]] named 'ghost'", { status: 404 }));
+    await expect(api.launchProducer("ghost")).rejects.toThrow(/API error 404/);
+  });
+});

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -1310,6 +1310,16 @@ export const api = {
       method: "POST",
       body: JSON.stringify(req),
     }),
+  // Engine-composed direct `claude` Producer launch (#566 / (B) Phase 2).
+  // The engine resolves the unit (a configured `[[unit]]`, or a repo/worktree
+  // basename that reduces to its owning unit), runs the shared launch builder
+  // (compose + #541 readiness + boot file #373 + the exact `claude` argv), and
+  // spawns `claude` DIRECTLY into a PTY with `is_producer` + `agent_type=claude`
+  // set at the spawn act — no bash-wrap / tmai-CLI chain. Body mirrors `/spawn`.
+  launchProducer: (unit: string) =>
+    apiFetch<SpawnResponse>(`/units/${encodeURIComponent(unit)}/producer/launch`, {
+      method: "POST",
+    }),
 
   // Worktree management
   listWorktrees: () => apiFetch<WorktreeSnapshot[]>("/worktrees"),

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -124,6 +124,7 @@ export const api = {
     rows?: number;
     cols?: number;
   }) => httpApi.spawnWorktree(req),
+  launchProducer: (unit: string) => httpApi.launchProducer(unit),
 
   // Worktree management
   listWorktrees: () => httpApi.listWorktrees(),


### PR DESCRIPTION
## What ((B) Phase 2)
App's `launchProducerAt` now calls **`POST /api/units/{unit}/producer/launch`** (#566, the Phase 1 endpoint) instead of the bash-wrap `/api/spawn` (`bash -c 'exec tmai producer "$0"'`). The engine composes the launch and spawns `claude` **directly**, so the launched process IS the Producer — `agent_type=claude` + `is_producer` set at the spawn act, no bash / tmai shim on the process tree.

The engine resolves the unit from the derived basename via `resolve_unit_or_cwd` — a configured `[[unit]]`, or a repo/worktree basename that reduces to its owning unit (the #379 phantom-unit reduction).

## Scope — additive cut-over, no rip
- The bash-wrap `/api/spawn` path stays a **live fallback** in tmai-core.
- The WebUI's bash-wrap handling (`isAiAgentLoose`'s bash-wrapped-Producer case, the `isHandoverAgent` detection) is **untouched** — retired separately once this is proven in dogfood, not here.
- `useHandover` already keys the Producer on the `is_producer` wire field, so the cut-over **strengthens** detection (the agent is now genuinely `claude`, not bash-wrapped under `Custom("bash")`).

## Tests / verification
- New `api-launch-producer.test.ts`: POST path, unit URL-encoding, 404 propagation.
- `biome` exit 0, `tsc -b` clean, `vite build` clean, full `vitest run` green (122 files, 1096 passed).
- **⚠ Live-launch is the real proof**: CI can't exercise an actual spawn. The decisive verification is an operator launching a Producer from the WebUI and confirming it comes up as `agent_type=claude` + `is_producer` (the dogfood test gating the bash-wrap retirement).

## Behavioural note
Vs the bash-wrap path (which passed `cwd=picked-path`), the endpoint resolves the launch dir from the unit **config** server-side. So launching an **unconfigured arbitrary directory** (no `[[unit]]`, name not a repo/worktree basename) now 404s instead of launching at that path. Configured units (the dogfood) are unaffected — this aligns launch with the unit-addressed identity model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **リファクタリング**
  * プロデューサ起動プロセスの内部実装を改善しました。従来のシェル経由の起動から、より直接的な起動パスに切り替えることで、プロセス管理をより効率化します。

* **テスト**
  * 新しい起動メカニズムに対応するテストスイートを追加しました。正常系の起動フロー、エラーハンドリング、パラメータエンコーディングを検証します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->