### PR TITLE
refactor(settings): rename the orchestrator settings client surface to producer (#583)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -442,7 +442,7 @@ export function App({
 
   // Project list derived from active agents (replaces the pre-registered list).
   // Used by the keyboard shortcuts to cycle the X-Tmai-Origin scope and by
-  // OrchestrationSection's per-project override selector.
+  // ProducerSection's per-project override selector.
   const projectPaths = useMemo(
     () => groupByProject(aiAgents, worktrees).map((p) => p.path),
     [aiAgents, worktrees],

--- a/clients/react/src/components/aim-console/Shead.tsx
+++ b/clients/react/src/components/aim-console/Shead.tsx
@@ -14,7 +14,7 @@
 // REUSE, DON'T REBUILD (issue #803): the ctx readout reuses
 // `ProducerCtxHeader`'s exported helpers (`formatThousands` / `renderBar` /
 // `thresholdColorClass`, import-only) and the same one-shot
-// `getOrchestratorSettings` threshold fetch; the handoff button fires the
+// `getProducerSettings` threshold fetch; the handoff button fires the
 // SAME App-lifted ritual `trigger` with the SAME confirm flow as
 // `ProducerConversationHeader` (which itself is untouched — the existing
 // console keeps using it).
@@ -210,7 +210,7 @@ function ProducerShead({
   useEffect(() => {
     let cancelled = false;
     api
-      .getOrchestratorSettings(currentProjectPath ?? undefined)
+      .getProducerSettings(currentProjectPath ?? undefined)
       .then((s) => {
         if (!cancelled) setThreshold(s.auto_handoff_threshold_pct);
       })

--- a/clients/react/src/components/aim-console/__tests__/SessionPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/SessionPane.test.tsx
@@ -45,7 +45,7 @@ vi.mock("@/lib/api", async () => {
       ...actual.api,
       // Park the threshold fetch in flight — the pane tests don't assert on
       // the ctx readout, and this keeps the network out of jsdom.
-      getOrchestratorSettings: () => new Promise<never>(() => {}),
+      getProducerSettings: () => new Promise<never>(() => {}),
     },
   };
 });

--- a/clients/react/src/components/aim-console/__tests__/Shead.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/Shead.test.tsx
@@ -9,14 +9,14 @@
 //   (kill → relaunch fresh at the same locus, behind a danger confirm).
 //   Worker variant: dot · name · model · repo/cwd · ✕ kill — violet accent.
 //
-// `getOrchestratorSettings` (the threshold fetch), `killAgent`, and
+// `getProducerSettings` (the threshold fetch), `killAgent`, and
 // `launchProducer` are mocked; the rest of the api stays real. The Producer
 // restart confirm uses `useConfirm`, so the Producer variant renders under
 // `renderWithProviders` (which mounts the ConfirmProvider).
 
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { type AgentSnapshot, api, type OrchestratorSettings, type SpawnResponse } from "@/lib/api";
+import { type AgentSnapshot, api, type ProducerSettings, type SpawnResponse } from "@/lib/api";
 import { renderWithProviders } from "@/test/render";
 import { Shead } from "../Shead";
 
@@ -26,14 +26,14 @@ vi.mock("@/lib/api", async () => {
     ...actual,
     api: {
       ...actual.api,
-      getOrchestratorSettings: vi.fn(),
+      getProducerSettings: vi.fn(),
       killAgent: vi.fn(),
       launchProducer: vi.fn(),
     },
   };
 });
 
-const getOrchestratorSettings = vi.mocked(api.getOrchestratorSettings);
+const getProducerSettings = vi.mocked(api.getProducerSettings);
 const killAgent = vi.mocked(api.killAgent);
 const launchProducer = vi.mocked(api.launchProducer);
 
@@ -101,12 +101,12 @@ function renderShead(overrides: Partial<Parameters<typeof Shead>[0]> = {}) {
 }
 
 beforeEach(() => {
-  getOrchestratorSettings.mockReset();
+  getProducerSettings.mockReset();
   killAgent.mockReset();
   launchProducer.mockReset();
-  getOrchestratorSettings.mockResolvedValue({
+  getProducerSettings.mockResolvedValue({
     auto_handoff_threshold_pct: 75,
-  } as OrchestratorSettings);
+  } as ProducerSettings);
   killAgent.mockResolvedValue(undefined);
   launchProducer.mockResolvedValue({} as SpawnResponse);
 });
@@ -192,9 +192,9 @@ describe("Shead — Producer variant", () => {
   });
 
   it("renders 'auto off' and no ┊ marker when the threshold is 0 (disabled)", async () => {
-    getOrchestratorSettings.mockResolvedValue({
+    getProducerSettings.mockResolvedValue({
       auto_handoff_threshold_pct: 0,
-    } as OrchestratorSettings);
+    } as ProducerSettings);
     const { container } = renderWithProviders(
       <Shead
         agent={PRODUCER}
@@ -233,6 +233,6 @@ describe("Shead — worker variant", () => {
     fireEvent.click(screen.getByRole("button", { name: "Kill agent" }));
     expect(killAgent).toHaveBeenCalledWith("claude:w1");
     // The worker variant never fetches the (Producer-only) threshold.
-    expect(getOrchestratorSettings).not.toHaveBeenCalled();
+    expect(getProducerSettings).not.toHaveBeenCalled();
   });
 });

--- a/clients/react/src/components/producer-console/ProducerConversationHeader.tsx
+++ b/clients/react/src/components/producer-console/ProducerConversationHeader.tsx
@@ -26,7 +26,7 @@
 //
 // The ctx readout reuses `ProducerCtxHeader`'s exported helpers
 // (`formatThousands` / `renderBar` / `thresholdColorClass`) and the same
-// threshold fetch (`getOrchestratorSettings`); the digest keeps the
+// threshold fetch (`getProducerSettings`); the digest keeps the
 // full-form `ProducerCtxHeader`. The status dot reuses AgentActions'
 // `attention`→colour/label mapping. The Handoff button fires the
 // App-level lifted ritual via `trigger` — there is exactly one
@@ -106,7 +106,7 @@ export function ProducerConversationHeader({
   useEffect(() => {
     let cancelled = false;
     api
-      .getOrchestratorSettings(currentProjectPath ?? undefined)
+      .getProducerSettings(currentProjectPath ?? undefined)
       .then((s) => {
         if (!cancelled) setThreshold(s.auto_handoff_threshold_pct);
       })

--- a/clients/react/src/components/producer-console/ProducerCtxHeader.tsx
+++ b/clients/react/src/components/producer-console/ProducerCtxHeader.tsx
@@ -6,7 +6,7 @@
 //   ctx: 142k / 200k (71%) ▮▮▮▮▮▮▮░░░ │ auto-handoff at 75% ⚙
 //
 // Surfaces the same wire data the auto-handoff trigger fires on
-// (`AgentSnapshot.ctx_usage.pct` vs `OrchestratorSettings
+// (`AgentSnapshot.ctx_usage.pct` vs `ProducerSettings
 // .auto_handoff_threshold_pct`), so the operator can predict
 // the trigger instead of being surprised by it.
 //
@@ -92,7 +92,7 @@ export function ProducerCtxHeader({
   useEffect(() => {
     let cancelled = false;
     api
-      .getOrchestratorSettings(currentProjectPath ?? undefined)
+      .getProducerSettings(currentProjectPath ?? undefined)
       .then((s) => {
         if (!cancelled) setThreshold(s.auto_handoff_threshold_pct);
       })

--- a/clients/react/src/components/producer-console/__tests__/ProducerConversationHeader.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerConversationHeader.test.tsx
@@ -16,7 +16,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentSnapshot } from "@/lib/api";
 import { ProducerConversationHeader } from "../ProducerConversationHeader";
 
-const getOrchestratorSettingsMock = vi.fn();
+const getProducerSettingsMock = vi.fn();
 const killAgentMock = vi.fn();
 
 // Preserve the actual module (the shared `findProducerForUnit` resolver
@@ -28,7 +28,7 @@ vi.mock("@/lib/api", async () => {
     ...actual,
     api: {
       ...actual.api,
-      getOrchestratorSettings: (project?: string) => getOrchestratorSettingsMock(project),
+      getProducerSettings: (project?: string) => getProducerSettingsMock(project),
       killAgent: (target: string) => killAgentMock(target),
     },
   };
@@ -80,8 +80,8 @@ function orchestratorFixture(threshold: number) {
 }
 
 beforeEach(() => {
-  getOrchestratorSettingsMock.mockReset();
-  getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+  getProducerSettingsMock.mockReset();
+  getProducerSettingsMock.mockResolvedValue(orchestratorFixture(75));
   killAgentMock.mockReset();
   killAgentMock.mockResolvedValue(undefined);
 });

--- a/clients/react/src/components/producer-console/__tests__/ProducerCtxHeader.test.tsx
+++ b/clients/react/src/components/producer-console/__tests__/ProducerCtxHeader.test.tsx
@@ -16,7 +16,7 @@ import {
   thresholdColorClass,
 } from "../ProducerCtxHeader";
 
-const getOrchestratorSettingsMock = vi.fn();
+const getProducerSettingsMock = vi.fn();
 
 vi.mock("@/lib/api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
@@ -24,7 +24,7 @@ vi.mock("@/lib/api", async () => {
     ...actual,
     api: {
       ...actual.api,
-      getOrchestratorSettings: (project?: string) => getOrchestratorSettingsMock(project),
+      getProducerSettings: (project?: string) => getProducerSettingsMock(project),
     },
   };
 });
@@ -107,11 +107,11 @@ describe("ProducerCtxHeader — pure helpers", () => {
 
 describe("ProducerCtxHeader — rendering", () => {
   beforeEach(() => {
-    getOrchestratorSettingsMock.mockReset();
+    getProducerSettingsMock.mockReset();
   });
 
   it("renders ctx Nk / Nk (pct%) from fixture ctx_usage", async () => {
-    getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+    getProducerSettingsMock.mockResolvedValue(orchestratorFixture(75));
     const producer = agent({
       id: "claude:abc",
       cwd: "/home/u/proj",
@@ -140,7 +140,7 @@ describe("ProducerCtxHeader — rendering", () => {
   });
 
   it("renders the 10-segment bar matching the pct", () => {
-    getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+    getProducerSettingsMock.mockResolvedValue(orchestratorFixture(75));
     const producer = agent({
       id: "claude:abc",
       ctx_usage: {
@@ -162,7 +162,7 @@ describe("ProducerCtxHeader — rendering", () => {
   });
 
   it("shows placeholder when no Producer matches the unit", async () => {
-    getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+    getProducerSettingsMock.mockResolvedValue(orchestratorFixture(75));
     render(
       <ProducerCtxHeader agents={[]} currentProjectPath="/home/u/proj" onOpenSettings={vi.fn()} />,
     );
@@ -174,7 +174,7 @@ describe("ProducerCtxHeader — rendering", () => {
   });
 
   it("shows placeholder when Producer exists but ctx_usage is absent", async () => {
-    getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+    getProducerSettingsMock.mockResolvedValue(orchestratorFixture(75));
     const producer = agent({ id: "claude:abc", ctx_usage: null });
     render(
       <ProducerCtxHeader
@@ -187,7 +187,7 @@ describe("ProducerCtxHeader — rendering", () => {
   });
 
   it("labels the threshold as 'disabled' when set to 0", async () => {
-    getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(0));
+    getProducerSettingsMock.mockResolvedValue(orchestratorFixture(0));
     render(
       <ProducerCtxHeader agents={[]} currentProjectPath="/home/u/proj" onOpenSettings={vi.fn()} />,
     );
@@ -197,7 +197,7 @@ describe("ProducerCtxHeader — rendering", () => {
   });
 
   it("⚙ click invokes onOpenSettings", async () => {
-    getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+    getProducerSettingsMock.mockResolvedValue(orchestratorFixture(75));
     const onOpenSettings = vi.fn();
     render(
       <ProducerCtxHeader
@@ -211,7 +211,7 @@ describe("ProducerCtxHeader — rendering", () => {
   });
 
   it("does not pick a worktree-Producer (is_worktree gate)", () => {
-    getOrchestratorSettingsMock.mockResolvedValue(orchestratorFixture(75));
+    getProducerSettingsMock.mockResolvedValue(orchestratorFixture(75));
     const worktreeProducer = agent({
       id: "claude:wt",
       is_worktree: true,

--- a/clients/react/src/components/project/DirBrowser.tsx
+++ b/clients/react/src/components/project/DirBrowser.tsx
@@ -6,7 +6,7 @@ import { cn } from "@/lib/utils";
 interface DirBrowserProps {
   /** Default confirm-and-close handler bound to "Select this" + entry
    *  double-click. Required for the picker mode (GeneralSection /
-   *  OrchestrationSection); ignored when `actionSlot` is provided. */
+   *  ProducerSection); ignored when `actionSlot` is provided. */
   onSelect?: (path: string) => void;
   onCancel: () => void;
   /** Initial directory to load. When unset, the backend picks a default

--- a/clients/react/src/components/settings/HandoffThresholdSection.tsx
+++ b/clients/react/src/components/settings/HandoffThresholdSection.tsx
@@ -2,17 +2,17 @@
 //
 // Operators routinely tune this (handoff-lifecycle DR §E says "primary,
 // not Advanced"), so the control sits in the top Producer group rather
-// than inside `OrchestrationSection` which is collapsed behind the
+// than inside `ProducerSection` which is collapsed behind the
 // Advanced expandable.
 //
-// Persists `auto_handoff_threshold_pct` on the (global) OrchestratorSettings
+// Persists `auto_handoff_threshold_pct` on the (global) ProducerSettings
 // object via the same PUT helper calibration / orchestration rules use.
 // `0` is a sentinel that disables the auto-trigger entirely; the manual
 // `Handoff & restart` button still works.
 
 import { useEffect, useState } from "react";
 import { useSaveTracker } from "@/hooks/useSaveTracker";
-import { api, type OrchestratorSettings } from "@/lib/api";
+import { api, type ProducerSettings } from "@/lib/api";
 import { SaveStatus } from "./SaveStatus";
 
 const INPUT_CLS =
@@ -35,14 +35,14 @@ function validate(value: string): { ok: true; pct: number } | { ok: false; error
 }
 
 export function HandoffThresholdSection() {
-  const [orchestrator, setOrchestrator] = useState<OrchestratorSettings | null>(null);
+  const [orchestrator, setOrchestrator] = useState<ProducerSettings | null>(null);
   const [draft, setDraft] = useState("");
   const [localError, setLocalError] = useState<string | null>(null);
   const save = useSaveTracker();
 
   useEffect(() => {
     api
-      .getOrchestratorSettings()
+      .getProducerSettings()
       .then((s) => {
         setOrchestrator(s);
         setDraft(String(s.auto_handoff_threshold_pct ?? 0));
@@ -64,7 +64,7 @@ export function HandoffThresholdSection() {
     const prev = orchestrator;
     setOrchestrator({ ...orchestrator, auto_handoff_threshold_pct: next });
     setDraft(String(next));
-    void save.track(() => api.updateOrchestratorSettings({ auto_handoff_threshold_pct: next }), {
+    void save.track(() => api.updateProducerSettings({ auto_handoff_threshold_pct: next }), {
       onError: () => {
         setOrchestrator(prev);
         setDraft(String(prev.auto_handoff_threshold_pct));

--- a/clients/react/src/components/settings/PrMonitorSection.tsx
+++ b/clients/react/src/components/settings/PrMonitorSection.tsx
@@ -1,5 +1,5 @@
 import type { useSaveTracker } from "@/hooks/useSaveTracker";
-import { api, type OrchestratorSettings } from "@/lib/api";
+import { api, type ProducerSettings } from "@/lib/api";
 
 /** PR Monitor settings — automatic PR/CI status monitoring */
 export function PrMonitorSection({
@@ -8,8 +8,8 @@ export function PrMonitorSection({
   orchProject,
   save,
 }: {
-  orchestrator: OrchestratorSettings;
-  setOrchestrator: (v: OrchestratorSettings) => void;
+  orchestrator: ProducerSettings;
+  setOrchestrator: (v: ProducerSettings) => void;
   orchProject: string | undefined;
   save: ReturnType<typeof useSaveTracker>;
 }) {
@@ -17,7 +17,7 @@ export function PrMonitorSection({
     const clamped = Math.max(10, Math.min(3600, value));
     setOrchestrator({ ...orchestrator, pr_monitor_interval_secs: clamped });
     void save.track(() =>
-      api.updateOrchestratorSettings({ pr_monitor_interval_secs: clamped }, orchProject),
+      api.updateProducerSettings({ pr_monitor_interval_secs: clamped }, orchProject),
     );
   };
 
@@ -40,7 +40,7 @@ export function PrMonitorSection({
               const next = !orchestrator.pr_monitor_enabled;
               setOrchestrator({ ...orchestrator, pr_monitor_enabled: next });
               void save.track(
-                () => api.updateOrchestratorSettings({ pr_monitor_enabled: next }, orchProject),
+                () => api.updateProducerSettings({ pr_monitor_enabled: next }, orchProject),
                 {
                   onError: () => setOrchestrator({ ...orchestrator, pr_monitor_enabled: !next }),
                 },

--- a/clients/react/src/components/settings/ProducerDispatchSection.tsx
+++ b/clients/react/src/components/settings/ProducerDispatchSection.tsx
@@ -39,16 +39,16 @@ const ROLES: DispatchRole[] = [
  * vendor CLI default" checkbox) persist on change; the model text field
  * persists on blur or Enter so we do not flicker validation errors mid-typing.
  *
- * Reads the bundles from `GET /settings/orchestrator` (the global settings
+ * Reads the bundles from `GET /settings/producer` (the global settings
  * endpoint that carries the dispatch fields) and saves them via the same
- * endpoint's PUT — server-side `OrchestrationSettings` is the single source
+ * endpoint's PUT — server-side `ProducerSettings` is the single source
  * of truth, so this component only roundtrips the dispatch subset of fields.
  *
  * Backend 400s surface as inline error text. For atomic changes we roll back
  * to the last-saved bundle; for text-commit errors we leave the user's draft
  * in place so they can correct it.
  */
-export function OrchestrationDispatchSection() {
+export function ProducerDispatchSection() {
   const [state, setState] = useState<DispatchState | null>(null);
   const [status, setStatus] = useState<AutoSaveStatus>("idle");
   const [error, setError] = useState<string | null>(null);
@@ -57,7 +57,7 @@ export function OrchestrationDispatchSection() {
 
   useEffect(() => {
     api
-      .getOrchestratorSettings()
+      .getProducerSettings()
       .then((s) => {
         const initial = {
           dispatch: s.dispatch,
@@ -77,7 +77,7 @@ export function OrchestrationDispatchSection() {
       setStatus("saving");
       setError(null);
       try {
-        await api.updateOrchestratorSettings({
+        await api.updateProducerSettings({
           dispatch: next.dispatch,
         });
         lastSavedRef.current = next;
@@ -127,7 +127,7 @@ export function OrchestrationDispatchSection() {
   return (
     <section>
       <div className="flex items-center gap-2">
-        <h3 className="text-sm font-medium text-foreground">Orchestration dispatch</h3>
+        <h3 className="text-sm font-medium text-foreground">Producer dispatch</h3>
         <SaveStatus status={status} error={error} variant="section" />
       </div>
       <p className="mt-1 text-xs text-subtle-foreground">

--- a/clients/react/src/components/settings/ProducerSection.tsx
+++ b/clients/react/src/components/settings/ProducerSection.tsx
@@ -1,11 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { DirBrowser } from "@/components/project/DirBrowser";
 import { useSaveTracker } from "@/hooks/useSaveTracker";
-import { api, type OrchestratorSettings } from "@/lib/api";
+import { api, type ProducerSettings } from "@/lib/api";
 import { PrMonitorSection } from "./PrMonitorSection";
 import { SaveStatus } from "./SaveStatus";
 
-interface OrchestrationSectionProps {
+interface ProducerSectionProps {
   /** Project paths derived from currently active agents — used to seed the
    *  scope dropdown so the common case (override the project I'm working
    *  on) is one click. Arbitrary paths can still be picked via the Browse
@@ -15,7 +15,7 @@ interface OrchestrationSectionProps {
 }
 
 /**
- * Settings section that hosts the orchestrator agent's configuration:
+ * Settings section that hosts the Producer agent's configuration:
  * scope (global vs per-project override), enabled toggle, and the composed
  * PR Monitor sub-section.
  *
@@ -23,8 +23,8 @@ interface OrchestrationSectionProps {
  * load — the parent SettingsPanel does not need to refresh this section.
  * Switching `orchScope` re-fetches the merged settings for that scope.
  */
-export function OrchestrationSection({ projects }: OrchestrationSectionProps) {
-  const [orchestrator, setOrchestrator] = useState<OrchestratorSettings | null>(null);
+export function ProducerSection({ projects }: ProducerSectionProps) {
+  const [orchestrator, setOrchestrator] = useState<ProducerSettings | null>(null);
   const [orchScope, setOrchScope] = useState<string>("global");
   const [browsing, setBrowsing] = useState(false);
   const [defaultRoot, setDefaultRoot] = useState<string | null>(null);
@@ -47,7 +47,7 @@ export function OrchestrationSection({ projects }: OrchestrationSectionProps) {
 
   const orchProject = orchScope === "global" ? undefined : orchScope;
   const refreshOrchestrator = useCallback(() => {
-    api.getOrchestratorSettings(orchProject).then(setOrchestrator).catch(console.error);
+    api.getProducerSettings(orchProject).then(setOrchestrator).catch(console.error);
   }, [orchProject]);
 
   useEffect(() => {
@@ -69,12 +69,11 @@ export function OrchestrationSection({ projects }: OrchestrationSectionProps) {
   return (
     <section>
       <div className="flex items-center gap-2">
-        <h3 className="text-sm font-medium text-foreground">Orchestration</h3>
+        <h3 className="text-sm font-medium text-foreground">Producer</h3>
         <SaveStatus status={save.status} error={save.error} variant="section" />
       </div>
       <p className="mt-1 text-xs text-subtle-foreground">
-        Configure the orchestrator agent that coordinates sub-agents for parallel development
-        workflows.
+        Configure the Producer agent that coordinates sub-agents for parallel development workflows.
       </p>
 
       <div className="mt-3 rounded-lg border border-hairline-strong bg-surface p-3 space-y-4">
@@ -86,7 +85,7 @@ export function OrchestrationSection({ projects }: OrchestrationSectionProps) {
               value={orchScope}
               onChange={(e) => setOrchScope(e.target.value)}
               className="flex-1 min-w-0 rounded-md border border-hairline-strong bg-surface px-2.5 py-1.5 text-xs text-foreground outline-none focus:border-primary/30"
-              aria-label="Orchestration scope"
+              aria-label="Producer scope"
             >
               <option value="global">Global (default)</option>
               {scopeOptions.map((p) => (
@@ -141,7 +140,7 @@ export function OrchestrationSection({ projects }: OrchestrationSectionProps) {
           <div className="flex-1">
             <span className="text-sm text-foreground">Enabled</span>
             <p className="text-[11px] text-subtle-foreground mt-0.5">
-              Enable orchestrator workflow features.
+              Enable Producer workflow features.
             </p>
           </div>
           <button
@@ -151,7 +150,7 @@ export function OrchestrationSection({ projects }: OrchestrationSectionProps) {
               setOrchestrator({ ...orchestrator, enabled: next });
               void save.track(
                 async () => {
-                  await api.updateOrchestratorSettings({ enabled: next }, orchProject);
+                  await api.updateProducerSettings({ enabled: next }, orchProject);
                   refreshOrchestrator();
                 },
                 { onError: () => setOrchestrator({ ...orchestrator, enabled: !next }) },

--- a/clients/react/src/components/settings/SettingsPanel.tsx
+++ b/clients/react/src/components/settings/SettingsPanel.tsx
@@ -4,8 +4,8 @@ import { DisplayLayoutSection } from "./DisplayLayoutSection";
 import { GeneralSection } from "./GeneralSection";
 import { HandoffThresholdSection } from "./HandoffThresholdSection";
 import { NotificationSection } from "./NotificationSection";
-import { OrchestrationDispatchSection } from "./OrchestrationDispatchSection";
-import { OrchestrationSection } from "./OrchestrationSection";
+import { ProducerDispatchSection } from "./ProducerDispatchSection";
+import { ProducerSection } from "./ProducerSection";
 import { ThemeSection } from "./ThemeSection";
 import { WorkflowSection } from "./WorkflowSection";
 import { WorktreeSection } from "./WorktreeSection";
@@ -40,7 +40,7 @@ function GroupHeader({ label, description }: { label: string; description: strin
 /**
  * Settings panel layout shell. Each section component owns its own state,
  * save tracker, and load. The shell only sources the project list — derived
- * from currently active agents — used by `OrchestrationSection`'s per-project
+ * from currently active agents — used by `ProducerSection`'s per-project
  * override scope selector.
  *
  * Phase B layout: Producer-relevant sections sit at the top of the Core
@@ -105,8 +105,8 @@ export function SettingsPanel({ onClose, defaultOpenAdvanced = false }: Settings
             </p>
           </summary>
           <div className="space-y-6 border-t border-hairline px-4 py-4">
-            <OrchestrationSection projects={projects} />
-            <OrchestrationDispatchSection />
+            <ProducerSection projects={projects} />
+            <ProducerDispatchSection />
             <WorkflowSection />
             <WorktreeSection />
           </div>

--- a/clients/react/src/components/settings/__tests__/HandoffThresholdSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/HandoffThresholdSection.test.tsx
@@ -1,14 +1,14 @@
 // @vitest-environment jsdom
 //
 // HandoffThresholdSection — auto-handoff threshold control. Verifies:
-//   - reads current value from `api.getOrchestratorSettings()`
-//   - PUT round-trip via `api.updateOrchestratorSettings`
+//   - reads current value from `api.getProducerSettings()`
+//   - PUT round-trip via `api.updateProducerSettings`
 //   - 0 ⇒ "Disabled" label
 //   - out-of-range values surface inline validation error and skip PUT
 
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { OrchestratorSettings } from "@/lib/api";
+import type { ProducerSettings } from "@/lib/api";
 import { HandoffThresholdSection } from "../HandoffThresholdSection";
 
 const getMock = vi.fn();
@@ -20,13 +20,13 @@ vi.mock("@/lib/api", async () => {
     ...actual,
     api: {
       ...actual.api,
-      getOrchestratorSettings: () => getMock(),
-      updateOrchestratorSettings: (params: unknown) => updateMock(params),
+      getProducerSettings: () => getMock(),
+      updateProducerSettings: (params: unknown) => updateMock(params),
     },
   };
 });
 
-function orchestrator(threshold: number): OrchestratorSettings {
+function orchestrator(threshold: number): ProducerSettings {
   return {
     enabled: true,
     pr_monitor_enabled: false,
@@ -70,7 +70,7 @@ describe("HandoffThresholdSection", () => {
   // "Disabled" (truthful) rather than fabricate "Triggers at undefined%".
   it("missing wire field renders as Disabled (not 'Triggers at undefined%')", async () => {
     const stale = orchestrator(0);
-    delete (stale as Partial<OrchestratorSettings>).auto_handoff_threshold_pct;
+    delete (stale as Partial<ProducerSettings>).auto_handoff_threshold_pct;
     getMock.mockResolvedValue(stale);
     render(<HandoffThresholdSection />);
     await waitFor(() => {

--- a/clients/react/src/components/settings/__tests__/ProducerSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/ProducerSection.test.tsx
@@ -1,28 +1,28 @@
 // @vitest-environment jsdom
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { OrchestratorSettings } from "@/lib/api";
+import type { ProducerSettings } from "@/lib/api";
 
 vi.mock("@/lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/api")>();
   return {
     ...actual,
     api: {
-      getOrchestratorSettings: vi.fn(),
-      updateOrchestratorSettings: vi.fn(),
+      getProducerSettings: vi.fn(),
+      updateProducerSettings: vi.fn(),
       getGeneralSettings: vi.fn(),
     },
   };
 });
 
 const { api } = await import("@/lib/api");
-const { OrchestrationSection } = await import("../OrchestrationSection");
+const { ProducerSection } = await import("../ProducerSection");
 
 /**
- * A fully-populated OrchestratorSettings with the orchestrator enabled so the
+ * A fully-populated ProducerSettings with the orchestrator enabled so the
  * PR-monitor sub-section actually renders.
  */
-function makeSettings(overrides: Partial<OrchestratorSettings> = {}): OrchestratorSettings {
+function makeSettings(overrides: Partial<ProducerSettings> = {}): ProducerSettings {
   return {
     enabled: true,
     pr_monitor_enabled: false,
@@ -37,7 +37,7 @@ function makeSettings(overrides: Partial<OrchestratorSettings> = {}): Orchestrat
   };
 }
 
-describe("OrchestrationSection", () => {
+describe("ProducerSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.mocked(api.getGeneralSettings).mockResolvedValue({ default_project_root: null });
@@ -47,9 +47,9 @@ describe("OrchestrationSection", () => {
   // textareas. The section now hosts only scope, the enabled toggle, and the
   // composed PR Monitor sub-section — guard that the dead fields stay gone.
   it("renders the PR Monitor sub-section without the retired role/rules textareas", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(makeSettings());
+    vi.mocked(api.getProducerSettings).mockResolvedValue(makeSettings());
 
-    render(<OrchestrationSection projects={[]} />);
+    render(<ProducerSection projects={[]} />);
 
     expect(await screen.findByText("PR Monitor")).toBeTruthy();
     expect(screen.queryByLabelText("Role")).toBeNull();

--- a/clients/react/src/components/settings/__tests__/SettingsPanel-autosave.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel-autosave.test.tsx
@@ -1,7 +1,7 @@
 // @vitest-environment jsdom
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { OrchestratorSettings, WorkflowSettings, WorktreeSettings } from "@/lib/api";
+import type { ProducerSettings, WorkflowSettings, WorktreeSettings } from "@/lib/api";
 import { renderWithProviders as render } from "@/test/render";
 
 vi.mock("@/lib/api", async (importOriginal) => {
@@ -12,8 +12,8 @@ vi.mock("@/lib/api", async (importOriginal) => {
       listAgents: vi.fn(),
       getGeneralSettings: vi.fn(),
       updateGeneralSettings: vi.fn(),
-      getOrchestratorSettings: vi.fn(),
-      updateOrchestratorSettings: vi.fn(),
+      getProducerSettings: vi.fn(),
+      updateProducerSettings: vi.fn(),
       getNotificationSettings: vi.fn(),
       updateNotificationSettings: vi.fn(),
       getWorkflowSettings: vi.fn(),
@@ -36,7 +36,7 @@ const WORKTREE: WorktreeSettings = {
   branch_depth_warning: 5,
 };
 
-function makeOrchestrator(): OrchestratorSettings {
+function makeOrchestrator(): ProducerSettings {
   return {
     enabled: true,
     pr_monitor_enabled: false,
@@ -53,7 +53,7 @@ function makeOrchestrator(): OrchestratorSettings {
 function setupDefaults() {
   vi.mocked(api.listAgents).mockResolvedValue([]);
   vi.mocked(api.getGeneralSettings).mockResolvedValue({ default_project_root: null });
-  vi.mocked(api.getOrchestratorSettings).mockResolvedValue(makeOrchestrator());
+  vi.mocked(api.getProducerSettings).mockResolvedValue(makeOrchestrator());
   vi.mocked(api.getNotificationSettings).mockResolvedValue({
     notify_on_idle: true,
     notify_idle_threshold_secs: 10,

--- a/clients/react/src/components/settings/__tests__/SettingsPanel-producer.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel-producer.test.tsx
@@ -1,29 +1,29 @@
 // @vitest-environment jsdom
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { OrchestratorSettings } from "@/lib/api";
+import type { ProducerSettings } from "@/lib/api";
 
 vi.mock("@/lib/api", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@/lib/api")>();
   return {
     ...actual,
     api: {
-      getOrchestratorSettings: vi.fn(),
-      updateOrchestratorSettings: vi.fn(),
+      getProducerSettings: vi.fn(),
+      updateProducerSettings: vi.fn(),
     },
   };
 });
 
 const { api } = await import("@/lib/api");
-const { OrchestrationDispatchSection } = await import("../OrchestrationDispatchSection");
+const { ProducerDispatchSection } = await import("../ProducerDispatchSection");
 
 /**
- * Build a minimal OrchestratorSettings for the dispatch-section tests. The
+ * Build a minimal ProducerSettings for the dispatch-section tests. The
  * section under test only reads `dispatch`; the other fields are default-ish
  * placeholders. (The orchestrator config rip retired the role/rules and the
  * orchestrator dispatch bundle — only the implementer role remains.)
  */
-function makeSettings(overrides: Partial<OrchestratorSettings>): OrchestratorSettings {
+function makeSettings(overrides: Partial<ProducerSettings>): ProducerSettings {
   return {
     enabled: true,
     pr_monitor_enabled: false,
@@ -51,14 +51,14 @@ const EXPLICIT_SETTINGS = makeSettings({
   },
 });
 
-describe("OrchestrationDispatchSection", () => {
+describe("ProducerDispatchSection", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
   it("renders the implementer bundle section after load (no orchestrator row)", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(BASE_SETTINGS);
-    render(<OrchestrationDispatchSection />);
+    vi.mocked(api.getProducerSettings).mockResolvedValue(BASE_SETTINGS);
+    render(<ProducerDispatchSection />);
     await waitFor(() => {
       expect(screen.getByText("Implementer")).toBeTruthy();
     });
@@ -66,8 +66,8 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("shows default checkbox checked when the bundle is null", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(BASE_SETTINGS);
-    render(<OrchestrationDispatchSection />);
+    vi.mocked(api.getProducerSettings).mockResolvedValue(BASE_SETTINGS);
+    render(<ProducerDispatchSection />);
     await waitFor(() => {
       const checkboxes = screen.getAllByRole("checkbox");
       // Implementer bundle null → its "Use vendor CLI default" checkbox checked.
@@ -78,8 +78,8 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("shows default checkbox unchecked when the bundle is explicit", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
-    render(<OrchestrationDispatchSection />);
+    vi.mocked(api.getProducerSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    render(<ProducerDispatchSection />);
     await waitFor(() => {
       const checkboxes = screen.getAllByRole("checkbox");
       for (const cb of checkboxes) {
@@ -89,9 +89,9 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("switching vendor resets the model input to empty", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
-    vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
-    render(<OrchestrationDispatchSection />);
+    vi.mocked(api.getProducerSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateProducerSettings).mockResolvedValue(undefined as never);
+    render(<ProducerDispatchSection />);
 
     await waitFor(() => screen.getByText("Implementer"));
 
@@ -109,12 +109,12 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("auto permission option is disabled for non-opus claude model", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
+    vi.mocked(api.getProducerSettings).mockResolvedValue(
       makeSettings({
         dispatch: { implementer: { vendor: "claude", model: "claude-sonnet-4-6" } },
       }),
     );
-    render(<OrchestrationDispatchSection />);
+    render(<ProducerDispatchSection />);
     await waitFor(() => screen.getByText("Implementer"));
 
     const permissionSelects = screen.getAllByRole("combobox", { name: /permission mode for/i });
@@ -128,12 +128,12 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("auto permission option is enabled for opus model", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
+    vi.mocked(api.getProducerSettings).mockResolvedValue(
       makeSettings({
         dispatch: { implementer: { vendor: "claude", model: "claude-opus-4-6" } },
       }),
     );
-    render(<OrchestrationDispatchSection />);
+    render(<ProducerDispatchSection />);
     await waitFor(() => screen.getByText("Implementer"));
 
     const permissionSelects = screen.getAllByRole("combobox", { name: /permission mode for/i });
@@ -147,14 +147,14 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("auto permission option is disabled for non-claude vendor", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
+    vi.mocked(api.getProducerSettings).mockResolvedValue(
       makeSettings({
         dispatch: {
           implementer: { vendor: "codex", model: "codex-1" },
         },
       }),
     );
-    render(<OrchestrationDispatchSection />);
+    render(<ProducerDispatchSection />);
     await waitFor(() => screen.getByText("Implementer"));
 
     const permissionSelects = screen.getAllByRole("combobox", { name: /permission mode for/i });
@@ -168,26 +168,26 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("effort dropdown is hidden for codex vendor", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
+    vi.mocked(api.getProducerSettings).mockResolvedValue(
       makeSettings({
         dispatch: {
           implementer: { vendor: "codex", model: "codex-1" },
         },
       }),
     );
-    render(<OrchestrationDispatchSection />);
+    render(<ProducerDispatchSection />);
     await waitFor(() => screen.getByText("Implementer"));
 
     expect(screen.getByText("(n/a — codex)")).toBeTruthy();
   });
 
   it("effort dropdown is shown for claude vendor", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(
+    vi.mocked(api.getProducerSettings).mockResolvedValue(
       makeSettings({
         dispatch: { implementer: { vendor: "claude", model: "claude-opus-4-6" } },
       }),
     );
-    render(<OrchestrationDispatchSection />);
+    render(<ProducerDispatchSection />);
     await waitFor(() => screen.getByText("Implementer"));
 
     const effortSelects = screen.getAllByRole("combobox", { name: /effort for/i });
@@ -197,33 +197,33 @@ describe("OrchestrationDispatchSection", () => {
   // ── #578 auto-save behaviour ──────────────────────────────────────
 
   it("no Save button is rendered (auto-save replaces explicit Save)", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
-    render(<OrchestrationDispatchSection />);
+    vi.mocked(api.getProducerSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    render(<ProducerDispatchSection />);
     await waitFor(() => screen.getByText("Implementer"));
     expect(screen.queryByRole("button", { name: /^save/i })).toBeNull();
   });
 
   it("changing an atomic field (effort) triggers a single PUT immediately", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
-    vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
-    render(<OrchestrationDispatchSection />);
+    vi.mocked(api.getProducerSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateProducerSettings).mockResolvedValue(undefined as never);
+    render(<ProducerDispatchSection />);
     await waitFor(() => screen.getByText("Implementer"));
 
     const effortSelects = screen.getAllByRole("combobox", { name: /effort for/i });
     fireEvent.change(effortSelects[0], { target: { value: "low" } });
 
     await waitFor(() => {
-      expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(api.updateProducerSettings)).toHaveBeenCalledTimes(1);
     });
-    expect(vi.mocked(api.updateOrchestratorSettings).mock.calls[0][0]).toMatchObject({
+    expect(vi.mocked(api.updateProducerSettings).mock.calls[0][0]).toMatchObject({
       dispatch: { implementer: expect.objectContaining({ effort: "low" }) },
     });
   });
 
   it("typing in the model field does NOT trigger a PUT mid-stream", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
-    vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
-    render(<OrchestrationDispatchSection />);
+    vi.mocked(api.getProducerSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateProducerSettings).mockResolvedValue(undefined as never);
+    render(<ProducerDispatchSection />);
     await waitFor(() => screen.getByText("Implementer"));
 
     const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
@@ -231,14 +231,14 @@ describe("OrchestrationDispatchSection", () => {
     fireEvent.change(modelInputs[0], { target: { value: "claude-opus-4-7-extra" } });
 
     // No await — the PUT should never be called from typing alone.
-    expect(vi.mocked(api.updateOrchestratorSettings)).not.toHaveBeenCalled();
+    expect(vi.mocked(api.updateProducerSettings)).not.toHaveBeenCalled();
     expect((modelInputs[0] as HTMLInputElement).value).toBe("claude-opus-4-7-extra");
   });
 
   it("blurring the model field commits the draft as a PUT", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
-    vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
-    render(<OrchestrationDispatchSection />);
+    vi.mocked(api.getProducerSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateProducerSettings).mockResolvedValue(undefined as never);
+    render(<ProducerDispatchSection />);
     await waitFor(() => screen.getByText("Implementer"));
 
     const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
@@ -246,17 +246,17 @@ describe("OrchestrationDispatchSection", () => {
     fireEvent.blur(modelInputs[0]);
 
     await waitFor(() => {
-      expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(api.updateProducerSettings)).toHaveBeenCalledTimes(1);
     });
-    expect(vi.mocked(api.updateOrchestratorSettings).mock.calls[0][0]).toMatchObject({
+    expect(vi.mocked(api.updateProducerSettings).mock.calls[0][0]).toMatchObject({
       dispatch: { implementer: expect.objectContaining({ model: "claude-opus-4-7" }) },
     });
   });
 
   it("Enter on the model field commits the draft as a PUT", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
-    vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
-    render(<OrchestrationDispatchSection />);
+    vi.mocked(api.getProducerSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateProducerSettings).mockResolvedValue(undefined as never);
+    render(<ProducerDispatchSection />);
     await waitFor(() => screen.getByText("Implementer"));
 
     const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
@@ -264,18 +264,18 @@ describe("OrchestrationDispatchSection", () => {
     fireEvent.keyDown(modelInputs[0], { key: "Enter" });
 
     await waitFor(() => {
-      expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(api.updateProducerSettings)).toHaveBeenCalledTimes(1);
     });
   });
 
   it("backend 400 on atomic change rolls back local state and surfaces inline error", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
-    vi.mocked(api.updateOrchestratorSettings).mockRejectedValue(
+    vi.mocked(api.getProducerSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateProducerSettings).mockRejectedValue(
       new Error(
         "API error 400: [orchestration.dispatch.implementer] permission_mode `auto` is not allowed",
       ),
     );
-    render(<OrchestrationDispatchSection />);
+    render(<ProducerDispatchSection />);
     await waitFor(() => screen.getByText("Implementer"));
 
     const effortSelects = screen.getAllByRole("combobox", { name: /effort for/i });
@@ -290,11 +290,11 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("backend 400 on text-field commit keeps the user's draft so they can correct", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
-    vi.mocked(api.updateOrchestratorSettings).mockRejectedValue(
+    vi.mocked(api.getProducerSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateProducerSettings).mockRejectedValue(
       new Error("API error 400: model `not-a-model` is unknown"),
     );
-    render(<OrchestrationDispatchSection />);
+    render(<ProducerDispatchSection />);
     await waitFor(() => screen.getByText("Implementer"));
 
     const modelInputs = screen.getAllByRole("textbox", { name: /model for/i });
@@ -310,18 +310,18 @@ describe("OrchestrationDispatchSection", () => {
   });
 
   it("toggling 'Use vendor CLI default' sends null and persists immediately", async () => {
-    vi.mocked(api.getOrchestratorSettings).mockResolvedValue(EXPLICIT_SETTINGS);
-    vi.mocked(api.updateOrchestratorSettings).mockResolvedValue(undefined as never);
-    render(<OrchestrationDispatchSection />);
+    vi.mocked(api.getProducerSettings).mockResolvedValue(EXPLICIT_SETTINGS);
+    vi.mocked(api.updateProducerSettings).mockResolvedValue(undefined as never);
+    render(<ProducerDispatchSection />);
     await waitFor(() => screen.getByText("Implementer"));
 
     const checkboxes = screen.getAllByRole("checkbox");
     fireEvent.click(checkboxes[0]); // implementer's "Use vendor CLI default"
 
     await waitFor(() => {
-      expect(vi.mocked(api.updateOrchestratorSettings)).toHaveBeenCalledTimes(1);
+      expect(vi.mocked(api.updateProducerSettings)).toHaveBeenCalledTimes(1);
     });
-    expect(vi.mocked(api.updateOrchestratorSettings).mock.calls[0][0]).toMatchObject({
+    expect(vi.mocked(api.updateProducerSettings).mock.calls[0][0]).toMatchObject({
       dispatch: { implementer: null },
     });
   });

--- a/clients/react/src/components/settings/__tests__/SettingsPanel.test.tsx
+++ b/clients/react/src/components/settings/__tests__/SettingsPanel.test.tsx
@@ -25,11 +25,11 @@ vi.mock("../HandoffThresholdSection", () => ({
 vi.mock("../NotificationSection", () => ({
   NotificationSection: () => <div data-testid="section-notification">Notification</div>,
 }));
-vi.mock("../OrchestrationSection", () => ({
-  OrchestrationSection: () => <div data-testid="section-orchestration">Orchestration</div>,
+vi.mock("../ProducerSection", () => ({
+  ProducerSection: () => <div data-testid="section-orchestration">Orchestration</div>,
 }));
-vi.mock("../OrchestrationDispatchSection", () => ({
-  OrchestrationDispatchSection: () => <div data-testid="section-dispatch">Dispatch</div>,
+vi.mock("../ProducerDispatchSection", () => ({
+  ProducerDispatchSection: () => <div data-testid="section-dispatch">Dispatch</div>,
 }));
 vi.mock("../WorkflowSection", () => ({
   WorkflowSection: () => <div data-testid="section-workflow">Workflow</div>,

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -904,7 +904,7 @@ export interface SpawnResponse {
 
 export type PrMonitorScope = "current_project" | "all";
 
-export interface OrchestratorSettings {
+export interface ProducerSettings {
   enabled: boolean;
   pr_monitor_enabled: boolean;
   pr_monitor_interval_secs: number;
@@ -1258,11 +1258,11 @@ export const api = {
     apiFetch<MdTreeEntry[]>(`/files/md-tree?root=${encodeURIComponent(root)}`),
 
   // Orchestrator settings (accepts optional project path for per-project scope)
-  getOrchestratorSettings: (project?: string) =>
-    apiFetch<OrchestratorSettings>(
-      `/settings/orchestrator${project ? `?project=${encodeURIComponent(project)}` : ""}`,
+  getProducerSettings: (project?: string) =>
+    apiFetch<ProducerSettings>(
+      `/settings/producer${project ? `?project=${encodeURIComponent(project)}` : ""}`,
     ),
-  updateOrchestratorSettings: (
+  updateProducerSettings: (
     params: {
       enabled?: boolean;
       pr_monitor_enabled?: boolean;
@@ -1276,7 +1276,7 @@ export const api = {
     },
     project?: string,
   ) =>
-    apiFetch(`/settings/orchestrator${project ? `?project=${encodeURIComponent(project)}` : ""}`, {
+    apiFetch(`/settings/producer${project ? `?project=${encodeURIComponent(project)}` : ""}`, {
       method: "PUT",
       body: JSON.stringify(params),
     }),

--- a/clients/react/src/lib/api-tauri.ts
+++ b/clients/react/src/lib/api-tauri.ts
@@ -175,8 +175,8 @@ export const api = {
   mdTree: (root: string) => httpApi.mdTree(root),
 
   // Orchestrator settings (per-project scope via optional project param)
-  getOrchestratorSettings: (project?: string) => httpApi.getOrchestratorSettings(project),
-  updateOrchestratorSettings: (
+  getProducerSettings: (project?: string) => httpApi.getProducerSettings(project),
+  updateProducerSettings: (
     params: {
       enabled?: boolean;
       pr_monitor_enabled?: boolean;
@@ -189,7 +189,7 @@ export const api = {
       dispatch?: WorkerDispatchMap;
     },
     project?: string,
-  ) => httpApi.updateOrchestratorSettings(params, project),
+  ) => httpApi.updateProducerSettings(params, project),
 
   // Notification settings
   getNotificationSettings: () => httpApi.getNotificationSettings(),


### PR DESCRIPTION
## What

Hub follow-through for the core container rename ([tmai-core #598](https://github.com/trust-delta/tmai-core/pull/598)). Renames the hand-written client + settings UI to match the engine's new `/settings/producer` endpoint and `ProducerSettings` shape.

**No generated artifacts touched** — the orchestrator settings endpoint is not in `api-spec/openapi.json` (the response is `Serialize`-only on the engine side), so there is no `gen-spec` mirror; this is a pure hand-written-consumer rename.

## Changes
- `lib/api-http.ts` / `lib/api-tauri.ts`: interface `OrchestratorSettings` → `ProducerSettings`; `getOrchestratorSettings` → `getProducerSettings`; `updateOrchestratorSettings` → `updateProducerSettings`; URL `/settings/orchestrator` → `/settings/producer`.
- Components renamed (files + names): `OrchestrationSection` → `ProducerSection`, `OrchestrationDispatchSection` → `ProducerDispatchSection`. Visible headings "Orchestration" → "Producer", "Orchestration dispatch" → "Producer dispatch", "Orchestration scope" aria-label → "Producer scope".
- Consumers updated: `PrMonitorSection`, `HandoffThresholdSection`, `SettingsPanel`, plus the threshold readers in `producer-console` (`ProducerCtxHeader`, `ProducerConversationHeader`) and `aim-console` (`Shead`).
- Tests renamed + updated to the new symbols/labels.

Internal variable names (`orchestrator` state, `orchProject`) are intentionally left — the agreed scope is the type, client fns, endpoint, component/file names, and visible labels.

## Coordination
Wire-affecting (the client now calls `/settings/producer`). Runtime cutover happens when the engine is rebuilt+restarted to pick up #598 (and #597); until then the **old engine + old UI keep working** on `/settings/orchestrator`. The operator's `config.toml` `[orchestration]` → `[producer]` (hard rename) should land with the restart.

## Gate
- `pnpm lint` + `pnpm tsc -b` + `pnpm test` (963 pass, 2 skip) + `pnpm build` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 設定画面の「Advanced」内で、Producer関連の設定が表示・編集できるようになりました。
  * 既定でAdvancedパネルを開いた状態にできるようになり、深い設定へすぐアクセスしやすくなりました。
* **Bug Fixes**
  * 自動ハンドオフしきい値や関連設定が、Producer向けの正しい設定内容を反映するようになりました。
  * 閾値や各種切り替えの表示・保存の整合性が改善されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->