### PR TITLE
chore(deps): bump quinn-proto to 0.11.15 (RUSTSEC-2026-0185)

### DIFF
--- a/clients/ratatui/Cargo.lock
+++ b/clients/ratatui/Cargo.lock
@@ -1582,9 +1582,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.14"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+checksum = "4fcb935c5bec503c2f0e306bdd3e58bb9029dcb14fa8d9ac76e3a5256ac0763e"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",


### PR DESCRIPTION
## What

Bump `quinn-proto` `0.11.14` → `0.11.15` in `clients/ratatui/Cargo.lock` (transitive dependency; lockfile-only).

## Why

The `Build ratatui` job has been red on `main` since the advisory landed (2026-06-23): `cargo audit --deny warnings` flags **RUSTSEC-2026-0185** — *remote memory exhaustion in quinn-proto from unbounded out-of-order stream reassembly* (high). The fix is `>=0.11.15`. Pre-existing, not introduced by recent work.

## Verification (local, `clients/ratatui`, mirrors the CI job)

- `cargo audit --deny warnings` — ✅ advisory cleared
- `cargo fmt --check` — ✅
- `cargo clippy --all-targets -- -D warnings` — ✅
- `cargo test` — ✅
- `cargo build --release` — ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)