### PR TITLE
feat(aim-console): source unit tabs from the live Producer-slot set (producer-cwd todo② Phase B)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -31,6 +31,7 @@ import { useIdleNotification } from "@/hooks/useIdleNotification";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useNotificationConfig } from "@/hooks/useNotificationConfig";
 import { useResponsiveLayout } from "@/hooks/useResponsiveLayout";
+import { useSlots } from "@/hooks/useSlots";
 import { useSplitPane } from "@/hooks/useSplitPane";
 import { useUnits } from "@/hooks/useUnits";
 import { useWorktrees } from "@/hooks/useWorktrees";
@@ -206,6 +207,14 @@ export function App({
   // `currentProject` happens to point at. `useHandover` consumes the same wire
   // for cross-unit reconciliation.
   const { data: unitsData, loading: unitsLoading } = useUnits();
+
+  // Live Producer-slot set (tmai-core #580 — aim `producer-cwd`): the
+  // agent-primacy tab source for the aim console. Distinct from `useUnits`
+  // (configured `[[unit]]` membership, kept above for agent→unit resolution
+  // + the legacy unit-tab strip): `slotsData` reflects only units with a live
+  // Producer, so the aim-console tabs become "where a Producer stood" rather
+  // than the static config enumeration.
+  const { data: slotsData } = useSlots();
 
   // The active unit NAME, fed to the unit-scoped wires (`GET
   // /api/units/{unit}/…`). Anchored to the unit that OWNS `currentProject` in
@@ -682,7 +691,7 @@ export function App({
     return (
       <>
         <AimConsole
-          units={unitsData?.units ?? []}
+          units={slotsData?.slots ?? []}
           activeUnitName={unitName}
           onSelectUnit={handleSelectUnit}
           onAddUnit={openLaunchPicker}

--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -32,7 +32,7 @@
 
 import { type CSSProperties, useCallback, useState } from "react";
 import { useConfirm } from "@/components/layout/ConfirmDialog";
-import type { AgentSnapshot, TriggerHandoffRitualRequest, UnitResponse } from "@/lib/api";
+import type { AgentSnapshot, SlotResponse, TriggerHandoffRitualRequest } from "@/lib/api";
 import {
   AIM_CONSOLE_LAYOUT_DEFAULTS,
   type AimConsoleLayout,
@@ -67,14 +67,17 @@ function repoBasename(path: string): string {
 }
 
 interface AimConsoleProps {
-  /** Configured `[[unit]]` membership (App's `useUnits`), rendered as the
-   *  top-bar unit tabs. Empty = no tabs (cwd-synthesized units aren't
-   *  enumerated; same convention as the existing UnitTabs). */
-  units: UnitResponse[];
+  /** Live Producer-slot set (App's `useSlots`, tmai-core #580 — aim
+   *  `producer-cwd`), rendered as the top-bar unit tabs: a project is *where a
+   *  Producer stood*, so a dormant `[[unit]]` with no live Producer is not a
+   *  tab until its "+" Add-unit launch stands one. Empty = no live slots. Each
+   *  slot carries `name + repos` (same membership the tabs + per-repo footer
+   *  use) plus a lifecycle `state` (occupied / vacant / halted). */
+  units: SlotResponse[];
   /** Name of the currently focused unit, so the matching tab highlights. */
   activeUnitName: string | null;
   /** Re-scope the focused unit to the clicked tab. */
-  onSelectUnit: (unit: UnitResponse) => void;
+  onSelectUnit: (unit: SlotResponse) => void;
   /** "Add unit = launch Producer" affordance — opens App's repo-root launch
    *  picker (the launch cwd defines the unit; aim `producer-cwd`). */
   onAddUnit: () => void;
@@ -82,7 +85,7 @@ interface AimConsoleProps {
    *  footer bash (the `producer-kill` teardown, the sole `producer-slot-
    *  invariant` carve-out: close does NOT respawn). Gated behind an always-on
    *  confirm in the tab; called ONLY after that confirm is accepted. */
-  onCloseUnit: (unit: UnitResponse) => void;
+  onCloseUnit: (unit: SlotResponse) => void;
   /** Switch back to the existing ProducerConsole (the default view). The
    *  ENTER toggle lives in StatusBar; this is its EXIT pair, since the
    *  full-window aim console replaces the existing chrome incl. StatusBar. */
@@ -278,7 +281,7 @@ function AimUnitTab({
   onSelect,
   onClose,
 }: {
-  unit: UnitResponse;
+  unit: SlotResponse;
   active: boolean;
   onSelect: () => void;
   onClose: () => void;

--- a/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
@@ -17,7 +17,7 @@
 import { fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import { ConfirmProvider } from "@/components/layout/ConfirmDialog";
-import type { AimsResponse, UnitIssuesResponse, UnitPrsResponse, UnitResponse } from "@/lib/api";
+import type { AimsResponse, SlotResponse, UnitIssuesResponse, UnitPrsResponse } from "@/lib/api";
 import { UIPrefsProvider } from "@/lib/ui-prefs-provider";
 import { AimConsole } from "../AimConsole";
 
@@ -36,13 +36,14 @@ vi.mock("@/lib/api", async () => {
   };
 });
 
-const UNITS: UnitResponse[] = [
+const UNITS: SlotResponse[] = [
   {
     name: "tmai",
     repos: [
       { path: "/home/u/tmai", primary: true },
       { path: "/home/u/tmai-core", primary: false },
     ],
+    state: "occupied",
   },
 ];
 

--- a/clients/react/src/components/aim-console/__tests__/Gutters.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/Gutters.test.tsx
@@ -17,9 +17,9 @@ import { ConfirmProvider } from "@/components/layout/ConfirmDialog";
 import type {
   AgentSnapshot,
   AimsResponse,
+  SlotResponse,
   UnitIssuesResponse,
   UnitPrsResponse,
-  UnitResponse,
 } from "@/lib/api";
 import {
   AIM_CONSOLE_LAYOUT_DEFAULTS,
@@ -46,13 +46,14 @@ vi.mock("@/lib/api", async () => {
   };
 });
 
-const UNITS: UnitResponse[] = [
+const UNITS: SlotResponse[] = [
   {
     name: "tmai",
     repos: [
       { path: "/home/u/tmai", primary: true },
       { path: "/home/u/tmai-core", primary: false },
     ],
+    state: "occupied",
   },
 ];
 

--- a/clients/react/src/hooks/useSlots.ts
+++ b/clients/react/src/hooks/useSlots.ts
@@ -1,0 +1,70 @@
+// Polling hook for the live Producer-slot set (tmai-core #580 — aim
+// `producer-cwd`), the agent-primacy tab source for the aim console.
+//
+// `GET /api/slots` reflects only LIVE Producer slots — a project is *where a
+// Producer stood*, not a configured `[[unit]]` enumeration. Each slot carries
+// the same `name + repos` membership as `GET /api/units` plus a lifecycle
+// `state` (`occupied` healthy / `vacant` mid-respawn / `halted` crash-loop;
+// `closed` never surfaces). Where `useUnits` is the dormant-aware CONFIGURED
+// membership (and stays the source for agent→unit resolution + the legacy
+// unit-tab strip), this is the LIVE set the aim-console tabs read: a dormant
+// `[[unit]]` that has never launched a Producer is not a tab until its "+"
+// Add-unit launch stands one.
+//
+// Unlike the human-paced `useUnits` (config.toml edits, 60-second poll), slots
+// are live state — a Producer launch / crash / handoff changes the set — so a
+// shorter 10-second poll keeps a freshly-launched unit's tab appearing
+// promptly. The previous response stays visible during a re-fetch so the tab
+// strip does not flicker; `loading` reflects only the initial fetch.
+
+import { useEffect, useState } from "react";
+import { api, type SlotsResponse } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 10_000;
+
+export interface UseSlotsResult {
+  data: SlotsResponse | null;
+  loading: boolean;
+  error: Error | null;
+}
+
+export function useSlots(): UseSlotsResult {
+  const [data, setData] = useState<SlotsResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  useEffect(() => {
+    // One global live-slot list — no unit-scope discriminator that could swap
+    // mid-flight, so (like `useUnits`) the per-unit generation guard the
+    // unit-scoped hooks use isn't needed here.
+    let cancelled = false;
+
+    const fetchOnce = async () => {
+      try {
+        const res = await api.slots();
+        if (cancelled) return;
+        setData(res);
+        setError(null);
+      } catch (e) {
+        if (cancelled) return;
+        setError(e instanceof Error ? e : new Error(String(e)));
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    };
+
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, []);
+
+  return { data, loading, error };
+}

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -29,6 +29,9 @@ import type { RepoSlackWire } from "@/types/generated/RepoSlackWire";
 import type { RuntimeSnapshot } from "@/types/generated/RuntimeSnapshot";
 import type { SlackCaptureRequest } from "@/types/generated/SlackCaptureRequest";
 import type { SlackOreWire } from "@/types/generated/SlackOreWire";
+import type { SlotResponse } from "@/types/generated/SlotResponse";
+import type { SlotStateWire } from "@/types/generated/SlotStateWire";
+import type { SlotsResponse } from "@/types/generated/SlotsResponse";
 import type { SpawnRole } from "@/types/generated/SpawnRole";
 import type { SpawnRuntime } from "@/types/generated/SpawnRuntime";
 import type { TerminalSubscription } from "@/types/generated/TerminalSubscription";
@@ -69,6 +72,9 @@ export type {
   RepoSlackWire,
   SlackCaptureRequest,
   SlackOreWire,
+  SlotResponse,
+  SlotStateWire,
+  SlotsResponse,
   SpawnRole,
   SpawnRuntime,
   TerminalSubscription,
@@ -1441,6 +1447,15 @@ export const api = {
   // client-derived state pill.
   units: () => apiFetch<UnitsResponse>("/units"),
   unit: (name: string) => apiFetch<UnitResponse>(`/units/${encodeURIComponent(name)}`),
+
+  // Live Producer-slot set (tmai-core #580 — aim producer-cwd) — the
+  // agent-primacy tab source: a project is *where a Producer stood*, not a
+  // configured `[[unit]]` enumeration. Unlike `/units` (dormant-aware
+  // membership), `/slots` reflects only live Producers (Occupied) plus the
+  // supervisor's transient Vacant / Halted states (Closed never surfaces),
+  // each carrying the same `name + repos` membership. The aim-console tab
+  // source reads this instead of `/units`.
+  slots: () => apiFetch<SlotsResponse>("/slots"),
 
   // Hand-over batons (read-only) — the operator-side half of tmai-core PR
   // #473's handoffs endpoint. `unitHandoffs` lists the unit's batons

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -256,6 +256,10 @@ export const api = {
   units: () => httpApi.units(),
   unit: (name: string) => httpApi.unit(name),
 
+  // Live Producer-slot set (HTTP only — the agent-primacy aim-console tab
+  // source, tmai-core #580; no Tauri-specific path needed)
+  slots: () => httpApi.slots(),
+
   // Hand-over batons (HTTP only — read-only file-backed baton store, the
   // operator-side half of tmai-core #473; no Tauri-specific path needed)
   unitHandoffs: (unit: string) => httpApi.unitHandoffs(unit),


### PR DESCRIPTION
## Why

Phase B of aim **producer-cwd** todo② — the aim-console **tab source rewire**, completing the live-slot work begun in tmai-core #580 (`GET /api/slots`, mirrored here in #879).

The aim-console's top-bar tabs are sourced from `GET /api/units` — the configured `[[unit]]` enumeration. Per agent-primacy (*a project is where a Producer stood*), the tabs should reflect the **live Producer slots**. This switches the source to `GET /api/slots`.

## What

- **`api.slots()`** (`api-http.ts` + `api-tauri.ts` wrapper) + `SlotResponse` / `SlotsResponse` / `SlotStateWire` re-exported from `@/lib/api`.
- **`useSlots`** hook — polls `/slots` at **10s** (live state — a launch/crash/handoff changes the set — vs `useUnits`' 60s config cadence).
- **`App`**: feeds `<AimConsole units>` from `useSlots`. `useUnits` **stays** for agent→unit resolution (`resolveUnitName` / `unitName` / `unitReposForCurrent`) and the legacy `UnitTabs` strip — only the aim-console tab source moved.
- **`AimConsole`**: `units` prop + tab callbacks typed `SlotResponse` (same `name + repos` membership plus a lifecycle `state`). Test fixtures updated.

## Behavioral consequence (intended)

A **dormant `[[unit]]` that has never launched a Producer is no longer a tab** — it appears once its "+" Add-unit launch stands a Producer (the bootstrap the `producer-slot-invariant` safety-net presupposes). This is the agent-primacy intent.

The slot `state` (`occupied` / `vacant` / `halted`) is now available to the tab UI but **not yet rendered** — a health-badge follow-up.

## Gate (CI parity — all green locally)

- `tsc -b` (typecheck)
- `biome check src/` (lint)
- `vitest run` (961 passed, 2 skipped)
- `pnpm build` (`tsc -b && vite build`)

## Refs

- design intent: `tmai-core:doc/aims/producer-cwd.md` (PROCESS todo②) + `producer-slot-invariant.md`
- backend: tmai-core #580 (`GET /api/slots`); types mirror #879

🤖 Generated with [Claude Code](https://claude.com/claude-code)