### PR TITLE
fix(producer-console): producer vocab in Open-Settings affordance (#583 §軸A)

### DIFF
--- a/clients/react/src/components/producer-console/ProducerConsole.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsole.tsx
@@ -57,7 +57,7 @@ interface ProducerConsoleProps {
   /** Phase B: operator-override callbacks. The override expandable
    *  in the footer needs to spawn agents (re-using `NewAgentLauncher`),
    *  re-expand the (now default-collapsed) sidebar, and deep-link
-   *  into the Settings page where orchestration / dispatch-bundle
+   *  into the Settings page where producer / dispatch-bundle
    *  config still lives. All three are pass-through to App.tsx
    *  handlers — the console is purely a routing surface. */
   onOverrideSpawned: (sessionId: string) => void;

--- a/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
+++ b/clients/react/src/components/producer-console/ProducerConsoleActions.tsx
@@ -197,11 +197,11 @@ export function ProducerConsoleActions({
               type="button"
               onClick={onOpenSettings}
               className="block w-full rounded-md border border-hairline bg-surface px-3 py-2 text-left text-xs text-foreground transition-colors hover:bg-surface"
-              title="Open Settings — orchestration / dispatch bundles still live here"
+              title="Open Settings — producer settings / dispatch bundles still live here"
             >
               Open Settings ▸{" "}
               <span className="text-muted-foreground">
-                (orchestration rules, dispatch bundles, …)
+                (producer settings, dispatch bundles, …)
               </span>
             </button>
           </div>


### PR DESCRIPTION
## What

The Producer console's **Open Settings** affordance still read `orchestration` in its tooltip and label — leftover from before the orchestrator→producer rename. #598/#599 swept **core** user-facing strings only; this is the hub-side residual surfaced by the 2026-06-29 rip-completeness review (tmai-core#583 finding B).

- `ProducerConsoleActions.tsx:200,204` — tooltip + label: `orchestration` → `producer settings`.
- `ProducerConsole.tsx:60` — stale doc-comment likewise.

`dispatch bundles` is **kept** — `ProducerDispatchSection` / `DispatchBundleEditor` are live settings surfaces.

## Out of scope (deliberate)

`SettingsPanel.tsx`'s **"Advanced — orchestrator-era controls"** framing is left untouched: it's a meaningful historical label for the Producer-bypass overrides, not stale residue. Renaming it is an operator UX wording call.

## Risk

String/comment only. No type or behavior change; no test pins these strings.

Refs: tmai-core#583 (§軸A / finding B)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 画面内の説明文やボタン文言を更新し、Settings 関連の表記をより分かりやすくしました。
  * 「orchestration」表記を「producer」や「producer settings」に置き換えました。
  * 「Open Settings」ボタン周辺の補足テキストも更新されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->