### PR TITLE
feat(aim-console): restart button + focus persistence (post slot-rip)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -60,6 +60,12 @@ import { useUIPref } from "@/lib/ui-prefs-provider";
 // committed px, so the two guards compose. The pref key is kept as
 // `attentionStripWidth` post-rename for back-compat (storage migration is
 // churn for no benefit — the field's meaning is unchanged).
+// Grace window before the focus auto-default bounces a unit whose Producer
+// briefly left the live set (handoff respawn / restart kill→relaunch) to
+// another live unit. Comfortably covers the respawn launch window; a genuine
+// stop still resets after it (aim `handoff-producer-unit-focus`).
+const FOCUS_GRACE_MS = 12_000;
+
 function rPanelViewportWidth(): number {
   return typeof window !== "undefined" && window.innerWidth > 0 ? window.innerWidth : 1440;
 }
@@ -451,17 +457,34 @@ export function App({
   // PRIMARY repo while the Producer's wrapper cwd is the derived projectPath, so
   // a literal `includes` reset bounced an explicit tab selection to the wrong
   // unit once a second unit was live (#581 dogfood).
+  //
+  // Grace window (aim `handoff-producer-unit-focus`): a unit's Producer briefly
+  // leaves the live set during a handoff respawn or a restart (kill→relaunch).
+  // When OTHER units remain live, don't bounce focus to one of them for that
+  // transient gap — hold the selection and only reset if the unit stays gone
+  // past the window (a genuine stop). If the unit re-enters `projectPaths`
+  // first, this effect re-runs, the membership check passes, and the pending
+  // timer is cleared — focus is preserved across the blink.
   useEffect(() => {
     if (projectPaths.length === 0) {
+      // No live unit at all (e.g. engine restart) — nothing to focus.
       if (currentProject !== null) setCurrentProject(null);
       return;
     }
-    if (
-      currentProject === null ||
-      !currentProjectBelongsToLiveProject(currentProject, projectPaths)
-    ) {
+    if (currentProject === null) {
       setCurrentProject(projectPaths[0]);
+      return;
     }
+    if (currentProjectBelongsToLiveProject(currentProject, projectPaths)) {
+      return; // still live — keep focus
+    }
+    // Left the live set while other units remain: a respawn/restart gap or a
+    // genuine stop. Hold focus for the grace window, then reset only if it has
+    // not come back.
+    const id = window.setTimeout(() => {
+      setCurrentProject(projectPaths[0]);
+    }, FOCUS_GRACE_MS);
+    return () => window.clearTimeout(id);
   }, [currentProject, projectPaths]);
 
   // Derive selected agent from selection.

--- a/clients/react/src/components/aim-console/Shead.tsx
+++ b/clients/react/src/components/aim-console/Shead.tsx
@@ -7,7 +7,7 @@
 //
 //   Producer: dot · name · model · ctx bar (with the auto-handoff threshold
 //             marker ┊) · pct · auto N% · unit/cwd · ⤺ handoff & restart ·
-//             ⚙ settings · ⟳ re-spawn
+//             ⚙ settings · ⟳ restart
 //   Worker:   dot · name · model · ctx bar (violet accent) · pct ·
 //             repo/cwd · ✕ kill
 //
@@ -113,8 +113,8 @@ function StatusDot({ attention }: { attention: AgentSnapshot["attention"] }) {
 }
 
 // Plain kill — the WORKER header's terminal. Killing a worker is legitimate
-// and bounded (no slot supervisor respawns it), so it stays a bare ✕ kill,
-// no confirm. (The Producer header uses `RespawnButton` instead — see below.)
+// and bounded (nothing respawns it), so it stays a bare ✕ kill, no confirm.
+// (The Producer header uses `RestartButton` instead — see below.)
 function KillButton({ target }: { target: string }) {
   return (
     <button
@@ -129,35 +129,44 @@ function KillButton({ target }: { target: string }) {
   );
 }
 
-// The PRODUCER header's affordance. A Producer sits in a supervised slot
-// (`producer-slot-invariant`): `api.killAgent` does NOT close the slot, so the
-// engine's slot-supervisor auto-respawns a fresh Producer. So this "kill" is
-// really a RE-SPAWN, not a terminal — the only terminal is the tab close `×`
-// (`closeUnitSlot`). We relabel/re-icon it as a ⟳ re-spawn and gate it behind
-// a confirm (it had none): a no-baton re-spawn discards the current session's
-// conversation context, so it must never be silent. Same `POST /api/agents/
-// {target}/kill` call (no wire/spec change); the supervisor does the respawn.
-function RespawnButton({ target }: { target: string }) {
+// The PRODUCER header's RESTART affordance. With `unit ≡ live Producer` (aim
+// `producer-slot-invariant` is `dead`) there is no slot-supervisor auto-respawn:
+// killing the Producer just ends it. So restart is an explicit two-step — kill
+// the current Producer, then relaunch a fresh one at the SAME locus (`agent.cwd`,
+// the launch dir the unit derives from) via `POST /api/producer/launch`. The
+// peer of ⤺ handoff: handoff carries a baton (context preserved), restart does
+// NOT (context discarded), so it stays behind a danger confirm. The brief
+// Producer-absent gap between kill and relaunch keeps the unit's tab focused —
+// App's grace-window auto-default holds the selection (aim
+// `handoff-producer-unit-focus`). The terminal (unit gone for good) remains the
+// tab close `×` (`closeUnitSlot`), not this.
+function RestartButton({ target, launchPath }: { target: string; launchPath: string }) {
   const confirm = useConfirm();
-  const handleRespawn = async () => {
+  const handleRestart = async () => {
     const ok = await confirm({
-      title: "Re-spawn this Producer?",
+      title: "Restart this Producer?",
       message:
-        "The current session is killed and a fresh Producer starts with NO hand-off — " +
-        "its conversation context is lost. Use Handoff & Restart (⤺) instead to preserve context.",
-      confirmLabel: "Re-spawn",
+        "The current session is killed and a fresh Producer is launched at the same " +
+        "location with NO hand-off — its conversation context is lost. Use Handoff & " +
+        "restart (⤺) instead to preserve context.",
+      confirmLabel: "Restart",
       cancelLabel: "Cancel",
       variant: "danger",
     });
-    if (ok) killAgent(target);
+    if (!ok) return;
+    // Kill then relaunch at the same locus. Best-effort on both (an
+    // already-gone agent / a transient launch hiccup shouldn't throw to the
+    // operator); the tab is held across the gap by the focus grace window.
+    await api.killAgent(target).catch(() => {});
+    await api.launchProducer(launchPath).catch(() => {});
   };
   return (
     <button
       type="button"
       className="ic respawn"
-      onClick={handleRespawn}
-      title="Re-spawn Producer (kill + auto-respawn; no hand-off)"
-      aria-label="Re-spawn Producer (kill + auto-respawn; no hand-off)"
+      onClick={handleRestart}
+      title="Restart Producer (kill + relaunch fresh; no hand-off)"
+      aria-label="Restart Producer (kill + relaunch fresh; no hand-off)"
     >
       ⟳
     </button>
@@ -277,7 +286,7 @@ function ProducerShead({
         >
           ⚙
         </button>
-        <RespawnButton target={agent.target} />
+        <RestartButton target={agent.target} launchPath={agent.cwd} />
       </span>
     </div>
   );

--- a/clients/react/src/components/aim-console/__tests__/Shead.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/Shead.test.tsx
@@ -5,18 +5,18 @@
 //
 //   Producer variant: status dot · name · model · ctx bar with the
 //   auto-handoff threshold marker ┊ · pct · ⤺ handoff & restart (the
-//   App-lifted ritual `trigger`, confirm flow preserved) · ⚙ · ⟳ re-spawn
-//   (kill → slot-supervisor auto-respawn, behind a danger confirm).
+//   App-lifted ritual `trigger`, confirm flow preserved) · ⚙ · ⟳ restart
+//   (kill → relaunch fresh at the same locus, behind a danger confirm).
 //   Worker variant: dot · name · model · repo/cwd · ✕ kill — violet accent.
 //
-// `getOrchestratorSettings` (the threshold fetch) and `killAgent` are
-// mocked; the rest of the api stays real. The Producer re-spawn confirm uses
-// `useConfirm`, so the Producer variant renders under `renderWithProviders`
-// (which mounts the ConfirmProvider).
+// `getOrchestratorSettings` (the threshold fetch), `killAgent`, and
+// `launchProducer` are mocked; the rest of the api stays real. The Producer
+// restart confirm uses `useConfirm`, so the Producer variant renders under
+// `renderWithProviders` (which mounts the ConfirmProvider).
 
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { type AgentSnapshot, api, type OrchestratorSettings } from "@/lib/api";
+import { type AgentSnapshot, api, type OrchestratorSettings, type SpawnResponse } from "@/lib/api";
 import { renderWithProviders } from "@/test/render";
 import { Shead } from "../Shead";
 
@@ -28,12 +28,14 @@ vi.mock("@/lib/api", async () => {
       ...actual.api,
       getOrchestratorSettings: vi.fn(),
       killAgent: vi.fn(),
+      launchProducer: vi.fn(),
     },
   };
 });
 
 const getOrchestratorSettings = vi.mocked(api.getOrchestratorSettings);
 const killAgent = vi.mocked(api.killAgent);
+const launchProducer = vi.mocked(api.launchProducer);
 
 function stubAgent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot {
   return {
@@ -101,10 +103,12 @@ function renderShead(overrides: Partial<Parameters<typeof Shead>[0]> = {}) {
 beforeEach(() => {
   getOrchestratorSettings.mockReset();
   killAgent.mockReset();
+  launchProducer.mockReset();
   getOrchestratorSettings.mockResolvedValue({
     auto_handoff_threshold_pct: 75,
   } as OrchestratorSettings);
   killAgent.mockResolvedValue(undefined);
+  launchProducer.mockResolvedValue({} as SpawnResponse);
 });
 
 afterEach(() => {
@@ -157,30 +161,34 @@ describe("Shead — Producer variant", () => {
     expect(props.onOpenSettings).toHaveBeenCalled();
   });
 
-  it("re-spawns (kill → supervisor respawn) only after the danger confirm is accepted", async () => {
+  it("restarts (kill → relaunch at the same locus) only after the danger confirm is accepted", async () => {
     renderShead();
-    // The Producer header carries a ⟳ re-spawn, NOT a bare ✕ kill.
+    // The Producer header carries a ⟳ restart, NOT a bare ✕ kill.
     expect(screen.queryByRole("button", { name: "Kill agent" })).toBeNull();
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Re-spawn Producer (kill + auto-respawn; no hand-off)",
+        name: "Restart Producer (kill + relaunch fresh; no hand-off)",
       }),
     );
     // Nothing fires until the confirm is accepted.
     expect(killAgent).not.toHaveBeenCalled();
-    fireEvent.click(await screen.findByRole("button", { name: "Re-spawn" }));
+    fireEvent.click(await screen.findByRole("button", { name: "Restart" }));
+    // No supervisor auto-respawns now (unit ≡ live Producer): kill THEN relaunch
+    // at the Producer's launch cwd.
     await waitFor(() => expect(killAgent).toHaveBeenCalledWith("claude:prod"));
+    await waitFor(() => expect(launchProducer).toHaveBeenCalledWith("/home/u/tmai"));
   });
 
-  it("does NOT re-spawn when the confirm is declined", async () => {
+  it("does NOT restart when the confirm is declined", async () => {
     renderShead();
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Re-spawn Producer (kill + auto-respawn; no hand-off)",
+        name: "Restart Producer (kill + relaunch fresh; no hand-off)",
       }),
     );
     fireEvent.click(await screen.findByRole("button", { name: "Cancel" }));
     expect(killAgent).not.toHaveBeenCalled();
+    expect(launchProducer).not.toHaveBeenCalled();
   });
 
   it("renders 'auto off' and no ┊ marker when the threshold is 0 (disabled)", async () => {
@@ -211,15 +219,15 @@ describe("Shead — worker variant", () => {
     expect(screen.getByText("sonnet-4.6")).toBeTruthy();
     expect(screen.getByText(/repo tmai · main · \.\.\/tmai-wt-attn-ui/)).toBeTruthy();
     // No handoff ritual, no settings — the worker bar carries kill only.
-    // And no re-spawn: a worker is bounded (no slot supervisor respawns it),
-    // so killing it is a legitimate terminal, kept as a plain ✕ kill.
+    // And no restart: a worker is bounded (nothing respawns it), so killing it
+    // is a legitimate terminal, kept as a plain ✕ kill.
     expect(screen.queryByRole("button", { name: /handoff & restart/i })).toBeNull();
     expect(
       screen.queryByRole("button", { name: "Open settings — auto-handoff threshold" }),
     ).toBeNull();
     expect(
       screen.queryByRole("button", {
-        name: "Re-spawn Producer (kill + auto-respawn; no hand-off)",
+        name: "Restart Producer (kill + relaunch fresh; no hand-off)",
       }),
     ).toBeNull();
     fireEvent.click(screen.getByRole("button", { name: "Kill agent" }));


### PR DESCRIPTION
## What

Two coupled UI affordances completing the **unit ≡ live Producer** model (aim `producer-slot-invariant` is `dead` — tmai-core #587 + hub #887).

### 1. Shead `RestartButton` (re-purposed from the #885 "re-spawn")

With the slot supervisor gone, `api.killAgent` no longer auto-respawns — the old ⟳ button silently became kill-only and its *"kill + auto-respawn"* label was a lie. Re-purposed to an explicit **restart**: kill the Producer, then relaunch a fresh one at the same locus (`api.launchProducer(agent.cwd)`). The peer of ⤺ handoff:

| | context | mechanism |
|---|---|---|
| ⤺ handoff & restart | preserved (baton) | ritual |
| ⟳ restart | discarded | kill + relaunch |
| × close (tab) | — (unit gone) | terminal |

Kept behind the danger confirm (no-baton ⇒ context loss). The terminal (unit gone for good) stays the tab `×`.

### 2. Focus persistence (aim `handoff-producer-unit-focus`)

A unit's Producer briefly leaves the live set during a handoff respawn **or** this restart (kill→relaunch). App's `currentProject` auto-default used to bounce focus to another live unit for that transient gap. Added a **12s grace window** — hold the selection across the blink, reset only if the unit stays gone past the window (a genuine stop). If it re-enters `projectPaths` first, the effect re-runs, membership passes, and the pending timer is cleared.

The restart's own kill→relaunch gap is exactly this case, so the two ship together. **blink accepted** (the tab may flash during the gap); the operator's *focus* is what's preserved.

## Verification

- `pnpm build` (tsc + vite) ✅
- `pnpm lint` (biome, 240 files) ✅
- `pnpm test` ✅ (969 passed, 2 skipped) — incl. updated `Shead.test.tsx` (restart kill→relaunch, mocks `launchProducer`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)