### PR TITLE
fix(test): normalize path separators in the no-raw-palette repo-lock (Windows)

### DIFF
--- a/clients/react/src/lib/__tests__/no-raw-palette.test.ts
+++ b/clients/react/src/lib/__tests__/no-raw-palette.test.ts
@@ -18,11 +18,19 @@
 //     holds colour *values* (hex/oklch), never Tailwind palette classes.
 
 import { readdirSync, readFileSync, statSync } from "node:fs";
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, join, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import { describe, expect, it } from "vitest";
 
 const SRC = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+// `relative()` yields the host separator (`\` on Windows), so normalize to
+// forward slashes before comparing against EXCLUDED / building messages —
+// otherwise the `lib/theme.ts` exclusion silently misses on Windows (`rel`
+// is `lib\theme.ts`), the SoT file gets scanned, and its comments that
+// *mention* palette classes (`bg-white/N`, `text-purple-400`) trip the
+// regex as false positives. POSIX runs (CI) are unaffected.
+const relPosix = (p: string): string => relative(SRC, p).split(sep).join("/");
 
 // Paths (relative to src/) excluded from the scan.
 const EXCLUDED = new Set(["types/generated", "lib/theme.ts"]);
@@ -42,7 +50,7 @@ const RAW_PALETTE = new RegExp(
 function* walk(dir: string): Generator<string> {
   for (const entry of readdirSync(dir)) {
     const p = join(dir, entry);
-    const rel = relative(SRC, p);
+    const rel = relPosix(p);
     if (EXCLUDED.has(rel)) continue;
     if (statSync(p).isDirectory()) {
       if (entry === "__tests__") continue;
@@ -69,7 +77,7 @@ describe("semantic-token migration — repo-wide lock", () => {
       text.split("\n").forEach((line, i) => {
         const hits = line.match(RAW_PALETTE);
         if (hits) {
-          violations.push(`${relative(SRC, file)}:${i + 1}  ${[...new Set(hits)].join(" ")}`);
+          violations.push(`${relPosix(file)}:${i + 1}  ${[...new Set(hits)].join(" ")}`);
         }
       });
     }
@@ -88,7 +96,7 @@ describe("semantic-token migration — repo-wide lock", () => {
       for (const m of text.matchAll(IDENTICAL_TERNARY)) {
         if (m[1] === m[2]) {
           const ln = text.slice(0, m.index).split("\n").length;
-          violations.push(`${relative(SRC, file)}:${ln}  ${m[1]}`);
+          violations.push(`${relPosix(file)}:${ln}  ${m[1]}`);
         }
       }
     }


### PR DESCRIPTION
## What

Fixes a **Windows-only** false failure in the semantic-token repo-lock (`no-raw-palette.test.ts`). The test is green on CI (Linux) but fails on a Windows checkout — discovered while running the full suite on the D:\ review machine.

## Root cause

The lock excludes `lib/theme.ts` — the colour-value SoT, whose *comments* legitimately mention palette classes (`bg-white/N` at :72, `text-purple-400` at :370) to document what each semantic token replaced. The exclusion check is:

```ts
const rel = relative(SRC, p);
if (EXCLUDED.has(rel)) continue; // EXCLUDED = {"types/generated", "lib/theme.ts"}
```

`relative()` returns the **host** separator, so on Windows `rel` is `lib\theme.ts`, which never matches the forward-slash `"lib/theme.ts"`. The exclusion silently misses, `theme.ts` gets scanned, and its comment text trips the `RAW_PALETTE` regex:

```
lib\theme.ts:72   bg-white border-white
lib\theme.ts:370  text-purple-400
```

## Fix

Normalize `relative()` output to POSIX separators via a small `relPosix` helper, used for the `EXCLUDED` check and the violation messages. POSIX behaviour is unchanged; Windows now matches CI. **No production code touched** — `theme.ts` is correct as-is.

## Verify

- `no-raw-palette.test.ts` green on Windows (was failing): 2/2.
- `tsc -b` green, biome clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
