### PR TITLE
chore(gen): sync generated spec + types from tmai-core@a1dac80 (#583)

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -459,21 +459,6 @@
             "kind"
           ],
           "type": "object"
-        },
-        {
-          "description": "An orchestrator dispatch.",
-          "properties": {
-            "kind": {
-              "enum": [
-                "orchestrator"
-              ],
-              "type": "string"
-            }
-          },
-          "required": [
-            "kind"
-          ],
-          "type": "object"
         }
       ]
     },
@@ -1733,7 +1718,6 @@
     "SpawnRole": {
       "description": "Role of a spawned agent.",
       "enum": [
-        "orchestrator",
         "implementer",
         "manual"
       ],

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -1946,21 +1946,6 @@
                 ]
               }
             }
-          },
-          {
-            "type": "object",
-            "description": "An orchestrator dispatch.",
-            "required": [
-              "kind"
-            ],
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": [
-                  "orchestrator"
-                ]
-              }
-            }
           }
         ],
         "description": "Classification of what was dispatched. Drives notification phrasing,\ngatekeeper rules (#11), and selector disambiguation (multiple dispatches\nmay reference the same PR number; the resolver reports them as ambiguous)."
@@ -3222,7 +3207,6 @@
         "type": "string",
         "description": "Role of a spawned agent.",
         "enum": [
-          "orchestrator",
           "implementer",
           "manual"
         ]

--- a/clients/ratatui/src/types/generated/spawn_role.rs
+++ b/clients/ratatui/src/types/generated/spawn_role.rs
@@ -10,7 +10,6 @@ use std::collections::HashMap;
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 pub enum SpawnRole {
-    orchestrator,
     implementer,
     manual,
 }

--- a/clients/react/src/components/settings/OrchestrationDispatchSection.tsx
+++ b/clients/react/src/components/settings/OrchestrationDispatchSection.tsx
@@ -7,15 +7,13 @@ import { DispatchBundleEditor } from "./DispatchBundleEditor";
 import { SaveStatus } from "./SaveStatus";
 
 interface DispatchState {
-  orchestrator: DispatchBundle | null;
   dispatch: WorkerDispatchMap;
 }
 
 /**
  * A "role" describes one editable bundle: how to read it from state and how to
- * write a new bundle back. Keeping orchestrator / implementer as data here
- * rather than near-identical handler triplets lets the render loop stay
- * declarative.
+ * write a new bundle back. Keeping each role as data here rather than
+ * near-identical handler triplets lets the render loop stay declarative.
  */
 interface DispatchRole {
   title: string;
@@ -26,12 +24,6 @@ interface DispatchRole {
 
 const ROLES: DispatchRole[] = [
   {
-    title: "Orchestrator",
-    subtitle: "the agent you attach to",
-    read: (s) => s.orchestrator,
-    write: (s, bundle) => ({ ...s, orchestrator: bundle }),
-  },
-  {
     title: "Implementer",
     subtitle: "dispatch_issue / spawn_worktree",
     read: (s) => s.dispatch.implementer ?? null,
@@ -40,18 +32,17 @@ const ROLES: DispatchRole[] = [
 ];
 
 /**
- * Settings section that exposes per-role dispatch bundle editing for
- * orchestrator / implementer (#578 — auto-save).
+ * Settings section that exposes per-role dispatch bundle editing
+ * (#578 — auto-save).
  *
  * Atomic fields (vendor / permission_mode / effort dropdowns and the "Use
  * vendor CLI default" checkbox) persist on change; the model text field
  * persists on blur or Enter so we do not flicker validation errors mid-typing.
  *
  * Reads the bundles from `GET /settings/orchestrator` (the global settings
- * endpoint that carries the dispatch fields alongside notify/rules/...)
- * and saves them via the same endpoint's PUT — server-side `OrchestrationSettings`
- * is the single source of truth, so this component only roundtrips the dispatch
- * subset of fields.
+ * endpoint that carries the dispatch fields) and saves them via the same
+ * endpoint's PUT — server-side `OrchestrationSettings` is the single source
+ * of truth, so this component only roundtrips the dispatch subset of fields.
  *
  * Backend 400s surface as inline error text. For atomic changes we roll back
  * to the last-saved bundle; for text-commit errors we leave the user's draft
@@ -69,7 +60,6 @@ export function OrchestrationDispatchSection() {
       .getOrchestratorSettings()
       .then((s) => {
         const initial = {
-          orchestrator: s.orchestrator ?? null,
           dispatch: s.dispatch,
         };
         setState(initial);
@@ -88,7 +78,6 @@ export function OrchestrationDispatchSection() {
       setError(null);
       try {
         await api.updateOrchestratorSettings({
-          orchestrator: next.orchestrator,
           dispatch: next.dispatch,
         });
         lastSavedRef.current = next;
@@ -110,8 +99,8 @@ export function OrchestrationDispatchSection() {
 
   if (!state) return null;
 
-  // Build the three handler triplets from the ROLES table. Each role differs
-  // only by its read/write lens; the persistence semantics (atomic = persist
+  // Build the handler triplet for each role in the ROLES table. Each role
+  // differs only by its read/write lens; the persistence semantics (atomic = persist
   // immediately with rollback, text draft = local-only + clear error, text
   // commit = persist without rollback) are identical, so we keep them in a
   // single place.

--- a/clients/react/src/components/settings/OrchestrationSection.tsx
+++ b/clients/react/src/components/settings/OrchestrationSection.tsx
@@ -1,44 +1,9 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { DirBrowser } from "@/components/project/DirBrowser";
 import { useSaveTracker } from "@/hooks/useSaveTracker";
-import { api, type OrchestratorSettings, withOrchestratorDefaults } from "@/lib/api";
+import { api, type OrchestratorSettings } from "@/lib/api";
 import { PrMonitorSection } from "./PrMonitorSection";
 import { SaveStatus } from "./SaveStatus";
-
-const ROW_INPUT_CLS =
-  "w-full rounded-md border border-hairline-strong bg-surface px-2.5 py-1.5 text-xs text-foreground placeholder-subtle-foreground outline-none focus:border-primary/30 resize-y";
-
-const RULE_FIELDS = [
-  {
-    key: "branch",
-    label: "Branch rules",
-    placeholder: "Rules for branch naming and strategy...",
-    rows: 2,
-  },
-  {
-    key: "merge",
-    label: "Merge rules",
-    placeholder: "Rules for merge strategy and conflict resolution...",
-    rows: 2,
-  },
-  {
-    key: "review",
-    label: "Review rules",
-    placeholder: "Rules for code review process...",
-    rows: 2,
-  },
-  {
-    key: "custom",
-    label: "Custom rules",
-    placeholder: "Additional custom rules for the orchestrator...",
-    rows: 3,
-  },
-] as const satisfies ReadonlyArray<{
-  key: keyof OrchestratorSettings["rules"];
-  label: string;
-  placeholder: string;
-  rows: number;
-}>;
 
 interface OrchestrationSectionProps {
   /** Project paths derived from currently active agents — used to seed the
@@ -50,9 +15,9 @@ interface OrchestrationSectionProps {
 }
 
 /**
- * Settings section that hosts the orchestrator agent's full configuration:
- * scope (global vs per-project override), enabled toggle, role + workflow
- * rule textareas, and the composed PR Monitor sub-section.
+ * Settings section that hosts the orchestrator agent's configuration:
+ * scope (global vs per-project override), enabled toggle, and the composed
+ * PR Monitor sub-section.
  *
  * Owns its own state (`orchestrator`, `orchScope`, `orchestratorSave`) and
  * load — the parent SettingsPanel does not need to refresh this section.
@@ -82,13 +47,7 @@ export function OrchestrationSection({ projects }: OrchestrationSectionProps) {
 
   const orchProject = orchScope === "global" ? undefined : orchScope;
   const refreshOrchestrator = useCallback(() => {
-    // Coalesce wire-omitted sub-tables (notify / rules) to their engine
-    // defaults here at the boundary so the sub-sections never deref an
-    // `undefined` object and black out the panel.
-    api
-      .getOrchestratorSettings(orchProject)
-      .then((s) => setOrchestrator(withOrchestratorDefaults(s)))
-      .catch(console.error);
+    api.getOrchestratorSettings(orchProject).then(setOrchestrator).catch(console.error);
   }, [orchProject]);
 
   useEffect(() => {
@@ -215,40 +174,6 @@ export function OrchestrationSection({ projects }: OrchestrationSectionProps) {
 
         {orchestrator.enabled && (
           <div className="space-y-3 border-t border-hairline pt-3">
-            <OrchestrationRuleTextarea
-              label="Role"
-              placeholder="Describe the orchestrator's role and persona..."
-              rows={2}
-              value={orchestrator.role}
-              save={save}
-              onDraft={(role) => setOrchestrator({ ...orchestrator, role })}
-              onCommit={(role) => api.updateOrchestratorSettings({ role }, orchProject)}
-            />
-
-            <p className="text-[11px] font-medium text-muted-foreground uppercase tracking-wider">
-              Workflow Rules
-            </p>
-
-            {RULE_FIELDS.map(({ key, label, placeholder, rows }) => (
-              <OrchestrationRuleTextarea
-                key={key}
-                label={label}
-                placeholder={placeholder}
-                rows={rows}
-                value={orchestrator.rules[key]}
-                save={save}
-                onDraft={(value) =>
-                  setOrchestrator({
-                    ...orchestrator,
-                    rules: { ...orchestrator.rules, [key]: value },
-                  })
-                }
-                onCommit={(value) =>
-                  api.updateOrchestratorSettings({ rules: { [key]: value } }, orchProject)
-                }
-              />
-            ))}
-
             <PrMonitorSection
               orchestrator={orchestrator}
               setOrchestrator={setOrchestrator}
@@ -259,58 +184,5 @@ export function OrchestrationSection({ projects }: OrchestrationSectionProps) {
         )}
       </div>
     </section>
-  );
-}
-
-/**
- * Auto-saved textarea used by the orchestration role / workflow-rule fields.
- * Local edits stream through `onDraft`; on blur (or Cmd/Ctrl+Enter) the value
- * is committed via `onCommit`, routed through the section's save tracker so
- * Saving / Saved / error indicators stay in sync. Mid-typing keystrokes clear
- * a stale error so the inline message doesn't linger after the user starts
- * correcting it.
- */
-function OrchestrationRuleTextarea({
-  label,
-  placeholder,
-  rows,
-  value,
-  save,
-  onDraft,
-  onCommit,
-}: {
-  label: string;
-  placeholder: string;
-  rows: number;
-  value: string;
-  save: ReturnType<typeof useSaveTracker>;
-  onDraft: (value: string) => void;
-  onCommit: (value: string) => Promise<unknown>;
-}) {
-  return (
-    <div>
-      <span className="block text-xs text-muted-foreground mb-1">{label}</span>
-      <textarea
-        value={value}
-        onChange={(e) => {
-          save.clearError();
-          onDraft(e.target.value);
-        }}
-        onBlur={() => {
-          const commit = value;
-          void save.track(() => onCommit(commit));
-        }}
-        onKeyDown={(e) => {
-          if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) {
-            e.preventDefault();
-            (e.currentTarget as HTMLTextAreaElement).blur();
-          }
-        }}
-        rows={rows}
-        placeholder={placeholder}
-        className={ROW_INPUT_CLS}
-        aria-label={label}
-      />
-    </div>
   );
 }

--- a/clients/react/src/components/settings/__tests__/HandoffThresholdSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/HandoffThresholdSection.test.tsx
@@ -29,8 +29,6 @@ vi.mock("@/lib/api", async () => {
 function orchestrator(threshold: number): OrchestratorSettings {
   return {
     enabled: true,
-    role: "",
-    rules: { branch: "", merge: "", review: "", custom: "" },
     pr_monitor_enabled: false,
     pr_monitor_interval_secs: 60,
     pr_monitor_exclude_authors: [],
@@ -38,7 +36,6 @@ function orchestrator(threshold: number): OrchestratorSettings {
     inject_state_snapshot: false,
     auto_handoff_threshold_pct: threshold,
     is_project_override: false,
-    orchestrator: null,
     dispatch: { implementer: null },
   };
 }

--- a/clients/react/src/components/settings/__tests__/OrchestrationSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/OrchestrationSection.test.tsx
@@ -1,5 +1,5 @@
 // @vitest-environment jsdom
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { OrchestratorSettings } from "@/lib/api";
 
@@ -20,15 +20,11 @@ const { OrchestrationSection } = await import("../OrchestrationSection");
 
 /**
  * A fully-populated OrchestratorSettings with the orchestrator enabled so the
- * PR-monitor / rule sub-sections actually render. Individual tests `delete`
- * sub-tables off this to simulate a tmai-core binary that omits
- * `[orchestration.*]` tables absent from config.toml.
+ * PR-monitor sub-section actually renders.
  */
 function makeSettings(overrides: Partial<OrchestratorSettings> = {}): OrchestratorSettings {
   return {
     enabled: true,
-    role: "",
-    rules: { branch: "", merge: "", review: "", custom: "" },
     pr_monitor_enabled: false,
     pr_monitor_interval_secs: 60,
     pr_monitor_exclude_authors: [],
@@ -36,56 +32,28 @@ function makeSettings(overrides: Partial<OrchestratorSettings> = {}): Orchestrat
     inject_state_snapshot: false,
     auto_handoff_threshold_pct: 75,
     is_project_override: false,
-    orchestrator: null,
     dispatch: { implementer: null },
     ...overrides,
   };
 }
 
-describe("OrchestrationSection — missing-sub-table tolerance", () => {
+describe("OrchestrationSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(api.getGeneralSettings).mockResolvedValue({ default_project_root: null });
   });
 
-  // A tmai-core binary omits the `[orchestration]` rule sub-table from the GET
-  // response when it is absent from config.toml. The rule textareas read
-  // `orchestrator.rules[...]`, so an omitted sub-table used to throw and — with
-  // no error boundary around SettingsPanel — black out the whole panel.
-  it("renders the whole section when rules are omitted from the wire", async () => {
-    const stale = makeSettings();
-    const partial = stale as Partial<OrchestratorSettings>;
-    delete partial.rules;
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(stale);
+  // The orchestrator config rip (#583/#597) retired the role + workflow-rule
+  // textareas. The section now hosts only scope, the enabled toggle, and the
+  // composed PR Monitor sub-section — guard that the dead fields stay gone.
+  it("renders the PR Monitor sub-section without the retired role/rules textareas", async () => {
+    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(makeSettings());
 
     render(<OrchestrationSection projects={[]} />);
 
-    // Sub-sections render without throwing…
     expect(await screen.findByText("PR Monitor")).toBeTruthy();
-    // …rules default to empty textareas (clearly editable, not fabricated)…
-    expect((screen.getByLabelText("Branch rules") as HTMLTextAreaElement).value).toBe("");
-    // …and nothing rendered the literal string "undefined".
-    expect(screen.queryByText(/undefined/)).toBeNull();
-  });
-
-  // Defaulting must not freeze the inputs — an edit still round-trips a PUT.
-  it("keeps the defaulted rule textareas editable (blur commits a PUT)", async () => {
-    const stale = makeSettings();
-    delete (stale as Partial<OrchestratorSettings>).rules;
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(stale);
-    vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
-
-    render(<OrchestrationSection projects={[]} />);
-
-    const branch = (await screen.findByLabelText("Branch rules")) as HTMLTextAreaElement;
-    fireEvent.change(branch, { target: { value: "squash only" } });
-    fireEvent.blur(branch);
-
-    await waitFor(() => {
-      expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalled();
-    });
-    expect(vi.mocked(api.updateOrchestratorSettings).mock.calls[0][0]).toMatchObject({
-      rules: { branch: "squash only" },
-    });
+    expect(screen.queryByLabelText("Role")).toBeNull();
+    expect(screen.queryByLabelText("Branch rules")).toBeNull();
+    expect(screen.queryByText("Workflow Rules")).toBeNull();
   });
 });

--- a/clients/react/src/components/settings/__tests__/SettingsPanel-autosave.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel-autosave.test.tsx
@@ -39,8 +39,6 @@ const WORKTREE: WorktreeSettings = {
 function makeOrchestrator(): OrchestratorSettings {
   return {
     enabled: true,
-    role: "",
-    rules: { branch: "", merge: "", review: "", custom: "" },
     pr_monitor_enabled: false,
     pr_monitor_interval_secs: 60,
     pr_monitor_exclude_authors: [],
@@ -48,7 +46,6 @@ function makeOrchestrator(): OrchestratorSettings {
     inject_state_snapshot: false,
     auto_handoff_threshold_pct: 75,
     is_project_override: false,
-    orchestrator: null,
     dispatch: { implementer: null },
   };
 }

--- a/clients/react/src/components/settings/__tests__/SettingsPanel-orchestration.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel-orchestration.test.tsx
@@ -18,16 +18,14 @@ const { api } = await import("@/lib/api");
 const { OrchestrationDispatchSection } = await import("../OrchestrationDispatchSection");
 
 /**
- * Build a minimal OrchestratorSettings for the dispatch-section tests.
- * Other fields (role, rules, ...) are filled with default-ish
- * placeholders since the section under test only reads `orchestrator` /
- * `dispatch`.
+ * Build a minimal OrchestratorSettings for the dispatch-section tests. The
+ * section under test only reads `dispatch`; the other fields are default-ish
+ * placeholders. (The orchestrator config rip retired the role/rules and the
+ * orchestrator dispatch bundle — only the implementer role remains.)
  */
 function makeSettings(overrides: Partial<OrchestratorSettings>): OrchestratorSettings {
   return {
     enabled: true,
-    role: "",
-    rules: { branch: "", merge: "", review: "", custom: "" },
     pr_monitor_enabled: false,
     pr_monitor_interval_secs: 0,
     pr_monitor_exclude_authors: [],
@@ -35,7 +33,6 @@ function makeSettings(overrides: Partial<OrchestratorSettings>): OrchestratorSet
     inject_state_snapshot: false,
     auto_handoff_threshold_pct: 75,
     is_project_override: false,
-    orchestrator: null,
     dispatch: { implementer: null },
     ...overrides,
   };
@@ -44,12 +41,6 @@ function makeSettings(overrides: Partial<OrchestratorSettings>): OrchestratorSet
 const BASE_SETTINGS = makeSettings({});
 
 const EXPLICIT_SETTINGS = makeSettings({
-  orchestrator: {
-    vendor: "claude",
-    model: "claude-opus-4-6",
-    permission_mode: "auto",
-    effort: "high",
-  },
   dispatch: {
     implementer: {
       vendor: "claude",
@@ -65,29 +56,28 @@ describe("OrchestrationDispatchSection", () => {
     vi.clearAllMocks();
   });
 
-  it("renders both bundle sections after load", async () => {
+  it("renders the implementer bundle section after load (no orchestrator row)", async () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(BASE_SETTINGS);
     render(<OrchestrationDispatchSection />);
     await waitFor(() => {
-      expect(screen.getByText("Orchestrator")).toBeTruthy();
       expect(screen.getByText("Implementer")).toBeTruthy();
     });
+    expect(screen.queryByText("Orchestrator")).toBeNull();
   });
 
-  it("shows default checkbox checked when bundles are null", async () => {
+  it("shows default checkbox checked when the bundle is null", async () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(BASE_SETTINGS);
     render(<OrchestrationDispatchSection />);
     await waitFor(() => {
       const checkboxes = screen.getAllByRole("checkbox");
-      // Both bundles null → both "Use vendor CLI default" checkboxes
-      // should be checked.
+      // Implementer bundle null → its "Use vendor CLI default" checkbox checked.
       for (const cb of checkboxes) {
         expect((cb as HTMLInputElement).checked).toBe(true);
       }
     });
   });
 
-  it("shows default checkbox unchecked when bundles are explicit", async () => {
+  it("shows default checkbox unchecked when the bundle is explicit", async () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
     render(<OrchestrationDispatchSection />);
     await waitFor(() => {
@@ -103,15 +93,15 @@ describe("OrchestrationDispatchSection", () => {
     vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
     render(<OrchestrationDispatchSection />);
 
-    await waitFor(() => screen.getByText("Orchestrator"));
+    await waitFor(() => screen.getByText("Implementer"));
 
     const vendorSelects = screen.getAllByRole("combobox", { name: /vendor for/i });
-    const orchestratorVendor = vendorSelects[0];
+    const implementerVendor = vendorSelects[0];
 
     const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
     expect((modelInputs[0] as HTMLInputElement).value).toBe("claude-opus-4-6");
 
-    fireEvent.change(orchestratorVendor, { target: { value: "codex" } });
+    fireEvent.change(implementerVendor, { target: { value: "codex" } });
 
     await waitFor(() => {
       expect((modelInputs[0] as HTMLInputElement).value).toBe("");
@@ -121,16 +111,16 @@ describe("OrchestrationDispatchSection", () => {
   it("auto permission option is disabled for non-opus claude model", async () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
       makeSettings({
-        orchestrator: { vendor: "claude", model: "claude-sonnet-4-6" },
+        dispatch: { implementer: { vendor: "claude", model: "claude-sonnet-4-6" } },
       }),
     );
     render(<OrchestrationDispatchSection />);
-    await waitFor(() => screen.getByText("Orchestrator"));
+    await waitFor(() => screen.getByText("Implementer"));
 
     const permissionSelects = screen.getAllByRole("combobox", { name: /permission mode for/i });
-    const orchestratorPerm = permissionSelects[0];
+    const implementerPerm = permissionSelects[0];
 
-    const autoOption = Array.from(orchestratorPerm.querySelectorAll("option")).find(
+    const autoOption = Array.from(implementerPerm.querySelectorAll("option")).find(
       (o) => o.value === "auto",
     );
     expect(autoOption).toBeTruthy();
@@ -140,16 +130,16 @@ describe("OrchestrationDispatchSection", () => {
   it("auto permission option is enabled for opus model", async () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
       makeSettings({
-        orchestrator: { vendor: "claude", model: "claude-opus-4-6" },
+        dispatch: { implementer: { vendor: "claude", model: "claude-opus-4-6" } },
       }),
     );
     render(<OrchestrationDispatchSection />);
-    await waitFor(() => screen.getByText("Orchestrator"));
+    await waitFor(() => screen.getByText("Implementer"));
 
     const permissionSelects = screen.getAllByRole("combobox", { name: /permission mode for/i });
-    const orchestratorPerm = permissionSelects[0];
+    const implementerPerm = permissionSelects[0];
 
-    const autoOption = Array.from(orchestratorPerm.querySelectorAll("option")).find(
+    const autoOption = Array.from(implementerPerm.querySelectorAll("option")).find(
       (o) => o.value === "auto",
     );
     expect(autoOption).toBeTruthy();
@@ -168,7 +158,7 @@ describe("OrchestrationDispatchSection", () => {
     await waitFor(() => screen.getByText("Implementer"));
 
     const permissionSelects = screen.getAllByRole("combobox", { name: /permission mode for/i });
-    const implementerPerm = permissionSelects[1];
+    const implementerPerm = permissionSelects[0];
 
     const autoOption = Array.from(implementerPerm.querySelectorAll("option")).find(
       (o) => o.value === "auto",
@@ -194,11 +184,11 @@ describe("OrchestrationDispatchSection", () => {
   it("effort dropdown is shown for claude vendor", async () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
       makeSettings({
-        orchestrator: { vendor: "claude", model: "claude-opus-4-6" },
+        dispatch: { implementer: { vendor: "claude", model: "claude-opus-4-6" } },
       }),
     );
     render(<OrchestrationDispatchSection />);
-    await waitFor(() => screen.getByText("Orchestrator"));
+    await waitFor(() => screen.getByText("Implementer"));
 
     const effortSelects = screen.getAllByRole("combobox", { name: /effort for/i });
     expect(effortSelects.length).toBeGreaterThan(0);
@@ -209,7 +199,7 @@ describe("OrchestrationDispatchSection", () => {
   it("no Save button is rendered (auto-save replaces explicit Save)", async () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
     render(<OrchestrationDispatchSection />);
-    await waitFor(() => screen.getByText("Orchestrator"));
+    await waitFor(() => screen.getByText("Implementer"));
     expect(screen.queryByRole("button", { name: /^save/i })).toBeNull();
   });
 
@@ -217,7 +207,7 @@ describe("OrchestrationDispatchSection", () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
     vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
     render(<OrchestrationDispatchSection />);
-    await waitFor(() => screen.getByText("Orchestrator"));
+    await waitFor(() => screen.getByText("Implementer"));
 
     const effortSelects = screen.getAllByRole("combobox", { name: /effort for/i });
     fireEvent.change(effortSelects[0], { target: { value: "low" } });
@@ -226,7 +216,7 @@ describe("OrchestrationDispatchSection", () => {
       expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledTimes(1);
     });
     expect(vi.mocked(api.updateOrchestratorSettings).mock.calls[0][0]).toMatchObject({
-      orchestrator: expect.objectContaining({ effort: "low" }),
+      dispatch: { implementer: expect.objectContaining({ effort: "low" }) },
     });
   });
 
@@ -234,7 +224,7 @@ describe("OrchestrationDispatchSection", () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
     vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
     render(<OrchestrationDispatchSection />);
-    await waitFor(() => screen.getByText("Orchestrator"));
+    await waitFor(() => screen.getByText("Implementer"));
 
     const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
     fireEvent.change(modelInputs[0], { target: { value: "claude-opus-4-7" } });
@@ -249,7 +239,7 @@ describe("OrchestrationDispatchSection", () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
     vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
     render(<OrchestrationDispatchSection />);
-    await waitFor(() => screen.getByText("Orchestrator"));
+    await waitFor(() => screen.getByText("Implementer"));
 
     const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
     fireEvent.change(modelInputs[0], { target: { value: "claude-opus-4-7" } });
@@ -259,7 +249,7 @@ describe("OrchestrationDispatchSection", () => {
       expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledTimes(1);
     });
     expect(vi.mocked(api.updateOrchestratorSettings).mock.calls[0][0]).toMatchObject({
-      orchestrator: expect.objectContaining({ model: "claude-opus-4-7" }),
+      dispatch: { implementer: expect.objectContaining({ model: "claude-opus-4-7" }) },
     });
   });
 
@@ -267,7 +257,7 @@ describe("OrchestrationDispatchSection", () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
     vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
     render(<OrchestrationDispatchSection />);
-    await waitFor(() => screen.getByText("Orchestrator"));
+    await waitFor(() => screen.getByText("Implementer"));
 
     const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
     fireEvent.change(modelInputs[0], { target: { value: "claude-opus-4-7" } });
@@ -286,7 +276,7 @@ describe("OrchestrationDispatchSection", () => {
       ),
     );
     render(<OrchestrationDispatchSection />);
-    await waitFor(() => screen.getByText("Orchestrator"));
+    await waitFor(() => screen.getByText("Implementer"));
 
     const effortSelects = screen.getAllByRole("combobox", { name: /effort for/i });
     fireEvent.change(effortSelects[0], { target: { value: "low" } });
@@ -305,7 +295,7 @@ describe("OrchestrationDispatchSection", () => {
       new Error("API error 400: model `not-a-model` is unknown"),
     );
     render(<OrchestrationDispatchSection />);
-    await waitFor(() => screen.getByText("Orchestrator"));
+    await waitFor(() => screen.getByText("Implementer"));
 
     const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
     fireEvent.change(modelInputs[0], { target: { value: "not-a-model" } });
@@ -323,16 +313,16 @@ describe("OrchestrationDispatchSection", () => {
     vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
     vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
     render(<OrchestrationDispatchSection />);
-    await waitFor(() => screen.getByText("Orchestrator"));
+    await waitFor(() => screen.getByText("Implementer"));
 
     const checkboxes = screen.getAllByRole("checkbox");
-    fireEvent.click(checkboxes[0]); // orchestrator's "Use vendor CLI default"
+    fireEvent.click(checkboxes[0]); // implementer's "Use vendor CLI default"
 
     await waitFor(() => {
       expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledTimes(1);
     });
     expect(vi.mocked(api.updateOrchestratorSettings).mock.calls[0][0]).toMatchObject({
-      orchestrator: null,
+      dispatch: { implementer: null },
     });
   });
 });

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -902,19 +902,10 @@ export interface SpawnResponse {
   command: string;
 }
 
-export interface OrchestratorRules {
-  branch: string;
-  merge: string;
-  review: string;
-  custom: string;
-}
-
 export type PrMonitorScope = "current_project" | "all";
 
 export interface OrchestratorSettings {
   enabled: boolean;
-  role: string;
-  rules: OrchestratorRules;
   pr_monitor_enabled: boolean;
   pr_monitor_interval_secs: number;
   pr_monitor_exclude_authors: string[];
@@ -929,50 +920,10 @@ export interface OrchestratorSettings {
   /** Whether this is a per-project override (true) or global fallback (false) */
   is_project_override: boolean;
   /**
-   * Orchestrator's own dispatch bundle (`[orchestration.orchestrator]`).
-   * `null` / omitted when unset — the orchestrator launches with the vendor
-   * CLI's user-global default.
-   */
-  orchestrator?: DispatchBundle | null;
-  /**
-   * Per-role dispatch bundles for orchestration workers
+   * Per-role dispatch bundles for worker dispatches
    * (`[orchestration.dispatch.<role>]`).
    */
   dispatch: WorkerDispatchMap;
-}
-
-/** Engine defaults for the `[orchestration]` rule textareas (empty = unset). */
-export const DEFAULT_ORCHESTRATOR_RULES: OrchestratorRules = {
-  branch: "",
-  merge: "",
-  review: "",
-  custom: "",
-};
-
-/**
- * The orchestrator-settings wire shape as actually served. A tmai-core binary
- * omits the `[orchestration.*]` object sub-tables (`rules`) when they are
- * absent from config.toml, even though the contract types them as required.
- * Reading e.g. `settings.rules[field]` on such a response throws `Cannot read
- * properties of undefined` and — with no error boundary around SettingsPanel —
- * blacks out the whole panel. Normalize with `withOrchestratorDefaults` at the
- * fetch boundary.
- */
-export type WireOrchestratorSettings = Omit<OrchestratorSettings, "rules"> &
-  Partial<Pick<OrchestratorSettings, "rules">>;
-
-/**
- * Coalesce a wire orchestrator-settings response into a fully-populated
- * `OrchestratorSettings` so every downstream consumer (the rule textareas)
- * reads a defined sub-object rather than crashing on a deref of an omitted
- * sub-table. Apply once at the fetch boundary — mirrors the `?? default`
- * defense PR #684 added for `auto_handoff_threshold_pct`.
- */
-export function withOrchestratorDefaults(s: WireOrchestratorSettings): OrchestratorSettings {
-  return {
-    ...s,
-    rules: s.rules ?? DEFAULT_ORCHESTRATOR_RULES,
-  };
 }
 
 export interface SpawnRequest {
@@ -1314,19 +1265,12 @@ export const api = {
   updateOrchestratorSettings: (
     params: {
       enabled?: boolean;
-      role?: string;
-      rules?: Partial<OrchestratorRules>;
       pr_monitor_enabled?: boolean;
       pr_monitor_interval_secs?: number;
       pr_monitor_exclude_authors?: string[];
       pr_monitor_scope?: PrMonitorScope;
       inject_state_snapshot?: boolean;
       auto_handoff_threshold_pct?: number;
-      /**
-       * Tri-state: omit → leave unchanged. `null` → clear the bundle. Object →
-       * replace. Persists to `[orchestration.orchestrator]` in config.toml.
-       */
-      orchestrator?: DispatchBundle | null;
       /** Replaces the entire `[orchestration.dispatch]` table. */
       dispatch?: WorkerDispatchMap;
     },

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -8,8 +8,6 @@ import type {
   AgentSnapshot,
   AimCreateRequest,
   AimEditRequest,
-  DispatchBundle,
-  OrchestratorRules,
   PrMergeMethod,
   PrMergeOverride,
   PrMonitorScope,
@@ -181,16 +179,12 @@ export const api = {
   updateOrchestratorSettings: (
     params: {
       enabled?: boolean;
-      role?: string;
-      rules?: Partial<OrchestratorRules>;
       pr_monitor_enabled?: boolean;
       pr_monitor_interval_secs?: number;
       pr_monitor_exclude_authors?: string[];
       pr_monitor_scope?: PrMonitorScope;
       inject_state_snapshot?: boolean;
       auto_handoff_threshold_pct?: number;
-      /** Tri-state: omit → unchanged. `null` → clear. Object → replace. */
-      orchestrator?: DispatchBundle | null;
       /** Replaces the entire `[orchestration.dispatch]` table. */
       dispatch?: WorkerDispatchMap;
     },

--- a/clients/react/src/types/generated/DispatchKind.ts
+++ b/clients/react/src/types/generated/DispatchKind.ts
@@ -13,4 +13,4 @@ number: bigint, } | { "kind": "pr",
 /**
  * PR number.
  */
-number: bigint, } | { "kind": "standalone" } | { "kind": "orchestrator" };
+number: bigint, } | { "kind": "standalone" };

--- a/clients/react/src/types/generated/SpawnRole.ts
+++ b/clients/react/src/types/generated/SpawnRole.ts
@@ -3,4 +3,4 @@
 /**
  * Role of a spawned agent.
  */
-export type SpawnRole = "orchestrator" | "implementer" | "manual";
+export type SpawnRole = "implementer" | "manual";


### PR DESCRIPTION
## What

Mirrors the orchestrator-config rip (tmai-core #597, `a1dac80`) into the hub — the manual `gen-spec` mirror for the orchestrator phase of #583 (billing on tmai-core is exhausted, so the `gen-spec-pr` bot cannot run; regenerated by hand on a `bot/gen-spec-<sha>` branch).

## Generated (regenerated from core main `a1dac80`)

Verified the regenerated delta is **exactly** this rip (`diff` vs hub for every artifact; `mcp-tools.json` and ratatui `dispatch_kind.rs` unchanged):

- `api-spec/openapi.json` + `corevents.schema.json` — drop the `DispatchKind` `orchestrator` variant and the `orchestrator` `SpawnRole` enum value.
- `clients/react/src/types/generated/{DispatchKind,SpawnRole}.ts` — same.
- `clients/ratatui/src/types/generated/spawn_role.rs` — drop `orchestrator`.

## Hand-written consumers (the wire-shape change breaks `tsc` — fixed here)

The engine's `OrchestratorSettingsResponse` dropped `role` / `rules` / `orchestrator` (`Serialize`-only, so it never appeared in `openapi.json`; the hub mirrors it by hand):

- `api-http.ts` / `api-tauri.ts` — drop `role`, `rules`, and the `orchestrator` dispatch bundle from `OrchestratorSettings` + the update params; remove the now-dead `OrchestratorRules`, `DEFAULT_ORCHESTRATOR_RULES`, `WireOrchestratorSettings`, and the `withOrchestratorDefaults` normalizer.
- `OrchestrationSection.tsx` — remove the role + workflow-rule textareas (and the now-dead `OrchestrationRuleTextarea`); keep scope / enabled / PR Monitor.
- `OrchestrationDispatchSection.tsx` — remove the Orchestrator dispatch row and the `DispatchState.orchestrator` field; only the Implementer role remains.
- Settings tests — drop `role`/`rules`/`orchestrator` from fixtures and retarget the dispatch-section tests to the Implementer role + the `{ dispatch: { implementer } }` PUT shape.

## Gate

- react: `pnpm lint` + `tsc -b` + `pnpm test` (963 pass, 2 skip) + `pnpm build` — green
- `api-spec`: `npm test` (redocly lint + AJV schema fixtures) — green
- `clients/ratatui`: `cargo check` — green
- No orphan `orchestrator` fixtures in `api-spec/tests`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 設定画面から、不要になったオーケストレーター関連の項目やルール編集欄を削除しました。
  * 表示や保存内容が整理され、現在の設定項目だけが反映されるようになりました。
  * 関連するAPI定義も更新され、利用できる値が最新の画面内容に一致するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->