### PR TITLE
feat(theme): System / Light / Dark theme-mode selector, default System

### DIFF
--- a/clients/react/src/aim-offline.tsx
+++ b/clients/react/src/aim-offline.tsx
@@ -12,7 +12,12 @@ import { type ReactElement, StrictMode, useCallback, useState } from "react";
 import { createRoot } from "react-dom/client";
 import { AimFace } from "@/components/aim-console/AimPane";
 import { setAimsDirectory } from "@/lib/api-files";
-import { applyThemeToDocument, resolveTheme } from "@/lib/theme";
+import {
+  applyThemeToDocument,
+  resolveTheme,
+  resolveThemeMode,
+  systemPrefersLight,
+} from "@/lib/theme";
 import { loadUIPrefs } from "@/lib/ui-prefs";
 import { UIPrefsProvider } from "@/lib/ui-prefs-provider";
 import "@fontsource/ibm-plex-mono/400.css";
@@ -90,7 +95,7 @@ function AimOffline(): ReactElement {
   );
 }
 
-applyThemeToDocument(resolveTheme(loadUIPrefs().theme));
+applyThemeToDocument(resolveTheme(resolveThemeMode(loadUIPrefs().themeMode, systemPrefersLight())));
 
 const rootEl = document.getElementById("root");
 if (rootEl === null) {

--- a/clients/react/src/components/settings/ThemeSection.tsx
+++ b/clients/react/src/components/settings/ThemeSection.tsx
@@ -1,34 +1,35 @@
-import { THEME_NAMES, THEMES } from "@/lib/theme";
+import { THEME_MODE_OPTIONS, THEMES } from "@/lib/theme";
 import { useUIPref } from "@/lib/ui-prefs-provider";
 
 /**
- * WebUI-only setting: the colour theme. Lives in the unified WebUI prefs
- * blob (localStorage), not in tmai-core's config.toml — theme is pure
- * presentation and has no meaning for the CLI / TUI clients. Selecting a
- * theme persists immediately and re-skins the terminal and the rest of
- * the UI live (App's `useApplyTheme` + useTerminal both read the same
- * `lib/theme` source), so there is no Save button and no reload.
+ * WebUI-only setting: the colour-theme MODE (System / Light / Dark). Lives in
+ * the unified WebUI prefs blob (localStorage), not in tmai-core's config.toml —
+ * theme is pure presentation and has no meaning for the CLI / TUI clients
+ * (provisional store: a later core config field may pick it up). Picking a mode
+ * persists immediately and re-skins the terminal + the rest of the UI live
+ * (App's `useApplyTheme` + useTerminal both resolve the same `lib/theme`
+ * source), so there is no Save button and no reload. `System` additionally
+ * follows the OS appearance live via `prefers-color-scheme`.
  */
 export function ThemeSection() {
-  const [theme, setTheme] = useUIPref("theme");
+  const [mode, setMode] = useUIPref("themeMode");
 
   return (
     <section>
       <h3 className="text-sm font-medium text-foreground">Theme</h3>
       <p className="mt-1 text-xs text-subtle-foreground">
         Colours for the whole WebUI, including the terminal palette. Stored per-browser; applies
-        instantly.
+        instantly. <span className="text-muted-foreground">System</span> follows your OS appearance.
       </p>
 
-      <div className="mt-3 grid grid-cols-2 gap-2">
-        {THEME_NAMES.map((name) => {
-          const t = THEMES[name];
-          const active = theme === name;
+      <div className="mt-3 grid grid-cols-3 gap-2">
+        {THEME_MODE_OPTIONS.map((opt) => {
+          const active = mode === opt.mode;
           return (
             <button
-              key={name}
+              key={opt.mode}
               type="button"
-              onClick={() => setTheme(name)}
+              onClick={() => setMode(opt.mode)}
               aria-pressed={active}
               className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-left transition-colors ${
                 active
@@ -36,20 +37,37 @@ export function ThemeSection() {
                   : "border-hairline-strong bg-surface text-muted-foreground hover:border-hairline-strong hover:text-foreground"
               }`}
             >
-              {/* Swatch: the theme's terminal bg framed by its accent so
-                  the choice is recognisable without applying it. */}
-              <span
-                className="h-5 w-5 shrink-0 rounded border-2"
-                style={{
-                  backgroundColor: t.palette.terminalBackground,
-                  borderColor: t.palette.tokens.ring,
-                }}
-              />
-              <span className="text-sm">{t.label}</span>
+              <Swatch swatch={opt.swatch} />
+              <span className="text-sm">{opt.label}</span>
             </button>
           );
         })}
       </div>
     </section>
+  );
+}
+
+// A recognisable preview of a mode's colours without applying it. A concrete
+// theme (light / dark) shows its terminal bg framed by its accent ring; the
+// `system` mode (no single colour) shows a split of the two it chooses between.
+function Swatch({ swatch }: { swatch: (typeof THEME_MODE_OPTIONS)[number]["swatch"] }) {
+  if (swatch === null) {
+    const dark = THEMES.tokyonight.palette.terminalBackground;
+    const light = THEMES.light.palette.terminalBackground;
+    return (
+      <span
+        aria-hidden="true"
+        className="h-5 w-5 shrink-0 rounded border-2 border-hairline-strong"
+        style={{ background: `linear-gradient(135deg, ${dark} 0 50%, ${light} 50% 100%)` }}
+      />
+    );
+  }
+  const t = THEMES[swatch];
+  return (
+    <span
+      aria-hidden="true"
+      className="h-5 w-5 shrink-0 rounded border-2"
+      style={{ backgroundColor: t.palette.terminalBackground, borderColor: t.palette.tokens.ring }}
+    />
   );
 }

--- a/clients/react/src/components/settings/__tests__/ThemeSection.test.tsx
+++ b/clients/react/src/components/settings/__tests__/ThemeSection.test.tsx
@@ -5,40 +5,53 @@ import { UI_PREFS_STORAGE_KEY } from "@/lib/ui-prefs";
 import { renderWithProviders } from "@/test/render";
 import { ThemeSection } from "../ThemeSection";
 
-describe("ThemeSection", () => {
+function storedMode(): string | undefined {
+  return JSON.parse(localStorage.getItem(UI_PREFS_STORAGE_KEY) ?? "{}").themeMode;
+}
+
+describe("ThemeSection — System / Light / Dark mode picker", () => {
   beforeEach(() => {
     localStorage.clear();
   });
 
-  it("shows Tokyo Night selected by default, with Zinc and the Day theme available", () => {
+  it("offers exactly System / Light / Dark, with System selected by default", () => {
     renderWithProviders(<ThemeSection />);
-    // Exact-anchored so it doesn't also match "Tokyo Night Day".
-    expect(screen.getByRole("button", { name: /^Tokyo Night$/ }).getAttribute("aria-pressed")).toBe(
+    expect(screen.getByRole("button", { name: /System/ }).getAttribute("aria-pressed")).toBe(
       "true",
     );
-    expect(screen.getByRole("button", { name: /Zinc/ }).getAttribute("aria-pressed")).toBe("false");
-    expect(
-      screen.getByRole("button", { name: /Tokyo Night Day/ }).getAttribute("aria-pressed"),
-    ).toBe("false");
+    expect(screen.getByRole("button", { name: /^Light$/ }).getAttribute("aria-pressed")).toBe(
+      "false",
+    );
+    expect(screen.getByRole("button", { name: /^Dark$/ }).getAttribute("aria-pressed")).toBe(
+      "false",
+    );
   });
 
-  it("persists a Zinc selection to the ui-prefs blob and reflects it", () => {
+  it("persists a Dark selection to the ui-prefs blob and reflects it", () => {
     renderWithProviders(<ThemeSection />);
-
-    fireEvent.click(screen.getByRole("button", { name: /Zinc/ }));
-
-    expect(screen.getByRole("button", { name: /Zinc/ }).getAttribute("aria-pressed")).toBe("true");
-    expect(JSON.parse(localStorage.getItem(UI_PREFS_STORAGE_KEY) ?? "{}").theme).toBe("zinc");
+    fireEvent.click(screen.getByRole("button", { name: /^Dark$/ }));
+    expect(screen.getByRole("button", { name: /^Dark$/ }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+    expect(storedMode()).toBe("dark");
   });
 
-  it("the migration landed: the light theme is selectable and persists", () => {
+  it("persists a Light selection", () => {
     renderWithProviders(<ThemeSection />);
+    fireEvent.click(screen.getByRole("button", { name: /^Light$/ }));
+    expect(screen.getByRole("button", { name: /^Light$/ }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+    expect(storedMode()).toBe("light");
+  });
 
-    fireEvent.click(screen.getByRole("button", { name: /Tokyo Night Day/ }));
-
-    expect(
-      screen.getByRole("button", { name: /Tokyo Night Day/ }).getAttribute("aria-pressed"),
-    ).toBe("true");
-    expect(JSON.parse(localStorage.getItem(UI_PREFS_STORAGE_KEY) ?? "{}").theme).toBe("light");
+  it("can return to System (follow the OS)", () => {
+    renderWithProviders(<ThemeSection />);
+    fireEvent.click(screen.getByRole("button", { name: /^Dark$/ }));
+    fireEvent.click(screen.getByRole("button", { name: /System/ }));
+    expect(screen.getByRole("button", { name: /System/ }).getAttribute("aria-pressed")).toBe(
+      "true",
+    );
+    expect(storedMode()).toBe("system");
   });
 });

--- a/clients/react/src/hooks/__tests__/useTerminal-theme.test.tsx
+++ b/clients/react/src/hooks/__tests__/useTerminal-theme.test.tsx
@@ -65,7 +65,7 @@ globalThis.ResizeObserver = function ResizeObserver() {
   return { observe: vi.fn(), disconnect: vi.fn(), unobserve: vi.fn() };
 } as unknown as typeof ResizeObserver;
 
-import { THEMES, toXtermTheme } from "@/lib/theme";
+import { THEMES, themeCssVars, toXtermTheme } from "@/lib/theme";
 import { UIPrefsProvider, useUIPref } from "@/lib/ui-prefs-provider";
 import { useApplyTheme } from "../useActiveTheme";
 import { useTerminal } from "../useTerminal";
@@ -74,13 +74,13 @@ function Harness() {
   const containerRef = useRef<HTMLDivElement>(null);
   useApplyTheme(); // CSS-var surface (rest of the UI)
   useTerminal({ agentId: "claude:x", containerRef }); // terminal surface
-  const [, setTheme] = useUIPref("theme");
+  const [, setMode] = useUIPref("themeMode");
   const [, setFont] = useUIPref("terminalFontSize");
   return (
     <div>
       <div ref={containerRef} />
-      <button type="button" onClick={() => setTheme("zinc")}>
-        to-zinc
+      <button type="button" onClick={() => setMode("light")}>
+        to-light
       </button>
       <button type="button" onClick={() => setFont(20)}>
         font-20
@@ -120,22 +120,22 @@ describe("theme drives both surfaces (single source)", () => {
     expect(document.documentElement.dataset.theme).toBe("tokyonight");
   });
 
-  it("switching the theme pref live-updates both surfaces", () => {
+  it("switching the theme mode live-updates both surfaces", () => {
     render(
       <UIPrefsProvider>
         <Harness />
       </UIPrefsProvider>,
     );
 
-    fireEvent.click(screen.getByText("to-zinc"));
+    fireEvent.click(screen.getByText("to-light"));
 
-    // Terminal surface rebuilt with the zinc ITheme (no ANSI overrides).
-    expect(lastTheme()).toEqual(toXtermTheme(THEMES.zinc));
-    // Rest-of-UI surface flipped to zinc's verbatim OKLch tokens.
+    // Terminal surface rebuilt with the light (Tokyo Night Day) ITheme.
+    expect(lastTheme()).toEqual(toXtermTheme(THEMES.light));
+    // Rest-of-UI surface flipped to the light theme's tokens.
     expect(document.documentElement.style.getPropertyValue("--color-background")).toBe(
-      "oklch(0.145 0 0)",
+      themeCssVars(THEMES.light)["--color-background"],
     );
-    expect(document.documentElement.dataset.theme).toBe("zinc");
+    expect(document.documentElement.dataset.theme).toBe("light");
   });
 
   it("uses the ui-prefs terminal font size and updates it live without a rebuild", () => {

--- a/clients/react/src/hooks/useActiveTheme.ts
+++ b/clients/react/src/hooks/useActiveTheme.ts
@@ -5,18 +5,35 @@
 // vars onto <html> so the whole UI re-skins live (no reload) whenever the
 // pref changes — it is mounted once near the App root.
 
-import { useEffect } from "react";
-import { applyThemeToDocument, resolveTheme, type Theme } from "@/lib/theme";
+import { useEffect, useSyncExternalStore } from "react";
+import {
+  applyThemeToDocument,
+  resolveTheme,
+  resolveThemeMode,
+  subscribeSystemPrefersLight,
+  systemPrefersLight,
+  type Theme,
+} from "@/lib/theme";
 import { loadUIPrefs } from "@/lib/ui-prefs";
 import { useUIPrefsOptional } from "@/lib/ui-prefs-provider";
 
+// The OS `prefers-color-scheme` as live React state. When the mode is
+// `system`, an OS appearance flip re-renders consumers (and re-applies the
+// theme) with no reload. `getServerSnapshot` returns false (dark) for any
+// non-browser render.
+export function useSystemPrefersLight(): boolean {
+  return useSyncExternalStore(subscribeSystemPrefersLight, systemPrefersLight, () => false);
+}
+
 export function useActiveTheme(): Theme {
-  // When a provider is present (the real app) this is reactive: changing
-  // the `theme` pref re-renders consumers. Without one (isolated terminal
-  // unit tests) fall back to the persisted / default value.
+  // When a provider is present (the real app) this is reactive: changing the
+  // `themeMode` pref re-renders consumers. Without one (isolated terminal unit
+  // tests) fall back to the persisted / default value. The mode resolves to a
+  // concrete theme via the OS signal when `system`.
   const ctx = useUIPrefsOptional();
-  const name = ctx ? ctx.prefs.theme : loadUIPrefs().theme;
-  return resolveTheme(name);
+  const mode = ctx ? ctx.prefs.themeMode : loadUIPrefs().themeMode;
+  const prefersLight = useSystemPrefersLight();
+  return resolveTheme(resolveThemeMode(mode, prefersLight));
 }
 
 export function useApplyTheme(): Theme {

--- a/clients/react/src/lib/__tests__/theme.test.ts
+++ b/clients/react/src/lib/__tests__/theme.test.ts
@@ -2,9 +2,14 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   applyThemeToDocument,
+  DEFAULT_THEME_MODE,
   DEFAULT_THEME_NAME,
   resolveTheme,
+  resolveThemeMode,
   SEMANTIC_TOKENS,
+  systemPrefersLight,
+  THEME_MODE_OPTIONS,
+  THEME_MODES,
   THEME_NAMES,
   THEMES,
   themeCssVars,
@@ -37,6 +42,70 @@ describe("theme registry", () => {
     // migrating onto semantic tokens (Settings switcher + ui-prefs
     // validation both key off THEME_NAMES).
     expect(THEME_NAMES as readonly string[]).toEqual(["tokyonight", "zinc", "light"]);
+  });
+});
+
+describe("theme MODE (System / Light / Dark)", () => {
+  it("offers exactly the three user-facing modes, default system", () => {
+    expect(THEME_MODES as readonly string[]).toEqual(["system", "light", "dark"]);
+    expect(DEFAULT_THEME_MODE).toBe("system");
+  });
+
+  it("pins light → light and dark → the current dark set (tokyonight), OS-agnostic", () => {
+    // Pinned modes ignore the OS signal entirely.
+    expect(resolveThemeMode("light", false)).toBe("light");
+    expect(resolveThemeMode("light", true)).toBe("light");
+    expect(resolveThemeMode("dark", false)).toBe("tokyonight");
+    expect(resolveThemeMode("dark", true)).toBe("tokyonight");
+  });
+
+  it("follows the OS signal under `system`", () => {
+    expect(resolveThemeMode("system", true)).toBe("light");
+    expect(resolveThemeMode("system", false)).toBe("tokyonight");
+  });
+
+  it("maps each picker option to the theme its swatch previews", () => {
+    const byMode = Object.fromEntries(THEME_MODE_OPTIONS.map((o) => [o.mode, o]));
+    expect(byMode.system.swatch).toBeNull(); // split swatch, no single colour
+    expect(byMode.light.swatch).toBe("light");
+    expect(byMode.dark.swatch).toBe("tokyonight");
+    expect(THEME_MODE_OPTIONS.map((o) => o.label)).toEqual(["System", "Light", "Dark"]);
+  });
+});
+
+describe("systemPrefersLight — OS prefers-color-scheme read", () => {
+  const realMatchMedia = window.matchMedia;
+  beforeEach(() => {
+    window.matchMedia = realMatchMedia;
+  });
+
+  function stubMatchMedia(lightMatches: boolean): void {
+    window.matchMedia = ((query: string) => ({
+      matches: query.includes("light") ? lightMatches : false,
+      media: query,
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      addListener: () => {},
+      removeListener: () => {},
+      onchange: null,
+      dispatchEvent: () => false,
+    })) as unknown as typeof window.matchMedia;
+  }
+
+  it("reports the OS light preference when matchMedia matches", () => {
+    stubMatchMedia(true);
+    expect(systemPrefersLight()).toBe(true);
+  });
+
+  it("reports dark (false) when the OS prefers dark", () => {
+    stubMatchMedia(false);
+    expect(systemPrefersLight()).toBe(false);
+  });
+
+  it("falls back to dark (false) when matchMedia is unavailable", () => {
+    // Some environments (older jsdom, SSR) lack matchMedia — must not throw.
+    (window as { matchMedia?: unknown }).matchMedia = undefined;
+    expect(systemPrefersLight()).toBe(false);
   });
 });
 

--- a/clients/react/src/lib/__tests__/ui-prefs.test.ts
+++ b/clients/react/src/lib/__tests__/ui-prefs.test.ts
@@ -17,23 +17,23 @@ describe("ui-prefs", () => {
     expect(loadUIPrefs()).toEqual(DEFAULT_UI_PREFS);
   });
 
-  it("defaults the theme to tokyonight (matches the operator's tmux)", () => {
-    expect(loadUIPrefs().theme).toBe("tokyonight");
+  it("defaults the theme mode to system (follow the OS appearance)", () => {
+    expect(loadUIPrefs().themeMode).toBe("system");
   });
 
-  it("round-trips a theme selection through localStorage", () => {
-    saveUIPrefs({ ...DEFAULT_UI_PREFS, theme: "zinc" });
+  it("round-trips a theme-mode selection through localStorage", () => {
+    saveUIPrefs({ ...DEFAULT_UI_PREFS, themeMode: "light" });
     // Persisted to the consolidated blob, not a side key.
-    expect(JSON.parse(localStorage.getItem(UI_PREFS_STORAGE_KEY) ?? "{}").theme).toBe("zinc");
-    expect(loadUIPrefs().theme).toBe("zinc");
+    expect(JSON.parse(localStorage.getItem(UI_PREFS_STORAGE_KEY) ?? "{}").themeMode).toBe("light");
+    expect(loadUIPrefs().themeMode).toBe("light");
   });
 
-  it("falls back to the default theme for an unknown theme value", () => {
+  it("falls back to the default mode for an unknown theme-mode value", () => {
     localStorage.setItem(
       UI_PREFS_STORAGE_KEY,
-      JSON.stringify({ ...DEFAULT_UI_PREFS, theme: "midnight" }),
+      JSON.stringify({ ...DEFAULT_UI_PREFS, themeMode: "midnight" }),
     );
-    expect(loadUIPrefs().theme).toBe(DEFAULT_UI_PREFS.theme);
+    expect(loadUIPrefs().themeMode).toBe(DEFAULT_UI_PREFS.themeMode);
   });
 
   it("defaults the terminal font size to 13 and round-trips a change", () => {
@@ -100,7 +100,7 @@ describe("ui-prefs", () => {
   it("round-trips a saved blob", () => {
     const next: UIPrefs = {
       ...DEFAULT_UI_PREFS,
-      theme: "zinc",
+      themeMode: "dark",
       terminalFontSize: 18,
       attentionStripWidth: 440,
       attentionStripCollapsed: true,
@@ -109,13 +109,13 @@ describe("ui-prefs", () => {
     expect(loadUIPrefs()).toEqual(next);
   });
 
-  it("falls back to defaults for an invalid theme without nuking siblings", () => {
+  it("falls back to defaults for an invalid theme mode without nuking siblings", () => {
     localStorage.setItem(
       UI_PREFS_STORAGE_KEY,
-      JSON.stringify({ theme: "garbage", terminalFontSize: 18, attentionStripWidth: 440 }),
+      JSON.stringify({ themeMode: "garbage", terminalFontSize: 18, attentionStripWidth: 440 }),
     );
     const loaded = loadUIPrefs();
-    expect(loaded.theme).toBe(DEFAULT_UI_PREFS.theme);
+    expect(loaded.themeMode).toBe(DEFAULT_UI_PREFS.themeMode);
     expect(loaded.terminalFontSize).toBe(18);
     expect(loaded.attentionStripWidth).toBe(440);
   });
@@ -187,10 +187,10 @@ describe("ui-prefs", () => {
   });
 
   it("does not sweep legacy keys when a consolidated blob already exists", () => {
-    saveUIPrefs({ ...DEFAULT_UI_PREFS, theme: "zinc" });
+    saveUIPrefs({ ...DEFAULT_UI_PREFS, themeMode: "dark" });
     localStorage.setItem("tmai:split-ratio", "0.7");
     const loaded = loadUIPrefs();
-    expect(loaded.theme).toBe("zinc");
+    expect(loaded.themeMode).toBe("dark");
     // Legacy key is left in place since the sweep only fires when the new blob is absent.
     expect(localStorage.getItem("tmai:split-ratio")).toBe("0.7");
   });

--- a/clients/react/src/lib/theme.ts
+++ b/clients/react/src/lib/theme.ts
@@ -38,6 +38,70 @@ export type ThemeName = (typeof THEME_NAMES)[number];
 // tmux out of the box.
 export const DEFAULT_THEME_NAME: ThemeName = "tokyonight";
 
+// ── theme MODE (the user-facing System / Light / Dark choice) ──────────────
+// The settings switcher stores a *mode*, not a resolved theme name: the
+// operator picks intent — follow the OS, or pin light / dark — and the app
+// resolves it to a concrete `ThemeName` at apply time. "dark" is the current
+// dark colour set (Tokyo Night); "light" is Tokyo Night Day; "system" follows
+// the OS `prefers-color-scheme`. (`zinc` stays in the registry + `resolveTheme`
+// for anyone who has it persisted, but is no longer offered in the picker.)
+//
+// Stored in the ui-prefs localStorage blob (provisional — a later tmai-core
+// config field may pick it up; until then it is purely browser-side, like
+// every other ui-pref).
+export const THEME_MODES = ["system", "light", "dark"] as const;
+export type ThemeMode = (typeof THEME_MODES)[number];
+
+// New installs follow the OS appearance out of the box.
+export const DEFAULT_THEME_MODE: ThemeMode = "system";
+
+// The concrete themes a mode resolves to.
+const DARK_THEME_NAME: ThemeName = "tokyonight";
+const LIGHT_THEME_NAME: ThemeName = "light";
+
+// Per-mode descriptor for the settings picker, so the mode→theme mapping lives
+// in ONE place (this module) instead of being re-derived in the UI. `swatch`
+// is the theme whose colours preview the mode; `null` (system) renders a
+// split dark/light swatch since it has no single colour.
+export interface ThemeModeOption {
+  mode: ThemeMode;
+  label: string;
+  swatch: ThemeName | null;
+}
+export const THEME_MODE_OPTIONS: readonly ThemeModeOption[] = [
+  { mode: "system", label: "System", swatch: null },
+  { mode: "light", label: "Light", swatch: LIGHT_THEME_NAME },
+  { mode: "dark", label: "Dark", swatch: DARK_THEME_NAME },
+];
+
+// Resolve a mode to a concrete theme name. `prefersLight` is the OS signal,
+// passed IN (not read here) so this stays pure + SSR/test-safe — the caller
+// owns the matchMedia read via `systemPrefersLight()` /
+// `useSystemPrefersLight()`.
+export function resolveThemeMode(mode: ThemeMode, prefersLight: boolean): ThemeName {
+  if (mode === "light") return LIGHT_THEME_NAME;
+  if (mode === "dark") return DARK_THEME_NAME;
+  return prefersLight ? LIGHT_THEME_NAME : DARK_THEME_NAME;
+}
+
+// The OS appearance, read once. Guarded for non-browser / matchMedia-less
+// environments (returns false ⇒ dark, matching the dark default). The query
+// is `light` so any absence falls back to dark.
+export function systemPrefersLight(): boolean {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return false;
+  return window.matchMedia("(prefers-color-scheme: light)").matches;
+}
+
+// Subscribe to OS appearance changes (shaped for `useSyncExternalStore`).
+// No-op when matchMedia is unavailable. Uses the same `addEventListener`
+// pattern as `useResponsiveLayout`.
+export function subscribeSystemPrefersLight(onChange: () => void): () => void {
+  if (typeof window === "undefined" || typeof window.matchMedia !== "function") return () => {};
+  const mql = window.matchMedia("(prefers-color-scheme: light)");
+  mql.addEventListener("change", onChange);
+  return () => mql.removeEventListener("change", onChange);
+}
+
 // The Tailwind semantic tokens, as their `--color-<name>` custom-property
 // suffix. Iterated by `themeCssVars` so the css-var emission and the
 // `Theme` shape can never fall out of sync.

--- a/clients/react/src/lib/ui-prefs.ts
+++ b/clients/react/src/lib/ui-prefs.ts
@@ -8,7 +8,7 @@
 // `tmai:ui:prefs` localStorage key so cross-tab sync (storage events)
 // fires once per change instead of once per field.
 
-import { DEFAULT_THEME_NAME, THEME_NAMES, type ThemeName } from "@/lib/theme";
+import { DEFAULT_THEME_MODE, THEME_MODES, type ThemeMode } from "@/lib/theme";
 
 // Which mode the Aim panel (◎ Aims, Stage B convergence) opens in. `frontier`
 // = the owed worklist (default — the load-bearing thesis: the panel is a WRITE
@@ -59,9 +59,12 @@ export interface RemoteDeltaCursor {
 }
 
 export interface UIPrefs {
-  // WebUI colour theme. Presentation-only; lives here (not in tmai-core
-  // config / api-spec) by the same convention as every other field.
-  theme: ThemeName;
+  // WebUI colour-theme MODE — the System / Light / Dark intent the operator
+  // picks (resolved to a concrete theme at apply time via resolveThemeMode +
+  // the OS prefers-color-scheme). Presentation-only; lives here (not in
+  // tmai-core config / api-spec) by the same convention as every other field.
+  // Provisional store: a later core config field may pick this up.
+  themeMode: ThemeMode;
   // xterm font size (px). Presentation-only, browser-side; replaces the
   // old hardcoded `fontSize: 13` in useTerminal.
   terminalFontSize: number;
@@ -128,7 +131,7 @@ export const AIM_CONSOLE_LAYOUT_DEFAULTS: AimConsoleLayout = {
 };
 
 export const DEFAULT_UI_PREFS: UIPrefs = {
-  theme: DEFAULT_THEME_NAME,
+  themeMode: DEFAULT_THEME_MODE,
   terminalFontSize: 13,
   attentionStripCollapsed: false,
   attentionStripWidth: ATTENTION_STRIP_WIDTH_DEFAULT,
@@ -141,7 +144,7 @@ export const DEFAULT_UI_PREFS: UIPrefs = {
 
 export const UI_PREFS_STORAGE_KEY = "tmai:ui:prefs";
 
-const VALID_THEMES: readonly ThemeName[] = THEME_NAMES;
+const VALID_THEME_MODES: readonly ThemeMode[] = THEME_MODES;
 
 // Keep the terminal legible and the layout sane at the extremes.
 export const TERMINAL_FONT_SIZE_MIN = 8;
@@ -265,9 +268,9 @@ function coercePrefs(raw: unknown): UIPrefs {
   if (raw === null || typeof raw !== "object") return { ...DEFAULT_UI_PREFS };
   const r = raw as Record<string, unknown>;
   return {
-    theme: VALID_THEMES.includes(r.theme as ThemeName)
-      ? (r.theme as ThemeName)
-      : DEFAULT_UI_PREFS.theme,
+    themeMode: VALID_THEME_MODES.includes(r.themeMode as ThemeMode)
+      ? (r.themeMode as ThemeMode)
+      : DEFAULT_UI_PREFS.themeMode,
     terminalFontSize: clampFontSize(r.terminalFontSize, DEFAULT_UI_PREFS.terminalFontSize),
     attentionStripCollapsed:
       typeof r.attentionStripCollapsed === "boolean"

--- a/clients/react/src/main.tsx
+++ b/clients/react/src/main.tsx
@@ -2,17 +2,22 @@ import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import { ConfirmProvider } from "@/components/layout/ConfirmDialog";
 import { SSEProvider } from "@/lib/sse-provider";
-import { applyThemeToDocument, resolveTheme } from "@/lib/theme";
+import {
+  applyThemeToDocument,
+  resolveTheme,
+  resolveThemeMode,
+  systemPrefersLight,
+} from "@/lib/theme";
 import { loadUIPrefs } from "@/lib/ui-prefs";
 import { UIPrefsProvider } from "@/lib/ui-prefs-provider";
 import { App } from "./App";
 import "./styles/globals.css";
 
-// Apply the persisted theme synchronously, before the first React paint,
-// so a non-default theme (e.g. zinc) doesn't flash the tokyonight `@theme`
-// defaults for a frame. `useApplyTheme` (in App) takes over for live
-// switching after mount.
-applyThemeToDocument(resolveTheme(loadUIPrefs().theme));
+// Resolve + apply the persisted theme MODE synchronously, before the first
+// React paint, so a non-dark choice (light, or system on a light OS) doesn't
+// flash the tokyonight `@theme` defaults for a frame. `useApplyTheme` (in App)
+// takes over for live switching + OS-appearance changes after mount.
+applyThemeToDocument(resolveTheme(resolveThemeMode(loadUIPrefs().themeMode, systemPrefersLight())));
 
 // biome-ignore lint/style/noNonNullAssertion: root element guaranteed by index.html
 createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
## What

Replaces the raw theme-name picker (Tokyo Night / Zinc / Day) with the **System / Light / Dark** mode triple the operator actually reasons about, defaulting to **System** (follow the OS appearance). Dark keeps the current colour set unchanged.

## How

- **`lib/theme.ts`**: new `ThemeMode = "system" | "light" | "dark"`, `DEFAULT_THEME_MODE = "system"`, and `resolveThemeMode(mode, prefersLight)`:
  - `dark` → `tokyonight` (the **current** dark set, unchanged)
  - `light` → `light` (Tokyo Night Day)
  - `system` → OS `prefers-color-scheme`
  - `systemPrefersLight()` / `subscribeSystemPrefersLight()` are guarded `matchMedia` helpers — fall back to **dark** when matchMedia is absent (old jsdom / SSR), so the default is never light by accident.
- **ui-prefs**: the stored field is now `themeMode` (default `system`). The resolved `ThemeName` is **computed, not stored** — no vestigial second field. `zinc` stays in the registry + `resolveTheme` for anyone who has it persisted, but is no longer offered in the picker.
- **`useActiveTheme`**: resolves mode + OS via `useSyncExternalStore`, so an OS appearance flip re-skins **live** under System with no reload. Provider-less terminal unit tests keep working (server snapshot = dark).
- **First paint** (`main.tsx`, `aim-offline.tsx`): resolves the mode synchronously so a light / system-light choice doesn't flash dark for a frame.
- **`ThemeSection`**: a 3-way mode picker; `System` renders a split dark/light swatch (it has no single colour).

Store stays **browser-side localStorage** (provisional — a later tmai-core config field may pick it up; per the user's framing).

## ⚠ Scope boundary — the aim console (default surface) stays dark

This re-skins every **semantic-token** surface: the producer console, settings, dialogs, and the terminal palette. The **aim console** — currently the *default* surface — paints from its own **hardcoded dark dev-tool tokens** in `styles/aim-console.css` (`--bg`, `--cyan`, …), which do **not** derive from the theme. So under **Light** (or System-on-a-light-OS) the aim console remains dark while the rest goes light.

Making the aim console themeable is a **separate design task** (a light dev-tool palette has to be designed, then `aim-console.css` taught to branch on `data-theme` / derive from the theme vars). Left for a follow-up so this PR stays a clean, reversible wiring change. Flagging explicitly rather than shipping a silent half-light surface.

## Verify

- New/updated tests: `resolveThemeMode` (pinned vs system), `systemPrefersLight` (matchMedia stub + absence), ui-prefs `themeMode` round-trip/coercion, `ThemeSection` 3-way picker, `useTerminal` live mode switch.
- Local: affected suite 55 green, `tsc -b` green, biome clean. Full suite: the only failure is the pre-existing Windows-only `no-raw-palette` path bug (fixed independently in #908), unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
