### PR TITLE
feat(aim-console): conversation-anchor layout — reorder + Remote overlay/dock

### DIFF
--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -37,13 +37,14 @@ import type { AgentSnapshot, SlotResponse, TriggerHandoffRitualRequest } from "@
 import {
   AIM_CONSOLE_LAYOUT_DEFAULTS,
   type AimConsoleLayout,
+  clampAimConsoleConvWidth,
   clampAimConsolePrWidth,
   normalizeAimConsoleLayout,
 } from "@/lib/ui-prefs";
 import { useUIPref } from "@/lib/ui-prefs-provider";
 import { cn } from "@/lib/utils";
 import { AimPane } from "./AimPane";
-import { AimSessionGutter, SessionPrGutter } from "./Gutters";
+import { AimRemoteGutter, ConvAimGutter } from "./Gutters";
 import { PrRail } from "./PrRail";
 import { SessionPane } from "./SessionPane";
 // Bundled dev-tool typography (offline-robust @fontsource, NOT a Google Fonts
@@ -118,12 +119,17 @@ export function AimConsole({
   trigger,
   onOpenSettings,
 }: AimConsoleProps) {
-  // PR-rail expand state — the S1 shell's mechanism. The collapsed 46px rail
-  // expands via the `.pr-open` modifier on the root + the inline `--pr`
-  // (S7: the persisted drag width, 320px default). The state stays HERE;
-  // `PrRail` only renders the rail/panel CONTENT (S5) and calls back to
-  // toggle it.
-  const [prOpen, setPrOpen] = useState(false);
+  // Remote-panel state (root-layout `conversation-anchor`). The collapsed 46px
+  // rail (right edge) `remoteOpen`s to the Remote panel. The DEFAULT open mode
+  // is an OVERLAY drawer that floats over the right of the Aim pane — the
+  // Conversation (left, fixed-px anchor) and Aim columns do NOT reflow, so the
+  // operator's fixation point never shifts. `remoteDocked` is the transient
+  // opt-in to push the Aim pane aside instead (both visible side-by-side); it
+  // resets to overlay on close (no persisted mode — a momentary need, not a
+  // standing preference). The state stays HERE; `PrRail` renders the
+  // rail/panel CONTENT and calls back to toggle.
+  const [remoteOpen, setRemoteOpen] = useState(false);
+  const [remoteDocked, setRemoteDocked] = useState(false);
   const metaUnit = activeUnitName ?? units[0]?.name ?? "—";
   // The focused unit's repos drive the Session pane's per-repo bash footer
   // tabs (S4). A cwd-synthesized unit isn't in the configured membership, so
@@ -145,54 +151,58 @@ export function AimConsole({
     activeUnitName === null ? null : effectiveCursor(cursors, activeUnitName, "prs");
   const issuesCursor =
     activeUnitName === null ? null : effectiveCursor(cursors, activeUnitName, "issues");
-  // Rail-collapse close act: stamp the unit's `panel` cursor (the "when the
-  // operator last stopped looking" timestamp), then collapse. Expanding the rail
-  // is the START of looking, not a close act, so `onExpand` stays the plain
-  // `setPrOpen(true)`.
-  const collapseRail = useCallback(() => {
+  // Remote-collapse close act: stamp the unit's `panel` cursor (the "when the
+  // operator last stopped looking" timestamp), then collapse + reset the dock
+  // mode to the overlay default. Expanding is the START of looking, not a close
+  // act, so opening stays the plain `setRemoteOpen(true)`.
+  const collapseRemote = useCallback(() => {
     if (activeUnitName !== null) {
       setCursors(advanceCursor(cursors, activeUnitName, "panel", new Date().toISOString()));
     }
-    setPrOpen(false);
+    setRemoteOpen(false);
+    setRemoteDocked(false);
   }, [activeUnitName, cursors, setCursors]);
 
-  // S7 drag-resizable layout. The persisted pref IS the layout state — a drag
+  // Drag-resizable layout. The persisted pref IS the layout state — a drag
   // adjusts the custom properties imperatively (no re-render per move, see
   // `Gutters`) and commits here once on pointerup; the committed values then
   // render as the same inline custom properties, so React reconciliation and
   // the imperative drag agree. `null` = untouched → defaults.
   const [storedLayout, setStoredLayout] = useUIPref("aimConsoleLayout");
   const layout: AimConsoleLayout = storedLayout ?? AIM_CONSOLE_LAYOUT_DEFAULTS;
+  const conv = clampAimConsoleConvWidth(layout.conv);
+  const pr = clampAimConsolePrWidth(layout.pr);
   const layoutStyle = {
-    "--aim": `${layout.aim}fr`,
-    "--sess": `${layout.sess}fr`,
-    // Collapsed rail: leave `--pr` to the stylesheet's 46px so the stored
-    // expanded width survives without driving the collapsed track.
-    "--pr": prOpen ? `${clampAimConsolePrWidth(layout.pr)}px` : undefined,
+    // Conversation anchor width (capped to 62vw live so a wide value never
+    // starves the Aim + Remote side on a small window).
+    "--conv": `${conv}px`,
+    // Drives the overlay drawer width + the docked Remote track only while open;
+    // collapsed leaves it to the stylesheet's 46px rail so the stored open width
+    // survives a collapse.
+    "--pr": remoteOpen ? `${pr}px` : undefined,
   } as CSSProperties;
 
-  const commitPanes = useCallback(
-    (aim: number, sess: number) =>
+  const commitConv = useCallback(
+    (c: number) =>
       setStoredLayout(
-        normalizeAimConsoleLayout({ ...(storedLayout ?? AIM_CONSOLE_LAYOUT_DEFAULTS), aim, sess }),
+        normalizeAimConsoleLayout({ ...(storedLayout ?? AIM_CONSOLE_LAYOUT_DEFAULTS), conv: c }),
       ),
     [storedLayout, setStoredLayout],
   );
-  const resetPanes = useCallback(
+  const resetConv = useCallback(
     () =>
       setStoredLayout(
         normalizeAimConsoleLayout({
           ...(storedLayout ?? AIM_CONSOLE_LAYOUT_DEFAULTS),
-          aim: AIM_CONSOLE_LAYOUT_DEFAULTS.aim,
-          sess: AIM_CONSOLE_LAYOUT_DEFAULTS.sess,
+          conv: AIM_CONSOLE_LAYOUT_DEFAULTS.conv,
         }),
       ),
     [storedLayout, setStoredLayout],
   );
   const commitPr = useCallback(
-    (pr: number) =>
+    (prPx: number) =>
       setStoredLayout(
-        normalizeAimConsoleLayout({ ...(storedLayout ?? AIM_CONSOLE_LAYOUT_DEFAULTS), pr }),
+        normalizeAimConsoleLayout({ ...(storedLayout ?? AIM_CONSOLE_LAYOUT_DEFAULTS), pr: prPx }),
       ),
     [storedLayout, setStoredLayout],
   );
@@ -209,7 +219,11 @@ export function AimConsole({
 
   return (
     <div
-      className={cn("aim-console", prOpen && "pr-open")}
+      className={cn(
+        "aim-console",
+        remoteOpen && "remote-open",
+        remoteOpen && remoteDocked && "remote-dock",
+      )}
       data-testid="aim-console"
       style={layoutStyle}
     >
@@ -249,21 +263,14 @@ export function AimConsole({
         </button>
       </div>
 
-      {/* ── 3-pane grid + 5px gutter tracks (S7) ── */}
+      {/* ── 3-pane grid (Conversation anchor | Aim | Remote) + gutters ──
+          Order: Conversation LEFT (the fixed-px fixation anchor) → Aim MIDDLE
+          (1fr, the sole absorber) → Remote RIGHT (rail / overlay / docked). So
+          opening / docking the Remote only ever moves the Aim pane; the
+          conversation never shifts. `.ac-main` is the positioned ancestor the
+          overlay drawer floats over (see aim-console.css). */}
       <div className="ac-main">
-        {/* AIM — S2 worklist (Frontier⊥Tree, ledger, ruler, inspector, modal) */}
-        <section className="ac-col ac-aim" aria-label="Aim">
-          <AimPane unitName={activeUnitName} />
-        </section>
-
-        {/* gutter A — Aim|Session */}
-        <AimSessionGutter
-          aimShare={(layout.aim / (layout.aim + layout.sess)) * 100}
-          onCommit={commitPanes}
-          onReset={resetPanes}
-        />
-
-        {/* SESSION — S3 conversation (tabs + shead + term) + S4 bash footer */}
+        {/* CONVERSATION — the anchor (tabs + shead + term + S4 bash footer) */}
         <section className="ac-col ac-session" aria-label="Session">
           <SessionPane
             agents={agents}
@@ -275,24 +282,35 @@ export function AimConsole({
           />
         </section>
 
-        {/* gutter B — Session|PR (inert while the rail is collapsed) */}
-        <SessionPrGutter
-          open={prOpen}
-          prWidth={clampAimConsolePrWidth(layout.pr)}
+        {/* gutter A — Conversation|Aim (resizes the anchor width) */}
+        <ConvAimGutter convWidth={conv} onCommit={commitConv} onReset={resetConv} />
+
+        {/* AIM — worklist (Frontier⊥Tree, ledger, ruler, inspector, modal) */}
+        <section className="ac-col ac-aim" aria-label="Aim">
+          <AimPane unitName={activeUnitName} />
+        </section>
+
+        {/* gutter B — Aim|Remote (only active while the Remote is DOCKED;
+            inert as a 0px collapsed/overlay track) */}
+        <AimRemoteGutter
+          active={remoteOpen && remoteDocked}
+          prWidth={pr}
           onCommit={commitPr}
           onReset={resetPr}
         />
 
-        {/* PR RAIL — collapsed rail ⇄ expanded panel (S1 mechanism); the
-            per-repo PR + Issue lists + live counts are the real S5 content */}
+        {/* REMOTE — collapsed rail ⇄ overlay drawer ⇄ docked column. The
+            per-repo PR + Issue lists + live counts + remote-Δ are the content. */}
         <section className="ac-col ac-pr" aria-label="PR / Issue rail">
           <PrRail
             unitName={activeUnitName}
             unitLabel={metaUnit}
             repos={activeUnit?.repos ?? []}
-            open={prOpen}
-            onExpand={() => setPrOpen(true)}
-            onCollapse={collapseRail}
+            open={remoteOpen}
+            docked={remoteOpen && remoteDocked}
+            onExpand={() => setRemoteOpen(true)}
+            onCollapse={collapseRemote}
+            onToggleDock={() => setRemoteDocked((d) => !d)}
             prsCursor={prsCursor}
             issuesCursor={issuesCursor}
           />

--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -30,7 +30,7 @@
 // from the persisted `aimConsoleLayout` ui-pref, and drag end (not per-move)
 // writes it back.
 
-import { type CSSProperties, useCallback, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useState } from "react";
 import { useConfirm } from "@/components/layout/ConfirmDialog";
 import { advanceCursor, effectiveCursor } from "@/components/producer-console/r-panel/remote-delta";
 import type { AgentSnapshot, SlotResponse, TriggerHandoffRitualRequest } from "@/lib/api";
@@ -162,6 +162,22 @@ export function AimConsole({
     setRemoteOpen(false);
     setRemoteDocked(false);
   }, [activeUnitName, cursors, setCursors]);
+
+  // Click-outside-to-close, OVERLAY ONLY. The overlay is a transient peek with
+  // no ✕ — a pointerdown anywhere outside the floating drawer collapses it
+  // (which stamps the close-act cursor via `collapseRemote`). A docked Remote
+  // is a deliberate side-by-side and is NOT dismissed by outside clicks (it has
+  // its own ✕); clicks INSIDE the drawer (incl. the ⊟/⊞ toggle) never close.
+  useEffect(() => {
+    if (!remoteOpen || remoteDocked) return;
+    const onPointerDown = (e: PointerEvent) => {
+      const target = e.target as Element | null;
+      if (target?.closest(".ac-prfull")) return;
+      collapseRemote();
+    };
+    document.addEventListener("pointerdown", onPointerDown, true);
+    return () => document.removeEventListener("pointerdown", onPointerDown, true);
+  }, [remoteOpen, remoteDocked, collapseRemote]);
 
   // Drag-resizable layout. The persisted pref IS the layout state — a drag
   // adjusts the custom properties imperatively (no re-render per move, see

--- a/clients/react/src/components/aim-console/Gutters.tsx
+++ b/clients/react/src/components/aim-console/Gutters.tsx
@@ -22,18 +22,19 @@
 
 import { useCallback, useRef, useState } from "react";
 import {
+  AIM_CONSOLE_CONV_WIDTH_MAX,
+  AIM_CONSOLE_CONV_WIDTH_MIN,
   AIM_CONSOLE_FOOTER_MIN,
   AIM_CONSOLE_PR_WIDTH_MAX,
   AIM_CONSOLE_PR_WIDTH_MIN,
+  clampAimConsoleConvWidth,
   clampAimConsolePrWidth,
 } from "@/lib/ui-prefs";
 import { cn } from "@/lib/utils";
 
-// Drag clamps (mock gutA/gutF): pane floors keep the Aim worklist and the
-// Session conversation usable at the extremes; the footer may take at most
-// 60% of the Session pane so the conversation never collapses under it.
-export const AIM_PANE_MIN_PX = 230;
-export const SESSION_PANE_MIN_PX = 300;
+// The footer may take at most 60% of the Session pane so the conversation
+// never collapses under it. (The pane-width floors now live in the ui-prefs
+// conv / pr clamps the gutters call directly.)
 export const FOOTER_MAX_SESSION_RATIO = 0.6;
 
 interface ReadoutState {
@@ -157,51 +158,42 @@ function rootOf(gutter: HTMLElement): HTMLElement | null {
   return gutter.closest<HTMLElement>(".aim-console");
 }
 
-/** Gutter A — Aim|Session. Rewrites BOTH fr tracks from the live px split
- *  (mock gutA), so the two panes keep window-scaling after the drag while
- *  honouring the px floors at drag time. `aimShare` (the committed Aim share
- *  of the two panes, 0–100) feeds aria-valuenow. */
-export function AimSessionGutter({
-  aimShare,
+/** Gutter A — Conversation|Aim. Rewrites `--conv` (the Conversation anchor
+ *  width in px) from the live drag, clamped to the storage bounds (the CSS
+ *  applies the live 62vw ceiling on top). `convWidth` (the committed anchor
+ *  width) feeds aria-valuenow. */
+export function ConvAimGutter({
+  convWidth,
   onCommit,
   onReset,
 }: {
-  aimShare: number;
-  onCommit: (aim: number, sess: number) => void;
+  convWidth: number;
+  onCommit: (conv: number) => void;
   onReset: () => void;
 }) {
-  const measureRef = useRef({ aim0: 0, total: 0 });
-  const valueRef = useRef<{ aim: number; sess: number } | null>(null);
+  const conv0Ref = useRef(0);
+  const valueRef = useRef<number | null>(null);
 
   const onStart = useCallback((gutter: HTMLElement) => {
-    const root = rootOf(gutter);
-    const aimEl = root?.querySelector(".ac-aim");
-    const sessEl = root?.querySelector(".ac-session");
-    if (!aimEl || !sessEl) return false;
-    const aim0 = aimEl.getBoundingClientRect().width;
-    const total = aim0 + sessEl.getBoundingClientRect().width;
-    if (total <= 0) return false;
-    measureRef.current = { aim0, total };
+    const sessEl = rootOf(gutter)?.querySelector(".ac-session");
+    if (!sessEl) return false;
+    const conv0 = sessEl.getBoundingClientRect().width;
+    if (conv0 <= 0) return false;
+    conv0Ref.current = conv0;
     valueRef.current = null;
     return true;
   }, []);
 
   const onMove = useCallback((gutter: HTMLElement, delta: number) => {
-    const { aim0, total } = measureRef.current;
-    const aim = Math.round(
-      Math.min(Math.max(aim0 + delta, AIM_PANE_MIN_PX), total - SESSION_PANE_MIN_PX),
-    );
-    const sess = Math.round(total) - aim;
-    valueRef.current = { aim, sess };
-    const root = rootOf(gutter);
-    root?.style.setProperty("--aim", `${aim}fr`);
-    root?.style.setProperty("--sess", `${sess}fr`);
-    return `aim ${aim}px · sess ${sess}px`;
+    // Dragging right widens the conversation anchor.
+    const conv = clampAimConsoleConvWidth(conv0Ref.current + delta);
+    valueRef.current = conv;
+    rootOf(gutter)?.style.setProperty("--conv", `${conv}px`);
+    return `conv ${conv}px`;
   }, []);
 
   const onEnd = useCallback(() => {
-    const v = valueRef.current;
-    if (v) onCommit(v.aim, v.sess);
+    if (valueRef.current !== null) onCommit(valueRef.current);
   }, [onCommit]);
 
   const { live, readout, handlers } = useGutterDrag({ axis: "x", onStart, onMove, onEnd, onReset });
@@ -213,10 +205,10 @@ export function AimSessionGutter({
       role="separator"
       tabIndex={0}
       aria-orientation="vertical"
-      aria-label="Resize Aim / Session panes"
-      aria-valuenow={Math.round(aimShare)}
-      aria-valuemin={0}
-      aria-valuemax={100}
+      aria-label="Resize Conversation / Aim panes"
+      aria-valuenow={Math.round(convWidth)}
+      aria-valuemin={AIM_CONSOLE_CONV_WIDTH_MIN}
+      aria-valuemax={AIM_CONSOLE_CONV_WIDTH_MAX}
       title="Drag to resize · double-click to reset"
       {...handlers}
     >
@@ -225,16 +217,17 @@ export function AimSessionGutter({
   );
 }
 
-/** Gutter B — Session|PR rail. Adjusts `--pr` (px) while the rail is open;
- *  inert (`off`) while it is collapsed to the 46px rail (mock gutB).
- *  `prWidth` (the committed rail width) feeds aria-valuenow. */
-export function SessionPrGutter({
-  open,
+/** Gutter B — Aim|Remote. Adjusts `--pr` (px) while the Remote is DOCKED;
+ *  inert (`off`) while collapsed or overlaid (the overlay drawer carries its
+ *  own edge handle). `prWidth` (the committed Remote width) feeds
+ *  aria-valuenow. */
+export function AimRemoteGutter({
+  active,
   prWidth,
   onCommit,
   onReset,
 }: {
-  open: boolean;
+  active: boolean;
   prWidth: number;
   onCommit: (pr: number) => void;
   onReset: () => void;
@@ -251,11 +244,11 @@ export function SessionPrGutter({
   }, []);
 
   const onMove = useCallback((gutter: HTMLElement, delta: number) => {
-    // The rail grows leftwards: pointer left = wider rail.
+    // The Remote grows leftwards: pointer left = wider panel.
     const pr = clampAimConsolePrWidth(pr0Ref.current - delta);
     valueRef.current = pr;
     rootOf(gutter)?.style.setProperty("--pr", `${pr}px`);
-    return `pr ${pr}px`;
+    return `remote ${pr}px`;
   }, []);
 
   const onEnd = useCallback(() => {
@@ -264,7 +257,7 @@ export function SessionPrGutter({
 
   const { live, readout, handlers } = useGutterDrag({
     axis: "x",
-    disabled: !open,
+    disabled: !active,
     onStart,
     onMove,
     onEnd,
@@ -274,16 +267,16 @@ export function SessionPrGutter({
   return (
     // biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter (RPanel precedent)
     <div
-      className={cn("ac-vgut", !open && "off", live && "live")}
+      className={cn("ac-vgut", !active && "off", live && "live")}
       role="separator"
-      tabIndex={open ? 0 : -1}
+      tabIndex={active ? 0 : -1}
       aria-orientation="vertical"
-      aria-label="Resize PR rail"
-      aria-disabled={!open}
+      aria-label="Resize Remote panel"
+      aria-disabled={!active}
       aria-valuenow={Math.round(prWidth)}
       aria-valuemin={AIM_CONSOLE_PR_WIDTH_MIN}
       aria-valuemax={AIM_CONSOLE_PR_WIDTH_MAX}
-      title={open ? "Drag to resize · double-click to reset" : undefined}
+      title={active ? "Drag to resize · double-click to reset" : undefined}
       {...handlers}
     >
       <ReadoutChip readout={readout} />

--- a/clients/react/src/components/aim-console/PrRail.tsx
+++ b/clients/react/src/components/aim-console/PrRail.tsx
@@ -181,7 +181,7 @@ export function PrRail({
       {/* ── expanded panel (per-repo PR + Issue inventory) ── */}
       <div className="ac-prfull">
         <div className="ac-prh">
-          PR / ISSUE — unit {unitLabel} · {repos.length} repos
+          {/* Dock ⇄ float toggle at the TOP-LEFT (⊟ overlay → ⊞ docked). */}
           {onToggleDock !== undefined && (
             <button
               type="button"
@@ -198,15 +198,22 @@ export function PrRail({
               {docked ? "⊞" : "⊟"}
             </button>
           )}
-          <button
-            type="button"
-            className="ac-x"
-            onClick={onCollapse}
-            title="Collapse PR / Issue rail"
-            aria-label="Collapse PR / Issue rail"
-          >
-            ✕
-          </button>
+          <span className="ac-prh-title">
+            PR / ISSUE — unit {unitLabel} · {repos.length} repos
+          </span>
+          {/* Explicit close ONLY when docked — the overlay closes by clicking
+              outside it (AimConsole), so it carries no ✕. */}
+          {docked === true && (
+            <button
+              type="button"
+              className="ac-x"
+              onClick={onCollapse}
+              title="Collapse PR / Issue rail"
+              aria-label="Collapse PR / Issue rail"
+            >
+              ✕
+            </button>
+          )}
         </div>
         <div className="ac-prb">
           <PrGroup repos={prRepos} count={openPrCount} cursor={prsCursor} />

--- a/clients/react/src/components/aim-console/PrRail.tsx
+++ b/clients/react/src/components/aim-console/PrRail.tsx
@@ -79,15 +79,20 @@ interface PrRailProps {
    *  count. Empty for a cwd-synthesized unit (same convention as the S4
    *  bash footer's fallback). */
   repos: UnitRepoWire[];
-  /** Whether the rail is expanded — drives `aria-expanded` on the collapsed
-   *  rail button. The actual show/hide is the root's `.pr-open` display
-   *  toggle (S1), untouched here. */
+  /** Whether the Remote panel is expanded — drives `aria-expanded` on the
+   *  collapsed rail button. The actual show/hide + overlay/dock positioning is
+   *  the root's `.remote-open` / `.remote-dock` classes (AimConsole), not here. */
   open: boolean;
-  /** The S1 mechanism's `setPrOpen(true)` (collapsed rail click) /
-   *  `setPrOpen(false)` (✕), threaded in so the open state stays in
-   *  `AimConsole`. */
+  /** Whether the open panel is DOCKED (push, both panes visible) vs the default
+   *  OVERLAY (floats over the Aim pane). Drives the dock-toggle pressed state. */
+  docked?: boolean;
+  /** `setRemoteOpen(true)` (collapsed rail click) / collapse (✕), threaded in so
+   *  the open state stays in `AimConsole`. */
   onExpand: () => void;
   onCollapse: () => void;
+  /** Toggle dock ⇄ overlay for the open panel (the ⊟ control). Absent in
+   *  isolation renders → the control is not shown. */
+  onToggleDock?: () => void;
   /** Remote-Δ effective cursor for the PRs / Issues sections (#822), each =
    *  MAX(unit panel close, that section's close), threaded from `AimConsole`
    *  (which owns the shared `remoteDeltaCursors` ui-pref). `null` = no close
@@ -115,8 +120,10 @@ export function PrRail({
   unitLabel,
   repos,
   open,
+  docked,
   onExpand,
   onCollapse,
+  onToggleDock,
   prsCursor,
   issuesCursor,
 }: PrRailProps) {
@@ -175,6 +182,22 @@ export function PrRail({
       <div className="ac-prfull">
         <div className="ac-prh">
           PR / ISSUE — unit {unitLabel} · {repos.length} repos
+          {onToggleDock !== undefined && (
+            <button
+              type="button"
+              className={cn("ac-prdock", docked && "on")}
+              onClick={onToggleDock}
+              aria-pressed={docked === true}
+              title={
+                docked
+                  ? "Float — overlay the Remote panel over the Aim pane"
+                  : "Dock — push the Aim pane aside so both stay visible"
+              }
+              aria-label={docked ? "Float the Remote panel (overlay)" : "Dock the Remote panel"}
+            >
+              {docked ? "⊞" : "⊟"}
+            </button>
+          )}
           <button
             type="button"
             className="ac-x"

--- a/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
@@ -115,19 +115,31 @@ describe("AimConsole — S1 shell", () => {
     expect(pills[1].getAttribute("data-primary")).toBe("false");
   });
 
-  it("expands and collapses the PR rail (the S1 transition, via .pr-open)", () => {
+  it("opens the Remote as an OVERLAY by default; ⊟ docks it; ✕ collapses + resets to overlay", () => {
     renderConsole();
     const root = screen.getByTestId("aim-console");
-    // Collapsed by default.
-    expect(root.className).not.toContain("pr-open");
+    // Collapsed by default — neither open nor docked.
+    expect(root.className).not.toContain("remote-open");
+    expect(root.className).not.toContain("remote-dock");
 
-    // Click the collapsed rail → expands.
+    // Click the collapsed rail → opens as the default OVERLAY (open, not docked).
     fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
-    expect(root.className).toContain("pr-open");
+    expect(root.className).toContain("remote-open");
+    expect(root.className).not.toContain("remote-dock");
 
-    // The expanded panel's close (✕) → collapses again.
+    // ⊟ docks (push the Aim aside — both visible).
+    fireEvent.click(screen.getByRole("button", { name: "Dock the Remote panel" }));
+    expect(root.className).toContain("remote-dock");
+    // ⊞ floats it back to overlay.
+    fireEvent.click(screen.getByRole("button", { name: "Float the Remote panel (overlay)" }));
+    expect(root.className).not.toContain("remote-dock");
+
+    // Re-dock, then collapse: ✕ closes AND resets the mode to overlay default.
+    fireEvent.click(screen.getByRole("button", { name: "Dock the Remote panel" }));
+    expect(root.className).toContain("remote-dock");
     fireEvent.click(screen.getByRole("button", { name: "Collapse PR / Issue rail" }));
-    expect(root.className).not.toContain("pr-open");
+    expect(root.className).not.toContain("remote-open");
+    expect(root.className).not.toContain("remote-dock");
   });
 
   it("calls onSelectUnit / onAddUnit / onExit from the top bar", () => {

--- a/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
@@ -182,12 +182,16 @@ describe("AimConsole — remote-Δ close act (#606 §1, default surface)", () =>
     return raw === null ? {} : (JSON.parse(raw).remoteDeltaCursors ?? {});
   }
 
-  it("stamps the focused unit's panel cursor on rail collapse (the close act)", async () => {
+  it("stamps the focused unit's panel cursor on close (the close act)", async () => {
     localStorage.clear();
     renderConsole({ activeUnitName: "tmai" });
-    // Expand (start looking — NOT a close act) then collapse (the close act).
+    // Expand (start looking — NOT a close act) then close. The default open mode
+    // is OVERLAY, which closes by clicking OUTSIDE the drawer (no ✕).
     fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
-    fireEvent.click(screen.getByRole("button", { name: "Collapse PR / Issue rail" }));
+    expect(screen.getByTestId("aim-console").className).toContain("remote-open");
+    fireEvent.pointerDown(screen.getByLabelText("Aim"));
+    // The outside click collapses the overlay (and stamps the close-act cursor).
+    expect(screen.getByTestId("aim-console").className).not.toContain("remote-open");
     await waitFor(() => {
       expect(typeof readCursors().tmai?.panel).toBe("string");
     });
@@ -199,10 +203,23 @@ describe("AimConsole — remote-Δ close act (#606 §1, default surface)", () =>
     // must key on the real focus, so no cursor is written.
     renderConsole({ activeUnitName: null });
     fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
-    fireEvent.click(screen.getByRole("button", { name: "Collapse PR / Issue rail" }));
+    fireEvent.pointerDown(screen.getByLabelText("Aim"));
     await waitFor(() => {
       // The pref blob persists on mount; remoteDeltaCursors must stay empty.
       expect(Object.keys(readCursors())).toHaveLength(0);
     });
+  });
+
+  it("does NOT close a DOCKED Remote on an outside click (only overlay does)", () => {
+    localStorage.clear();
+    renderConsole({ activeUnitName: "tmai" });
+    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
+    fireEvent.click(screen.getByRole("button", { name: "Dock the Remote panel" }));
+    const root = screen.getByTestId("aim-console");
+    expect(root.className).toContain("remote-dock");
+    // Docked is a deliberate side-by-side — an outside click leaves it open.
+    fireEvent.pointerDown(screen.getByLabelText("Aim"));
+    expect(root.className).toContain("remote-open");
+    expect(root.className).toContain("remote-dock");
   });
 });

--- a/clients/react/src/components/aim-console/__tests__/Gutters.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/Gutters.test.tsx
@@ -112,92 +112,97 @@ beforeEach(() => {
   vi.restoreAllMocks();
 });
 
-describe("AimSessionGutter — Aim|Session pane gutter", () => {
+describe("ConvAimGutter — Conversation|Aim pane gutter", () => {
   function setup() {
     renderConsole();
     const root = screen.getByTestId("aim-console");
-    stubRect(root.querySelector(".ac-aim") as Element, { width: 590 });
-    stubRect(root.querySelector(".ac-session") as Element, { width: 500 });
-    const sep = screen.getByRole("separator", { name: "Resize Aim / Session panes" });
+    stubRect(root.querySelector(".ac-session") as Element, { width: 700 });
+    const sep = screen.getByRole("separator", { name: "Resize Conversation / Aim panes" });
     return { root, sep };
   }
 
-  it("rewrites --aim/--sess per move and persists ONCE on pointerup", () => {
+  it("rewrites --conv per move and persists ONCE on pointerup", () => {
     const { root, sep } = setup();
-    fireEvent.pointerDown(sep, { clientX: 600, clientY: 300, pointerId: 1, button: 0 });
-    fireEvent.pointerMove(sep, { clientX: 650, clientY: 300, pointerId: 1 });
+    fireEvent.pointerDown(sep, { clientX: 700, clientY: 300, pointerId: 1, button: 0 });
+    fireEvent.pointerMove(sep, { clientX: 760, clientY: 300, pointerId: 1 });
 
-    // Live: the fr tracks follow the pointer (590+50 / 500-50 of total 1090)…
-    expect(root.style.getPropertyValue("--aim")).toBe("640fr");
-    expect(root.style.getPropertyValue("--sess")).toBe("450fr");
+    // Live: the conversation anchor widens with the pointer (700 + 60)…
+    expect(root.style.getPropertyValue("--conv")).toBe("760px");
     // …with the mono readout chip showing the live px…
-    expect(screen.getByTestId("ac-gutter-readout").textContent).toBe("aim 640px · sess 450px");
+    expect(screen.getByTestId("ac-gutter-readout").textContent).toBe("conv 760px");
     // …but NOTHING persisted yet (written on drag end, not per-move).
     expect(storedLayout()).toBeNull();
 
-    fireEvent.pointerUp(sep, { clientX: 650, clientY: 300, pointerId: 1 });
-    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, aim: 640, sess: 450 });
-    // The chip is gone once the drag ends.
+    fireEvent.pointerUp(sep, { clientX: 760, clientY: 300, pointerId: 1 });
+    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, conv: 760 });
     expect(screen.queryByTestId("ac-gutter-readout")).toBeNull();
   });
 
-  it("clamps at both ends: aim >= 230px and session >= 300px", () => {
+  it("clamps the anchor width to [360, 1400]px", () => {
     const { root, sep } = setup();
-    // Far left: aim floors at 230 (total 1090 → sess 860).
-    drag(sep, { x: 600, y: 300 }, { x: 0, y: 300 });
-    expect(root.style.getPropertyValue("--aim")).toBe("230fr");
-    expect(root.style.getPropertyValue("--sess")).toBe("860fr");
-
-    // Far right: session floors at 300 (aim caps at 1090-300=790).
-    drag(sep, { x: 600, y: 300 }, { x: 1900, y: 300 });
-    expect(root.style.getPropertyValue("--aim")).toBe("790fr");
-    expect(root.style.getPropertyValue("--sess")).toBe("300fr");
-    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, aim: 790, sess: 300 });
+    // Far left: conv floors at 360.
+    drag(sep, { x: 700, y: 300 }, { x: 0, y: 300 });
+    expect(root.style.getPropertyValue("--conv")).toBe("360px");
+    // Far right: conv caps at 1400.
+    drag(sep, { x: 700, y: 300 }, { x: 2400, y: 300 });
+    expect(root.style.getPropertyValue("--conv")).toBe("1400px");
+    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, conv: 1400 });
   });
 
-  it("double-click resets to the defaults and clears the stored layout", () => {
+  it("double-click resets to the default anchor width and clears the stored layout", () => {
     const { root, sep } = setup();
-    drag(sep, { x: 600, y: 300 }, { x: 650, y: 300 });
+    drag(sep, { x: 700, y: 300 }, { x: 760, y: 300 });
     expect(storedLayout()).not.toBeNull();
 
     fireEvent.doubleClick(sep);
-    // Back to the untouched defaults — stored layout CLEARED, not re-pinned.
     expect(storedLayout()).toBeNull();
-    expect(root.style.getPropertyValue("--aim")).toBe("1.18fr");
-    expect(root.style.getPropertyValue("--sess")).toBe("1fr");
+    expect(root.style.getPropertyValue("--conv")).toBe("720px");
   });
 });
 
-describe("SessionPrGutter — Session|PR rail gutter", () => {
-  it("is inert while the rail is collapsed", () => {
+describe("AimRemoteGutter — Aim|Remote gutter (docked only)", () => {
+  // Open the Remote, then dock it (the gutter is inert while collapsed AND
+  // while overlaid — only the docked column is drag-resizable).
+  function openAndDock() {
+    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
+    fireEvent.click(screen.getByRole("button", { name: "Dock the Remote panel" }));
+  }
+
+  it("is inert while the Remote is collapsed", () => {
     renderConsole();
     const root = screen.getByTestId("aim-console");
-    const sep = screen.getByRole("separator", { name: "Resize PR rail" });
+    const sep = screen.getByRole("separator", { name: "Resize Remote panel" });
     expect(sep.className).toContain("off");
-
     stubRect(root.querySelector(".ac-pr") as Element, { width: 46 });
     drag(sep, { x: 1000, y: 300 }, { x: 900, y: 300 });
     fireEvent.doubleClick(sep);
-    // No live track write, no persistence — the gutter ignored everything.
     expect(root.style.getPropertyValue("--pr")).toBe("");
     expect(storedLayout()).toBeNull();
   });
 
-  it("drags the open rail within 240–520px and persists on pointerup", () => {
+  it("is inert while the Remote is OVERLAID (open but not docked)", () => {
+    renderConsole();
+    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
+    const sep = screen.getByRole("separator", { name: "Resize Remote panel" });
+    // Overlay is the default open mode — the edge gutter stays inert.
+    expect(sep.className).toContain("off");
+  });
+
+  it("drags the docked Remote within 240–520px and persists on pointerup", () => {
     renderConsole();
     const root = screen.getByTestId("aim-console");
-    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
-    // Open: the inline --pr carries the persisted (default) width.
-    expect(root.style.getPropertyValue("--pr")).toBe("320px");
+    openAndDock();
+    // Open carries the persisted (default) width.
+    expect(root.style.getPropertyValue("--pr")).toBe("360px");
 
-    const sep = screen.getByRole("separator", { name: "Resize PR rail" });
+    const sep = screen.getByRole("separator", { name: "Resize Remote panel" });
     expect(sep.className).not.toContain("off");
-    stubRect(root.querySelector(".ac-pr") as Element, { width: 320 });
+    stubRect(root.querySelector(".ac-pr") as Element, { width: 360 });
 
-    // Pointer left = wider rail: 320 - (-100) = 420.
+    // Pointer left = wider panel: 360 - (-100) = 460.
     drag(sep, { x: 1000, y: 300 }, { x: 900, y: 300 });
-    expect(root.style.getPropertyValue("--pr")).toBe("420px");
-    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, pr: 420 });
+    expect(root.style.getPropertyValue("--pr")).toBe("460px");
+    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, pr: 460 });
 
     // Clamp floor (240) and ceiling (520).
     drag(sep, { x: 1000, y: 300 }, { x: 1900, y: 300 });
@@ -206,10 +211,9 @@ describe("SessionPrGutter — Session|PR rail gutter", () => {
     expect(root.style.getPropertyValue("--pr")).toBe("520px");
     expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, pr: 520 });
 
-    // Double-click resets the rail width (and clears the all-default blob).
     fireEvent.doubleClick(sep);
     expect(storedLayout()).toBeNull();
-    expect(root.style.getPropertyValue("--pr")).toBe("320px");
+    expect(root.style.getPropertyValue("--pr")).toBe("360px");
   });
 });
 
@@ -308,13 +312,13 @@ describe("FooterGutter — bash-footer height gutter", () => {
 });
 
 describe("aimConsoleLayout prefs round-trip", () => {
-  it("restores a stored layout on mount (panes, rail, footer)", () => {
-    seedLayout({ aim: 700, sess: 380, pr: 400, footer: 240 });
+  it("restores a stored layout on mount (anchor, remote, footer)", () => {
+    seedLayout({ conv: 820, pr: 400, footer: 240 });
     renderConsole();
     const root = screen.getByTestId("aim-console");
-    expect(root.style.getPropertyValue("--aim")).toBe("700fr");
-    expect(root.style.getPropertyValue("--sess")).toBe("380fr");
-    // The rail width applies once the rail opens.
+    // The conversation anchor applies immediately.
+    expect(root.style.getPropertyValue("--conv")).toBe("820px");
+    // The Remote width applies once it opens.
     expect(root.style.getPropertyValue("--pr")).toBe("");
     fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
     expect(root.style.getPropertyValue("--pr")).toBe("400px");
@@ -326,15 +330,10 @@ describe("aimConsoleLayout prefs round-trip", () => {
   it("coerces a corrupt / out-of-range stored layout on load", () => {
     localStorage.setItem(
       UI_PREFS_STORAGE_KEY,
-      JSON.stringify({ aimConsoleLayout: { aim: -3, sess: "x", pr: 9999, footer: 12 } }),
+      JSON.stringify({ aimConsoleLayout: { conv: 9999, pr: 9999, footer: 12 } }),
     );
-    // Bad fr weights fall back per-field; px values clamp to their windows.
-    expect(loadUIPrefs().aimConsoleLayout).toEqual({
-      aim: AIM_CONSOLE_LAYOUT_DEFAULTS.aim,
-      sess: AIM_CONSOLE_LAYOUT_DEFAULTS.sess,
-      pr: 520,
-      footer: 110,
-    });
+    // Out-of-range px values clamp to their windows (conv → 1400, pr → 520).
+    expect(loadUIPrefs().aimConsoleLayout).toEqual({ conv: 1400, pr: 520, footer: 110 });
 
     // A non-object blob (or an all-defaults one) normalises to null.
     localStorage.setItem(UI_PREFS_STORAGE_KEY, JSON.stringify({ aimConsoleLayout: "garbage" }));

--- a/clients/react/src/components/aim-console/__tests__/PrRail.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/PrRail.test.tsx
@@ -373,10 +373,56 @@ describe("PrRail — expand / collapse (S1 mechanism, threaded callbacks)", () =
     expect(props.onExpand).toHaveBeenCalledTimes(1);
   });
 
-  it("clicking the ✕ calls onCollapse", () => {
-    const props = renderRail({ open: true });
+  it("shows the ✕ ONLY when docked (the overlay closes by clicking outside)", () => {
+    // Overlay (open, not docked) — no ✕.
+    const { rerender } = render(
+      <PrRail
+        unitName="tmai"
+        unitLabel="tmai"
+        repos={REPOS}
+        open={true}
+        docked={false}
+        onExpand={vi.fn()}
+        onCollapse={vi.fn()}
+        onToggleDock={vi.fn()}
+      />,
+    );
+    expect(screen.queryByRole("button", { name: "Collapse PR / Issue rail" })).toBeNull();
+
+    // Docked — the ✕ appears and calls onCollapse.
+    const onCollapse = vi.fn();
+    rerender(
+      <PrRail
+        unitName="tmai"
+        unitLabel="tmai"
+        repos={REPOS}
+        open={true}
+        docked={true}
+        onExpand={vi.fn()}
+        onCollapse={onCollapse}
+        onToggleDock={vi.fn()}
+      />,
+    );
     fireEvent.click(screen.getByRole("button", { name: "Collapse PR / Issue rail" }));
-    expect(props.onCollapse).toHaveBeenCalledTimes(1);
+    expect(onCollapse).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the dock ⊟/⊞ toggle and calls onToggleDock", () => {
+    const onToggleDock = vi.fn();
+    render(
+      <PrRail
+        unitName="tmai"
+        unitLabel="tmai"
+        repos={REPOS}
+        open={true}
+        docked={false}
+        onExpand={vi.fn()}
+        onCollapse={vi.fn()}
+        onToggleDock={onToggleDock}
+      />,
+    );
+    fireEvent.click(screen.getByRole("button", { name: "Dock the Remote panel" }));
+    expect(onToggleDock).toHaveBeenCalledTimes(1);
   });
 
   it("reflects the open state on the rail's aria-expanded", () => {

--- a/clients/react/src/lib/ui-prefs.ts
+++ b/clients/react/src/lib/ui-prefs.ts
@@ -19,16 +19,19 @@ import { DEFAULT_THEME_MODE, THEME_MODES, type ThemeMode } from "@/lib/theme";
 export type AimMode = "frontier" | "tree";
 export const AIM_MODES: readonly AimMode[] = ["frontier", "tree"];
 
-// Drag-resized aim-console layout (S7). `aim`/`sess` are the pane fr WEIGHTS
-// (the live px captured at drag end, used as `Nfr` so the panes keep scaling
-// with the window); `pr` the expanded PR-rail width in px; `footer` the bash
-// footer's terminal-area height in px (the mock's `--fh`). `null` = never
-// dragged / reset — the console then uses AIM_CONSOLE_LAYOUT_DEFAULTS, and a
-// double-click reset stores `null` rather than a copy of the defaults so a
-// future default change reaches untouched layouts.
+// Drag-resized aim-console layout. `conv` is the Conversation (Session) pane's
+// width in PX — the fixed left-edge ANCHOR: it is the operator's continuous
+// fixation point, so expanding the Remote panel must never shift it. Keeping it
+// a fixed px (not an fr weight) makes the Aim pane (1fr) the sole absorber of
+// every Remote state change, so the conversation is structurally non-perturbable
+// (and a capped reading width is a feature for the chat column). `pr` is the
+// Remote panel's open width in px (overlay drawer + docked column); `footer` the
+// bash footer's terminal-area height in px. `null` = never dragged / reset — the
+// console then uses AIM_CONSOLE_LAYOUT_DEFAULTS, and a double-click reset stores
+// `null` rather than a copy of the defaults so a future default change reaches
+// untouched layouts.
 export interface AimConsoleLayout {
-  aim: number;
-  sess: number;
+  conv: number;
   pr: number;
   footer: number;
 }
@@ -116,6 +119,12 @@ export const ATTENTION_STRIP_WIDTH_DEFAULT = 320;
 export const AIM_CONSOLE_PR_WIDTH_MIN = 240;
 export const AIM_CONSOLE_PR_WIDTH_MAX = 520;
 export const AIM_CONSOLE_FOOTER_MIN = 110;
+// Conversation anchor width (px). Floor keeps it readable; ceiling is enforced
+// LIVE in CSS as a vw cap (clamp(...,62vw)) so a wide stored value never starves
+// the Aim + Remote side on a small window — storage only enforces the floor and
+// a sane absolute ceiling.
+export const AIM_CONSOLE_CONV_WIDTH_MIN = 360;
+export const AIM_CONSOLE_CONV_WIDTH_MAX = 1400;
 
 // aim-inspector (detail panel) drag-resize bounds (px). Floor-only: the
 // ceiling is a live 70vh cap applied in CSS (min(var, 70vh)), so storage only
@@ -124,9 +133,8 @@ export const AIM_INSPECTOR_HEIGHT_MIN = 140;
 export const AIM_INSPECTOR_HEIGHT_DEFAULT = 400;
 
 export const AIM_CONSOLE_LAYOUT_DEFAULTS: AimConsoleLayout = {
-  aim: 1.18,
-  sess: 1,
-  pr: 320,
+  conv: 720,
+  pr: 360,
   footer: 180,
 };
 
@@ -181,6 +189,18 @@ export function clampAimConsolePrWidth(value: number): number {
   return Math.max(AIM_CONSOLE_PR_WIDTH_MIN, Math.min(AIM_CONSOLE_PR_WIDTH_MAX, Math.round(value)));
 }
 
+// Conversation anchor width — same compose-with-coerce convention as the PR
+// width: the drag commit path clamps with the rule coerce applies on load. The
+// vw ceiling is applied LIVE in CSS, so this only enforces the px floor + a sane
+// absolute ceiling.
+export function clampAimConsoleConvWidth(value: number): number {
+  if (!Number.isFinite(value)) return AIM_CONSOLE_LAYOUT_DEFAULTS.conv;
+  return Math.max(
+    AIM_CONSOLE_CONV_WIDTH_MIN,
+    Math.min(AIM_CONSOLE_CONV_WIDTH_MAX, Math.round(value)),
+  );
+}
+
 // Floor-only: the footer's ceiling (60% of the Session pane) is a LIVE
 // measurement the storage layer cannot know — the console re-clamps it on
 // mount / drag / window resize.
@@ -201,30 +221,20 @@ export function clampAimInspectorHeight(value: number): number {
 // of today's defaults into every blob.
 export function normalizeAimConsoleLayout(layout: AimConsoleLayout): AimConsoleLayout | null {
   const d = AIM_CONSOLE_LAYOUT_DEFAULTS;
-  if (
-    layout.aim === d.aim &&
-    layout.sess === d.sess &&
-    layout.pr === d.pr &&
-    layout.footer === d.footer
-  ) {
+  if (layout.conv === d.conv && layout.pr === d.pr && layout.footer === d.footer) {
     return null;
   }
   return layout;
-}
-
-// Pane fr weights are free-form positive numbers (1.18 at rest, live px after
-// a drag) — only reject the degenerate ones that would zero out a pane.
-function coerceFrWeight(value: unknown, fallback: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return fallback;
-  return value;
 }
 
 function coerceAimConsoleLayout(value: unknown): AimConsoleLayout | null {
   if (value === null || value === undefined || typeof value !== "object") return null;
   const v = value as Record<string, unknown>;
   return normalizeAimConsoleLayout({
-    aim: coerceFrWeight(v.aim, AIM_CONSOLE_LAYOUT_DEFAULTS.aim),
-    sess: coerceFrWeight(v.sess, AIM_CONSOLE_LAYOUT_DEFAULTS.sess),
+    conv:
+      typeof v.conv === "number"
+        ? clampAimConsoleConvWidth(v.conv)
+        : AIM_CONSOLE_LAYOUT_DEFAULTS.conv,
     pr: typeof v.pr === "number" ? clampAimConsolePrWidth(v.pr) : AIM_CONSOLE_LAYOUT_DEFAULTS.pr,
     footer:
       typeof v.footer === "number"

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -1117,12 +1117,10 @@
   font-size: 10.5px;
   color: var(--dim);
 }
-/* Dock ⇄ float toggle (⊟ / ⊞), then the collapse ✕; the dock button carries
-   the margin so the pair sits flush-right (the ✕ keeps its own auto for the
-   isolation case where no dock control renders). */
+/* Dock ⇄ float toggle (⊟ / ⊞) sits at the TOP-LEFT of the header; the title
+   fills the middle; the collapse ✕ (docked only) goes flush-right. */
 .aim-console .ac-prh .ac-prdock {
-  margin-left: auto;
-  margin-right: 11px;
+  margin-right: 9px;
   border: none;
   background: transparent;
   color: inherit;
@@ -1135,8 +1133,15 @@
 .aim-console .ac-prh .ac-prdock.on {
   color: var(--cyan);
 }
+.aim-console .ac-prh .ac-prh-title {
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: ellipsis;
+}
 .aim-console .ac-prh .ac-x {
-  margin-left: auto;
+  margin-left: 9px;
   border: none;
   background: transparent;
   color: inherit;

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -251,9 +251,22 @@
    via the `--pr` change; a live drag suppresses the transition (below). */
 .aim-console .ac-main {
   display: grid;
-  grid-template-columns: var(--aim, 1.18fr) 5px var(--sess, 1fr) 5px var(--pr, 46px);
+  /* Conversation anchor (fixed px, capped to 62vw live) | gutA | Aim (1fr, the
+     sole absorber) | gutB (0px inert) | Remote rail (46px). The anchor is the
+     operator's fixation point — keeping it a fixed track and the Aim the only
+     fr track means opening / docking the Remote never shifts the conversation. */
+  grid-template-columns:
+    clamp(360px, var(--conv, 720px), 62vw) 5px minmax(0, 1fr) 0px 46px;
   min-height: 0;
+  /* Containing block for the overlay Remote drawer (see `.ac-prfull`). */
+  position: relative;
   transition: grid-template-columns 0.2s ease;
+}
+/* Docked Remote: gutB becomes a real 5px gutter and the Remote a --pr column;
+   the Aim (1fr) absorbs the width, so the conversation anchor still never moves. */
+.aim-console.remote-dock .ac-main {
+  grid-template-columns:
+    clamp(360px, var(--conv, 720px), 62vw) 5px minmax(0, 1fr) 5px var(--pr, 360px);
 }
 .aim-console .ac-col {
   min-width: 0;
@@ -1026,7 +1039,7 @@
   background: transparent;
   cursor: pointer;
 }
-.aim-console.pr-open .ac-prrail {
+.aim-console.remote-open .ac-prrail {
   display: none;
 }
 .aim-console .ac-prrail .ac-v {
@@ -1065,8 +1078,35 @@
   flex-direction: column;
   height: 100%;
 }
-.aim-console.pr-open .ac-prfull {
+/* Open = the default OVERLAY: the panel floats over the right of the Aim pane.
+   `.ac-pr` (the 46px rail track) becomes positioned + non-clipping so the panel
+   (abspos, width --pr) extends leftwards over the Aim without reflowing it —
+   the conversation + Aim columns don't move; only the Aim's right is covered. */
+.aim-console.remote-open .ac-pr {
+  position: relative;
+  overflow: visible;
+  z-index: 5;
+}
+.aim-console.remote-open .ac-prfull {
   display: flex;
+  position: absolute;
+  inset: 0 0 0 auto;
+  width: var(--pr, 360px);
+  background: var(--panel);
+  border-left: 1px solid var(--line);
+  box-shadow: -22px 0 46px -24px rgba(0, 0, 0, 0.5);
+}
+/* DOCKED: the panel sits in-flow, filling the --pr Remote column (the Aim pane
+   shrank to make room); no overlay float. */
+.aim-console.remote-dock .ac-pr {
+  position: static;
+  overflow: hidden;
+  z-index: auto;
+}
+.aim-console.remote-dock .ac-prfull {
+  position: static;
+  width: auto;
+  box-shadow: none;
 }
 .aim-console .ac-prh {
   display: flex;
@@ -1076,6 +1116,24 @@
   font-family: var(--mono);
   font-size: 10.5px;
   color: var(--dim);
+}
+/* Dock ⇄ float toggle (⊟ / ⊞), then the collapse ✕; the dock button carries
+   the margin so the pair sits flush-right (the ✕ keeps its own auto for the
+   isolation case where no dock control renders). */
+.aim-console .ac-prh .ac-prdock {
+  margin-left: auto;
+  margin-right: 11px;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: inherit;
+  cursor: pointer;
+}
+.aim-console .ac-prh .ac-prdock:hover {
+  color: var(--txt);
+}
+.aim-console .ac-prh .ac-prdock.on {
+  color: var(--cyan);
 }
 .aim-console .ac-prh .ac-x {
   margin-left: auto;
@@ -2568,4 +2626,9 @@
 /* modal drop shadow (dark #000) → soft cool shadow on light */
 [data-theme="light"] .aim-console .ac-modal {
   box-shadow: 0 24px 70px -22px rgba(39, 50, 48, 0.18);
+}
+
+/* Remote overlay drawer float shadow (dark rgba black) → soft cool on light */
+[data-theme="light"] .aim-console.remote-open .ac-prfull {
+  box-shadow: -22px 0 46px -24px rgba(39, 50, 48, 0.2);
 }


### PR DESCRIPTION
## What

Reworks the aim-console's **root layout** so the **Conversation pane — the operator's continuous fixation point — never shifts** when the Remote panel expands.

**Before:** `Aim | Conversation | Remote` (`1.18fr 1fr var(--pr)`). Opening the Remote rail re-shared the fr space, so the conversation both **shrank and slid** — a structural friction (a *centred* pane between two peripherals can't stay put when the right one expands, short of overlaying the conversation — the worse option).

## The invariant

> Conversation = the fixation anchor. Peripheral state changes (Aim, Remote) must neither shift it nor occlude it. Aim is the panel that *may* move/be-occluded.

This forces edge-anchoring the conversation (proof + design deliberation in the linked discussion). The settled design:

- **Reorder to `Conversation | Aim | Remote`.** The conversation is a **fixed-px anchor** (`--conv`, drag-resizable, clamped to 62vw live); the **Aim pane is the sole `1fr` absorber**; the Remote is the rightmost rail. Every Remote change is absorbed by Aim alone → the conversation is **structurally non-perturbable** (a capped chat width reads better too).
- **Remote opens as an OVERLAY by default (L2).** The panel floats (`position:absolute` over `.ac-main`) over the right of the Aim pane at its natural width — nothing reflows, the Aim's left peeks. (Occluding *Aim* is the low-cost case vs occluding the conversation.)
- **Dock (transient L1) via the ⊟ control.** Docking pushes the Aim aside so both stay visible (Remote → real `--pr` column, Aim shrinks); ⊞ floats back. **Not persisted** — resets to overlay on close (a momentary need, not a standing preference — avoids a vestigial mode setting + stale-mode hazard).

## Verify (with screenshots)

Visually verified via **headless Edge against the REAL AimConsole** — collapsed / overlay / dock, in light. **The conversation's left edge + width are identical across all three states.** In overlay the Remote floats over Aim's right (Aim's left peeks); in dock the Aim shrinks and the Remote is a full column. Screenshots shared with the author out-of-band.

- `tsc -b` + full suite green (**980 passed**, 0 failed); biome clean.

## Mechanics

`aimConsoleLayout` → `{conv, pr, footer}` (conv px replaces the aim/sess fr weights). `ConvAimGutter` resizes the anchor; `AimRemoteGutter` resizes the docked Remote (inert while collapsed/overlaid). `.ac-main` is the positioned ancestor; `.ac-pr` goes non-clipping in overlay so the drawer escapes its 46px track. Keys on `.remote-open` / `.remote-dock` classes (replacing `.pr-open`).

## Scope / follow-up

This is the **layout + overlay + button-dock**. The **drag-to-auto-dock** gesture (pull the overlay's edge past a threshold to snap into dock, drag back to undock) is a **fast follow-up** — the dock is already reachable via the ⊟ control here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * Aim Console のレイアウトが、会話・Aim・Remote の3列構成に刷新されました。
  * Remote パネルに、オーバーレイ表示とドッキング表示の切り替えが追加されました。
  * 会話ペインの幅や Remote 幅をドラッグで調整しやすくなりました。

* **バグ修正**
  * レイアウトの保存・復元が新しい構成に対応し、再表示時の崩れを改善しました。
  * ドラッグ時の幅制限やダブルクリックでの既定値復帰が一貫して動作するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->