### PR TITLE
docs(terminal): document the chromeless ⇒ host-owns-mode invariant (#890 follow-up)

### DIFF
--- a/clients/react/src/components/terminal/TerminalPanel.tsx
+++ b/clients/react/src/components/terminal/TerminalPanel.tsx
@@ -14,7 +14,13 @@ interface TerminalPanelProps {
   /** Suppress this panel's own chrome — no `TerminalSessionHeader`, no
    *  footer bar, no focus shadow — for hosts that draw their own (the
    *  aim-console's spine + status strip, #803). Default `false` keeps the
-   *  existing rendering unchanged. */
+   *  existing rendering unchanged.
+   *
+   *  Invariant (since #889): the footer's `ModeToggleButton` is the ONLY
+   *  built-in entry to Select mode — a pointer/touch press no longer
+   *  auto-enters it. A chromeless host renders no footer, so it MUST drive
+   *  the controlled `inputMode` prop (e.g. the aim-console status strip)
+   *  to offer Select mode; otherwise the panel is stuck in Input mode. */
   chromeless?: boolean;
   /** Controlled Input/Select mode (#803). When provided, the host owns the
    *  mode value (e.g. the aim-console status strip); the internal semantics

--- a/clients/react/src/components/terminal/TerminalPanel.tsx
+++ b/clients/react/src/components/terminal/TerminalPanel.tsx
@@ -24,7 +24,7 @@ interface TerminalPanelProps {
   chromeless?: boolean;
   /** Controlled Input/Select mode (#803). When provided, the host owns the
    *  mode value (e.g. the aim-console status strip); the internal semantics
-   *  (mousedown→select, Enter-in-select→input, xterm keyboard attach) stay
+   *  (Enter-in-select→input, xterm keyboard attach) stay
    *  this one implementation and report transitions via `onInputModeChange`.
    *  When absent, the original internal `useState` behavior is unchanged. */
   inputMode?: boolean;


### PR DESCRIPTION
## Why

Follow-up to #890 (#889). After pointer/touch auto-enter-select was removed, the footer `ModeToggleButton` is the **only** built-in entry to Select mode. A `chromeless` `TerminalPanel` renders no footer, so a chromeless host **must** drive the controlled `inputMode` prop or the panel is stuck in Input mode forever.

The sole current chromeless consumer — the aim-console's `WireTerminal` — already supplies this via its status strip, so nothing is broken today. This JSDoc makes the now-load-bearing invariant explicit for the next chromeless embedder. Surfaced by the #889 worker's friction note.

## Change

Comment-only: augments the `chromeless` prop JSDoc in `clients/react/src/components/terminal/TerminalPanel.tsx`. No behavior change.

Local gate: `pnpm lint` (biome) ✅, `pnpm tsc --noEmit` ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)