### PR TITLE
fix(aim-console): inspector — sticky close ✕ + drag-resizable height

### DIFF
--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -1006,87 +1006,91 @@ function Inspector({
         ✕
       </button>
 
-      {/* Ought-ancestry breadcrumb — every ancestor selectable; the node itself
+      {/* Sticky close ✕ above; everything below scrolls so a long body never
+          scrolls the close affordance out of reach. */}
+      <div className="ac-insp-scroll" data-testid="aim-inspector-scroll">
+        {/* Ought-ancestry breadcrumb — every ancestor selectable; the node itself
           is the cyan tail. */}
-      <nav className="ac-icrumb">
-        {chain.map((a, i) =>
-          i < chain.length - 1 ? (
-            <span key={a.slug} className="ac-icrumb-item">
-              <button
-                type="button"
-                className="ac-icrumb-link"
-                onClick={() => onSelectAncestor(a.slug)}
-                title={a.aim}
-              >
-                {a.aim.slice(0, 18)}…
-              </button>
-              <span className="s" aria-hidden="true">
-                ›
+        <nav className="ac-icrumb">
+          {chain.map((a, i) =>
+            i < chain.length - 1 ? (
+              <span key={a.slug} className="ac-icrumb-item">
+                <button
+                  type="button"
+                  className="ac-icrumb-link"
+                  onClick={() => onSelectAncestor(a.slug)}
+                  title={a.aim}
+                >
+                  {a.aim.slice(0, 18)}…
+                </button>
+                <span className="s" aria-hidden="true">
+                  ›
+                </span>
               </span>
-            </span>
-          ) : (
-            <span key={a.slug} className="ac-icrumb-cur">
-              {a.slug}
-            </span>
-          ),
-        )}
-      </nav>
+            ) : (
+              <span key={a.slug} className="ac-icrumb-cur">
+                {a.slug}
+              </span>
+            ),
+          )}
+        </nav>
 
-      <div className="ac-iought">
-        <b>aim:</b> {node.aim}
-      </div>
+        <div className="ac-iought">
+          <b>aim:</b> {node.aim}
+        </div>
 
-      <div className="ac-imeta">
-        <span className={cn("ac-pill", repo.primary && "op")}>repo: {repo.repo_label}</span>
-        <span className="ac-pill op">
-          state: {AIM_STATE_LABEL[node.state]}
-          {node.parent === null ? " · root" : ""}
-        </span>
-        {node.drift !== null && (
-          <span
-            className="ac-pill dr"
-            data-testid="aim-drift-pill"
-            title={`ancestor anchor moved ${node.drift.ancestor_change_date} (${node.drift.ancestor_change_sha}); this node last changed ${node.drift.aim_change_date}`}
-          >
-            ⚠ {node.state === "done" ? "done · " : ""}drift ← 祖先{" "}
-            {node.drift.stale_from_ancestor_slug}
+        <div className="ac-imeta">
+          <span className={cn("ac-pill", repo.primary && "op")}>repo: {repo.repo_label}</span>
+          <span className="ac-pill op">
+            state: {AIM_STATE_LABEL[node.state]}
+            {node.parent === null ? " · root" : ""}
           </span>
-        )}
-        {/* Working-delta fact line (#817) — presence only, beside (never inside)
+          {node.drift !== null && (
+            <span
+              className="ac-pill dr"
+              data-testid="aim-drift-pill"
+              title={`ancestor anchor moved ${node.drift.ancestor_change_date} (${node.drift.ancestor_change_sha}); this node last changed ${node.drift.aim_change_date}`}
+            >
+              ⚠ {node.state === "done" ? "done · " : ""}drift ← 祖先{" "}
+              {node.drift.stale_from_ancestor_slug}
+            </span>
+          )}
+          {/* Working-delta fact line (#817) — presence only, beside (never inside)
             the drift pill: a node can be both drifted at HEAD and dirty in the
             working tree, and the two facts stay separately stated. */}
-        {wd !== null && (
-          <span className="ac-pill wd" data-testid="aim-wd-pill" data-wd={wd}>
-            {WORKING_DELTA_GLYPH} {WORKING_DELTA_FACT[wd]}
-          </span>
-        )}
-      </div>
+          {wd !== null && (
+            <span className="ac-pill wd" data-testid="aim-wd-pill" data-wd={wd}>
+              {WORKING_DELTA_GLYPH} {WORKING_DELTA_FACT[wd]}
+            </span>
+          )}
+        </div>
 
-      <AimBody
-        body={node.body}
-        variant="console"
-        resolves={(slug) => bySlug.has(slug)}
-        onNavigate={onSelectAncestor}
-      />
+        <AimBody
+          body={node.body}
+          variant="console"
+          resolves={(slug) => bySlug.has(slug)}
+          onNavigate={onSelectAncestor}
+        />
 
-      {/* Resignation inventory (#811) — done is reversible attention-parking,
+        {/* Resignation inventory (#811) — done is reversible attention-parking,
           so on an already-done node the parked objects stay visible, quietly.
           Read-only context for the (reversible) state edit — never a gate. */}
-      {node.state === "done" && (
-        <ResignationInventoryView
-          title="resignation inventory — この done が駐車したもの"
-          node={node}
-          nodes={repo.aims}
-        />
-      )}
+        {node.state === "done" && (
+          <ResignationInventoryView
+            title="resignation inventory — この done が駐車したもの"
+            node={node}
+            nodes={repo.aims}
+          />
+        )}
 
-      <div className="ac-insp-actions">
-        <button type="button" className="ac-btn small" onClick={onEdit}>
-          ✎ 編集
-        </button>{" "}
-        <button type="button" className="ac-btn small" onClick={() => onAddChild(node.slug)}>
-          ＋ 子 aim を作成
-        </button>
+        <div className="ac-insp-actions">
+          <button type="button" className="ac-btn small" onClick={onEdit}>
+            ✎ 編集
+          </button>{" "}
+          <button type="button" className="ac-btn small" onClick={() => onAddChild(node.slug)}>
+            ＋ 子 aim を作成
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -35,8 +35,10 @@
 // NO counters, NO badges, ever.
 
 import {
+  type CSSProperties,
   type FormEvent,
   type ReactNode,
+  type PointerEvent as ReactPointerEvent,
   useCallback,
   useEffect,
   useMemo,
@@ -72,6 +74,11 @@ import {
 } from "@/components/producer-console/r-panel/aim-tree";
 import { useUnitAims } from "@/hooks/useUnitAims";
 import { api } from "@/lib/api";
+import {
+  AIM_INSPECTOR_HEIGHT_DEFAULT,
+  AIM_INSPECTOR_HEIGHT_MIN,
+  clampAimInspectorHeight,
+} from "@/lib/ui-prefs";
 import { useUIPref } from "@/lib/ui-prefs-provider";
 import { cn } from "@/lib/utils";
 import type { AimState } from "@/types/generated/AimState";
@@ -167,6 +174,45 @@ export function AimFace({ unitName }: { unitName: string | null }) {
   const [expanded, setExpanded] = useState<Set<string>>(() => seedExpanded(repos));
   const [modal, setModal] = useState<ModalDescriptor | null>(null);
   const listRef = useRef<HTMLDivElement>(null);
+
+  // Drag-resizable inspector (detail panel) height. `storedInspH` is the
+  // persisted ui-pref; `dragInspH` is the live value while the top grip is
+  // dragged (it overrides the stored one until pointerup commits). Mirrors the
+  // footer/PR-rail drag idiom: track the pointer 1:1, commit once on release.
+  const [storedInspH, setStoredInspH] = useUIPref("aimInspectorHeight");
+  const [dragInspH, setDragInspH] = useState<number | null>(null);
+  const inspDragRef = useRef<{ startY: number; startH: number } | null>(null);
+  const inspHeight = dragInspH ?? storedInspH ?? AIM_INSPECTOR_HEIGHT_DEFAULT;
+  const onInspGripDown = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      e.preventDefault();
+      inspDragRef.current = {
+        startY: e.clientY,
+        startH: storedInspH ?? AIM_INSPECTOR_HEIGHT_DEFAULT,
+      };
+      setDragInspH(inspDragRef.current.startH);
+      e.currentTarget.setPointerCapture(e.pointerId);
+    },
+    [storedInspH],
+  );
+  const onInspGripMove = useCallback((e: ReactPointerEvent<HTMLDivElement>) => {
+    const d = inspDragRef.current;
+    if (d === null) return;
+    // Drag UP (clientY decreases) grows the inspector upward into the worklist.
+    setDragInspH(clampAimInspectorHeight(d.startH + (d.startY - e.clientY)));
+  }, []);
+  const onInspGripUp = useCallback(
+    (e: ReactPointerEvent<HTMLDivElement>) => {
+      const d = inspDragRef.current;
+      if (d === null) return;
+      inspDragRef.current = null;
+      setStoredInspH(clampAimInspectorHeight(d.startH + (d.startY - e.clientY)));
+      setDragInspH(null);
+      e.currentTarget.releasePointerCapture(e.pointerId);
+    },
+    [setStoredInspH],
+  );
+
   const seededRef = useRef(false);
   const prevUnitRef = useRef(unitName);
 
@@ -357,7 +403,26 @@ export function AimFace({ unitName }: { unitName: string | null }) {
         <OverviewRuler ticks={ticks} onReveal={reveal} />
       </div>
 
-      <div className={cn("ac-insp", sel !== null && "on")}>
+      <div
+        className={cn("ac-insp", sel !== null && "on", dragInspH !== null && "dragging")}
+        style={{ "--ac-insp-h": `${inspHeight}px` } as CSSProperties}
+      >
+        {sel !== null && (
+          // biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter (Gutters precedent)
+          <div
+            className={cn("ac-insp-grip", dragInspH !== null && "active")}
+            role="separator"
+            tabIndex={0}
+            aria-orientation="horizontal"
+            aria-label="詳細パネルの高さを調整"
+            aria-valuenow={Math.round(inspHeight)}
+            aria-valuemin={AIM_INSPECTOR_HEIGHT_MIN}
+            title="ドラッグで詳細パネルの高さを調整"
+            onPointerDown={onInspGripDown}
+            onPointerMove={onInspGripMove}
+            onPointerUp={onInspGripUp}
+          />
+        )}
         {sel !== null && (
           <Inspector
             key={sel.node.slug}

--- a/clients/react/src/lib/ui-prefs.ts
+++ b/clients/react/src/lib/ui-prefs.ts
@@ -90,6 +90,10 @@ export interface UIPrefs {
   // honest "一度も見ていない"; self-clears on the first collapse). See
   // RemoteDeltaCursor for the load-bearing exclusions.
   remoteDeltaCursors: Record<string, RemoteDeltaCursor>;
+  // Drag-resized aim-inspector (detail panel) height in px; `null` until the
+  // operator drags the inspector's top grip. Capped live at 70vh by CSS
+  // (min(var, 70vh)); the floor (AIM_INSPECTOR_HEIGHT_MIN) is enforced here.
+  aimInspectorHeight: number | null;
 }
 
 // Attention-strip width bounds (px). Floor keeps the section content
@@ -110,6 +114,12 @@ export const AIM_CONSOLE_PR_WIDTH_MIN = 240;
 export const AIM_CONSOLE_PR_WIDTH_MAX = 520;
 export const AIM_CONSOLE_FOOTER_MIN = 110;
 
+// aim-inspector (detail panel) drag-resize bounds (px). Floor-only: the
+// ceiling is a live 70vh cap applied in CSS (min(var, 70vh)), so storage only
+// enforces the floor (keep the close ✕ + breadcrumb + a few body lines).
+export const AIM_INSPECTOR_HEIGHT_MIN = 140;
+export const AIM_INSPECTOR_HEIGHT_DEFAULT = 400;
+
 export const AIM_CONSOLE_LAYOUT_DEFAULTS: AimConsoleLayout = {
   aim: 1.18,
   sess: 1,
@@ -126,6 +136,7 @@ export const DEFAULT_UI_PREFS: UIPrefs = {
   aimMode: "frontier",
   aimConsoleLayout: null,
   remoteDeltaCursors: {},
+  aimInspectorHeight: null,
 };
 
 export const UI_PREFS_STORAGE_KEY = "tmai:ui:prefs";
@@ -173,6 +184,13 @@ export function clampAimConsolePrWidth(value: number): number {
 export function clampAimConsoleFooterHeight(value: number): number {
   if (!Number.isFinite(value)) return AIM_CONSOLE_LAYOUT_DEFAULTS.footer;
   return Math.max(AIM_CONSOLE_FOOTER_MIN, Math.round(value));
+}
+
+// Floor-only (matches the footer): the inspector's ceiling is the live 70vh
+// CSS cap, not a storage-time bound.
+export function clampAimInspectorHeight(value: number): number {
+  if (!Number.isFinite(value)) return AIM_INSPECTOR_HEIGHT_DEFAULT;
+  return Math.max(AIM_INSPECTOR_HEIGHT_MIN, Math.round(value));
 }
 
 // Collapse an all-defaults layout back to `null` so a double-click reset
@@ -265,6 +283,10 @@ function coercePrefs(raw: unknown): UIPrefs {
       : DEFAULT_UI_PREFS.aimMode,
     aimConsoleLayout: coerceAimConsoleLayout(r.aimConsoleLayout),
     remoteDeltaCursors: coerceRemoteDeltaCursors(r.remoteDeltaCursors),
+    aimInspectorHeight:
+      typeof r.aimInspectorHeight === "number"
+        ? clampAimInspectorHeight(r.aimInspectorHeight)
+        : DEFAULT_UI_PREFS.aimInspectorHeight,
   };
 }
 

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -1742,14 +1742,31 @@
   transition: max-height 0.22s ease;
 }
 .aim-console .ac-insp.on {
-  max-height: 400px;
+  max-height: min(var(--ac-insp-h, 400px), 70vh);
+}
+/* No height animation while the top grip is being dragged — the panel must
+   track the pointer 1:1, not ease toward each intermediate value. */
+.aim-console .ac-insp.dragging {
+  transition: none;
+}
+/* Top drag grip — drag to resize the inspector height (persisted as the
+   aimInspectorHeight ui-pref; floor AIM_INSPECTOR_HEIGHT_MIN, live 70vh cap). */
+.aim-console .ac-insp-grip {
+  height: 6px;
+  cursor: ns-resize;
+  background: transparent;
+  touch-action: none;
+}
+.aim-console .ac-insp-grip:hover,
+.aim-console .ac-insp-grip.active {
+  background: var(--line);
 }
 .aim-console .ac-insp-in {
   padding: 12px 14px 14px;
   overflow: hidden;
   display: flex;
   flex-direction: column;
-  max-height: 400px;
+  max-height: min(var(--ac-insp-h, 400px), 70vh);
   position: relative;
 }
 /* Only the body scrolls; the ✕ (absolute on the non-scrolling .ac-insp-in)

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -1746,18 +1746,31 @@
 }
 .aim-console .ac-insp-in {
   padding: 12px 14px 14px;
-  overflow: auto;
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
   max-height: 400px;
   position: relative;
+}
+/* Only the body scrolls; the ✕ (absolute on the non-scrolling .ac-insp-in)
+   stays put so a long aim body never scrolls the close affordance away. */
+.aim-console .ac-insp-scroll {
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow: auto;
 }
 .aim-console .ac-insp-x {
   position: absolute;
   top: 9px;
   right: 12px;
+  z-index: 2;
   color: var(--faint);
   cursor: pointer;
-  background: transparent;
+  background: var(--panel);
   border: none;
+  border-radius: 3px;
+  line-height: 1;
+  padding: 2px 4px;
   font-size: inherit;
 }
 .aim-console .ac-insp-x:hover {


### PR DESCRIPTION
Two small UX fixes to the aim-console's **inspector** (the aim detail panel). Two independent commits.

## 1. Close ✕ stays visible while a long body scrolls

The ✕ was `position: absolute` **inside** `.ac-insp-in`, which was itself the scroll container — so scrolling a long aim body carried the close affordance out of view. Move the scroll onto an inner `.ac-insp-scroll` wrapper; `.ac-insp-in` (and its absolute ✕) no longer scrolls, so ✕ stays pinned top-right. A small panel-bg chip behind ✕ keeps it legible over scrolling text.

## 2. Inspector height is drag-resizable (was fixed 400px)

Every other console region (panes, PR rail, bash footer) is drag-resizable; the inspector was capped at a fixed `400px`. Add a top grip (`.ac-insp-grip`) — a window-splitter mirroring the footer gutter's `role="separator"` / `tabIndex` / `aria-*`. It drives a `--ac-insp-h` CSS var, **clamped to a 140px floor and a live 70vh ceiling** (`min(var, 70vh)`), persisted as a new `aimInspectorHeight` ui-pref. The open/close `max-height` transition is suppressed during the drag so the panel tracks the pointer 1:1.

## Verification (this machine — no engine/browser)

- `biome check` clean, `tsc -b` clean.
- `AimPane` suite 35/35, `ui-prefs` suite green.
- The repo's **pre-existing** `no-raw-palette` failure (`lib/theme.ts:72,370`) is unrelated — untouched here (identical to `origin/main`).
- ⚠ **Visual / drag-interaction not verified in the running app** (D:\ review machine has no engine). Worth an eyeball: ✕ legibility over scroll, grip hit-area, drag direction/feel.