### PR TITLE
feat(aim-console): relabel the Producer bare-kill button to a re-spawn affordance (#884)

### DIFF
--- a/clients/react/src/components/aim-console/Shead.tsx
+++ b/clients/react/src/components/aim-console/Shead.tsx
@@ -7,7 +7,7 @@
 //
 //   Producer: dot · name · model · ctx bar (with the auto-handoff threshold
 //             marker ┊) · pct · auto N% · unit/cwd · ⤺ handoff & restart ·
-//             ⚙ settings · ✕ kill
+//             ⚙ settings · ⟳ re-spawn
 //   Worker:   dot · name · model · ctx bar (violet accent) · pct ·
 //             repo/cwd · ✕ kill
 //
@@ -21,6 +21,7 @@
 
 import type { ReactNode } from "react";
 import { useEffect, useState } from "react";
+import { useConfirm } from "@/components/layout/ConfirmDialog";
 import {
   formatThousands,
   renderBar,
@@ -111,6 +112,9 @@ function StatusDot({ attention }: { attention: AgentSnapshot["attention"] }) {
   );
 }
 
+// Plain kill — the WORKER header's terminal. Killing a worker is legitimate
+// and bounded (no slot supervisor respawns it), so it stays a bare ✕ kill,
+// no confirm. (The Producer header uses `RespawnButton` instead — see below.)
 function KillButton({ target }: { target: string }) {
   return (
     <button
@@ -121,6 +125,41 @@ function KillButton({ target }: { target: string }) {
       aria-label="Kill agent"
     >
       ✕
+    </button>
+  );
+}
+
+// The PRODUCER header's affordance. A Producer sits in a supervised slot
+// (`producer-slot-invariant`): `api.killAgent` does NOT close the slot, so the
+// engine's slot-supervisor auto-respawns a fresh Producer. So this "kill" is
+// really a RE-SPAWN, not a terminal — the only terminal is the tab close `×`
+// (`closeUnitSlot`). We relabel/re-icon it as a ⟳ re-spawn and gate it behind
+// a confirm (it had none): a no-baton re-spawn discards the current session's
+// conversation context, so it must never be silent. Same `POST /api/agents/
+// {target}/kill` call (no wire/spec change); the supervisor does the respawn.
+function RespawnButton({ target }: { target: string }) {
+  const confirm = useConfirm();
+  const handleRespawn = async () => {
+    const ok = await confirm({
+      title: "Re-spawn this Producer?",
+      message:
+        "The current session is killed and a fresh Producer starts with NO hand-off — " +
+        "its conversation context is lost. Use Handoff & Restart (⤺) instead to preserve context.",
+      confirmLabel: "Re-spawn",
+      cancelLabel: "Cancel",
+      variant: "danger",
+    });
+    if (ok) killAgent(target);
+  };
+  return (
+    <button
+      type="button"
+      className="ic respawn"
+      onClick={handleRespawn}
+      title="Re-spawn Producer (kill + auto-respawn; no hand-off)"
+      aria-label="Re-spawn Producer (kill + auto-respawn; no hand-off)"
+    >
+      ⟳
     </button>
   );
 }
@@ -238,7 +277,7 @@ function ProducerShead({
         >
           ⚙
         </button>
-        <KillButton target={agent.target} />
+        <RespawnButton target={agent.target} />
       </span>
     </div>
   );

--- a/clients/react/src/components/aim-console/__tests__/SessionPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/SessionPane.test.tsx
@@ -15,9 +15,10 @@
 // list, the LOCAL session selection, the shead split, and the addressee
 // threading. `api` is mocked so Shead's settings fetch never hits the network.
 
-import { fireEvent, render, screen } from "@testing-library/react";
+import { fireEvent, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 import type { AgentSnapshot } from "@/lib/api";
+import { renderWithProviders } from "@/test/render";
 import { SessionPane } from "../SessionPane";
 
 vi.mock("@/components/terminal/TerminalPanel", () => ({
@@ -140,7 +141,7 @@ function renderPane(overrides: Partial<Parameters<typeof SessionPane>[0]> = {}) 
     ],
     ...overrides,
   };
-  render(<SessionPane {...props} />);
+  renderWithProviders(<SessionPane {...props} />);
   return props;
 }
 

--- a/clients/react/src/components/aim-console/__tests__/Shead.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/Shead.test.tsx
@@ -5,15 +5,19 @@
 //
 //   Producer variant: status dot · name · model · ctx bar with the
 //   auto-handoff threshold marker ┊ · pct · ⤺ handoff & restart (the
-//   App-lifted ritual `trigger`, confirm flow preserved) · ⚙ · ✕ kill.
+//   App-lifted ritual `trigger`, confirm flow preserved) · ⚙ · ⟳ re-spawn
+//   (kill → slot-supervisor auto-respawn, behind a danger confirm).
 //   Worker variant: dot · name · model · repo/cwd · ✕ kill — violet accent.
 //
 // `getOrchestratorSettings` (the threshold fetch) and `killAgent` are
-// mocked; the rest of the api stays real.
+// mocked; the rest of the api stays real. The Producer re-spawn confirm uses
+// `useConfirm`, so the Producer variant renders under `renderWithProviders`
+// (which mounts the ConfirmProvider).
 
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { type AgentSnapshot, api, type OrchestratorSettings } from "@/lib/api";
+import { renderWithProviders } from "@/test/render";
 import { Shead } from "../Shead";
 
 vi.mock("@/lib/api", async () => {
@@ -90,7 +94,7 @@ function renderShead(overrides: Partial<Parameters<typeof Shead>[0]> = {}) {
     onOpenSettings: vi.fn(),
     ...overrides,
   };
-  render(<Shead {...props} />);
+  renderWithProviders(<Shead {...props} />);
   return props;
 }
 
@@ -109,7 +113,7 @@ afterEach(() => {
 
 describe("Shead — Producer variant", () => {
   it("renders dot · name · model · ctx bar (with ┊ threshold marker) · pct", async () => {
-    const { container } = render(
+    const { container } = renderWithProviders(
       <Shead
         agent={PRODUCER}
         isProducer
@@ -147,19 +151,43 @@ describe("Shead — Producer variant", () => {
     expect(props.trigger).not.toHaveBeenCalled();
   });
 
-  it("opens settings via ⚙ and kills via ✕", () => {
+  it("opens settings via ⚙", () => {
     const props = renderShead();
     fireEvent.click(screen.getByRole("button", { name: "Open settings — auto-handoff threshold" }));
     expect(props.onOpenSettings).toHaveBeenCalled();
-    fireEvent.click(screen.getByRole("button", { name: "Kill agent" }));
-    expect(killAgent).toHaveBeenCalledWith("claude:prod");
+  });
+
+  it("re-spawns (kill → supervisor respawn) only after the danger confirm is accepted", async () => {
+    renderShead();
+    // The Producer header carries a ⟳ re-spawn, NOT a bare ✕ kill.
+    expect(screen.queryByRole("button", { name: "Kill agent" })).toBeNull();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Re-spawn Producer (kill + auto-respawn; no hand-off)",
+      }),
+    );
+    // Nothing fires until the confirm is accepted.
+    expect(killAgent).not.toHaveBeenCalled();
+    fireEvent.click(await screen.findByRole("button", { name: "Re-spawn" }));
+    await waitFor(() => expect(killAgent).toHaveBeenCalledWith("claude:prod"));
+  });
+
+  it("does NOT re-spawn when the confirm is declined", async () => {
+    renderShead();
+    fireEvent.click(
+      screen.getByRole("button", {
+        name: "Re-spawn Producer (kill + auto-respawn; no hand-off)",
+      }),
+    );
+    fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
+    expect(killAgent).not.toHaveBeenCalled();
   });
 
   it("renders 'auto off' and no ┊ marker when the threshold is 0 (disabled)", async () => {
     getOrchestratorSettings.mockResolvedValue({
       auto_handoff_threshold_pct: 0,
     } as OrchestratorSettings);
-    const { container } = render(
+    const { container } = renderWithProviders(
       <Shead
         agent={PRODUCER}
         isProducer
@@ -183,9 +211,16 @@ describe("Shead — worker variant", () => {
     expect(screen.getByText("sonnet-4.6")).toBeTruthy();
     expect(screen.getByText(/repo tmai · main · \.\.\/tmai-wt-attn-ui/)).toBeTruthy();
     // No handoff ritual, no settings — the worker bar carries kill only.
+    // And no re-spawn: a worker is bounded (no slot supervisor respawns it),
+    // so killing it is a legitimate terminal, kept as a plain ✕ kill.
     expect(screen.queryByRole("button", { name: /handoff & restart/i })).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Open settings — auto-handoff threshold" }),
+    ).toBeNull();
+    expect(
+      screen.queryByRole("button", {
+        name: "Re-spawn Producer (kill + auto-respawn; no hand-off)",
+      }),
     ).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Kill agent" }));
     expect(killAgent).toHaveBeenCalledWith("claude:w1");

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -625,6 +625,11 @@
 .aim-console .ac-shead .ic.kill:hover {
   color: var(--danger);
 }
+/* Producer re-spawn ⟳ — a restart (not a terminal), so it hovers amber like
+   the ⤺ handoff & restart, not danger-red like a worker kill. */
+.aim-console .ac-shead .ic.respawn:hover {
+  color: var(--amber);
+}
 
 /* ── term (mock `.term`) — the conversation surface. TerminalPanel /
    PreviewPanel fill it; this is just the flex container. ────────────────── */


### PR DESCRIPTION
Resolves #884.

## What

The aim-console Producer header's bare-kill ✕ button (`Shead.tsx`'s `KillButton`, used by `ProducerShead`) called `api.killAgent` (`POST /api/agents/{target}/kill`). That does **NOT** close the supervised Producer slot (`producer-slot-invariant`) — the engine's slot-supervisor auto-respawns a fresh Producer. So the "kill" was really a **re-spawn, mislabeled**, and it had **no confirm**. The only terminal is the tab close `×` (`closeUnitSlot`); a silent bare-kill-that-respawns reads as "destroy this unit" but isn't — a footgun.

## Change (Producer header ONLY)

1. **Split the shared `KillButton` by usage.** The Worker header keeps the **plain ✕ kill** (a worker is bounded; killing it is a legitimate terminal, not a slot op). The Producer header gets a new `RespawnButton`.
2. **Re-icon + relabel** the Producer affordance to **⟳** with `title` + `aria-label` = "Re-spawn Producer (kill + auto-respawn; no hand-off)". Hovers amber (restart family, like ⤺ handoff & restart) rather than danger-red.
3. **Add a confirm** (it had none) via the existing `useConfirm` (`danger` variant — same pattern the tab close uses), since a no-baton re-spawn discards the current session's conversation context:
   > Re-spawn this Producer? The current session is killed and a fresh Producer starts with NO hand-off — its conversation context is lost. Use Handoff & Restart (⤺) instead to preserve context.

**Same wire**: keeps the `POST /api/agents/{target}/kill` call — NO new endpoint, NO spec/wire change; the slot-supervisor does the respawn.

## Scope guards honored

- **Worker header** `KillButton` is unchanged — still a plain ✕ kill, no confirm.
- Untouched: the tab close `×` / `closeUnitSlot` (the real terminal), the **Handoff & Restart** ⤺ button, the footer bash kill, and the legacy `producer-console/` components.

## Tests

Producer Shead now uses `useConfirm`, so its tests (and `SessionPane`'s, which render the Producer shead) run under `renderWithProviders` (ConfirmProvider). Added Producer-variant coverage: no plain "Kill agent" button; ⟳ re-spawn fires `killAgent` **only after** the danger confirm is accepted, and **not** when declined. Worker-variant test asserts it has the plain kill and **no** re-spawn button.

## Gate (clients/react CI parity)

| Step | Result |
| --- | --- |
| `pnpm lint` (biome) | ✅ Checked 240 files, no fixes applied |
| `pnpm tsc` | ✅ exit 0 |
| `pnpm build` | ✅ built (pre-existing chunk-size warning only) |
| `pnpm test` | ✅ 969 passed \| 2 skipped (107 files) |

🤖 Generated with [Claude Code](https://claude.com/claude-code)