### PR TITLE
chore(gen): sync generated spec + types from tmai-core@bf8b15575a

### DIFF
--- a/api-spec/mcp-tools.json
+++ b/api-spec/mcp-tools.json
@@ -985,24 +985,6 @@
     }
   },
   {
-    "description": "Mark an existing agent as orchestrator (e.g. after /resume recovery)",
-    "name": "set_orchestrator",
-    "parameters_schema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": {
-        "id": {
-          "description": "Agent ID — accepts stable ID, pane target, PTY session UUID, \"issue:N\", or \"pr:N\"",
-          "type": "string"
-        }
-      },
-      "required": [
-        "id"
-      ],
-      "title": "SetOrchestratorParams",
-      "type": "object"
-    }
-  },
-  {
     "description": "Spawn a new AI agent in a directory",
     "name": "spawn_agent",
     "parameters_schema": {
@@ -1041,49 +1023,6 @@
         "directory"
       ],
       "title": "SpawnAgentParams",
-      "type": "object"
-    }
-  },
-  {
-    "description": "Spawn an orchestrator agent with workflow settings from config",
-    "name": "spawn_orchestrator",
-    "parameters_schema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": {
-        "additional_instructions": {
-          "default": null,
-          "description": "Additional instructions appended to the composed orchestrator prompt",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "cwd": {
-          "default": null,
-          "description": "Working directory (optional, defaults to first registered project or cwd)",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "effort": {
-          "default": null,
-          "description": "Per-dispatch effort override. See `SpawnAgentParams::effort`.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "model": {
-          "default": null,
-          "description": "Per-dispatch model override. See `SpawnAgentParams::model`.",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "title": "SpawnOrchestratorParams",
       "type": "object"
     }
   },


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@bf8b15575aec8c0f8a339af3955dc7c610f5f147

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/mcp-tools.json | 61 -------------------------------------------------
 1 file changed, 61 deletions(-)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **削除**
  * `set_orchestrator` ツール定義を削除しました
  * `spawn_orchestrator` ツール定義を削除しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->