### PR TITLE
fix(terminal): make Select mode + auto-scroll opt-in (default OFF) (#889)

### DIFF
--- a/clients/react/src/components/aim-console/__tests__/WireTerminal.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/WireTerminal.test.tsx
@@ -64,7 +64,8 @@ describe("WireTerminal — hot/cold-wire surface (S6)", () => {
 
   it("the panel's internal mode transitions surface back to the wire + strip", () => {
     render(<WireTerminal agentId="claude:p3" who="producer" addressee="producer" />);
-    // e.g. mousedown-in-terminal → select, reported via onInputModeChange.
+    // Drive a panel-reported select-mode transition straight through
+    // onInputModeChange — the wire + strip must reflect it.
     act(() => panelProps?.onInputModeChange?.(false));
     expect(screen.getByTestId("ac-wire").className).toContain("select");
     expect(screen.getByRole("button", { name: /SELECT/ }).getAttribute("aria-pressed")).toBe(
@@ -80,13 +81,14 @@ describe("WireTerminal — hot/cold-wire surface (S6)", () => {
       </>,
     );
     const follow = screen.getByRole("button", { name: "follow" });
-    expect(follow.getAttribute("aria-pressed")).toBe("true");
-    expect(screen.getByTestId("follow-probe").textContent).toBe("true");
-    fireEvent.click(follow);
+    // Auto-scroll / follow defaults OFF (opt-in, #889).
     expect(follow.getAttribute("aria-pressed")).toBe("false");
+    expect(screen.getByTestId("follow-probe").textContent).toBe("false");
+    fireEvent.click(follow);
+    expect(follow.getAttribute("aria-pressed")).toBe("true");
     // The OTHER mounted consumer (the stand-in for TerminalPanel's internal
     // auto-scroll hook) re-rendered with the new value — no remount needed.
-    expect(screen.getByTestId("follow-probe").textContent).toBe("false");
+    expect(screen.getByTestId("follow-probe").textContent).toBe("true");
   });
 
   it("worker and shell addressees pick the violet / green accents", () => {

--- a/clients/react/src/components/terminal/TerminalPanel.tsx
+++ b/clients/react/src/components/terminal/TerminalPanel.tsx
@@ -134,9 +134,12 @@ export function TerminalPanel({
         <div
           ref={containerRef}
           className="h-full w-full bg-[var(--color-terminal-background)] p-1"
-          onMouseDown={() => {
-            if (inputMode) enterSelectMode();
-          }}
+          // Select mode is opt-in (#889): it is entered ONLY via the explicit
+          // footer ModeToggleButton, never automatically on pointer/touch
+          // press. This keeps the embedded xterm in Input mode by default so it
+          // coexists with Claude Code's fullscreen renderer. The onMouseUp
+          // handler only fires while ALREADY in select mode (entered via the
+          // toggle), so it stays as a harmless return-to-input affordance.
           onMouseUp={() => {
             if (!inputMode) {
               const sel = window.getSelection();
@@ -144,10 +147,6 @@ export function TerminalPanel({
                 enterInputMode();
               }
             }
-          }}
-          onTouchStart={() => {
-            // On touch, switch to select mode so text is selectable/copyable
-            if (inputMode) enterSelectMode();
           }}
         />
         {/* key: remount on agent switch so the previous session's detected

--- a/clients/react/src/components/terminal/__tests__/TerminalPanel.test.tsx
+++ b/clients/react/src/components/terminal/__tests__/TerminalPanel.test.tsx
@@ -47,11 +47,12 @@ beforeEach(() => {
 });
 
 describe("TerminalPanel — default chrome (must stay unchanged)", () => {
-  it("renders the session header AND the Input/Auto footer by default", () => {
+  it("renders the session header AND the Input/auto-scroll footer by default", () => {
     render(<TerminalPanel agentId="claude:a1" />);
     expect(screen.getByTestId("terminal-session-header")).toBeTruthy();
     expect(screen.getByRole("button", { name: /⌨ Input/ })).toBeTruthy();
-    expect(screen.getByRole("button", { name: /⇩ Auto/ })).toBeTruthy();
+    // Auto-scroll defaults OFF (opt-in, #889), so the toggle reads "⇩ Off".
+    expect(screen.getByRole("button", { name: /⇩ Off/ })).toBeTruthy();
   });
 
   it("keeps the internal (uncontrolled) mode toggle working", () => {
@@ -59,7 +60,7 @@ describe("TerminalPanel — default chrome (must stay unchanged)", () => {
     fireEvent.click(screen.getByRole("button", { name: /⌨ Input/ }));
     expect(screen.getByRole("button", { name: /📋 Select/ })).toBeTruthy();
     expect(setAttachable).toHaveBeenLastCalledWith(false);
-    // mousedown in select mode + empty selection on mouseup → back to input.
+    // empty selection on mouseup while in select mode → back to input.
     fireEvent.mouseUp(termContainer(container));
     expect(screen.getByRole("button", { name: /⌨ Input/ })).toBeTruthy();
     expect(setAttachable).toHaveBeenLastCalledWith(true);
@@ -76,7 +77,7 @@ describe("TerminalPanel — chromeless (#803 aim-console)", () => {
     expect(section?.className).not.toContain("shadow");
   });
 
-  it("reports internal mode transitions through onInputModeChange (controlled)", () => {
+  it("does NOT auto-enter select mode on pointer press — select is opt-in (#889)", () => {
     const onChange = vi.fn();
     const { container } = render(
       <TerminalPanel
@@ -86,11 +87,11 @@ describe("TerminalPanel — chromeless (#803 aim-console)", () => {
         onInputModeChange={onChange}
       />,
     );
-    // mousedown on the terminal → the panel's own select-mode semantics fire
-    // and surface to the host instead of (only) internal state.
+    // A pointer press on the terminal must NOT flip to select mode; only the
+    // explicit footer ModeToggleButton (or a host-driven inputMode prop) may.
+    // The Enter-to-exit path (covered below) is the only other transition.
     fireEvent.mouseDown(termContainer(container));
-    expect(onChange).toHaveBeenCalledWith(false);
-    expect(setAttachable).toHaveBeenLastCalledWith(false);
+    expect(onChange).not.toHaveBeenCalled();
   });
 
   it("follows a host-driven inputMode prop flip (keyboard attach in lock-step)", () => {

--- a/clients/react/src/hooks/__tests__/useAutoScrollPerAgent.test.tsx
+++ b/clients/react/src/hooks/__tests__/useAutoScrollPerAgent.test.tsx
@@ -6,9 +6,9 @@
 // module Map only on `agentId` change) onto `useSyncExternalStore`, because
 // the aim-console mounts TWO live consumers for the same agent at once: the
 // status strip's `follow` toggle and the chromeless TerminalPanel's internal
-// auto-scroll. These tests pin the original contract (default true, persists
-// across remounts, per-agent isolation, updater-function setter) AND the new
-// one (a set in one mounted instance reaches the other live).
+// auto-scroll. These tests pin the contract (default false — opt-in (#889);
+// persists across remounts, per-agent isolation, updater-function setter) AND
+// the live-sync (a set in one mounted instance reaches the other live).
 
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
@@ -18,9 +18,9 @@ import { useAutoScrollPerAgent } from "../useAutoScrollPerAgent";
 // agent id so they stay independent.
 
 describe("useAutoScrollPerAgent", () => {
-  it("defaults to true for an unseen agent", () => {
+  it("defaults to false for an unseen agent (opt-in, #889)", () => {
     const { result } = renderHook(() => useAutoScrollPerAgent("as:default"));
-    expect(result.current[0]).toBe(true);
+    expect(result.current[0]).toBe(false);
   });
 
   it("persists the chosen value across unmount/remount", () => {
@@ -36,40 +36,40 @@ describe("useAutoScrollPerAgent", () => {
   it("supports the useState-style updater function", () => {
     const { result } = renderHook(() => useAutoScrollPerAgent("as:updater"));
     act(() => result.current[1]((prev) => !prev));
-    expect(result.current[0]).toBe(false);
-    act(() => result.current[1]((prev) => !prev));
     expect(result.current[0]).toBe(true);
+    act(() => result.current[1]((prev) => !prev));
+    expect(result.current[0]).toBe(false);
   });
 
   it("isolates agents from each other", () => {
     const a = renderHook(() => useAutoScrollPerAgent("as:iso-a"));
     const b = renderHook(() => useAutoScrollPerAgent("as:iso-b"));
-    act(() => a.result.current[1](false));
-    expect(a.result.current[0]).toBe(false);
-    expect(b.result.current[0]).toBe(true);
+    act(() => a.result.current[1](true));
+    expect(a.result.current[0]).toBe(true);
+    expect(b.result.current[0]).toBe(false);
   });
 
   it("syncs SIMULTANEOUSLY mounted consumers of the same agent live (#803)", () => {
     const strip = renderHook(() => useAutoScrollPerAgent("as:live"));
     const panel = renderHook(() => useAutoScrollPerAgent("as:live"));
-    act(() => strip.result.current[1](false));
+    act(() => strip.result.current[1](true));
     // The other mounted instance picks the toggle up WITHOUT a remount —
     // this is what lets the aim-console strip drive the chromeless
     // TerminalPanel's internal auto-scroll.
-    expect(panel.result.current[0]).toBe(false);
-    act(() => panel.result.current[1](true));
-    expect(strip.result.current[0]).toBe(true);
+    expect(panel.result.current[0]).toBe(true);
+    act(() => panel.result.current[1](false));
+    expect(strip.result.current[0]).toBe(false);
   });
 
   it("re-reads the store when the same instance swaps agents", () => {
     const seed = renderHook(() => useAutoScrollPerAgent("as:swap-target"));
-    act(() => seed.result.current[1](false));
+    act(() => seed.result.current[1](true));
 
     const { result, rerender } = renderHook(({ id }) => useAutoScrollPerAgent(id), {
       initialProps: { id: "as:swap-origin" },
     });
-    expect(result.current[0]).toBe(true);
-    rerender({ id: "as:swap-target" });
     expect(result.current[0]).toBe(false);
+    rerender({ id: "as:swap-target" });
+    expect(result.current[0]).toBe(true);
   });
 });

--- a/clients/react/src/hooks/useAutoScrollPerAgent.ts
+++ b/clients/react/src/hooks/useAutoScrollPerAgent.ts
@@ -22,7 +22,9 @@ function subscribe(listener: () => void): () => void {
 
 /**
  * `useState`-shaped wrapper that persists the chosen value into a per-agent
- * map keyed by `agentId`. New agents default to `true` (auto-scroll on).
+ * map keyed by `agentId`. New agents default to `false` (auto-scroll off) so
+ * the panel is opt-in (#889) and does not fight Claude Code's fullscreen
+ * renderer; the footer toggle remains the way to turn it on.
  *
  * The setter accepts both a value and an updater function, mirroring the
  * `useState` setter shape so callers can drop it in without changing
@@ -33,11 +35,11 @@ function subscribe(listener: () => void): () => void {
 export function useAutoScrollPerAgent(
   agentId: string,
 ): [boolean, (next: boolean | ((prev: boolean) => boolean)) => void] {
-  const autoScroll = useSyncExternalStore(subscribe, () => autoScrollByAgent.get(agentId) ?? true);
+  const autoScroll = useSyncExternalStore(subscribe, () => autoScrollByAgent.get(agentId) ?? false);
 
   const setAutoScroll = useCallback(
     (next: boolean | ((prev: boolean) => boolean)) => {
-      const prev = autoScrollByAgent.get(agentId) ?? true;
+      const prev = autoScrollByAgent.get(agentId) ?? false;
       const value = typeof next === "function" ? next(prev) : next;
       autoScrollByAgent.set(agentId, value);
       for (const listener of listeners) {


### PR DESCRIPTION
## Summary

Closes #889. Makes the Producer's embedded xterm.js `TerminalPanel` coexist with Claude Code's new fullscreen renderer by defaulting its two interactive seams **OFF**. Both stay reachable through the existing footer toggles, so the change is **reversible** and **renderer-independent**.

## Changes (two files)

1. **`clients/react/src/components/terminal/TerminalPanel.tsx`** — Removed the automatic `enterSelectMode()` triggered by `onMouseDown` / `onTouchStart` while in Input mode. Select mode is now entered **only** via the explicit footer `ModeToggleButton`. Default stays **Input** mode.
   - Left in place: the `onMouseUp` → `enterInputMode` handler and the Enter-key select-exit. They only fire while *already* in select mode, so they remain as harmless return-to-input affordances.
2. **`clients/react/src/hooks/useAutoScrollPerAgent.ts`** — Per-agent auto-scroll default flipped from `?? true` to `?? false` in both spots (the `useSyncExternalStore` snapshot getter and the setter's `prev` default). The toggle UI is unchanged.

Tests in the same feature area were updated to pin the **new** opt-in contract (auto-scroll defaults `false`; a pointer press no longer auto-enters select mode). No other production code was touched.

## Scope boundaries (deferred)

- **OSC52 → clipboard bridge** — NOT added. That seam is undetermined; it is a separate additive PR only if dogfood later shows clipboard doesn't reach.
- **Renderer auto-detection** (`term.buffer.active.type`) to hide/disable the Select/Auto toggles — NOT added. Optional follow-up in a separate PR.

## Local gate (run in `clients/react/`, mirrors `.github/workflows/build-react.yml`)

| Step | Command | Result |
|------|---------|--------|
| Type check | `pnpm tsc --noEmit` | ✅ pass |
| Lint | `pnpm lint` (biome, 240 files) | ✅ pass |
| Test | `pnpm test` (vitest) | ✅ 969 passed, 2 skipped |
| Build | `pnpm build` | ✅ built |
| Audit | `pnpm audit --prod --audit-level high` | ✅ pass (only low/moderate, below threshold) |

## Note

The acceptance checklist (CC drag-select → clipboard, wheel/PgUp scroll reaching CC, old-renderer toggle behavior) requires a running engine + live browser + the new CC renderer — that is the Producer/operator's post-merge dogfood, not part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ターミナルの選択モードへの切り替えが、フッターの切替操作から行う明示的な方式になりました。
* **Bug Fixes**
  * 入力中の誤ったモード切替を防ぎ、クリックやタッチ開始で意図せず選択モードになる問題を改善しました。
  * 自動スクロールの初期状態が新規エージェントでオフになり、複数画面間での状態同期もより安定しました。
* **Tests**
  * モード切替と自動スクロールの初期値・共有挙動に関する検証を更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->