### PR TITLE
fix(aim-console): lift the remote-Δ freshness instrument into the default surface (#606 §1)

### DIFF
--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -32,6 +32,7 @@
 
 import { type CSSProperties, useCallback, useState } from "react";
 import { useConfirm } from "@/components/layout/ConfirmDialog";
+import { advanceCursor, effectiveCursor } from "@/components/producer-console/r-panel/remote-delta";
 import type { AgentSnapshot, SlotResponse, TriggerHandoffRitualRequest } from "@/lib/api";
 import {
   AIM_CONSOLE_LAYOUT_DEFAULTS,
@@ -128,6 +129,32 @@ export function AimConsole({
   // tabs (S4). A cwd-synthesized unit isn't in the configured membership, so
   // `repos` is empty there — the footer falls back to `currentProjectPath`.
   const activeUnit = units.find((u) => u.name === activeUnitName) ?? null;
+
+  // Remote-Δ freshness cursors (#822; #606 §1 lift) — the SAME `remoteDeltaCursors`
+  // ui-pref the producer-console R panel owns, so a looking-act in either console
+  // is one human looking-act (the cursor is mode-independent, per-unit). Client
+  // state only, never sent to core; the Producer never reads it. `AimConsole`
+  // owns the cursor here (mirroring `RPanel`); `PrRail` is presentational and
+  // only receives the effective cursors. The rail has ONE close act — the rail
+  // collapse — so it stamps the coarse `panel` cursor, which via `effectiveCursor`
+  // = MAX(panel, section) clears BOTH sections (collapsing the whole rail = done
+  // looking at all of it). No section-level close acts, no timers, no per-row
+  // marking (the operator-ratified exclusion list).
+  const [cursors, setCursors] = useUIPref("remoteDeltaCursors");
+  const prsCursor =
+    activeUnitName === null ? null : effectiveCursor(cursors, activeUnitName, "prs");
+  const issuesCursor =
+    activeUnitName === null ? null : effectiveCursor(cursors, activeUnitName, "issues");
+  // Rail-collapse close act: stamp the unit's `panel` cursor (the "when the
+  // operator last stopped looking" timestamp), then collapse. Expanding the rail
+  // is the START of looking, not a close act, so `onExpand` stays the plain
+  // `setPrOpen(true)`.
+  const collapseRail = useCallback(() => {
+    if (activeUnitName !== null) {
+      setCursors(advanceCursor(cursors, activeUnitName, "panel", new Date().toISOString()));
+    }
+    setPrOpen(false);
+  }, [activeUnitName, cursors, setCursors]);
 
   // S7 drag-resizable layout. The persisted pref IS the layout state — a drag
   // adjusts the custom properties imperatively (no re-render per move, see
@@ -265,7 +292,9 @@ export function AimConsole({
             repos={activeUnit?.repos ?? []}
             open={prOpen}
             onExpand={() => setPrOpen(true)}
-            onCollapse={() => setPrOpen(false)}
+            onCollapse={collapseRail}
+            prsCursor={prsCursor}
+            issuesCursor={issuesCursor}
           />
         </section>
       </div>

--- a/clients/react/src/components/aim-console/PrRail.tsx
+++ b/clients/react/src/components/aim-console/PrRail.tsx
@@ -25,7 +25,32 @@
 // modifier + the grid transition + the `prOpen` state in `AimConsole`); this
 // component only renders the rail/panel CONTENT and calls back the threaded
 // `onExpand` / `onCollapse` — it never owns the open state.
+//
+// REMOTE-Δ FRESHNESS (#606 §1 / aim `pr-issue-ci` / instrument #822): the
+// remote-Δ instrument used to live ONLY in the producer-console R panel
+// (`RPrsSection` / `RIssuesSection`), so the aim-console — the DEFAULT surface
+// since #850/#851 — showed PR/issue rows but not "which changed since you last
+// looked" (a stranding regression, the same shape as the #897/#898 handoff
+// overlay lift). This rail now carries the instrument too. WHAT it reuses: the
+// pure `remote-delta.ts` helpers (logic, no theme — same import category as the
+// `prStatusPills` derivation). WHAT it does NOT reuse: the producer-console
+// `UnobservedDelta` component, because it carries the producer theme's
+// `text-info` token; the dev-tool Δ accent is its own `.ac-unobs` (cyan = the
+// aim-console info-family token), keeping the #801 bounding (touch ONLY
+// `aim-console/**` + `aim-console.css`). The cursor itself is OWNED by
+// `AimConsole` (the rail-collapse close act stamps the unit's `panel` cursor in
+// the SHARED `remoteDeltaCursors` ui-pref — looking via either console is one
+// human looking-act, so the cursor is mode-independent); this component is
+// presentational and only receives the effective cursors as props. The Δ is an
+// info-tone freshness FACT ("changed since 見ていた"), never the owed amber.
 
+import {
+  issueVocabTimestamp,
+  isUnobserved,
+  prVocabTimestamp,
+  unobservedIssueCount,
+  unobservedPrCount,
+} from "@/components/producer-console/r-panel/remote-delta";
 import {
   issueStatusPills,
   type PillTone,
@@ -63,6 +88,14 @@ interface PrRailProps {
    *  `AimConsole`. */
   onExpand: () => void;
   onCollapse: () => void;
+  /** Remote-Δ effective cursor for the PRs / Issues sections (#822), each =
+   *  MAX(unit panel close, that section's close), threaded from `AimConsole`
+   *  (which owns the shared `remoteDeltaCursors` ui-pref). `null` = no close
+   *  act recorded yet (first run → every row unobserved, the honest
+   *  「一度も見ていない」); `undefined` = no freshness wiring at all (e.g.
+   *  isolation tests / no focused unit), rows + rail render accent-free. */
+  prsCursor?: string | null;
+  issuesCursor?: string | null;
 }
 
 // Map a categorical pill tone to the mock's `.pst` colour modifier
@@ -77,7 +110,16 @@ const PST_TONE_CLASS: Record<PillTone, string> = {
   muted: "d", // draft / closed → --dim
 };
 
-export function PrRail({ unitName, unitLabel, repos, open, onExpand, onCollapse }: PrRailProps) {
+export function PrRail({
+  unitName,
+  unitLabel,
+  repos,
+  open,
+  onExpand,
+  onCollapse,
+  prsCursor,
+  issuesCursor,
+}: PrRailProps) {
   // One poll each, feeding BOTH the collapsed counts and the expanded lists
   // (so the rail never double-polls). The endpoints are open-only + already
   // unit-scoped across every repo, so the totals are the live open counts.
@@ -88,6 +130,16 @@ export function PrRail({ unitName, unitLabel, repos, open, onExpand, onCollapse 
   const issueRepos = issueData?.repos ?? [];
   const openPrCount = prRepos.reduce((n, r) => n + r.prs.length, 0);
   const openIssueCount = issueRepos.reduce((n, r) => n + r.issues.length, 0);
+
+  // Remote-Δ unobserved totals (#822). `undefined` cursor = no freshness wiring
+  // (isolation / no focused unit) → 0, so the rail renders accent-free exactly
+  // as before. `null` cursor (first run, no close act yet) → the helpers treat
+  // every row as unobserved. The collapsed rail shows the unit total so the
+  // operator sees "something changed" WITHOUT expanding — the whole point of a
+  // freshness instrument on a default-collapsed rail.
+  const unobservedTotal =
+    (prsCursor === undefined ? 0 : unobservedPrCount(prRepos, prsCursor)) +
+    (issuesCursor === undefined ? 0 : unobservedIssueCount(issueRepos, issuesCursor));
 
   return (
     <>
@@ -104,6 +156,18 @@ export function PrRail({ unitName, unitLabel, repos, open, onExpand, onCollapse 
             it just shows the live open PR count. */}
         <span className="ac-v w">PR {openPrCount}</span>
         <span className="ac-v">Issue {openIssueCount}</span>
+        {/* Remote-Δ unit total: unobserved PR + issue rows since the close act.
+            Within-unit count only — info-tone (cyan) freshness fact, never the
+            owed amber; no cross-unit accent (deferred until a second unit). */}
+        {unobservedTotal > 0 && (
+          <span
+            className="ac-v dl"
+            data-testid="ac-rail-unobserved"
+            title={`${unobservedTotal} unobserved remote ${unobservedTotal === 1 ? "change" : "changes"} since you last looked`}
+          >
+            Δ {unobservedTotal}
+          </span>
+        )}
         <span className="ac-g">‹ EXTERNAL</span>
       </button>
 
@@ -122,8 +186,8 @@ export function PrRail({ unitName, unitLabel, repos, open, onExpand, onCollapse 
           </button>
         </div>
         <div className="ac-prb">
-          <PrGroup repos={prRepos} count={openPrCount} />
-          <IssueGroup repos={issueRepos} count={openIssueCount} />
+          <PrGroup repos={prRepos} count={openPrCount} cursor={prsCursor} />
+          <IssueGroup repos={issueRepos} count={openIssueCount} cursor={issuesCursor} />
         </div>
       </div>
     </>
@@ -132,8 +196,17 @@ export function PrRail({ unitName, unitLabel, repos, open, onExpand, onCollapse 
 
 // "Pull Requests · N" — the unit's open PRs, gathered flat across every repo
 // (primary first, then declaration order, as the endpoint returns them), each
-// row tagged with its owning repo pill.
-function PrGroup({ repos, count }: { repos: RepoPrsWire[]; count: number }) {
+// row tagged with its owning repo pill. `cursor` threads the remote-Δ freshness
+// down to each row (undefined ⇒ accent-free).
+function PrGroup({
+  repos,
+  count,
+  cursor,
+}: {
+  repos: RepoPrsWire[];
+  count: number;
+  cursor?: string | null;
+}) {
   return (
     <div className="ac-prg" data-testid="ac-pr-group">
       <h4>Pull Requests · {count}</h4>
@@ -142,7 +215,7 @@ function PrGroup({ repos, count }: { repos: RepoPrsWire[]; count: number }) {
       ) : (
         repos.flatMap((repo) =>
           repo.prs.map((pr) => (
-            <PrRow key={`${repo.repo_path}#${pr.number}`} pr={pr} repo={repo} />
+            <PrRow key={`${repo.repo_path}#${pr.number}`} pr={pr} repo={repo} cursor={cursor} />
           )),
         )
       )}
@@ -151,7 +224,15 @@ function PrGroup({ repos, count }: { repos: RepoPrsWire[]; count: number }) {
 }
 
 // "Issues · N" — same shape, the unit's open issues across every repo.
-function IssueGroup({ repos, count }: { repos: RepoIssuesWire[]; count: number }) {
+function IssueGroup({
+  repos,
+  count,
+  cursor,
+}: {
+  repos: RepoIssuesWire[];
+  count: number;
+  cursor?: string | null;
+}) {
   return (
     <div className="ac-prg" data-testid="ac-issue-group">
       <h4>Issues · {count}</h4>
@@ -160,7 +241,12 @@ function IssueGroup({ repos, count }: { repos: RepoIssuesWire[]; count: number }
       ) : (
         repos.flatMap((repo) =>
           repo.issues.map((issue) => (
-            <IssueRow key={`${repo.repo_path}#${issue.number}`} issue={issue} repo={repo} />
+            <IssueRow
+              key={`${repo.repo_path}#${issue.number}`}
+              issue={issue}
+              repo={repo}
+              cursor={cursor}
+            />
           )),
         )
       )}
@@ -168,7 +254,15 @@ function IssueGroup({ repos, count }: { repos: RepoIssuesWire[]; count: number }
   );
 }
 
-function PrRow({ pr, repo }: { pr: PrSummaryWire; repo: RepoPrsWire }) {
+function PrRow({
+  pr,
+  repo,
+  cursor,
+}: {
+  pr: PrSummaryWire;
+  repo: RepoPrsWire;
+  cursor?: string | null;
+}) {
   return (
     <Row
       repoLabel={repo.repo_label}
@@ -176,11 +270,20 @@ function PrRow({ pr, repo }: { pr: PrSummaryWire; repo: RepoPrsWire }) {
       number={pr.number}
       title={pr.title}
       pills={prStatusPills(pr)}
+      unobserved={cursor !== undefined && isUnobserved(prVocabTimestamp(pr), cursor)}
     />
   );
 }
 
-function IssueRow({ issue, repo }: { issue: IssueSummaryWire; repo: RepoIssuesWire }) {
+function IssueRow({
+  issue,
+  repo,
+  cursor,
+}: {
+  issue: IssueSummaryWire;
+  repo: RepoIssuesWire;
+  cursor?: string | null;
+}) {
   return (
     <Row
       repoLabel={repo.repo_label}
@@ -188,28 +291,43 @@ function IssueRow({ issue, repo }: { issue: IssueSummaryWire; repo: RepoIssuesWi
       number={issue.number}
       title={issue.title}
       pills={issueStatusPills(issue)}
+      unobserved={cursor !== undefined && isUnobserved(issueVocabTimestamp(issue), cursor)}
     />
   );
 }
 
-// One inventory row (mock `.pi`): repo pill (primary highlighted) + `#number`
-// (mono) + single-line ellipsised title + categorical status pill(s).
-// Display-only — no click target (see file header).
+// One inventory row (mock `.pi`): an optional leading remote-Δ accent + repo
+// pill (primary highlighted) + `#number` (mono) + single-line ellipsised title
+// + categorical status pill(s). Display-only — no click target (see header).
 function Row({
   repoLabel,
   primary,
   number,
   title,
   pills,
+  unobserved,
 }: {
   repoLabel: string;
   primary: boolean;
   number: bigint;
   title: string;
   pills: StatusPill[];
+  unobserved?: boolean;
 }) {
   return (
     <div className="ac-pi" data-testid="ac-pi">
+      {/* Remote-Δ accent (#822): leading Δ when this row's vocab ts is newer
+          than the close-act cursor. Observed rows render no counterpart at all
+          — observed is the unmarked default, not a second badge. */}
+      {unobserved === true && (
+        <span
+          className="ac-unobs"
+          data-testid="ac-unobserved"
+          title="unobserved — changed since you last looked"
+        >
+          Δ
+        </span>
+      )}
       <span
         className={cn("ac-repo", primary && "pri")}
         data-testid="ac-pi-repo"

--- a/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
@@ -18,6 +18,7 @@ import { fireEvent, render, screen, waitFor, within } from "@testing-library/rea
 import { describe, expect, it, vi } from "vitest";
 import { ConfirmProvider } from "@/components/layout/ConfirmDialog";
 import type { AimsResponse, SlotResponse, UnitIssuesResponse, UnitPrsResponse } from "@/lib/api";
+import { UI_PREFS_STORAGE_KEY } from "@/lib/ui-prefs";
 import { UIPrefsProvider } from "@/lib/ui-prefs-provider";
 import { AimConsole } from "../AimConsole";
 
@@ -154,5 +155,42 @@ describe("AimConsole — S1 shell", () => {
     renderConsole({ activeUnitName: null });
     // metaUnit = units[0].name when activeUnitName is null.
     expect(screen.getByText(/unit tmai · opus-4\.8 · max/)).toBeTruthy();
+  });
+});
+
+// The remote-Δ freshness instrument used to live ONLY in the producer-console R
+// panel, so the aim console — the DEFAULT surface — never recorded the
+// operator's looking-acts (#606 §1, the same stranding shape as #897/#898). The
+// close act (rail collapse) must stamp the unit's `panel` cursor in the SHARED
+// `remoteDeltaCursors` ui-pref. This guards that the instrument is wired in the
+// default surface, not just in the opt-out producer console.
+describe("AimConsole — remote-Δ close act (#606 §1, default surface)", () => {
+  function readCursors(): Record<string, { panel?: string }> {
+    const raw = localStorage.getItem(UI_PREFS_STORAGE_KEY);
+    return raw === null ? {} : (JSON.parse(raw).remoteDeltaCursors ?? {});
+  }
+
+  it("stamps the focused unit's panel cursor on rail collapse (the close act)", async () => {
+    localStorage.clear();
+    renderConsole({ activeUnitName: "tmai" });
+    // Expand (start looking — NOT a close act) then collapse (the close act).
+    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
+    fireEvent.click(screen.getByRole("button", { name: "Collapse PR / Issue rail" }));
+    await waitFor(() => {
+      expect(typeof readCursors().tmai?.panel).toBe("string");
+    });
+  });
+
+  it("does not stamp a cursor when no unit is focused (display fallback ≠ focus)", async () => {
+    localStorage.clear();
+    // metaUnit displays "tmai" (units[0]) but the FOCUS is null — the close act
+    // must key on the real focus, so no cursor is written.
+    renderConsole({ activeUnitName: null });
+    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
+    fireEvent.click(screen.getByRole("button", { name: "Collapse PR / Issue rail" }));
+    await waitFor(() => {
+      // The pref blob persists on mount; remoteDeltaCursors must stay empty.
+      expect(Object.keys(readCursors())).toHaveLength(0);
+    });
   });
 });

--- a/clients/react/src/components/aim-console/__tests__/PrRail.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/PrRail.test.tsx
@@ -251,6 +251,121 @@ describe("PrRail — expanded panel groups", () => {
   });
 });
 
+describe("PrRail — remote-Δ freshness (#822 / #606 §1)", () => {
+  const CURSOR = "2026-06-20T00:00:00Z";
+  const NEWER = "2026-06-25T00:00:00Z"; // after the cursor → unobserved
+  const OLDER = "2026-06-10T00:00:00Z"; // before the cursor → observed
+
+  it("renders no Δ accent when no cursor is wired (undefined ⇒ accent-free)", () => {
+    // The default render passes no cursor props — existing isolation behaviour.
+    renderRail();
+    expect(screen.queryByTestId("ac-unobserved")).toBeNull();
+    expect(screen.queryByTestId("ac-rail-unobserved")).toBeNull();
+  });
+
+  it("marks only the rows whose vocab ts is newer than the section cursor", () => {
+    useUnitPrsMock.mockReturnValue(
+      prsResult({
+        unit: "tmai",
+        repos: [
+          {
+            repo_path: "/home/u/tmai",
+            repo_label: "tmai",
+            primary: true,
+            prs: [
+              pr({ number: 1n, title: "fresh", created_at: NEWER }),
+              pr({ number: 2n, title: "stale", created_at: OLDER }),
+              pr({ number: 3n, title: "no vocab" }), // all-null vocab → observed
+            ],
+          },
+        ],
+      }),
+    );
+    useUnitIssuesMock.mockReturnValue(issuesResult({ unit: "tmai", repos: [] }));
+    renderRail({ prsCursor: CURSOR, issuesCursor: CURSOR });
+
+    // Exactly one row (the NEWER one) carries the Δ accent.
+    const group = screen.getByTestId("ac-pr-group");
+    const rows = within(group).getAllByTestId("ac-pi");
+    const hasDelta = (i: number) => within(rows[i]).queryByTestId("ac-unobserved") !== null;
+    expect(hasDelta(0)).toBe(true); // #1 fresh
+    expect(hasDelta(1)).toBe(false); // #2 stale
+    expect(hasDelta(2)).toBe(false); // #3 no vocab
+  });
+
+  it("treats every row as unobserved on the first run (null cursor)", () => {
+    useUnitPrsMock.mockReturnValue(
+      prsResult({
+        unit: "tmai",
+        repos: [
+          {
+            repo_path: "/home/u/tmai",
+            repo_label: "tmai",
+            primary: true,
+            prs: [pr({ number: 1n, created_at: OLDER }), pr({ number: 2n, created_at: NEWER })],
+          },
+        ],
+      }),
+    );
+    useUnitIssuesMock.mockReturnValue(issuesResult({ unit: "tmai", repos: [] }));
+    renderRail({ prsCursor: null, issuesCursor: null });
+    // null = "no close act recorded yet" → the honest 一度も見ていない: both rows.
+    expect(screen.getAllByTestId("ac-unobserved")).toHaveLength(2);
+  });
+
+  it("shows the unit-total Δ on the collapsed rail (PR + Issue unobserved)", () => {
+    useUnitPrsMock.mockReturnValue(
+      prsResult({
+        unit: "tmai",
+        repos: [
+          {
+            repo_path: "/home/u/tmai",
+            repo_label: "tmai",
+            primary: true,
+            prs: [pr({ number: 1n, created_at: NEWER }), pr({ number: 2n, created_at: OLDER })],
+          },
+        ],
+      }),
+    );
+    useUnitIssuesMock.mockReturnValue(
+      issuesResult({
+        unit: "tmai",
+        repos: [
+          {
+            repo_path: "/home/u/tmai",
+            repo_label: "tmai",
+            primary: true,
+            issues: [issue({ number: 9n, created_at: NEWER })],
+          },
+        ],
+      }),
+    );
+    renderRail({ prsCursor: CURSOR, issuesCursor: CURSOR });
+    // 1 unobserved PR + 1 unobserved issue = Δ 2.
+    const rail = screen.getByTestId("ac-rail-unobserved");
+    expect(rail.textContent).toContain("2");
+  });
+
+  it("omits the collapsed-rail Δ when nothing is unobserved", () => {
+    useUnitPrsMock.mockReturnValue(
+      prsResult({
+        unit: "tmai",
+        repos: [
+          {
+            repo_path: "/home/u/tmai",
+            repo_label: "tmai",
+            primary: true,
+            prs: [pr({ number: 1n, created_at: OLDER })],
+          },
+        ],
+      }),
+    );
+    useUnitIssuesMock.mockReturnValue(issuesResult({ unit: "tmai", repos: [] }));
+    renderRail({ prsCursor: CURSOR, issuesCursor: CURSOR });
+    expect(screen.queryByTestId("ac-rail-unobserved")).toBeNull();
+  });
+});
+
 describe("PrRail — expand / collapse (S1 mechanism, threaded callbacks)", () => {
   it("clicking the collapsed rail calls onExpand", () => {
     const props = renderRail({ open: false });

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -1051,6 +1051,15 @@
   padding-bottom: 12px;
   letter-spacing: 2px;
 }
+/* Remote-Δ unit total on the collapsed rail (#822 / #606 §1). Cyan = the
+   aim-console info-family token (NOT the owed amber `.ac-v.w`): "unobserved"
+   is a neutral freshness FACT, never a debt. Shares the `.ac-v` vertical look
+   so it sits inline with the PR / Issue counts. */
+.aim-console .ac-prrail .ac-v.dl {
+  color: var(--cyan);
+  border-color: var(--cyan-d);
+  background: var(--cyan-d);
+}
 .aim-console .ac-prfull {
   display: none;
   flex-direction: column;
@@ -1114,6 +1123,15 @@
    context; as a PR-row's first child it sits flush after the row padding. */
 .aim-console .ac-pi .ac-repo {
   margin-left: 0;
+}
+/* Remote-Δ leading accent on an unobserved row (#822 / #606 §1). Cyan
+   info-family token (NOT the owed amber): a freshness fact ("changed since
+   見ていた"), never a debt. Observed rows render no counterpart. */
+.aim-console .ac-pi .ac-unobs {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--cyan);
+  flex: none;
 }
 .aim-console .ac-pn {
   font-family: var(--mono);


### PR DESCRIPTION
## What

Lifts the **remote-Δ freshness instrument** (close-act cursor + unobserved-row Δ accents + the collapsed-rail unobserved total) into the **aim console** — the default surface — closing the §1 stranding in trust-delta/tmai-core#606.

The instrument shipped in #822/#823 but lived **only** in the producer-console R panel (`RPrsSection` / `RIssuesSection`). When the aim console became the default surface (#850/#851), its PR rail showed PR/issue rows but never *"which changed since you last looked"* — the same stranding shape as the #897/#898 handoff-overlay lift.

## How

- **`AimConsole` owns the cursor** (mirroring `RPanel`): it reads the **same `remoteDeltaCursors` ui-pref** the producer console uses, so looking via either console is **one human looking-act** — the cursor is mode-independent, per-unit, client-state-only (never sent to core). The rail has **one close act** (the rail collapse), which stamps the coarse `panel` cursor; via `effectiveCursor` = MAX(panel, section) that clears both sections. No section-level closes, no timers, no per-row marking (the operator-ratified exclusion list).
- **`PrRail` stays presentational**: it receives the effective `prsCursor` / `issuesCursor` (`undefined` ⇒ accent-free, as in isolation tests; `null` ⇒ first-run "never looked") and renders the leading Δ on unobserved rows + the unit-total Δ on the collapsed rail.
- **Reuse, not rebuild**: reuses the pure `remote-delta.ts` helpers (logic, no theme — same import category as the `prStatusPills` derivation). Does **not** reuse the producer-console `UnobservedDelta` component (it carries the producer `text-info` token); the Δ accent is its own `.ac-unobs` / `.ac-v.dl` in the cyan info-family token, keeping the #801 bounding (touch only `aim-console/**` + `aim-console.css`). Info-tone freshness **fact**, never the owed amber.

## Tests

- `PrRail.test.tsx`: row + collapsed-rail Δ coverage (newer / older / no-vocab rows, first-run `null` cursor, `undefined` ⇒ accent-free).
- `AimConsole.test.tsx`: default-surface regression guard that rail collapse stamps the unit's `panel` cursor (and does **not** when no unit is focused — display fallback ≠ focus).
- Local: targeted suite 25 green (was 18), producer-console remote-delta unchanged, `tsc -b` green, biome clean. Full suite: the only failure is a **pre-existing** `no-raw-palette` violation in `lib/theme.ts` (byte-identical to `origin/main`), unrelated to this change.

## Operator decision left open

This is the #897-style **minimal lift** — it restores the instrument's visibility. The deeper **"PrRail vs RPanel — merge the two PR/issue surfaces, or divide their roles"** question (tmai-core#606 §1) is intentionally **not decided here**; it's an irreducible design call for the operator.

## Out of scope

- §2 (data-freshness *last-sync* label) needs new **core wire** (last successful github-sync timestamp) → WSL.
- The tmai-core `pr-issue-ci` PROCESS mark for the stranding todo should flip to `[done]` **after this merges** (record↔code stays honest — don't mark done before it's on `main`).

Refs: trust-delta/tmai-core#606 §1 · instrument #822/#823 · same-shape lift #897/#898 · inversion #850/#851.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * PRレールと行表示に、更新の新しさを示す「Δ」バッジが追加されました。
  * 折りたたみ状態でも、未確認の件数が合計で表示されるようになりました。

* **改善**
  * レールの折りたたみ時に、現在の表示位置が適切に更新されるようになりました。
  * アクティブな表示がある場合のみ、より正確な表示位置を使うよう調整されました。

* **テスト**
  * 折りたたみ時の表示更新や、Δバッジの表示条件を確認するテストを追加・拡充しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->