### PR TITLE
docs(r-panel): fix stale aim-slug citation → pr-issue-ci (#606 §4)

### DIFF
--- a/clients/react/src/components/producer-console/r-panel/remote-delta.ts
+++ b/clients/react/src/components/producer-console/r-panel/remote-delta.ts
@@ -1,5 +1,5 @@
 // Remote-Δ freshness — pure helpers (#822; design: tmai-core
-// `doc/slack/2026-06-12-161334.md` §3, aim `aim-remote-delta-freshness`,
+// `doc/slack/2026-06-12-161334.md` §3, aim `pr-issue-ci`,
 // anchor 「リモートに変化があった場合、未観測の事実として表示する」).
 //
 // A row is UNOBSERVED when its newest vocab event timestamp is newer than

--- a/clients/react/src/lib/ui-prefs.ts
+++ b/clients/react/src/lib/ui-prefs.ts
@@ -34,7 +34,7 @@ export interface AimConsoleLayout {
 }
 
 // Remote-Δ freshness cursors (#822; design: tmai-core
-// `doc/slack/2026-06-12-161334.md` §3, aim `aim-remote-delta-freshness`).
+// `doc/slack/2026-06-12-161334.md` §3, aim `pr-issue-ci`).
 // Per unit, the ISO timestamps of the operator's last CLOSE acts: `panel` =
 // the R panel collapse, `prs`/`issues` = that section's collapse. The
 // effective cursor for a section is the MAX of `panel` and the section's own


### PR DESCRIPTION
## What

The remote-Δ freshness helpers cited the aim slug **`aim-remote-delta-freshness`**, which no longer exists after the aim-corpus rebuild. The current node is **`pr-issue-ci`** (`doc/aims/pr-issue-ci.md` in tmai-core).

- `clients/react/src/components/producer-console/r-panel/remote-delta.ts:2`
- `clients/react/src/lib/ui-prefs.ts:37`

Comment-only — no type or behaviour change.

Refs tmai-core#606 (§4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 参照している社内ドキュメントの識別子を更新し、関連コメントのリンク先を最新化しました。
  * 表示や動作への影響はなく、案内情報のみが整理されています。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->