### PR TITLE
chore(gen): sync generated spec + types from tmai-core@ac668df (#583)

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -399,7 +399,7 @@
       "type": "string"
     },
     "DispatchKind": {
-      "description": "Classification of what was dispatched. Drives notification phrasing,\ngatekeeper rules (#11), and selector disambiguation (e.g. an\nimplementer worktree and a review worktree both reference the same PR\nnumber — `kind` separates them).",
+      "description": "Classification of what was dispatched. Drives notification phrasing,\ngatekeeper rules (#11), and selector disambiguation (multiple dispatches\nmay reference the same PR number; the resolver reports them as ambiguous).",
       "oneOf": [
         {
           "description": "Work attached to a GitHub issue (no PR yet).",
@@ -456,28 +456,6 @@
             }
           },
           "required": [
-            "kind"
-          ],
-          "type": "object"
-        },
-        {
-          "description": "A reviewer dispatched against an existing PR.",
-          "properties": {
-            "kind": {
-              "enum": [
-                "review"
-              ],
-              "type": "string"
-            },
-            "pr": {
-              "description": "PR being reviewed.",
-              "format": "int64",
-              "minimum": 0,
-              "type": "integer"
-            }
-          },
-          "required": [
-            "pr",
             "kind"
           ],
           "type": "object"
@@ -1757,7 +1735,6 @@
       "enum": [
         "orchestrator",
         "implementer",
-        "reviewer",
         "manual"
       ],
       "type": "string"

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -1949,28 +1949,6 @@
           },
           {
             "type": "object",
-            "description": "A reviewer dispatched against an existing PR.",
-            "required": [
-              "pr",
-              "kind"
-            ],
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": [
-                  "review"
-                ]
-              },
-              "pr": {
-                "type": "integer",
-                "format": "int64",
-                "description": "PR being reviewed.",
-                "minimum": 0
-              }
-            }
-          },
-          {
-            "type": "object",
             "description": "An orchestrator dispatch.",
             "required": [
               "kind"
@@ -1985,7 +1963,7 @@
             }
           }
         ],
-        "description": "Classification of what was dispatched. Drives notification phrasing,\ngatekeeper rules (#11), and selector disambiguation (e.g. an\nimplementer worktree and a review worktree both reference the same PR\nnumber — `kind` separates them)."
+        "description": "Classification of what was dispatched. Drives notification phrasing,\ngatekeeper rules (#11), and selector disambiguation (multiple dispatches\nmay reference the same PR number; the resolver reports them as ambiguous)."
       },
       "DispatchRefs": {
         "type": "object",
@@ -3246,7 +3224,6 @@
         "enum": [
           "orchestrator",
           "implementer",
-          "reviewer",
           "manual"
         ]
       },

--- a/clients/ratatui/src/types/generated/spawn_role.rs
+++ b/clients/ratatui/src/types/generated/spawn_role.rs
@@ -12,6 +12,5 @@ use std::collections::HashMap;
 pub enum SpawnRole {
     orchestrator,
     implementer,
-    reviewer,
     manual,
 }

--- a/clients/react/src/components/settings/OrchestrationDispatchSection.tsx
+++ b/clients/react/src/components/settings/OrchestrationDispatchSection.tsx
@@ -13,9 +13,9 @@ interface DispatchState {
 
 /**
  * A "role" describes one editable bundle: how to read it from state and how to
- * write a new bundle back. Keeping orchestrator / implementer / reviewer as
- * data here rather than three near-identical handler triplets lets the render
- * loop stay declarative.
+ * write a new bundle back. Keeping orchestrator / implementer as data here
+ * rather than near-identical handler triplets lets the render loop stay
+ * declarative.
  */
 interface DispatchRole {
   title: string;
@@ -37,17 +37,11 @@ const ROLES: DispatchRole[] = [
     read: (s) => s.dispatch.implementer ?? null,
     write: (s, bundle) => ({ ...s, dispatch: { ...s.dispatch, implementer: bundle } }),
   },
-  {
-    title: "Reviewer",
-    subtitle: "dispatch_review",
-    read: (s) => s.dispatch.reviewer ?? null,
-    write: (s, bundle) => ({ ...s, dispatch: { ...s.dispatch, reviewer: bundle } }),
-  },
 ];
 
 /**
  * Settings section that exposes per-role dispatch bundle editing for
- * orchestrator / implementer / reviewer (#578 — auto-save).
+ * orchestrator / implementer (#578 — auto-save).
  *
  * Atomic fields (vendor / permission_mode / effort dropdowns and the "Use
  * vendor CLI default" checkbox) persist on change; the model text field

--- a/clients/react/src/components/settings/__tests__/HandoffThresholdSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/HandoffThresholdSection.test.tsx
@@ -39,7 +39,7 @@ function orchestrator(threshold: number): OrchestratorSettings {
     auto_handoff_threshold_pct: threshold,
     is_project_override: false,
     orchestrator: null,
-    dispatch: { implementer: null, reviewer: null },
+    dispatch: { implementer: null },
   };
 }
 

--- a/clients/react/src/components/settings/__tests__/OrchestrationSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/OrchestrationSection.test.tsx
@@ -37,7 +37,7 @@ function makeSettings(overrides: Partial<OrchestratorSettings> = {}): Orchestrat
     auto_handoff_threshold_pct: 75,
     is_project_override: false,
     orchestrator: null,
-    dispatch: { implementer: null, reviewer: null },
+    dispatch: { implementer: null },
     ...overrides,
   };
 }

--- a/clients/react/src/components/settings/__tests__/SettingsPanel-autosave.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel-autosave.test.tsx
@@ -49,7 +49,7 @@ function makeOrchestrator(): OrchestratorSettings {
     auto_handoff_threshold_pct: 75,
     is_project_override: false,
     orchestrator: null,
-    dispatch: { implementer: null, reviewer: null },
+    dispatch: { implementer: null },
   };
 }
 

--- a/clients/react/src/components/settings/__tests__/SettingsPanel-orchestration.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel-orchestration.test.tsx
@@ -36,7 +36,7 @@ function makeSettings(overrides: Partial<OrchestratorSettings>): OrchestratorSet
     auto_handoff_threshold_pct: 75,
     is_project_override: false,
     orchestrator: null,
-    dispatch: { implementer: null, reviewer: null },
+    dispatch: { implementer: null },
     ...overrides,
   };
 }
@@ -57,7 +57,6 @@ const EXPLICIT_SETTINGS = makeSettings({
       permission_mode: "auto",
       effort: "high",
     },
-    reviewer: { vendor: "codex", model: "codex-1", permission_mode: null, effort: null },
   },
 });
 
@@ -66,13 +65,12 @@ describe("OrchestrationDispatchSection", () => {
     vi.clearAllMocks();
   });
 
-  it("renders all three bundle sections after load", async () => {
+  it("renders both bundle sections after load", async () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(BASE_SETTINGS);
     render(<OrchestrationDispatchSection />);
     await waitFor(() => {
       expect(screen.getByText("Orchestrator")).toBeTruthy();
       expect(screen.getByText("Implementer")).toBeTruthy();
-      expect(screen.getByText("Reviewer")).toBeTruthy();
     });
   });
 
@@ -81,7 +79,7 @@ describe("OrchestrationDispatchSection", () => {
     render(<OrchestrationDispatchSection />);
     await waitFor(() => {
       const checkboxes = screen.getAllByRole("checkbox");
-      // All three bundles null → all three "Use vendor CLI default" checkboxes
+      // Both bundles null → both "Use vendor CLI default" checkboxes
       // should be checked.
       for (const cb of checkboxes) {
         expect((cb as HTMLInputElement).checked).toBe(true);
@@ -162,18 +160,17 @@ describe("OrchestrationDispatchSection", () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
       makeSettings({
         dispatch: {
-          implementer: null,
-          reviewer: { vendor: "codex", model: "codex-1" },
+          implementer: { vendor: "codex", model: "codex-1" },
         },
       }),
     );
     render(<OrchestrationDispatchSection />);
-    await waitFor(() => screen.getByText("Reviewer"));
+    await waitFor(() => screen.getByText("Implementer"));
 
     const permissionSelects = screen.getAllByRole("combobox", { name: /permission mode for/i });
-    const reviewerPerm = permissionSelects[2];
+    const implementerPerm = permissionSelects[1];
 
-    const autoOption = Array.from(reviewerPerm.querySelectorAll("option")).find(
+    const autoOption = Array.from(implementerPerm.querySelectorAll("option")).find(
       (o) => o.value === "auto",
     );
     expect(autoOption).toBeTruthy();
@@ -184,13 +181,12 @@ describe("OrchestrationDispatchSection", () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
       makeSettings({
         dispatch: {
-          implementer: null,
-          reviewer: { vendor: "codex", model: "codex-1" },
+          implementer: { vendor: "codex", model: "codex-1" },
         },
       }),
     );
     render(<OrchestrationDispatchSection />);
-    await waitFor(() => screen.getByText("Reviewer"));
+    await waitFor(() => screen.getByText("Implementer"));
 
     expect(screen.getByText("(n/a — codex)")).toBeTruthy();
   });

--- a/clients/react/src/types/generated/DispatchKind.ts
+++ b/clients/react/src/types/generated/DispatchKind.ts
@@ -2,9 +2,8 @@
 
 /**
  * Classification of what was dispatched. Drives notification phrasing,
- * gatekeeper rules (#11), and selector disambiguation (e.g. an
- * implementer worktree and a review worktree both reference the same PR
- * number — `kind` separates them).
+ * gatekeeper rules (#11), and selector disambiguation (multiple dispatches
+ * may reference the same PR number; the resolver reports them as ambiguous).
  */
 export type DispatchKind = { "kind": "issue", 
 /**
@@ -14,8 +13,4 @@ number: bigint, } | { "kind": "pr",
 /**
  * PR number.
  */
-number: bigint, } | { "kind": "standalone" } | { "kind": "review", 
-/**
- * PR being reviewed.
- */
-pr: bigint, } | { "kind": "orchestrator" };
+number: bigint, } | { "kind": "standalone" } | { "kind": "orchestrator" };

--- a/clients/react/src/types/generated/SpawnRole.ts
+++ b/clients/react/src/types/generated/SpawnRole.ts
@@ -3,4 +3,4 @@
 /**
  * Role of a spawned agent.
  */
-export type SpawnRole = "orchestrator" | "implementer" | "reviewer" | "manual";
+export type SpawnRole = "orchestrator" | "implementer" | "manual";

--- a/clients/react/src/types/generated/WorkerDispatchMap.ts
+++ b/clients/react/src/types/generated/WorkerDispatchMap.ts
@@ -2,9 +2,9 @@
 import type { DispatchBundle } from "./DispatchBundle";
 
 /**
- * Per-role dispatch bundles for worker roles (implementer, reviewer).
+ * Per-role dispatch bundles for worker roles (implementer).
  *
  * The orchestrator's own bundle lives at `OrchestrationSettings.orchestrator`,
  * not here.
  */
-export type WorkerDispatchMap = { implementer?: DispatchBundle | null, reviewer?: DispatchBundle | null, };
+export type WorkerDispatchMap = { implementer?: DispatchBundle | null, };


### PR DESCRIPTION
Mirrors the **dispatch_review residue rip** from tmai-core #596 (part of #583). Removes the phantom `DispatchKind::Review` variant, the `SpawnRole::Reviewer` role, and the `WorkerDispatchMap.reviewer` field from the wire contract, and brings the hub consumers in sync.

This is a manual gen-spec mirror (tmai-core is billing-dead, so the `gen-spec-pr` bot can't run). On a `bot/` branch so the no-hand-edit-generated check is exempt; it **bundles the hand-written consumer fixes** because the wire removal would otherwise break `tsc` (the gen-spec-breaks-consumers pattern).

## Regenerated artifacts (from `tmai-xtask` @ `ac668df`)
- `api-spec/openapi.json`, `api-spec/corevents.schema.json`
- `clients/react/src/types/generated/{DispatchKind,SpawnRole,WorkerDispatchMap}.ts`
- `clients/ratatui/src/types/generated/spawn_role.rs`

## Bundled consumer fixes
- `OrchestrationDispatchSection.tsx`: drop the dead **Reviewer** dispatch-bundle row (it read/wrote the now-removed `dispatch.reviewer`). Orchestrator + Implementer rows unchanged.
- Settings tests (`SettingsPanel-orchestration`, `OrchestrationSection`, `SettingsPanel-autosave`, `HandoffThresholdSection`): drop `reviewer` fixtures; retarget the two codex-vendor tests from the reviewer row to the implementer row.

## Deliberately untouched (NOT dispatch_review)
- The orchestrator **"Review rules"** workflow-rules textarea (`OrchestrationSection.tsx`) — part of the deferred `orchestrator → producer` surface.
- PR **review-decision** status pills (`RPrViewer`, `PrRail`).

## Gate (all green)
- `clients/react`: `pnpm lint` · `pnpm tsc --noEmit` · `pnpm test` (964 pass / 2 skip) · `pnpm build`
- `clients/ratatui`: `cargo check`
- `api-spec`: no orphan fixtures


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 設定画面のディスパッチ対象から不要な項目が整理され、表示・編集できる役割がより実際の利用形態に沿うようになりました。
  * 自動保存やオーケストレーション設定の動作確認を更新し、関連する表示や選択項目の不整合を防ぎました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->