### PR TITLE
chore(gen): sync generated spec + types from tmai-core@40dadf94d6

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -4280,21 +4280,6 @@
       "type": "object"
     },
     {
-      "description": "Usage data was updated (after a fetch cycle)",
-      "properties": {
-        "type": {
-          "enum": [
-            "UsageUpdated"
-          ],
-          "type": "string"
-        }
-      },
-      "required": [
-        "type"
-      ],
-      "type": "object"
-    },
-    {
       "description": "A tool call was deferred for external resolution",
       "properties": {
         "defer_id": {

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -2244,21 +2244,6 @@
           },
           {
             "type": "object",
-            "description": "Usage data was updated (after a fetch cycle)",
-            "required": [
-              "type"
-            ],
-            "properties": {
-              "type": {
-                "type": "string",
-                "enum": [
-                  "UsageUpdated"
-                ]
-              }
-            }
-          },
-          {
-            "type": "object",
             "description": "A tool call was deferred for external resolution",
             "required": [
               "defer_id",

--- a/clients/ratatui/src/types/generated/core_event.rs
+++ b/clients/ratatui/src/types/generated/core_event.rs
@@ -62,7 +62,6 @@ pub enum CoreEvent {
         prompt: String,
         target: String,
     },
-    UsageUpdated,
     ToolCallDeferred {
         defer_id: i64,
         target: String,

--- a/clients/react/src/types/generated/CoreEvent.ts
+++ b/clients/react/src/types/generated/CoreEvent.ts
@@ -132,7 +132,7 @@ target: string,
 /**
  * The prompt text to send
  */
-prompt: string, } | { "type": "UsageUpdated" } | { "type": "ToolCallDeferred", 
+prompt: string, } | { "type": "ToolCallDeferred", 
 /**
  * Unique deferred call ID
  */


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@40dadf94d6aa8ec5912b2935caf34295c2cb246b

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/corevents.schema.json                    | 15 ---------------
 api-spec/openapi.json                             | 15 ---------------
 clients/ratatui/src/types/generated/core_event.rs |  1 -
 clients/react/src/types/generated/CoreEvent.ts    |  2 +-
 4 files changed, 1 insertion(+), 32 deletions(-)
```

</details>