### PR TITLE
fix(app): keep an explicit tab selection across live units (#581 dogfood)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -45,6 +45,7 @@ import {
   type UnitResponse,
 } from "@/lib/api";
 import { closeUnitSlot } from "@/lib/close-unit-slot";
+import { currentProjectBelongsToLiveProject } from "@/lib/current-project";
 import { findProducerForUnit } from "@/lib/producer";
 import { useSSE } from "@/lib/sse-provider";
 import { ATTENTION_STRIP_WIDTH_DEFAULT, clampAttentionStripWidth } from "@/lib/ui-prefs";
@@ -445,13 +446,20 @@ export function App({
   // X-Tmai-Origin has a sensible scope before the user touches the sidebar.
   // Also reset the scope when the previously selected project disappears
   // (e.g. its last agent stopped) so we never keep sending a stale cwd —
-  // CodeRabbit caught this on PR #615 review.
+  // CodeRabbit caught this on PR #615 review. The membership is tree-tolerant
+  // (`currentProjectBelongsToLiveProject`): a multi-repo unit's tab selects its
+  // PRIMARY repo while the Producer's wrapper cwd is the derived projectPath, so
+  // a literal `includes` reset bounced an explicit tab selection to the wrong
+  // unit once a second unit was live (#581 dogfood).
   useEffect(() => {
     if (projectPaths.length === 0) {
       if (currentProject !== null) setCurrentProject(null);
       return;
     }
-    if (currentProject === null || !projectPaths.includes(currentProject)) {
+    if (
+      currentProject === null ||
+      !currentProjectBelongsToLiveProject(currentProject, projectPaths)
+    ) {
       setCurrentProject(projectPaths[0]);
     }
   }, [currentProject, projectPaths]);

--- a/clients/react/src/lib/__tests__/current-project.test.ts
+++ b/clients/react/src/lib/__tests__/current-project.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { currentProjectBelongsToLiveProject } from "@/lib/current-project";
+
+describe("currentProjectBelongsToLiveProject", () => {
+  it("keeps an exact projectPaths member", () => {
+    expect(currentProjectBelongsToLiveProject("/works/chm", ["/works/chm", "/works/tmai"])).toBe(
+      true,
+    );
+  });
+
+  it("keeps a multi-repo unit's PRIMARY repo when only the WRAPPER is a projectPath", () => {
+    // The #581 dogfood bug: tmai's Producer runs at the wrapper `/works/tmai`
+    // (the derived projectPath), but selecting tmai's tab sets currentProject
+    // to its primary repo `/works/tmai/tmai` (a descendant). It must be kept,
+    // not reset to projectPaths[0].
+    expect(
+      currentProjectBelongsToLiveProject("/works/tmai/tmai", [
+        "/works/conversation-handoff-mcp",
+        "/works/tmai",
+      ]),
+    ).toBe(true);
+    // The secondary repo of the same unit is likewise in-tree.
+    expect(currentProjectBelongsToLiveProject("/works/tmai/tmai-core", ["/works/tmai"])).toBe(true);
+  });
+
+  it("keeps a wrapper currentProject when a repo under it is the projectPath", () => {
+    expect(currentProjectBelongsToLiveProject("/works/tmai", ["/works/tmai/tmai"])).toBe(true);
+  });
+
+  it("rejects a genuinely stale path with no live-project tree relationship", () => {
+    expect(currentProjectBelongsToLiveProject("/works/old-gone", ["/works/tmai"])).toBe(false);
+  });
+
+  it("does not false-match a sibling that merely shares a name prefix", () => {
+    // `/works/tmai-extra` is NOT in `/works/tmai`'s tree — the `/` boundary
+    // must prevent the prefix from matching.
+    expect(currentProjectBelongsToLiveProject("/works/tmai-extra", ["/works/tmai"])).toBe(false);
+    expect(currentProjectBelongsToLiveProject("/works/tmai", ["/works/tmai-extra"])).toBe(false);
+  });
+
+  it("rejects against an empty project list", () => {
+    expect(currentProjectBelongsToLiveProject("/works/tmai", [])).toBe(false);
+  });
+});

--- a/clients/react/src/lib/current-project.ts
+++ b/clients/react/src/lib/current-project.ts
@@ -1,0 +1,31 @@
+// Whether the selected `currentProject` still belongs to a LIVE project.
+//
+// App's auto-default effect resets `currentProject` to `projectPaths[0]`
+// whenever the selection no longer belongs to a live project (so a stale cwd is
+// never sent on X-Tmai-Origin once its agents stop). The naive
+// `projectPaths.includes(currentProject)` membership is too strict for the
+// live-slot aim-console: a MULTI-REPO unit's Producer runs at the unit's
+// WRAPPER directory (e.g. `/works/tmai`, which is the agent-derived
+// `projectPath`), while selecting that unit's tab sets `currentProject` to the
+// unit's PRIMARY repo (`/works/tmai/tmai`, a DESCENDANT of the wrapper). The
+// descendant is not a literal `projectPaths` member, so the strict check reset
+// the explicit tab selection to `projectPaths[0]` — bouncing to the WRONG unit
+// once a second unit was live (#581 dogfood: "launching another unit makes tmai
+// unreachable; killing it returns").
+//
+// Tree-tolerant fix: `currentProject` belongs to a live project when it equals
+// a `projectPath` OR shares that unit's tree — an ancestor or descendant of one.
+// The trailing-`/` boundary prevents a sibling-prefix false match
+// (`/works/tmai` vs `/works/tmai-extra`). A genuinely stale path (no tree
+// relationship to any live project) still fails and is reset, as before.
+export function currentProjectBelongsToLiveProject(
+  currentProject: string,
+  projectPaths: string[],
+): boolean {
+  return projectPaths.some(
+    (p) =>
+      p === currentProject ||
+      currentProject.startsWith(`${p}/`) ||
+      p.startsWith(`${currentProject}/`),
+  );
+}


### PR DESCRIPTION
Dogfood follow-on of #581 (after the by-path launch + transcript-promotion fixes made two live units possible).

## Symptom

With two live units, selecting a **multi-repo** unit's tab couldn't return there — the operator had to **kill** the other unit's Producer to get back ("launching another unit makes tmai unreachable; killing it returns").

## Root cause

App's auto-default effect resets `currentProject` to `projectPaths[0]` whenever the selection isn't a literal `projectPaths` member (so a stale cwd is never sent on `X-Tmai-Origin`). But a **multi-repo unit's Producer runs at the WRAPPER** (e.g. `/works/tmai`, the agent-derived `projectPath`), while selecting that unit's tab sets `currentProject` to its **primary repo** (`/works/tmai/tmai`, a descendant). The descendant is not a `projectPaths` member → the strict `includes()` reset bounced the explicit tab selection to `projectPaths[0]` — the **other** unit, once a second unit was live. Killing the other unit shrank `projectPaths` so the default settled back on the wanted unit (the "kill to return").

Single-repo units (wrapper == repo, e.g. `conversation-handoff-mcp`) matched exactly, so the bug only bit the multi-repo `tmai` unit.

## Fix

Make the membership **tree-tolerant** (`lib/current-project.ts`): `currentProject` belongs to a live project when it equals a `projectPath` OR shares that unit's tree (ancestor/descendant), with a trailing-`/` boundary so a sibling name-prefix (`/works/tmai` vs `/works/tmai-extra`) never false-matches. A genuinely stale path (no tree relationship) is still reset, as before.

Pure helper + unit tests; **frontend only — no wire change**.

## Gate (CI parity — all green locally)

- `tsc -b`
- `biome check src/`
- `vitest run` (967 passed, +6 new `current-project` tests)
- `pnpm build`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * マルチリポジトリ環境におけるプロジェクト選択の判定ロジックを改善しました。

* **テスト**
  * プロジェクト選択判定ロジックのテストスイートを追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->