### PR TITLE
feat(launch): cut launchProducerAt over to the by-path endpoint (rip #581 ①, site 3)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -357,30 +357,27 @@ export function App({
   //     instead and calls `launchProducerAt` with the picked path.
   const launchProducerAt = useCallback(
     async (path: string) => {
-      const derivedUnit = path.split("/").filter(Boolean).pop();
-      if (!derivedUnit) {
-        toastInfo("Could not derive a unit name from the chosen path.");
+      if (!path) {
+        toastInfo("No path chosen.");
         return;
       }
+      // Display label only — the engine derives the REAL unit from the path.
+      const label = path.split("/").filter(Boolean).pop() ?? path;
       try {
-        // (B) Phase 2 — the engine composes + spawns the Producer directly via
-        // `POST /api/units/{unit}/producer/launch` (#566), so the launched
-        // process IS `claude` (`agent_type=claude` + `is_producer` set at the
-        // spawn act), with no bash / tmai shim on the process tree. The engine
-        // resolves the unit from the derived basename — a configured `[[unit]]`,
-        // or a repo/worktree basename that reduces to its owning unit
-        // (`resolve_unit_or_cwd`). An unresolvable name returns 404 and surfaces
-        // as the failure toast below.
-        //
-        // The bash-wrap `/api/spawn` path (`exec tmai producer "$0"`) stays as a
-        // live fallback in tmai-core until this engine-direct launch is proven
-        // in dogfood; it is retired separately, not in this cut-over.
-        const res = await api.launchProducer(derivedUnit);
+        // By-PATH launch (#581 — the `+` Add-unit bootstrap fix): send the
+        // picked ABSOLUTE PATH, not its basename. The engine derives the unit
+        // from it (`unit_for_path` — the owning `[[unit]]`, else a `from_dir`
+        // synthesis), so a brand-new project root launches where the old
+        // by-name basename 404'd (`no [[unit]] named '<basename>'`). The
+        // launched process IS `claude` (`agent_type=claude` + `is_producer` at
+        // the spawn act), no bash / tmai shim. A missing dir returns 400 → the
+        // failure toast below.
+        const res = await api.launchProducer(path);
         setSelection({ type: "agent", id: res.session_id });
         setCurrentProject(path);
         closeMainPanelOverlay();
         refresh();
-        toastSuccess(`Producer launched for ${derivedUnit}`);
+        toastSuccess(`Producer launched for ${label}`);
       } catch (e) {
         const reason = e instanceof Error ? e.message : String(e);
         toastInfo(`Failed to launch Producer: ${reason}`);

--- a/clients/react/src/lib/__tests__/api-launch-producer.test.ts
+++ b/clients/react/src/lib/__tests__/api-launch-producer.test.ts
@@ -1,9 +1,10 @@
 // @vitest-environment jsdom
 //
-// api.launchProducer — (B) Phase 2 engine-composed Producer launch (#566).
-// Asserts the wire contract: POST /units/{unit}/producer/launch (unit
-// URL-encoded), no request body (the unit in the path is the only input),
-// returns the SpawnResponse, and a backend rejection (404 unresolvable unit)
+// api.launchProducer — by-PATH engine-composed Producer launch (#581; the rip's
+// `+` Add-unit bootstrap fix, superseding the #566 by-name route). Asserts the
+// wire contract: POST /producer/launch with a `{ path }` body carrying the
+// picked ABSOLUTE PATH (not its basename — the engine derives the unit from the
+// path via `unit_for_path`), returns the SpawnResponse, and a backend rejection
 // propagates as an Error. Mirrors the fetch-mock shape of api-aim-write.test.ts.
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -36,25 +37,32 @@ describe("api.launchProducer", () => {
     vi.clearAllMocks();
   });
 
-  it("POSTs to /units/{unit}/producer/launch and returns the spawn response", async () => {
-    const result = await api.launchProducer("tmai");
+  it("POSTs to /producer/launch with the picked path body and returns the spawn response", async () => {
+    const result = await api.launchProducer("/home/u/works/new-project");
     expect(result).toEqual(SPAWN);
     expect(mockFetch).toHaveBeenCalledTimes(1);
     const [url, init] = mockFetch.mock.calls[0];
-    expect(url).toMatch(/\/api\/units\/tmai\/producer\/launch$/);
+    expect(url).toMatch(/\/api\/producer\/launch$/);
     expect((init as RequestInit).method).toBe("POST");
-    // No request body — the unit (in the path) is the only input.
-    expect((init as RequestInit).body).toBeUndefined();
+    expect(JSON.parse((init as RequestInit).body as string)).toEqual({
+      path: "/home/u/works/new-project",
+    });
   });
 
-  it("URL-encodes the unit name", async () => {
-    await api.launchProducer("a/b");
-    const [url] = mockFetch.mock.calls[0];
-    expect(url).toMatch(/\/units\/a%2Fb\/producer\/launch$/);
+  it("sends the FULL path, not its basename (the #581 by-path bootstrap)", async () => {
+    await api.launchProducer("/home/u/works/conversation-handoff-mcp");
+    const [, init] = mockFetch.mock.calls[0];
+    const body = JSON.parse((init as RequestInit).body as string);
+    // The engine derives the unit from the full path; sending only the basename
+    // is exactly the bug #581 fixes (an unconfigured basename 404'd).
+    expect(body.path).toBe("/home/u/works/conversation-handoff-mcp");
+    expect(body.path).not.toBe("conversation-handoff-mcp");
   });
 
-  it("propagates an unresolvable unit (404) as Error", async () => {
-    mockFetch.mockResolvedValueOnce(new Response("no [[unit]] named 'ghost'", { status: 404 }));
-    await expect(api.launchProducer("ghost")).rejects.toThrow(/API error 404/);
+  it("propagates a backend rejection (400 missing dir) as Error", async () => {
+    mockFetch.mockResolvedValueOnce(
+      new Response("Directory does not exist: /nope", { status: 400 }),
+    );
+    await expect(api.launchProducer("/nope")).rejects.toThrow(/API error 400/);
   });
 });

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -19,6 +19,7 @@ import type { IssueLabelWire } from "@/types/generated/IssueLabelWire";
 import type { IssueSummaryWire } from "@/types/generated/IssueSummaryWire";
 import type { PermissionMode } from "@/types/generated/PermissionMode";
 import type { PrDiffResponse } from "@/types/generated/PrDiffResponse";
+import type { ProducerLaunchRequest } from "@/types/generated/ProducerLaunchRequest";
 import type { PrSummaryWire } from "@/types/generated/PrSummaryWire";
 import type { QueueAgentEntry } from "@/types/generated/QueueAgentEntry";
 import type { QueueSnapshot } from "@/types/generated/QueueSnapshot";
@@ -63,6 +64,7 @@ export type {
   IssueSummaryWire,
   PermissionMode,
   PrDiffResponse,
+  ProducerLaunchRequest,
   PrSummaryWire,
   QueueAgentEntry,
   QueueSnapshot,
@@ -1082,15 +1084,18 @@ export const api = {
       method: "POST",
       body: JSON.stringify(req),
     }),
-  // Engine-composed direct `claude` Producer launch (#566 / (B) Phase 2).
-  // The engine resolves the unit (a configured `[[unit]]`, or a repo/worktree
-  // basename that reduces to its owning unit), runs the shared launch builder
-  // (compose + #541 readiness + boot file #373 + the exact `claude` argv), and
-  // spawns `claude` DIRECTLY into a PTY with `is_producer` + `agent_type=claude`
-  // set at the spawn act — no bash-wrap / tmai-CLI chain. Body mirrors `/spawn`.
-  launchProducer: (unit: string) =>
-    apiFetch<SpawnResponse>(`/units/${encodeURIComponent(unit)}/producer/launch`, {
+  // Engine-composed direct `claude` Producer launch, BY PATH (#581 — the rip's
+  // `+` Add-unit bootstrap fix). Sends the picked absolute path; the engine
+  // derives the unit from it (`unit_for_path` — the owning `[[unit]]`, else a
+  // `from_dir` synthesis, so a brand-new project root launches where the old
+  // by-name basename 404'd), runs the shared launch builder (compose + #541
+  // readiness + boot file #373 + the exact `claude` argv), and spawns `claude`
+  // DIRECTLY into a PTY with `is_producer` + `agent_type=claude` at the spawn
+  // act — no bash-wrap / tmai-CLI chain. Body mirrors `/spawn`'s response.
+  launchProducer: (path: string) =>
+    apiFetch<SpawnResponse>("/producer/launch", {
       method: "POST",
+      body: JSON.stringify({ path } satisfies ProducerLaunchRequest),
     }),
 
   // Worktree management

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -118,7 +118,7 @@ export const api = {
     rows?: number;
     cols?: number;
   }) => httpApi.spawnWorktree(req),
-  launchProducer: (unit: string) => httpApi.launchProducer(unit),
+  launchProducer: (path: string) => httpApi.launchProducer(path),
 
   // Worktree management
   listWorktrees: () => httpApi.listWorktrees(),


### PR DESCRIPTION
Companion to **tmai-core #582** (`POST /api/producer/launch`) — the hub half of rip #581 ①, completing the `+` Add-unit bootstrap fix.

## Why

The `+` Add-unit launcher was **broken for new projects** (dogfood-found). `launchProducerAt` discarded the picked **full path** and sent only its **basename** to the by-name endpoint, which **404s** a brand-new dir (`no [[unit]] named '<basename>'`). Per agent-primacy (`producer-cwd`: the launch cwd DEFINES the unit), send the full path; the engine derives the unit from it.

## What

- **`api.launchProducer(path)`** → `POST /producer/launch` with a `{ path }` body (`ProducerLaunchRequest`), replacing the by-name `/units/{unit}/producer/launch`. `api-tauri` passthrough updated.
- **`launchProducerAt`** sends the picked **absolute path** (basename kept only for the toast label). A missing dir → 400 → failure toast.
- `api-launch-producer` tests rewritten for the by-path wire (path body; full-path-not-basename guard; 400-rejection propagation).

## Verifies

End-to-end `+` Add-unit for a **new project** (the dogfood case `~/works/conversation-handoff-mcp`): pick the dir → engine synthesizes the unit via `from_dir` → spawns `claude` → a new live slot → a new aim-console tab. For a new single-repo project, `agent.unit` (= basename) already matches `findProducerForUnit`'s rule 3a, so handoff works too.

## Out of scope (rip #581, separable follow-up)

`producer.ts` **rule 3a (site 3)** convergence: `findProducerForUnit` derives the unit name from the primary repo basename rather than the wire `name`, so it can diverge from `agent.unit` for a **config-less wrapper whose member repos are NOT same-named as the wrapper** (②-b). That edge is **latent on `tmai/tmai`** (same-name convention) and unverifiable on the dogfood box, and the fix needs a `findProducerForUnit` signature change. ① (verifiable) is complete here; site 3 is tracked on #581.

## Gate (CI parity — all green locally)

- `tsc -b`
- `biome check src/`
- `vitest run` (961 passed, 2 skipped)
- `pnpm build` (`tsc -b && vite build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **リファクタリング**
  * プロデューサー起動処理をパス指定ベースに変更しました。パスが選択されていない場合は通知が表示され、成功時の通知メッセージもパス情報を反映するようになりました。

* **テスト**
  * プロデューサー起動機能のテストを新しい実装に対応させました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->