### PR TITLE
chore(gen): sync generated spec + types from tmai-core@40bb36d29e

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -2653,7 +2653,7 @@
       "type": "object"
     },
     {
-      "description": "A PR has been open without any CI run starting for longer than\n`OrchestrationSettings::pr_monitor_ci_start_timeout_secs`. Typically\nindicates GitHub Actions silently skipped (merge conflicts blocking\nCI, Actions disabled at the repo, etc.) — see #334. Counted from the\nfirst time the monitor observed the PR; warm-up baseline PRs are\nexempt so a tmai restart does not retro-fire the alarm. Emitted at\nmost once per PR.",
+      "description": "A PR has been open without any CI run starting for longer than\n`ProducerSettings::pr_monitor_ci_start_timeout_secs`. Typically\nindicates GitHub Actions silently skipped (merge conflicts blocking\nCI, Actions disabled at the repo, etc.) — see #334. Counted from the\nfirst time the monitor observed the PR; warm-up baseline PRs are\nexempt so a tmai restart does not retro-fire the alarm. Emitted at\nmost once per PR.",
       "properties": {
         "branch": {
           "description": "Head branch name",

--- a/api-spec/mcp-tools.json
+++ b/api-spec/mcp-tools.json
@@ -145,6 +145,25 @@
     }
   },
   {
+    "description": "Get the unit's aim-tree navigation (per repo: tree / DAG edges / drift / working_delta + per-node progress flag: some-todo|all-done|no-process|unknown). Body-less, read-only — pull current aim state before touching an aim or when code lands.",
+    "name": "get_aims",
+    "parameters_schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "description": "Params for the unit-scoped hand-off / file list tools (issue #472).",
+      "properties": {
+        "unit": {
+          "description": "Unit name — a configured `[[unit]]` (e.g. `tmai`, `tmai-product`).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "unit"
+      ],
+      "title": "UnitParams",
+      "type": "object"
+    }
+  },
+  {
     "description": "Get CI failure log for a branch",
     "name": "get_ci_failure_log",
     "parameters_schema": {

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -1520,7 +1520,7 @@
           },
           {
             "type": "object",
-            "description": "A PR has been open without any CI run starting for longer than\n`OrchestrationSettings::pr_monitor_ci_start_timeout_secs`. Typically\nindicates GitHub Actions silently skipped (merge conflicts blocking\nCI, Actions disabled at the repo, etc.) — see #334. Counted from the\nfirst time the monitor observed the PR; warm-up baseline PRs are\nexempt so a tmai restart does not retro-fire the alarm. Emitted at\nmost once per PR.",
+            "description": "A PR has been open without any CI run starting for longer than\n`ProducerSettings::pr_monitor_ci_start_timeout_secs`. Typically\nindicates GitHub Actions silently skipped (merge conflicts blocking\nCI, Actions disabled at the repo, etc.) — see #334. Counted from the\nfirst time the monitor observed the PR; warm-up baseline PRs are\nexempt so a tmai restart does not retro-fire the alarm. Emitted at\nmost once per PR.",
             "required": [
               "pr_number",
               "title",

--- a/clients/react/src/types/generated/DispatchBundle.ts
+++ b/clients/react/src/types/generated/DispatchBundle.ts
@@ -5,7 +5,7 @@ import type { Vendor } from "./Vendor";
 /**
  * Per-role dispatch bundle — vendor + optional model/permission_mode/effort.
  *
- * Stored under `[orchestration.dispatch.<role>]` or `[orchestration.orchestrator]`.
+ * Stored under `[producer.dispatch.<role>]`.
  * `validate(&role_path)` must be called before use to enforce the
  * `vendor_compat` matrix.
  */

--- a/clients/react/src/types/generated/WorkerDispatchMap.ts
+++ b/clients/react/src/types/generated/WorkerDispatchMap.ts
@@ -3,8 +3,5 @@ import type { DispatchBundle } from "./DispatchBundle";
 
 /**
  * Per-role dispatch bundles for worker roles (implementer).
- *
- * The orchestrator's own bundle lives at `OrchestrationSettings.orchestrator`,
- * not here.
  */
 export type WorkerDispatchMap = { implementer?: DispatchBundle | null, };


### PR DESCRIPTION
Manual gen-spec mirror — tmai-core is **billing-dead**, so the `gen-spec-pr` bot cannot run. Brings the hub generated artifacts current with `tmai-core` main (`40bb36d29e`).

## What changed (generated only — no hand edits)
- **`api-spec/mcp-tools.json`**: + the new READ-only **`get_aims`** MCP tool (tmai-core #609 — aim-tree navigation: body-less lean projection of `GET /api/units/{unit}/aims` + per-node `progress` flag).
- **`api-spec/openapi.json`**, **`corevents.schema.json`**, **`clients/react/.../DispatchBundle.ts`**, **`WorkerDispatchMap.ts`**: doc-string/comment refresh from the orchestrator→producer rename (tmai-core #598) — `OrchestrationSettings`→`ProducerSettings`, `[orchestration.*]`→`[producer.*]`. Outstanding since the bot never ran post-#598 (billing-dead).

**No field/type changes** — descriptions + one MCP tool entry only.

## Verified locally
`api-spec` lint:openapi + AJV schema validation · `clients/react` biome lint + `tsc -b` + test (964 pass) + build — all green. (Branch is `bot/`-prefixed so the no-hand-edits gate is exempt; hub CI runs free.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 取得用の新しいツールが追加され、ユニットの aim-tree ナビゲーション状態を読み取れるようになりました。必須パラメータとして unit を指定します。

* **Documentation**
  * PR CI 開始タイムアウト関連の説明が更新され、参照先の設定名が最新の内容に合わせて修正されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->