### PR TITLE
feat(aim-console): drag-to-dock with an Aim-room guard + pending-flip feedback

### DIFF
--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -30,7 +30,7 @@
 // from the persisted `aimConsoleLayout` ui-pref, and drag end (not per-move)
 // writes it back.
 
-import { type CSSProperties, useCallback, useEffect, useState } from "react";
+import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
 import { useConfirm } from "@/components/layout/ConfirmDialog";
 import { advanceCursor, effectiveCursor } from "@/components/producer-console/r-panel/remote-delta";
 import type { AgentSnapshot, SlotResponse, TriggerHandoffRitualRequest } from "@/lib/api";
@@ -44,7 +44,7 @@ import {
 import { useUIPref } from "@/lib/ui-prefs-provider";
 import { cn } from "@/lib/utils";
 import { AimPane } from "./AimPane";
-import { AimRemoteGutter, ConvAimGutter } from "./Gutters";
+import { AimRemoteGutter, ConvAimGutter, OverlayEdgeGutter } from "./Gutters";
 import { PrRail } from "./PrRail";
 import { SessionPane } from "./SessionPane";
 // Bundled dev-tool typography (offline-robust @fontsource, NOT a Google Fonts
@@ -63,6 +63,27 @@ import "@fontsource/inter-tight/600.css";
 import "@fontsource/noto-sans-jp/400.css";
 import "@fontsource/noto-sans-jp/500.css";
 import "@/styles/aim-console.css";
+
+// Drag-to-dock GUARD: dock only delivers its value (Aim + Remote both visible
+// AND usable) when the Aim pane keeps a usable width. So the dock/overlay
+// boundary is not a fixed --pr threshold but "does the Remote still leave Aim
+// at least this many px?" — window- and conversation-width adaptive. Pull the
+// Remote so wide that Aim would drop below this floor and it stays/floats to
+// OVERLAY instead of docking; keep it narrow enough and it docks. (Tunable by
+// feel.)
+const DOCK_MIN_AIM_PX = 400;
+// Two 5px pane gutters sit between Conversation | Aim | Remote when docked.
+const DOCK_GUTTERS_PX = 10;
+
+// The widest Remote (`--pr`) that can dock while leaving Aim ≥ DOCK_MIN_AIM_PX,
+// measured live off the grid. Below/at this width docking fits; above it, Aim
+// would be crushed, so the Remote stays an overlay.
+function maxDockablePr(main: HTMLElement | null): number {
+  if (main === null) return Number.POSITIVE_INFINITY;
+  const consoleW = main.getBoundingClientRect().width;
+  const convW = main.querySelector(".ac-session")?.getBoundingClientRect().width ?? 0;
+  return consoleW - convW - DOCK_GUTTERS_PX - DOCK_MIN_AIM_PX;
+}
 
 function repoBasename(path: string): string {
   return path.split("/").filter(Boolean).pop() ?? path;
@@ -172,7 +193,9 @@ export function AimConsole({
     if (!remoteOpen || remoteDocked) return;
     const onPointerDown = (e: PointerEvent) => {
       const target = e.target as Element | null;
-      if (target?.closest(".ac-prfull")) return;
+      // Inside the drawer, OR on its drag-to-dock edge handle (which lives just
+      // outside the drawer) — not an "outside" click, don't close.
+      if (target?.closest(".ac-prfull") || target?.closest(".ac-ovgut")) return;
       collapseRemote();
     };
     document.addEventListener("pointerdown", onPointerDown, true);
@@ -233,6 +256,26 @@ export function AimConsole({
     [storedLayout, setStoredLayout],
   );
 
+  // Drag-to-dock (GUARD): committing the Remote width also snaps the mode by the
+  // Aim-room guard — dock IF the released width still leaves Aim ≥ the usable
+  // floor, else float to overlay. So dragging the Remote to a width that fits
+  // beside Aim docks it; dragging it so wide (or on a window/conversation too
+  // narrow) that Aim would be crushed keeps/pops it to overlay. Decided on
+  // release (not per-move) so the overlay never re-positions mid-drag. The ⊟/⊞
+  // button is a manual override (it toggles directly, ignoring the guard).
+  const mainRef = useRef<HTMLDivElement>(null);
+  const commitRemoteWidth = useCallback(
+    (finalPr: number) => {
+      commitPr(finalPr);
+      setRemoteDocked(finalPr <= maxDockablePr(mainRef.current));
+    },
+    [commitPr],
+  );
+  // Live preview during a drag: "would this width dock?" — the gutters use it to
+  // signal (amber seam + "release to dock/float" readout) when releasing now
+  // would FLIP the mode, so the threshold is legible mid-drag.
+  const previewDock = useCallback((prPx: number) => prPx <= maxDockablePr(mainRef.current), []);
+
   return (
     <div
       className={cn(
@@ -285,7 +328,7 @@ export function AimConsole({
           opening / docking the Remote only ever moves the Aim pane; the
           conversation never shifts. `.ac-main` is the positioned ancestor the
           overlay drawer floats over (see aim-console.css). */}
-      <div className="ac-main">
+      <div className="ac-main" ref={mainRef}>
         {/* CONVERSATION — the anchor (tabs + shead + term + S4 bash footer) */}
         <section className="ac-col ac-session" aria-label="Session">
           <SessionPane
@@ -306,13 +349,14 @@ export function AimConsole({
           <AimPane unitName={activeUnitName} />
         </section>
 
-        {/* gutter B — Aim|Remote (only active while the Remote is DOCKED;
-            inert as a 0px collapsed/overlay track) */}
+        {/* gutter B — Aim|Remote (active while DOCKED; resizing narrower than
+            the undock threshold floats it back to overlay on release) */}
         <AimRemoteGutter
           active={remoteOpen && remoteDocked}
           prWidth={pr}
-          onCommit={commitPr}
+          onCommit={commitRemoteWidth}
           onReset={resetPr}
+          previewDock={previewDock}
         />
 
         {/* REMOTE — collapsed rail ⇄ overlay drawer ⇄ docked column. The
@@ -331,6 +375,17 @@ export function AimConsole({
             issuesCursor={issuesCursor}
           />
         </section>
+
+        {/* Overlay edge handle — drag the floating drawer's left edge to resize;
+            pulled wider than the dock threshold, it snaps to DOCK on release. */}
+        {remoteOpen && !remoteDocked && (
+          <OverlayEdgeGutter
+            prWidth={pr}
+            onCommit={commitRemoteWidth}
+            onReset={resetPr}
+            previewDock={previewDock}
+          />
+        )}
       </div>
     </div>
   );

--- a/clients/react/src/components/aim-console/Gutters.tsx
+++ b/clients/react/src/components/aim-console/Gutters.tsx
@@ -217,6 +217,78 @@ export function ConvAimGutter({
   );
 }
 
+/** Overlay edge handle — the LEFT edge of the floating Remote overlay drawer.
+ *  Dragging it resizes the overlay width (`--pr`); on release AimConsole snaps
+ *  it to DOCK if it was pulled wide enough (the "drag-to-dock" gesture). Unlike
+ *  `AimRemoteGutter` (a grid track) this is absolutely positioned at the
+ *  drawer's left edge (`right: var(--pr)`), so it only exists while overlaid. */
+export function OverlayEdgeGutter({
+  prWidth,
+  onCommit,
+  onReset,
+  previewDock,
+}: {
+  prWidth: number;
+  onCommit: (pr: number) => void;
+  onReset: () => void;
+  previewDock: (pr: number) => boolean;
+}) {
+  const pr0Ref = useRef(0);
+  const valueRef = useRef<number | null>(null);
+  const rootRef = useRef<HTMLElement | null>(null);
+
+  const onStart = useCallback((gutter: HTMLElement) => {
+    const root = rootOf(gutter);
+    const drawer = root?.querySelector(".ac-prfull");
+    if (!root || !drawer) return false;
+    rootRef.current = root;
+    pr0Ref.current = drawer.getBoundingClientRect().width;
+    valueRef.current = null;
+    return true;
+  }, []);
+
+  const onMove = useCallback(
+    (gutter: HTMLElement, delta: number) => {
+      // Pointer left = wider overlay. On release the Aim-room guard decides the
+      // mode (docks if it still fits beside Aim, floats otherwise). From OVERLAY
+      // that is a FLIP when the current width would dock — surface it live.
+      const pr = clampAimConsolePrWidth(pr0Ref.current - delta);
+      valueRef.current = pr;
+      const root = rootOf(gutter);
+      root?.style.setProperty("--pr", `${pr}px`);
+      const willFlip = previewDock(pr);
+      root?.classList.toggle("remote-pending-flip", willFlip);
+      return willFlip ? `remote ${pr}px · release to dock` : `remote ${pr}px`;
+    },
+    [previewDock],
+  );
+
+  const onEnd = useCallback(() => {
+    rootRef.current?.classList.remove("remote-pending-flip");
+    if (valueRef.current !== null) onCommit(valueRef.current);
+  }, [onCommit]);
+
+  const { live, readout, handlers } = useGutterDrag({ axis: "x", onStart, onMove, onEnd, onReset });
+
+  return (
+    // biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter (RPanel precedent)
+    <div
+      className={cn("ac-ovgut", live && "live")}
+      role="separator"
+      tabIndex={0}
+      aria-orientation="vertical"
+      aria-label="Resize Remote overlay"
+      aria-valuenow={Math.round(prWidth)}
+      aria-valuemin={AIM_CONSOLE_PR_WIDTH_MIN}
+      aria-valuemax={AIM_CONSOLE_PR_WIDTH_MAX}
+      title="Drag to resize · docks when it fits beside Aim · double-click to reset"
+      {...handlers}
+    >
+      <ReadoutChip readout={readout} />
+    </div>
+  );
+}
+
 /** Gutter B — Aim|Remote. Adjusts `--pr` (px) while the Remote is DOCKED;
  *  inert (`off`) while collapsed or overlaid (the overlay drawer carries its
  *  own edge handle). `prWidth` (the committed Remote width) feeds
@@ -226,32 +298,45 @@ export function AimRemoteGutter({
   prWidth,
   onCommit,
   onReset,
+  previewDock,
 }: {
   active: boolean;
   prWidth: number;
   onCommit: (pr: number) => void;
   onReset: () => void;
+  previewDock: (pr: number) => boolean;
 }) {
   const pr0Ref = useRef(0);
   const valueRef = useRef<number | null>(null);
+  const rootRef = useRef<HTMLElement | null>(null);
 
   const onStart = useCallback((gutter: HTMLElement) => {
-    const prEl = rootOf(gutter)?.querySelector(".ac-pr");
-    if (!prEl) return false;
+    const root = rootOf(gutter);
+    const prEl = root?.querySelector(".ac-pr");
+    if (!root || !prEl) return false;
+    rootRef.current = root;
     pr0Ref.current = prEl.getBoundingClientRect().width;
     valueRef.current = null;
     return true;
   }, []);
 
-  const onMove = useCallback((gutter: HTMLElement, delta: number) => {
-    // The Remote grows leftwards: pointer left = wider panel.
-    const pr = clampAimConsolePrWidth(pr0Ref.current - delta);
-    valueRef.current = pr;
-    rootOf(gutter)?.style.setProperty("--pr", `${pr}px`);
-    return `remote ${pr}px`;
-  }, []);
+  const onMove = useCallback(
+    (gutter: HTMLElement, delta: number) => {
+      // The Remote grows leftwards: pointer left = wider panel. From DOCK,
+      // releasing FLIPS to overlay when the width no longer fits beside Aim.
+      const pr = clampAimConsolePrWidth(pr0Ref.current - delta);
+      valueRef.current = pr;
+      const root = rootOf(gutter);
+      root?.style.setProperty("--pr", `${pr}px`);
+      const willFlip = !previewDock(pr);
+      root?.classList.toggle("remote-pending-flip", willFlip);
+      return willFlip ? `remote ${pr}px · release to float` : `remote ${pr}px`;
+    },
+    [previewDock],
+  );
 
   const onEnd = useCallback(() => {
+    rootRef.current?.classList.remove("remote-pending-flip");
     if (valueRef.current !== null) onCommit(valueRef.current);
   }, [onCommit]);
 

--- a/clients/react/src/components/aim-console/__tests__/Gutters.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/Gutters.test.tsx
@@ -188,32 +188,132 @@ describe("AimRemoteGutter — Aim|Remote gutter (docked only)", () => {
     expect(sep.className).toContain("off");
   });
 
-  it("drags the docked Remote within 240–520px and persists on pointerup", () => {
+  // The dock GUARD boundary: maxDockable = console − conversation − gutters −
+  // DOCK_MIN_AIM (400). With console 1500 + conversation 700 → 1500-700-10-400 =
+  // 390px. So the Remote docks while ≤ 390 (Aim keeps its floor) and floats when
+  // wider (Aim would be crushed).
+  function stubDockGeometry(root: Element) {
+    stubRect(root.querySelector(".ac-main") as Element, { width: 1500 });
+    stubRect(root.querySelector(".ac-session") as Element, { width: 700 });
+  }
+
+  it("resizes the docked Remote while it still fits beside Aim (stays docked)", () => {
     renderConsole();
     const root = screen.getByTestId("aim-console");
     openAndDock();
-    // Open carries the persisted (default) width.
     expect(root.style.getPropertyValue("--pr")).toBe("360px");
+    expect(root.className).toContain("remote-dock");
+    stubDockGeometry(root);
 
     const sep = screen.getByRole("separator", { name: "Resize Remote panel" });
     expect(sep.className).not.toContain("off");
     stubRect(root.querySelector(".ac-pr") as Element, { width: 360 });
 
-    // Pointer left = wider panel: 360 - (-100) = 460.
-    drag(sep, { x: 1000, y: 300 }, { x: 900, y: 300 });
-    expect(root.style.getPropertyValue("--pr")).toBe("460px");
-    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, pr: 460 });
-
-    // Clamp floor (240) and ceiling (520).
-    drag(sep, { x: 1000, y: 300 }, { x: 1900, y: 300 });
-    expect(root.style.getPropertyValue("--pr")).toBe("240px");
-    drag(sep, { x: 1000, y: 300 }, { x: 0, y: 300 });
-    expect(root.style.getPropertyValue("--pr")).toBe("520px");
-    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, pr: 520 });
+    // Narrow to 380 (≤ 390 maxDockable) → still fits → stays docked, persists.
+    drag(sep, { x: 1000, y: 300 }, { x: 980, y: 300 });
+    expect(root.style.getPropertyValue("--pr")).toBe("380px");
+    expect(root.className).toContain("remote-dock");
+    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, pr: 380 });
 
     fireEvent.doubleClick(sep);
     expect(storedLayout()).toBeNull();
     expect(root.style.getPropertyValue("--pr")).toBe("360px");
+  });
+
+  it("widening a docked panel until Aim would be crushed floats it back to overlay", () => {
+    renderConsole();
+    const root = screen.getByTestId("aim-console");
+    openAndDock();
+    expect(root.className).toContain("remote-dock");
+    stubDockGeometry(root);
+    const sep = screen.getByRole("separator", { name: "Resize Remote panel" });
+    stubRect(root.querySelector(".ac-pr") as Element, { width: 360 });
+
+    // 360 - (-100) = 460 > 390 → Aim would drop below its floor → floats.
+    drag(sep, { x: 1000, y: 300 }, { x: 900, y: 300 });
+    expect(root.className).not.toContain("remote-dock");
+    expect(root.className).toContain("remote-open");
+  });
+});
+
+describe("OverlayEdgeGutter — drag the overlay edge (dock when it fits)", () => {
+  const NAME = "Resize Remote overlay";
+
+  // Same guard geometry as above: maxDockable 390px.
+  function stubDockGeometry(root: Element) {
+    stubRect(root.querySelector(".ac-main") as Element, { width: 1500 });
+    stubRect(root.querySelector(".ac-session") as Element, { width: 700 });
+    stubRect(root.querySelector(".ac-prfull") as Element, { width: 360 });
+  }
+
+  it("exists only while overlaid (open, not docked)", () => {
+    renderConsole();
+    expect(screen.queryByRole("separator", { name: NAME })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
+    expect(screen.getByRole("separator", { name: NAME })).toBeTruthy();
+  });
+
+  it("drag-to-dock: releasing at a width that fits beside Aim docks it", () => {
+    renderConsole();
+    const root = screen.getByTestId("aim-console");
+    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
+    expect(root.className).toContain("remote-open");
+    expect(root.className).not.toContain("remote-dock");
+    stubDockGeometry(root);
+
+    const sep = screen.getByRole("separator", { name: NAME });
+    // 360 → 380 (≤ 390 maxDockable) → fits → docks on release.
+    drag(sep, { x: 1000, y: 300 }, { x: 980, y: 300 });
+    expect(root.style.getPropertyValue("--pr")).toBe("380px");
+    expect(root.className).toContain("remote-dock");
+    expect(storedLayout()).toEqual({ ...AIM_CONSOLE_LAYOUT_DEFAULTS, pr: 380 });
+  });
+
+  it("stays overlay when released too wide to fit beside Aim", () => {
+    renderConsole();
+    const root = screen.getByTestId("aim-console");
+    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
+    stubDockGeometry(root);
+
+    const sep = screen.getByRole("separator", { name: NAME });
+    // 360 → 460 (> 390 maxDockable) → Aim would be crushed → stays overlay.
+    drag(sep, { x: 1000, y: 300 }, { x: 900, y: 300 });
+    expect(root.style.getPropertyValue("--pr")).toBe("460px");
+    expect(root.className).not.toContain("remote-dock");
+    expect(root.className).toContain("remote-open");
+  });
+
+  it("signals a pending FLIP mid-drag (amber class + 'release to dock' readout), cleared on release", () => {
+    renderConsole();
+    const root = screen.getByTestId("aim-console");
+    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
+    stubDockGeometry(root);
+    const sep = screen.getByRole("separator", { name: NAME });
+
+    // Mid-drag to 380 (≤ 390 → would DOCK, a flip from overlay) — no release yet.
+    fireEvent.pointerDown(sep, { clientX: 1000, clientY: 300, pointerId: 1, button: 0 });
+    fireEvent.pointerMove(sep, { clientX: 980, clientY: 300, pointerId: 1 });
+    expect(root.className).toContain("remote-pending-flip");
+    expect(screen.getByTestId("ac-gutter-readout").textContent).toContain("release to dock");
+
+    // Release clears the flip signal.
+    fireEvent.pointerUp(sep, { clientX: 980, clientY: 300, pointerId: 1 });
+    expect(root.className).not.toContain("remote-pending-flip");
+  });
+
+  it("shows NO flip signal while the drag stays in the same mode", () => {
+    renderConsole();
+    const root = screen.getByTestId("aim-console");
+    fireEvent.click(screen.getByRole("button", { name: "Expand PR / Issue rail" }));
+    stubDockGeometry(root);
+    const sep = screen.getByRole("separator", { name: NAME });
+
+    // Mid-drag to 460 (> 390 → would stay OVERLAY, no flip).
+    fireEvent.pointerDown(sep, { clientX: 1000, clientY: 300, pointerId: 1, button: 0 });
+    fireEvent.pointerMove(sep, { clientX: 900, clientY: 300, pointerId: 1 });
+    expect(root.className).not.toContain("remote-pending-flip");
+    expect(screen.getByTestId("ac-gutter-readout").textContent).not.toContain("release");
+    fireEvent.pointerUp(sep, { clientX: 900, clientY: 300, pointerId: 1 });
   });
 });
 

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -371,6 +371,27 @@
   padding: 2px 7px;
 }
 
+/* Pending mode FLIP during a drag-to-dock: when releasing NOW would toggle
+   dock⇄overlay, the live seam + the readout chip turn amber (the "heads up,
+   you're crossing the line" accent) so the threshold is legible mid-drag. The
+   actual flip still happens only on release. */
+.aim-console.remote-pending-flip .ac-readout {
+  color: var(--amber);
+  border-color: var(--amber);
+}
+/* `.live` on both selectors keeps the specificity (0,4,1) above the cyan
+   `.ac-ovgut.live::before` / `.ac-vgut.live::before` rules regardless of source
+   order — the seam is always `.live` mid-drag, so this targets the active one. */
+.aim-console.remote-pending-flip .ac-ovgut.live::before,
+.aim-console.remote-pending-flip .ac-vgut.live::before {
+  background: var(--amber);
+  box-shadow: 0 0 8px rgba(207, 155, 70, 0.6);
+}
+.aim-console.remote-pending-flip .ac-ovgut.live::after,
+.aim-console.remote-pending-flip .ac-vgut.live::after {
+  color: var(--amber);
+}
+
 /* live-drag state (mock `body.dragging`, scoped on the root): suppress text
    selection, force the resize cursor window-wide, and disable the grid /
    footer height transitions so the tracks follow the pointer 1:1. */
@@ -1108,6 +1129,52 @@
   width: auto;
   box-shadow: none;
 }
+/* Overlay edge handle (drag-to-dock) — absolutely positioned at the floating
+   drawer's LEFT edge (`right: var(--pr)`), spanning the console height. Invisible
+   at rest; hover/drag lights the cyan seam + grip, same affordance language as
+   the grid gutters. Sits above the drawer so it stays grabbable. */
+.aim-console .ac-ovgut {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  right: var(--pr, 360px);
+  width: 11px;
+  transform: translateX(50%);
+  z-index: 6;
+  cursor: col-resize;
+}
+.aim-console .ac-ovgut::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 50%;
+  width: 2px;
+  transform: translateX(-50%);
+  background: transparent;
+  transition:
+    background 0.15s,
+    box-shadow 0.15s;
+}
+.aim-console .ac-ovgut:hover::before,
+.aim-console .ac-ovgut.live::before {
+  background: var(--cyan);
+  box-shadow: 0 0 7px rgba(74, 163, 157, 0.55);
+}
+.aim-console .ac-ovgut::after {
+  content: "⋮";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: var(--mono);
+  font-size: 10px;
+  color: transparent;
+  transition: color 0.15s;
+}
+.aim-console .ac-ovgut:hover::after {
+  color: var(--cyan);
+}
 .aim-console .ac-prh {
   display: flex;
   align-items: center;
@@ -1132,6 +1199,12 @@
 }
 .aim-console .ac-prh .ac-prdock.on {
   color: var(--cyan);
+}
+/* Pending mode FLIP during a drag: the dock toggle icon (⊟/⊞) also goes amber —
+   it IS the mode that's about to change. Placed after `.ac-prdock.on` so it
+   wins for a docked (.on) toggle too (same specificity, later in source). */
+.aim-console.remote-pending-flip .ac-prh .ac-prdock {
+  color: var(--amber);
 }
 .aim-console .ac-prh .ac-prh-title {
   flex: 1;


### PR DESCRIPTION
## What

Phase 2 of the conversation-anchor layout (#911): make the **overlay ⇄ dock** transition a **fluid drag**, decided by whether both panes can actually coexist.

## How

- **Drag-to-dock.** The floating overlay drawer gains a left-edge handle (`OverlayEdgeGutter`, absolutely positioned at `right: var(--pr)`). Dragging it resizes the Remote and, on release, snaps the mode.
- **Aim-room GUARD** (replaces the fixed 440/300 thresholds). Dock only delivers its value when both panes stay usable, so the boundary is **not a fixed --pr** but *"does the Remote still leave Aim ≥ `DOCK_MIN_AIM_PX` (400)?"* — measured **live off the grid**, so it adapts to the **window + conversation width**:
  - release at a width that **fits beside Aim** → **dock**;
  - release so wide (or on a window/conversation too narrow) that **Aim would be crushed** → stay / float to **overlay**.
  - The `AimRemoteGutter` resize re-evaluates the same way (widen a docked panel past the fit → float back). The ⊟/⊞ button stays a manual override.
- **Pending-flip feedback.** When releasing NOW would **flip** the mode, the live **seam**, the pointer **readout chip** (`… · release to dock` / `release to float`), **and the dock toggle icon** all turn **amber** — the threshold is legible mid-drag. The actual flip still happens only on release (no mid-drag re-position).
- **Fix.** The overlay edge handle sits just outside `.ac-prfull`, so the click-outside-to-close handler now also ignores `.ac-ovgut` (grabbing the handle must not dismiss the overlay).

## Design notes (this iterated with the operator)

The fixed-px dock threshold was reframed: dock's value (both panes visible AND usable) only holds when there's room, so the trigger is **Aim's resulting width**, not the Remote's. The `DOCK_MIN_AIM_PX` floor (400) is the one tunable knob — raise it → docking is pickier (more overlay), lower it → docks more eagerly. On a wide window there's always room, so dragging docks readily (faithful to "enough width → dock"); a transient peek is the click-to-open overlay + click-outside dismiss.

## Verify

- `tsc -b` + full suite green (**988 passed**, 0 failed); biome clean.
- Verified live against the real AimConsole in a local preview: overlay / dock / drag-to-dock, the guard adapting across window + conversation widths, and the amber flip cues on the seam + readout + toggle.

Follow-up to #911 (conversation-anchor layout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * リモートパネルの幅調整に、ドラッグ中の切り替え予告表示と新しい左端グリップを追加しました。
  * 画面幅に応じて、リリース時にドッキングするかオーバーレイのままにするかが分かりやすくなりました。

* **不具合修正**
  * パネル境界の操作時に、切り替え可能な範囲がより正確に判定されるようになりました。
  * クリック判定を調整し、リサイズ操作中に意図せず閉じてしまうケースを防ぎました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->