### PR TITLE
refactor(ui): read identity/attention/channels from wire (#583 §軸A)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -895,6 +895,7 @@ export function App({
                   agents={agents}
                   currentProjectPath={currentProject}
                   unitName={unitName}
+                  unitRepos={unitReposForCurrent}
                   trigger={triggerHandoff}
                   onOpenSettings={openSettingsFromOverride}
                 />

--- a/clients/react/src/components/agent/AgentCard.tsx
+++ b/clients/react/src/components/agent/AgentCard.tsx
@@ -4,6 +4,7 @@ import {
   type AgentType,
   type ConnectionChannels,
   type DetectionSource,
+  hasAttention,
   isAiAgent,
   type SendCapability,
 } from "@/lib/api";
@@ -177,7 +178,6 @@ export function AgentCard({ agent, selected, onClick, variant = "default" }: Age
   // with its own pill); `null`/absent renders a muted "Running" chip
   // (dogfood feedback 2026-05-10 — ambient state still wants a marker).
   const attention = agent.attention ?? null;
-  const hasAttention = attention !== null;
   const typeInfo = agentTypeLabel(agent.agent_type);
   const isAi = isAiAgent(agent.agent_type);
 
@@ -256,7 +256,7 @@ export function AgentCard({ agent, selected, onClick, variant = "default" }: Age
         // it reads as first-class above its subordinate worker roster.
         variant === "headline" && "!border-primary/25 bg-primary/[0.05]",
         selected && "!border-primary/30 !bg-primary/10",
-        hasAttention && "!border-warning/30 animate-glow-pulse",
+        hasAttention(agent) && "!border-warning/30 animate-glow-pulse",
         glow && selected && glow,
       )}
     >

--- a/clients/react/src/components/aim-console/SessionPane.tsx
+++ b/clients/react/src/components/aim-console/SessionPane.tsx
@@ -93,7 +93,14 @@ export function SessionPane({
   // the existing console exactly (same `findProducerForUnit`), so both
   // surfaces agree on who the Producer is.
   const { producer, sessionAgents } = useMemo(() => {
-    const prod = findProducerForUnit(agents, currentProjectPath);
+    // Resolve against the unit's MEMBERSHIP wire when AimConsole threaded it
+    // (`repos`, primary-first per `UnitRepoWire.primary`) so a multi-repo
+    // unit pins its Producer to the PRIMARY repo even when `currentProjectPath`
+    // points at a secondary repo — the same wire-read App already does (#583
+    // §軸A). Empty `repos` is a cwd-synthesized unit not in the configured
+    // membership; fall back to the single-path string so that case still
+    // resolves by cwd (back-compat overload).
+    const prod = findProducerForUnit(agents, repos.length > 0 ? repos : currentProjectPath);
     const unitAgents = agents
       .filter(isAiAgentLoose)
       .filter((a) => agentInUnit(a, unitName, currentProjectPath));
@@ -101,7 +108,7 @@ export function SessionPane({
       .filter((a) => a.target !== prod?.target)
       .sort((a, b) => a.display_name.localeCompare(b.display_name));
     return { producer: prod, sessionAgents: prod ? [prod, ...workers] : workers };
-  }, [agents, unitName, currentProjectPath]);
+  }, [agents, unitName, currentProjectPath, repos]);
 
   // Local selected SESSION — independent of App's main-pane selection, since
   // the aim console is a full-screen takeover. `null` falls through to the

--- a/clients/react/src/components/producer-console/ProducerConversationHeader.tsx
+++ b/clients/react/src/components/producer-console/ProducerConversationHeader.tsx
@@ -36,6 +36,7 @@ import { useEffect, useState } from "react";
 import { type AgentSnapshot, api, type TriggerHandoffRitualRequest } from "@/lib/api";
 import { findProducerForUnit } from "@/lib/producer";
 import { cn } from "@/lib/utils";
+import type { UnitRepoWire } from "@/types/generated/UnitRepoWire";
 import { formatThousands, renderBar, thresholdColorClass } from "./ProducerCtxHeader";
 
 interface ProducerConversationHeaderProps {
@@ -43,6 +44,13 @@ interface ProducerConversationHeaderProps {
   /** Repo root for the currently focused unit — drives the ctx readout
    *  and the single-Producer resolution. */
   currentProjectPath: string | null;
+  /** The focused unit's MEMBERSHIP wire (primary-first per
+   *  `UnitRepoWire.primary`), threaded from App's `unitReposForCurrent`.
+   *  When present the resolver pins the Producer to the unit's PRIMARY repo
+   *  even if `currentProjectPath` points at a secondary repo — the same
+   *  wire-read App's own `producerForUnit` uses (#583 §軸A). `null` (wire not
+   *  yet loaded, or a cwd-synthesized unit) falls back to `currentProjectPath`. */
+  unitRepos?: UnitRepoWire[] | null;
   /** Unit name (basename of `currentProjectPath`) — the handoff ritual
    *  endpoint keys on it. */
   unitName: string | null;
@@ -58,12 +66,14 @@ export function ProducerConversationHeader({
   agents,
   currentProjectPath,
   unitName,
+  unitRepos,
   trigger,
   onOpenSettings,
 }: ProducerConversationHeaderProps) {
   // Resolve the single live Producer via the shared resolver — the same
   // one the digest button and the ctx readout use, so all surfaces agree.
-  const producer = findProducerForUnit(agents, currentProjectPath);
+  // Prefer the membership wire (primary-pinned) over the single cwd path.
+  const producer = findProducerForUnit(agents, unitRepos ?? currentProjectPath);
   const ctx = producer?.ctx_usage ?? null;
   const disabled = producer === null || unitName === null;
 

--- a/clients/react/src/hooks/useAgents.ts
+++ b/clients/react/src/hooks/useAgents.ts
@@ -1,5 +1,5 @@
 import { useCallback } from "react";
-import type { AgentSnapshot } from "@/lib/api";
+import { type AgentSnapshot, hasAttention } from "@/lib/api";
 import { useSSEContext } from "@/lib/sse-provider";
 import { type CoreEvent, useTauriEvents } from "./useTauriEvents";
 
@@ -11,10 +11,9 @@ import { type CoreEvent, useTauriEvents } from "./useTauriEvents";
 export function useAgents() {
   const { cache, refreshCache } = useSSEContext();
   const { agents, loading } = cache;
-  // Decision tmai-core@2026-05-09 Phase 4: any non-null `attention`
-  // value (`"started" | "halted" | "completed"`) means the agent is
-  // waiting on the user. `null` is "running normally — no UI signal".
-  const attentionCount = agents.filter((a) => a.attention != null).length;
+  // Shared `hasAttention` predicate (see `@/lib/api`): count of agents on
+  // the user-blocked axis, fed to the StatusBar badge.
+  const attentionCount = agents.filter(hasAttention).length;
 
   // refreshCache triggers a full re-bootstrap; used by the Tauri event path
   // to pull a fresh snapshot when the desktop app signals an agent change.

--- a/clients/react/src/hooks/useHandover.ts
+++ b/clients/react/src/hooks/useHandover.ts
@@ -40,8 +40,8 @@ import { useUnits } from "@/hooks/useUnits";
 import { useWorktrees } from "@/hooks/useWorktrees";
 import {
   type AgentAttention,
-  type AgentSnapshot,
   groupByProject,
+  hasAttention,
   isAiAgentLoose,
   type ProjectGroup,
 } from "@/lib/api";
@@ -123,13 +123,6 @@ export interface HandoverDigest {
   missingPreconditions: MissingPreconditions;
 }
 
-// Narrowing predicate — keeps the AttentionAgentBrief map free of the
-// `attention!` non-null-assertion (would survive `noUncheckedIndexedAccess`
-// but reads as a code smell against the project's `any`-banned rule).
-function isAttentionAgent(a: AgentSnapshot): a is AgentSnapshot & { attention: AgentAttention } {
-  return a.attention != null;
-}
-
 function deriveUnitState(group: ProjectGroup): UnitState {
   if (group.attentionAgents > 0) return "needs-you";
   if (group.totalAgents > 0) return "in-progress";
@@ -175,7 +168,7 @@ export function useHandover(currentProjectPath: string | null): HandoverDigest {
             agentCount: wt.agents.length,
           }))
         : [],
-      attentionAgents: activeAgents.filter(isAttentionAgent).map((a) => ({
+      attentionAgents: activeAgents.filter(hasAttention).map((a) => ({
         target: a.target,
         displayName: a.display_name,
         attention: a.attention,

--- a/clients/react/src/lib/__tests__/has-attention.test.ts
+++ b/clients/react/src/lib/__tests__/has-attention.test.ts
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, expect, it } from "vitest";
+import { type AgentAttention, type AgentSnapshot, hasAttention } from "../api-http";
+
+// Minimal AgentSnapshot stub — `hasAttention` reads only `attention`, so the
+// rest are inert. `attention` defaults to `null` ("running normally").
+function stubAgent(overrides: Partial<AgentSnapshot> = {}): AgentSnapshot {
+  return {
+    id: "claude:agent",
+    target: "claude:agent",
+    agent_type: "ClaudeCode",
+    title: "",
+    cwd: "/home/u/works/tmai",
+    display_cwd: "/home/u/works/tmai",
+    display_name: "claude:agent",
+    detection_source: "HttpHook",
+    git_branch: null,
+    git_dirty: false,
+    is_worktree: false,
+    git_common_dir: "/home/u/works/tmai/.git",
+    worktree_name: null,
+    worktree_base_branch: null,
+    effort_level: null,
+    active_subagents: 0,
+    compaction_count: 0,
+    pty_session_id: null,
+    send_capability: "PtyInject",
+    is_virtual: false,
+    team_info: null,
+    attention: null,
+    ...overrides,
+  };
+}
+
+describe("hasAttention — shared user-blocked-axis predicate (#583 §軸A)", () => {
+  it("is false when attention is null (running normally)", () => {
+    expect(hasAttention(stubAgent({ attention: null }))).toBe(false);
+  });
+
+  it("is false when attention is absent on the wire (forward-compat / unknown)", () => {
+    // The sampler-bootstrap window omits `attention` entirely; `!= null`
+    // collapses both `null` and `undefined` to "no signal".
+    expect(hasAttention(stubAgent({ attention: undefined }))).toBe(false);
+  });
+
+  it.each<AgentAttention>([
+    "started",
+    "halted",
+    "completed",
+  ])("is true for the user-blocked state %s", (attention) => {
+    expect(hasAttention(stubAgent({ attention }))).toBe(true);
+  });
+
+  it("counts the blocked agents in a mixed list (the StatusBar / group-badge use)", () => {
+    const agents = [
+      stubAgent({ attention: null }),
+      stubAgent({ attention: "halted" }),
+      stubAgent({ attention: undefined }),
+      stubAgent({ attention: "completed" }),
+    ];
+    expect(agents.filter(hasAttention).length).toBe(2);
+  });
+
+  it("narrows `attention` to a non-null AgentAttention (type guard)", () => {
+    const agents = [stubAgent({ attention: "started" }), stubAgent({ attention: null })];
+    // After `filter(hasAttention)`, `a.attention` is `AgentAttention` — read
+    // it WITHOUT a non-null assertion. This compiling (tsc gate) is the
+    // narrowing contract the digest's `attentionAgents` map relies on.
+    const reasons: AgentAttention[] = agents.filter(hasAttention).map((a) => a.attention);
+    expect(reasons).toEqual(["started"]);
+  });
+});

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -164,6 +164,23 @@ export type SendCapability = "Ipc" | "Tmux" | "PtyInject" | "None";
 // - `"completed"` — turn finished; user must decide what to do next
 export type AgentAttention = "started" | "halted" | "completed";
 
+// The single "is this agent waiting on the user?" predicate (decision
+// tmai-core@2026-05-09 Phase 4). Any non-null `attention` value
+// (`"started" | "halted" | "completed"`) means the agent is on the
+// user-blocked axis; `null` / absent means "running normally — no UI
+// signal needed". Centralized here (#583 §軸A) so the ≥5 surfaces that
+// used to recompute `a.attention != null` inline — the StatusBar count
+// (`useAgents`), the per-group count (`groupByProject`), the hand-over
+// digest's attention list (`useHandover`), and the AgentCard glow — all
+// read ONE definition and can never drift apart. A type guard so the
+// digest's `attentionAgents` map narrows `attention` to the non-null
+// `AgentAttention` without an inline non-null assertion.
+export function hasAttention(
+  agent: AgentSnapshot,
+): agent is AgentSnapshot & { attention: AgentAttention } {
+  return agent.attention != null;
+}
+
 /// Which communication channels are currently available for this agent
 export interface ConnectionChannels {
   has_tmux: boolean;
@@ -612,9 +629,9 @@ export function groupByProject(
       });
     }
 
-    // Decision 2026-05-09 Phase 4: any non-null attention value means
-    // the agent is on the user-blocked axis.
-    const attentionCount = groupAgents.filter((a) => a.attention != null).length;
+    // Shared `hasAttention` predicate — the user-blocked-axis count for
+    // this group's badge (see the helper for the wire contract).
+    const attentionCount = groupAgents.filter(hasAttention).length;
 
     projects.push({
       // Display the unit name when grouped by unit; else the repo basename.
@@ -998,12 +1015,6 @@ export const api = {
 
   // Agent queries
   listAgents: () => apiFetch<AgentSnapshot[]>("/agents"),
-  attentionCount: async () => {
-    const agents = await apiFetch<AgentSnapshot[]>("/agents");
-    // Decision 2026-05-09 Phase 4: any non-null attention value flags
-    // the user-blocked axis.
-    return agents.filter((a) => a.attention != null).length;
-  },
 
   // Agent actions
   approve: (target: string) =>

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -59,15 +59,6 @@ export const api = {
     return await httpApi.listAgents();
   },
 
-  attentionCount: async (): Promise<number> => {
-    try {
-      if (await isInTauri()) {
-        return await tauri.attentionCount();
-      }
-    } catch (_e) {}
-    return await httpApi.attentionCount();
-  },
-
   // Agent actions - use Tauri IPC if available
   approve: async (target: string) => {
     try {

--- a/clients/react/src/lib/tauri.ts
+++ b/clients/react/src/lib/tauri.ts
@@ -69,10 +69,6 @@ export const tauri = {
     return convertTauriAgent(info);
   },
 
-  attentionCount: async (): Promise<number> => {
-    return await invoke<number>("attention_count");
-  },
-
   approveAgent: async (target: string): Promise<void> => {
     return await invoke<void>("approve_agent", { target });
   },


### PR DESCRIPTION
## What & why

§軸A (hub): the UI re-derives things the wire already carries. This replaces each *safe* re-derivation with a wire read, **preserving observable UI behavior exactly**. Scope is strictly `clients/react/`.

A live `GET /api/agents` snapshot was used to verify the wire fields before relying on them: `connection_channels`, `is_producer`, `unit`, `attention` are all present; `has_queued_prompt` / `queued_prompt_count` are **not** served by the running engine (type-only).

## Changes (per site)

### Site 1 — attention predicate dedup + dead refetch ✅
- **`hasAttention(agent)`** — one shared type-guard added to `api-http.ts`. The 4 live surfaces that recomputed `a.attention != null` inline now read it:
  - `useAgents.ts` (StatusBar count)
  - `api-http.ts` `groupByProject` (per-group badge count)
  - `useHandover.ts` (digest attention list — replaces its local `isAttentionAgent` guard)
  - `AgentCard.tsx` (card glow)
- **Removed the dead `api.attentionCount()` refetch** across `api-http.ts`, `api-tauri.ts`, `tauri.ts`. The count is recomputed client-side; no app code called the method (only internal wrapper delegations), so the whole chain was dead.

### Site 2 — single-path callers → membership wire ✅ (the two named callers)
- **`SessionPane.tsx`** — `findProducerForUnit` now resolves against its `repos` (`UnitRepoWire[]`, primary-first) when present, falling back to the cwd string for cwd-synthesized units. Same primary-pinned read App already does.
- **`ProducerConversationHeader.tsx`** — new optional `unitRepos` prop threaded from App's `unitReposForCurrent`; resolver prefers the membership wire over the single cwd path. (`App.tsx` passes it.)

### Tests
- Added `lib/__tests__/has-attention.test.ts`: `null`/`undefined` → false, the three blocked states → true, mixed-list count, and the type-guard narrowing (compiled under the tsc gate).

## Left untouched (reported, not forced)

- **Site 2 `producer.ts` internals (`unitName` basename, `id.startsWith` gate, rule-3b cwd) + `groupByProject:533` primary-by-basename.** `producer.ts` **already reads the wire as the primary path** (`is_producer` + `unit`, rule 3a, landed in #834); the residual basename/id-scheme/cwd derivations are the *documented forward-compat fallbacks* the brief itself says to keep. Converting `unitName`/`groupByProject` to pure `UnitRepoWire.primary` reads requires threading the units-membership wire through a **signature change across 6–10 callers** and changes behavior during the engine transition window — outside the "preserve observable behavior / don't force it" guardrail. The current basename approach is correct given primary-repo input.
- **Site 3 — queue count → wire.** No client-side queue-count *re-derivation* exists: the only count (`PreviewPanel`'s `queueItems.length`) is the length of the actual fetched items it renders, not a re-derivation. And `has_queued_prompt` / `queued_prompt_count` are **not served on the live wire** (type-only). No safe target — left.
- **Site 4 — connection channels → wire.** **Already done** in the existing code: `AgentSnapshot.connection_channels` is declared and `AgentCard.tsx` already reads `agent.connection_channels ?? {…reconstruction…}` with the reconstruction kept only as fallback. Verified against the live wire (`connection_channels` present). No change needed.

## Gate (run from `clients/react/`)

| step | result |
|------|--------|
| `pnpm lint` (biome) | ✅ clean |
| `pnpm tsc --noEmit` | ✅ exit 0 |
| `pnpm test` | ✅ 964 pass / 2 skip |
| `pnpm build` | ✅ built |

Do **not** merge — review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 会話ヘッダーやコンソール画面で、現在のユニットに対応するリポジトリ情報をより正確に参照できるようになりました。
* **バグ修正**
  * 単一プロデューサーの表示や操作可否が、提供されたユニット情報を優先して判定されるようになり、誤った対象が選ばれる問題を改善しました。
  * エージェントの注目状態の判定を統一し、件数表示や強調表示のズレを防ぎました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->