### PR TITLE
feat(aim-console): move the ⚙ Settings button to the top-bar AND open it in aim mode

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -788,6 +788,28 @@ export function App({
           onClose={() => setLaunchPickerOpen(false)}
           onLaunchProducerAt={launchProducerAt}
         />
+        {/* Settings in aim mode — the producer console renders SettingsPanel
+            inline in its centre pane, but the aim console is a full-window
+            takeover, so the SAME `showSettings` state surfaces here as a modal
+            overlay (lifted past the aim-mode early return — same shape as the
+            #897 globalOverlays / #907 remote-Δ lifts). The top-bar ⚙ sets it;
+            the panel's own close button + the backdrop dismiss it. */}
+        {showSettings && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-6">
+            {/* biome-ignore lint/a11y/useKeyWithClickEvents: backdrop tap to close */}
+            {/* biome-ignore lint/a11y/noStaticElementInteractions: backdrop tap to close */}
+            <div
+              className="absolute inset-0 bg-background/70 backdrop-blur-sm animate-fade-in"
+              onClick={closeMainPanelOverlay}
+            />
+            <div className="relative flex h-[85vh] w-[min(880px,92vw)] flex-col overflow-hidden rounded-xl border border-hairline-strong bg-background shadow-2xl animate-scale-in">
+              <SettingsPanel
+                onClose={closeMainPanelOverlay}
+                defaultOpenAdvanced={settingsOpenedFromOverride}
+              />
+            </div>
+          </div>
+        )}
         {globalOverlays}
       </>
     );

--- a/clients/react/src/__tests__/App.console-mode.test.tsx
+++ b/clients/react/src/__tests__/App.console-mode.test.tsx
@@ -85,17 +85,30 @@ vi.mock("@/components/agent/AgentActions", () => ({ AgentActions: () => null }))
 vi.mock("@/components/terminal/TerminalPanel", () => ({ TerminalPanel: () => null }));
 vi.mock("@/components/agent/AgentList", () => ({ AgentList: () => null }));
 vi.mock("@/components/terminal/TerminalList", () => ({ TerminalList: () => null }));
-vi.mock("@/components/settings/SettingsPanel", () => ({ SettingsPanel: () => null }));
+vi.mock("@/components/settings/SettingsPanel", () => ({
+  SettingsPanel: ({ onClose }: { onClose: () => void }) => (
+    <div data-testid="settings-panel-stub">
+      settings
+      <button type="button" onClick={onClose}>
+        close-settings
+      </button>
+    </div>
+  ),
+}));
 vi.mock("@/components/calibration/CalibrationPanel", () => ({ CalibrationPanel: () => null }));
 
-// The aim console is stubbed to a marker + an exit button wired to `onExit`,
-// so we can observe the switch and the return path without rendering the
-// real 3-pane shell.
+// The aim console is stubbed to a marker + an exit button wired to `onExit`
+// and an open-settings button wired to `onOpenSettings`, so we can observe the
+// switch, the return path, and the app-level settings lift without rendering
+// the real 3-pane shell.
 vi.mock("@/components/aim-console/AimConsole", () => ({
-  AimConsole: ({ onExit }: { onExit: () => void }) => (
+  AimConsole: ({ onExit, onOpenSettings }: { onExit: () => void; onOpenSettings: () => void }) => (
     <div data-testid="aim-console-stub">
       <button type="button" onClick={onExit}>
         exit-aim
+      </button>
+      <button type="button" onClick={onOpenSettings}>
+        open-settings-aim
       </button>
     </div>
   ),
@@ -198,5 +211,30 @@ describe("App — console-mode coexist toggle", () => {
     fireEvent.click(screen.getByLabelText("Switch to the aim console (preview)"));
     expect(screen.getByTestId("aim-console-stub")).toBeTruthy();
     expect(screen.queryByTestId("producer-console-stub")).toBeNull();
+  });
+
+  // The aim console is a full-window takeover, so the producer console's
+  // inline SettingsPanel is out of reach. The same `showSettings` state is
+  // lifted past the aim-mode early return as a modal overlay (#913), so the
+  // top-bar ⚙ actually opens settings — and the panel's own close dismisses it.
+  it("opens (and closes) the settings overlay in aim mode (#913)", () => {
+    renderWithProviders(<App />);
+
+    // Default aim mode — no settings overlay yet.
+    expect(screen.getByTestId("aim-console-stub")).toBeTruthy();
+    expect(screen.queryByTestId("settings-panel-stub")).toBeNull();
+
+    // The aim console's top-bar ⚙ lifts the app-level settings overlay.
+    fireEvent.click(screen.getByText("open-settings-aim"));
+    expect(screen.getByTestId("settings-panel-stub")).toBeTruthy();
+    // Still the aim console underneath — settings is a modal over it, not a
+    // mode switch (the producer console must NOT appear).
+    expect(screen.getByTestId("aim-console-stub")).toBeTruthy();
+    expect(screen.queryByTestId("producer-console-stub")).toBeNull();
+
+    // The panel's own close button dismisses the overlay back to the console.
+    fireEvent.click(screen.getByText("close-settings"));
+    expect(screen.queryByTestId("settings-panel-stub")).toBeNull();
+    expect(screen.getByTestId("aim-console-stub")).toBeTruthy();
   });
 });

--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -311,6 +311,18 @@ export function AimConsole({
         </button>
         <div className="ac-sp" />
         <div className="ac-meta">unit {metaUnit} · opus-4.8 · max</div>
+        {/* ⚙ Settings — app-level (the WebUI/Producer config affects the whole
+            console, not one conversation), so it lives in the top-bar chrome
+            beside the exit, not in a Session pane's shead. */}
+        <button
+          type="button"
+          className="ac-settings"
+          onClick={onOpenSettings}
+          title="Open settings"
+          aria-label="Open settings"
+        >
+          ⚙
+        </button>
         <button
           type="button"
           className="ac-exit"
@@ -336,7 +348,6 @@ export function AimConsole({
             unitName={activeUnitName}
             currentProjectPath={currentProjectPath}
             trigger={trigger}
-            onOpenSettings={onOpenSettings}
             repos={activeUnit?.repos ?? []}
           />
         </section>

--- a/clients/react/src/components/aim-console/SessionPane.tsx
+++ b/clients/react/src/components/aim-console/SessionPane.tsx
@@ -54,8 +54,6 @@ interface SessionPaneProps {
   /** App-level lifted handoff ritual trigger (one `useHandoffRitual`
    *  instance, in App). Threaded straight into `ProducerConversationHeader`. */
   trigger: (unit: string, body: TriggerHandoffRitualRequest) => Promise<void>;
-  /** ⚙ deep-link into Settings (auto-handoff threshold). */
-  onOpenSettings: () => void;
   /** The focused unit's repos (primary first), threaded from AimConsole's
    *  membership list — one per-repo bash tab each in the docked footer (S4).
    *  Empty for a cwd-synthesized unit not in the configured membership; the
@@ -85,7 +83,6 @@ export function SessionPane({
   unitName,
   currentProjectPath,
   trigger,
-  onOpenSettings,
   repos,
 }: SessionPaneProps) {
   // Producer + workers for the focused unit. The Producer (if any) leads;
@@ -167,7 +164,6 @@ export function SessionPane({
           unitName={unitName}
           currentProjectPath={currentProjectPath}
           trigger={trigger}
-          onOpenSettings={onOpenSettings}
         />
       )}
 

--- a/clients/react/src/components/aim-console/Shead.tsx
+++ b/clients/react/src/components/aim-console/Shead.tsx
@@ -7,7 +7,8 @@
 //
 //   Producer: dot · name · model · ctx bar (with the auto-handoff threshold
 //             marker ┊) · pct · auto N% · unit/cwd · ⤺ handoff & restart ·
-//             ⚙ settings · ⟳ restart
+//             ⟳ restart   (⚙ Settings moved to the app top-bar — it is
+//             app-level config, not a per-conversation control.)
 //   Worker:   dot · name · model · ctx bar (violet accent) · pct ·
 //             repo/cwd · ✕ kill
 //
@@ -39,7 +40,7 @@ import { statusClass, statusWord } from "./session-status";
 interface SheadProps {
   /** The selected session agent this bar describes. */
   agent: AgentSnapshot;
-  /** Producer variant (ctx threshold marker + handoff ritual + settings)
+  /** Producer variant (ctx threshold marker + handoff ritual)
    *  vs worker variant (repo/cwd + kill only). */
   isProducer: boolean;
   /** Unit name — keys the handoff ritual endpoint (Producer variant). */
@@ -50,8 +51,6 @@ interface SheadProps {
   /** App-level lifted handoff ritual trigger (one `useHandoffRitual`
    *  instance, in App). */
   trigger: (unit: string, body: TriggerHandoffRitualRequest) => Promise<void>;
-  /** ⚙ deep-link into Settings (auto-handoff threshold). */
-  onOpenSettings: () => void;
 }
 
 function repoBasename(path: string): string {
@@ -173,21 +172,13 @@ function RestartButton({ target, launchPath }: { target: string; launchPath: str
   );
 }
 
-export function Shead({
-  agent,
-  isProducer,
-  unitName,
-  currentProjectPath,
-  trigger,
-  onOpenSettings,
-}: SheadProps) {
+export function Shead({ agent, isProducer, unitName, currentProjectPath, trigger }: SheadProps) {
   return isProducer ? (
     <ProducerShead
       agent={agent}
       unitName={unitName}
       currentProjectPath={currentProjectPath}
       trigger={trigger}
-      onOpenSettings={onOpenSettings}
     />
   ) : (
     <WorkerShead agent={agent} />
@@ -199,7 +190,6 @@ function ProducerShead({
   unitName,
   currentProjectPath,
   trigger,
-  onOpenSettings,
 }: Omit<SheadProps, "isProducer">) {
   const ctx = agent.ctx_usage ?? null;
   const [threshold, setThreshold] = useState<number | null>(null);
@@ -276,15 +266,6 @@ function ProducerShead({
           }
         >
           ⤺ handoff &amp; restart
-        </button>
-        <button
-          type="button"
-          className="ic"
-          onClick={onOpenSettings}
-          title="Open settings — auto-handoff threshold"
-          aria-label="Open settings — auto-handoff threshold"
-        >
-          ⚙
         </button>
         <RestartButton target={agent.target} launchPath={agent.cwd} />
       </span>

--- a/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
@@ -142,7 +142,7 @@ describe("AimConsole — S1 shell", () => {
     expect(root.className).not.toContain("remote-dock");
   });
 
-  it("calls onSelectUnit / onAddUnit / onExit from the top bar", () => {
+  it("calls onSelectUnit / onAddUnit / onOpenSettings / onExit from the top bar", () => {
     const props = renderConsole();
 
     fireEvent.click(screen.getByRole("button", { name: "unit: tmai" }));
@@ -150,6 +150,10 @@ describe("AimConsole — S1 shell", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Add unit — launch Producer" }));
     expect(props.onAddUnit).toHaveBeenCalledTimes(1);
+
+    // ⚙ Settings lives in the app top-bar (config is app-level), not a Session shead.
+    fireEvent.click(screen.getByRole("button", { name: "Open settings" }));
+    expect(props.onOpenSettings).toHaveBeenCalledTimes(1);
 
     fireEvent.click(screen.getByRole("button", { name: "Return to the Producer console" }));
     expect(props.onExit).toHaveBeenCalledTimes(1);

--- a/clients/react/src/components/aim-console/__tests__/SessionPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/SessionPane.test.tsx
@@ -134,7 +134,6 @@ function renderPane(overrides: Partial<Parameters<typeof SessionPane>[0]> = {}) 
     unitName: "tmai" as string | null,
     currentProjectPath: "/home/u/tmai" as string | null,
     trigger: vi.fn(),
-    onOpenSettings: vi.fn(),
     repos: [
       { path: "/home/u/tmai", primary: true },
       { path: "/home/u/tmai-core", primary: false },

--- a/clients/react/src/components/aim-console/__tests__/Shead.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/Shead.test.tsx
@@ -93,7 +93,6 @@ function renderShead(overrides: Partial<Parameters<typeof Shead>[0]> = {}) {
     unitName: "tmai" as string | null,
     currentProjectPath: "/home/u/tmai" as string | null,
     trigger: vi.fn(() => Promise.resolve()),
-    onOpenSettings: vi.fn(),
     ...overrides,
   };
   renderWithProviders(<Shead {...props} />);
@@ -124,7 +123,6 @@ describe("Shead — Producer variant", () => {
         unitName="tmai"
         currentProjectPath="/home/u/tmai"
         trigger={vi.fn(() => Promise.resolve())}
-        onOpenSettings={vi.fn()}
       />,
     );
     const head = screen.getByTestId("ac-shead-producer");
@@ -155,10 +153,9 @@ describe("Shead — Producer variant", () => {
     expect(props.trigger).not.toHaveBeenCalled();
   });
 
-  it("opens settings via ⚙", () => {
-    const props = renderShead();
-    fireEvent.click(screen.getByRole("button", { name: "Open settings — auto-handoff threshold" }));
-    expect(props.onOpenSettings).toHaveBeenCalled();
+  it("has NO settings ⚙ (it moved to the app top-bar — config is app-level)", () => {
+    renderShead();
+    expect(screen.queryByRole("button", { name: /Open settings/ })).toBeNull();
   });
 
   it("restarts (kill → relaunch at the same locus) only after the danger confirm is accepted", async () => {
@@ -202,7 +199,6 @@ describe("Shead — Producer variant", () => {
         unitName="tmai"
         currentProjectPath="/home/u/tmai"
         trigger={vi.fn(() => Promise.resolve())}
-        onOpenSettings={vi.fn()}
       />,
     );
     await waitFor(() => expect(screen.getByText("auto off")).toBeTruthy());
@@ -218,13 +214,10 @@ describe("Shead — worker variant", () => {
     expect(screen.getByText("attention-ui")).toBeTruthy();
     expect(screen.getByText("sonnet-4.6")).toBeTruthy();
     expect(screen.getByText(/repo tmai · main · \.\.\/tmai-wt-attn-ui/)).toBeTruthy();
-    // No handoff ritual, no settings — the worker bar carries kill only.
+    // No handoff ritual — the worker bar carries kill only.
     // And no restart: a worker is bounded (nothing respawns it), so killing it
     // is a legitimate terminal, kept as a plain ✕ kill.
     expect(screen.queryByRole("button", { name: /handoff & restart/i })).toBeNull();
-    expect(
-      screen.queryByRole("button", { name: "Open settings — auto-handoff threshold" }),
-    ).toBeNull();
     expect(
       screen.queryByRole("button", {
         name: "Restart Producer (kill + relaunch fresh; no hand-off)",

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -224,6 +224,26 @@
   color: var(--faint);
   letter-spacing: 0.5px;
 }
+/* ⚙ Settings — app-level top-bar icon button (same affordance as the "+" add
+   button), beside the exit. Config is whole-console, not per-conversation. */
+.aim-console .ac-settings {
+  width: 26px;
+  height: 26px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-left: 10px;
+  border: 1px solid var(--line);
+  background: transparent;
+  color: var(--dim);
+  cursor: pointer;
+  font-size: 13px;
+  border-radius: 4px;
+}
+.aim-console .ac-settings:hover {
+  color: var(--cyan);
+  border-color: var(--cyan-d);
+}
 /* exit back to the existing ProducerConsole (the default view). The
    ENTER toggle lives in StatusBar; this is its EXIT pair, since the
    full-window aim console replaces the existing chrome incl. StatusBar. */


### PR DESCRIPTION
## What

Two parts, both about the **⚙ Settings** button on the aim console (the default surface):

1. **Move** it out of the Producer conversation pane and into the **app top-bar**. Config is **app-level** — it affects the whole console, not one conversation — so its home is the top-bar chrome (beside the exit `‹ console`), not inside a Session pane's shead.
2. **Open it.** The relocated ⚙ now actually surfaces the settings panel in aim mode (the stranding fix that was flagged out-of-scope in the first pass).

## How

### Move (first commit)
- Add the ⚙ to the AimConsole top bar (`.ac-settings`, same icon-button affordance as the "+" add-unit), wired to the existing `onOpenSettings`.
- Remove the ⚙ from `Shead`, and with it the now-**vestigial** `onOpenSettings` prop threaded through `SessionPane → Shead` (AimConsole calls it directly).

### Open (second commit)
- `openSettingsFromOverride` sets `mainPanel="settings"`, but `SettingsPanel` is rendered by the producer console's centre pane, **below** the `consoleMode === "aim"` early-return — so it was producer-mode-only (**the same stranding shape as #897 / #907**).
- Lift the **same** `showSettings` state past the aim-mode early return as a **modal overlay**: backdrop + the panel's own close button dismiss it; `settingsOpenedFromOverride` still drives the Advanced section.

## Tests

- `Shead` asserts it has **no** settings button; `AimConsole` asserts the top-bar ⚙ fires `onOpenSettings`.
- `App.console-mode` asserts the ⚙ **opens** (and the panel's close **dismisses**) the settings overlay in aim mode, with the aim console still underneath (modal, not a mode switch).

## Verify

- `tsc -b` + full suite green (**988 passed**, 0 failed); biome clean.
- ⚙ placement + open/close confirmed visually in a local preview (top-bar, between the meta readout and the exit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * aimモードで、設定画面を全画面オーバーレイとして開けるようになりました。
  * トップバーに共通の「設定」ボタンが追加され、設定へすぐ移動できます。

* **Bug Fixes**
  * 設定画面の表示・非表示が正しく切り替わるようになりました。
  * 設定を開いても、プロデューサー画面への不要な切り替えが起きないよう改善しました。

* **Tests**
  * aimモードの設定オーバーレイ表示と閉じる挙動を確認するテストを追加・更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->