### PR TITLE
fix(webui): mount handoff ritual UI in the default aim-console mode (#897)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -709,6 +709,59 @@ export function App({
     <RIssueViewer selected={selectedIssue} onClose={clearIssue} />
   ) : null;
 
+  // App-level GLOBAL overlays — mode-INDEPENDENT. The handoff ritual UI
+  // (in-progress overlay / failure dialog / ready toast), the toast container,
+  // and the help overlay must stay co-visible whether the centre is the legacy
+  // producer shell OR the full-screen aim console (now the DEFAULT). These used
+  // to be inlined in the producer-mode return ONLY, so the aim-console default
+  // stranded the whole handoff ritual (phases + escalated/crash failures) and
+  // the toasts/help below the aim-mode early return — invisible in the default
+  // surface (hub #897, surfaced by tmai-core #589 ④). They are `fixed`-
+  // positioned, so the DOM parent doesn't affect layout, and only one mode
+  // branch renders at a time (no double-mount). The single `useHandoffRitual`
+  // instance still lives at App level (above) — two would mean two overlays.
+  const globalOverlays = (
+    <>
+      <HelpOverlay isOpen={showHelp} onClose={() => setShowHelp(false)} />
+      <ToastContainer toasts={toast.toasts} onRemove={toast.removeToast} />
+      {ritualState.kind === "dispatching" && unitName !== null && (
+        <HandoffRitualOverlay unitName={unitName} ritualId={null} phases={[]} />
+      )}
+      {ritualState.kind === "in_progress" && (
+        <HandoffRitualOverlay
+          unitName={ritualState.unit}
+          ritualId={ritualState.ritualId}
+          phases={ritualState.phases}
+        />
+      )}
+      {ritualState.kind === "escalated" && ritualState.unit !== "" && (
+        <HandoffRitualFailureDialog
+          unitName={ritualState.unit}
+          reason={ritualState.reason}
+          message={ritualState.message}
+          // The supervisor's `crash_loop_halted` halt is a different failure
+          // than an operator-rejected handoff — manual relaunch, not retry.
+          mode={ritualState.reason === "crash_loop_halted" ? "crash_loop" : "handoff"}
+          producerAgentId={producerForUnit?.id ?? null}
+          retryCount={handoffRetryCount}
+          retryRefused={handoffRetryRefused}
+          onForceKill={() => void handleHandoffForceKill()}
+          onRetry={handleHandoffRetry}
+          onDismiss={dismissHandoff}
+        />
+      )}
+      {handoffReadyToastVisible && (
+        <div
+          role="status"
+          aria-live="polite"
+          className="fixed bottom-4 right-4 z-40 rounded-md border border-success/30 bg-surface-strong px-4 py-2 text-xs text-success shadow-lg"
+        >
+          Handoff complete — fresh Producer is ready.
+        </div>
+      )}
+    </>
+  );
+
   // Coexist: when the operator opts into aim-ui, the new full-window aim
   // console takes over the whole shell (its own top bar + 3-pane grid),
   // replacing the existing sidebar / digest / R panel. Returned AFTER every
@@ -735,6 +788,7 @@ export function App({
           onClose={() => setLaunchPickerOpen(false)}
           onLaunchProducerAt={launchProducerAt}
         />
+        {globalOverlays}
       </>
     );
   }
@@ -972,57 +1026,10 @@ export function App({
         />
       )}
 
-      {/* Help overlay */}
-      <HelpOverlay isOpen={showHelp} onClose={() => setShowHelp(false)} />
-
-      {/* Toast notifications */}
-      <ToastContainer toasts={toast.toasts} onRemove={toast.removeToast} />
-
-      {/* Producer slot-restart ritual UI — App-level single instance so it
-          stays co-visible regardless of the active centre view (digest,
-          Producer conversation, Settings, …). Hosts BOTH the operator
-          handoff (full 5-phase, the unchanged handoff-lifecycle DR §E
-          contract) and the supervisor crash-respawn (launching→ready, or a
-          `crash_loop_halted` escalate). The overlay/dialog read the ritual's
-          OWN `unit` (a supervisor respawn may target a non-focused unit) and
-          pick their copy off the `slot-supervisor:` id / reason. */}
-      {ritualState.kind === "dispatching" && unitName !== null && (
-        <HandoffRitualOverlay unitName={unitName} ritualId={null} phases={[]} />
-      )}
-      {ritualState.kind === "in_progress" && (
-        <HandoffRitualOverlay
-          unitName={ritualState.unit}
-          ritualId={ritualState.ritualId}
-          phases={ritualState.phases}
-        />
-      )}
-
-      {ritualState.kind === "escalated" && ritualState.unit !== "" && (
-        <HandoffRitualFailureDialog
-          unitName={ritualState.unit}
-          reason={ritualState.reason}
-          message={ritualState.message}
-          // The supervisor's `crash_loop_halted` halt is a different failure
-          // than an operator-rejected handoff — manual relaunch, not retry.
-          mode={ritualState.reason === "crash_loop_halted" ? "crash_loop" : "handoff"}
-          producerAgentId={producerForUnit?.id ?? null}
-          retryCount={handoffRetryCount}
-          retryRefused={handoffRetryRefused}
-          onForceKill={() => void handleHandoffForceKill()}
-          onRetry={handleHandoffRetry}
-          onDismiss={dismissHandoff}
-        />
-      )}
-
-      {handoffReadyToastVisible && (
-        <div
-          role="status"
-          aria-live="polite"
-          className="fixed bottom-4 right-4 z-40 rounded-md border border-success/30 bg-surface-strong px-4 py-2 text-xs text-success shadow-lg"
-        >
-          Handoff complete — fresh Producer is ready.
-        </div>
-      )}
+      {/* App-level global overlays (handoff ritual / toasts / help) — defined
+          once above and ALSO rendered in the aim-mode early return, so they
+          stay co-visible across both console modes (hub #897). */}
+      {globalOverlays}
     </div>
   );
 }

--- a/clients/react/src/__tests__/App.handoff.test.tsx
+++ b/clients/react/src/__tests__/App.handoff.test.tsx
@@ -99,6 +99,15 @@ vi.mock("@/components/agent/AgentList", () => ({ AgentList: () => null }));
 vi.mock("@/components/terminal/TerminalList", () => ({ TerminalList: () => null }));
 vi.mock("@/components/settings/SettingsPanel", () => ({ SettingsPanel: () => null }));
 vi.mock("@/components/calibration/CalibrationPanel", () => ({ CalibrationPanel: () => null }));
+// The aim console is the DEFAULT surface. Stub it so the aim-mode test below
+// observes whether the GLOBAL handoff overlay mounts alongside it, without
+// rendering the real 3-pane console (its own tests cover that).
+vi.mock("@/components/aim-console/AimConsole", () => ({
+  AimConsole: () => <div data-testid="aim-console-stub">aim-console</div>,
+}));
+vi.mock("@/components/project/ProducerLaunchPicker", () => ({
+  ProducerLaunchPicker: () => null,
+}));
 
 import { App } from "@/App";
 
@@ -254,6 +263,30 @@ describe("App — handoff ritual wiring", () => {
     // the trap that forced manual-kill (overlay only in the digest) is gone.
     fireEvent.click(screen.getByTitle("claude:prod"));
     expect(screen.getByTestId("preview-stub")).toBeTruthy();
+    expect(screen.getByTestId("phase-row-prompted")).toBeTruthy();
+  });
+
+  it("renders the handoff overlay in the DEFAULT aim-console mode (regression #897)", () => {
+    // aim is DEFAULT_CONSOLE_MODE. Before the fix, App's aim-mode early return
+    // rendered only <AimConsole> and stranded the global handoff overlay in the
+    // producer-mode return below it, so a handoff triggered from the default
+    // surface showed nothing. The overlay must now mount in BOTH modes.
+    useAgentsMock.mockReturnValue({
+      agents: [agent({ id: "claude:prod" })],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+    useHandoffRitualMock.mockReturnValue({
+      ...idleRitual(),
+      state: { kind: "in_progress", ritualId: "r-1", unit: "alpha", phases: [] },
+    });
+
+    renderWithProviders(<App initialConsoleMode="aim" />);
+
+    // The aim console is the active surface …
+    expect(screen.getByTestId("aim-console-stub")).toBeTruthy();
+    // … and the global handoff overlay is co-visible with it.
     expect(screen.getByTestId("phase-row-prompted")).toBeTruthy();
   });
 });

--- a/clients/react/src/__tests__/App.handoff.test.tsx
+++ b/clients/react/src/__tests__/App.handoff.test.tsx
@@ -282,9 +282,13 @@ describe("App — handoff ritual wiring", () => {
       state: { kind: "in_progress", ritualId: "r-1", unit: "alpha", phases: [] },
     });
 
-    renderWithProviders(<App initialConsoleMode="aim" />);
+    // Render WITHOUT initialConsoleMode so the test exercises the real
+    // DEFAULT_CONSOLE_MODE (= "aim") — the regression was specifically that
+    // the handoff overlay was invisible on the DEFAULT surface, so pinning the
+    // prop here would let a future default flip slip past (CodeRabbit #898).
+    renderWithProviders(<App />);
 
-    // The aim console is the active surface …
+    // The aim console is the default surface …
     expect(screen.getByTestId("aim-console-stub")).toBeTruthy();
     // … and the global handoff overlay is co-visible with it.
     expect(screen.getByTestId("phase-row-prompted")).toBeTruthy();


### PR DESCRIPTION
Fixes #897.

## Problem
Since the aim console became the default surface (#852), the Producer handoff ritual UI was invisible there. App's `consoleMode === "aim"` early return (`App.tsx`) rendered only `<AimConsole>` + `<ProducerLaunchPicker>`, while the handoff overlay / failure dialog / ready toast (plus `ToastContainer` and `HelpOverlay`) lived **only in the producer-mode return below it**. A handoff triggered from the default WebUI showed nothing — phases, `escalated`/`crash_loop_halted` failures, and completion all invisible. This breaks the visibility half of the `tmai-core` aims `conversation-handoff` / `handoff-non-blocking`.

## Fix (minimal — restore visibility)
Extract the mode-independent globals into one `globalOverlays` node and render it in **both** the aim-mode early return and the producer-mode return. They are `fixed`-positioned (DOM parent is layout-irrelevant) and only one mode branch renders at a time → no double-mount. The single App-level `useHandoffRitual` instance is unchanged; producer-mode behaviour is byte-for-byte preserved (same overlays, now via the shared node).

## Test
Regression test in `App.handoff.test.tsx`: with an `in_progress` ritual and `initialConsoleMode="aim"`, the overlay's `phase-row-prompted` now renders alongside the aim console. (Would fail before this change.)

## Out of scope
The deeper "retire the full-screen blocking modal, render phases in-surface non-blockingly" redesign is tracked by `tmai-core` aim `handoff-non-blocking` (PROCESS `[todo]`). This PR restores visibility without blocking on it.

## Gates (local, all green)
`pnpm lint` (biome, 237 files) · `tsc -b` · `pnpm test` (106 files, 964 passed / 2 skipped) · `pnpm build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `aim` モードでも、手渡し関連の案内・通知・失敗ダイアログをグローバルなオーバーレイとして常時表示するよう調整しました。
  * 表示タイミング条件によってオーバーレイが欠ける不具合を解消しました。
* **Tests**
  * `aim` モードでも手渡しオーバーレイ（フェーズ行）が同時表示されることを確認する回帰テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->