### PR TITLE
feat(handoff): scope the in-progress overlay to the conversation panel (translucent)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -709,31 +709,45 @@ export function App({
     <RIssueViewer selected={selectedIssue} onClose={clearIssue} />
   ) : null;
 
-  // App-level GLOBAL overlays — mode-INDEPENDENT. The handoff ritual UI
-  // (in-progress overlay / failure dialog / ready toast), the toast container,
-  // and the help overlay must stay co-visible whether the centre is the legacy
-  // producer shell OR the full-screen aim console (now the DEFAULT). These used
-  // to be inlined in the producer-mode return ONLY, so the aim-console default
-  // stranded the whole handoff ritual (phases + escalated/crash failures) and
-  // the toasts/help below the aim-mode early return — invisible in the default
-  // surface (hub #897, surfaced by tmai-core #589 ④). They are `fixed`-
-  // positioned, so the DOM parent doesn't affect layout, and only one mode
-  // branch renders at a time (no double-mount). The single `useHandoffRitual`
-  // instance still lives at App level (above) — two would mean two overlays.
+  // The IN-PROGRESS handoff overlay — scoped to the CONVERSATION PANEL, not a
+  // full-window takeover. A handoff busies ONE unit's conversation (its
+  // Producer is being killed + relaunched), so the overlay covers only that
+  // panel and leaves the unit tabs, the Aim worklist, and the Remote rail
+  // usable while the ritual runs — the operator can switch units, check PRs, or
+  // work the Aim tree instead of being walled out of the whole app. Rendered
+  // INSIDE the conversation panel in each mode (aim: the `.ac-session` column,
+  // via AimConsole's `handoffOverlay` prop; producer: the centre conversation
+  // div) — both panels are `position: relative` hosts for its `absolute inset-0`.
+  // Shown for the FOCUSED unit only, so switching units reveals the other unit's
+  // conversation cleanly; the ritual keeps running and re-appears on switch-back.
+  // (The terminal FAILURE dialog + ready toast + help stay app-global below —
+  // a failure / completion is app-level news, not one panel's busy-state.)
+  const handoffOverlay =
+    ritualState.kind === "dispatching" && unitName !== null ? (
+      <HandoffRitualOverlay unitName={unitName} ritualId={null} phases={[]} />
+    ) : ritualState.kind === "in_progress" && ritualState.unit === unitName ? (
+      <HandoffRitualOverlay
+        unitName={ritualState.unit}
+        ritualId={ritualState.ritualId}
+        phases={ritualState.phases}
+      />
+    ) : null;
+
+  // App-level GLOBAL overlays — mode-INDEPENDENT. The terminal handoff FAILURE
+  // dialog + ready toast, the toast container, and the help overlay must stay
+  // co-visible whether the centre is the legacy producer shell OR the
+  // full-screen aim console (now the DEFAULT). These used to be inlined in the
+  // producer-mode return ONLY, so the aim-console default stranded them below
+  // the aim-mode early return — invisible in the default surface (hub #897,
+  // surfaced by tmai-core #589 ④). They are `fixed`-positioned, so the DOM
+  // parent doesn't affect layout, and only one mode branch renders at a time
+  // (no double-mount). (The in-progress overlay is NO LONGER here — it moved
+  // into the conversation panel, see `handoffOverlay` above.) The single
+  // `useHandoffRitual` instance still lives at App level — two would mean two.
   const globalOverlays = (
     <>
       <HelpOverlay isOpen={showHelp} onClose={() => setShowHelp(false)} />
       <ToastContainer toasts={toast.toasts} onRemove={toast.removeToast} />
-      {ritualState.kind === "dispatching" && unitName !== null && (
-        <HandoffRitualOverlay unitName={unitName} ritualId={null} phases={[]} />
-      )}
-      {ritualState.kind === "in_progress" && (
-        <HandoffRitualOverlay
-          unitName={ritualState.unit}
-          ritualId={ritualState.ritualId}
-          phases={ritualState.phases}
-        />
-      )}
       {ritualState.kind === "escalated" && ritualState.unit !== "" && (
         <HandoffRitualFailureDialog
           unitName={ritualState.unit}
@@ -782,6 +796,7 @@ export function App({
           currentProjectPath={currentProject}
           trigger={triggerHandoff}
           onOpenSettings={openSettingsFromOverride}
+          handoffOverlay={handoffOverlay}
         />
         <ProducerLaunchPicker
           open={launchPickerOpen}
@@ -954,7 +969,12 @@ export function App({
           // ProducerConsole hand-over digest. Selecting an agent in the
           // sidebar drops into the conversation; clearing the selection
           // (returnToConsole) returns to the digest.
-          <div className="flex flex-1 flex-col overflow-hidden">
+          //
+          // `relative` makes this the positioned host for the in-progress
+          // handoff overlay (`handoffOverlay`, `absolute inset-0`): scoping it
+          // here covers the conversation while the sidebar + R panel stay
+          // usable, instead of the old app-wide fixed takeover.
+          <div className="relative flex flex-1 flex-col overflow-hidden">
             {/* One bar above the conversation. For the Producer it is the
                 merged ProducerConversationHeader — status dot + name +
                 Kill (subsuming AgentActions) PLUS the ctx% readout and
@@ -1003,6 +1023,9 @@ export function App({
                 onOpenSettings={openSettingsFromOverride}
               />
             )}
+            {/* In-progress handoff overlay — scoped to this conversation host
+                (`relative` above), translucent over whichever centre view shows. */}
+            {handoffOverlay}
           </div>
         )}
       </main>

--- a/clients/react/src/__tests__/App.handoff.test.tsx
+++ b/clients/react/src/__tests__/App.handoff.test.tsx
@@ -18,6 +18,7 @@
 // is mocked so we can drive `state` deterministically.
 
 import { fireEvent, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentSnapshot } from "@/lib/api";
 import { renderWithProviders } from "@/test/render";
@@ -100,10 +101,15 @@ vi.mock("@/components/terminal/TerminalList", () => ({ TerminalList: () => null 
 vi.mock("@/components/settings/SettingsPanel", () => ({ SettingsPanel: () => null }));
 vi.mock("@/components/calibration/CalibrationPanel", () => ({ CalibrationPanel: () => null }));
 // The aim console is the DEFAULT surface. Stub it so the aim-mode test below
-// observes whether the GLOBAL handoff overlay mounts alongside it, without
-// rendering the real 3-pane console (its own tests cover that).
+// observes whether the handoff overlay mounts alongside it, without rendering
+// the real 3-pane console (its own tests cover that). The in-progress overlay
+// is no longer an app-global fixed layer — it is threaded INTO the conversation
+// panel via `handoffOverlay`, so the stub must render that prop (the real
+// AimConsole places it inside its `.ac-session` column).
 vi.mock("@/components/aim-console/AimConsole", () => ({
-  AimConsole: () => <div data-testid="aim-console-stub">aim-console</div>,
+  AimConsole: ({ handoffOverlay }: { handoffOverlay?: ReactNode }) => (
+    <div data-testid="aim-console-stub">aim-console{handoffOverlay}</div>
+  ),
 }));
 vi.mock("@/components/project/ProducerLaunchPicker", () => ({
   ProducerLaunchPicker: () => null,
@@ -242,7 +248,7 @@ describe("App — handoff ritual wiring", () => {
     expect(screen.getByTestId("agent-actions-stub")).toBeTruthy();
   });
 
-  it("renders the in-progress overlay at App level — co-visible with the conversation view", () => {
+  it("renders the in-progress overlay in the conversation panel — co-visible with the conversation view", () => {
     useAgentsMock.mockReturnValue({
       agents: [agent({ id: "claude:prod" })],
       attentionCount: 0,
@@ -256,21 +262,50 @@ describe("App — handoff ritual wiring", () => {
 
     renderWithProviders(<App initialConsoleMode="producer" />);
 
-    // Overlay is present in the digest view …
+    // Overlay is present in the digest view (the conversation host wraps the
+    // digest) …
     expect(screen.getByTestId("phase-row-prompted")).toBeTruthy();
 
     // … and STILL present after switching to the Producer conversation —
     // the trap that forced manual-kill (overlay only in the digest) is gone.
+    // (It now scopes to the conversation PANEL instead of the whole app, but
+    // stays co-visible with whatever that panel shows.)
     fireEvent.click(screen.getByTitle("claude:prod"));
     expect(screen.getByTestId("preview-stub")).toBeTruthy();
     expect(screen.getByTestId("phase-row-prompted")).toBeTruthy();
   });
 
+  it("scopes the in-progress overlay to the FOCUSED unit (other units' conversations stay clear)", () => {
+    // The overlay is gated on `ritualState.unit === focused unit`: a handoff
+    // busies one unit's conversation, so focusing a DIFFERENT unit must show
+    // that unit's conversation cleanly (the ritual keeps running in the
+    // background and re-appears on switch-back). Here the focused unit resolves
+    // to "alpha" (the agent cwd basename), but the ritual is for "beta" — so no
+    // overlay renders over alpha's conversation.
+    useAgentsMock.mockReturnValue({
+      agents: [agent({ id: "claude:prod" })],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+    useHandoffRitualMock.mockReturnValue({
+      ...idleRitual(),
+      state: { kind: "in_progress", ritualId: "r-1", unit: "beta", phases: [] },
+    });
+
+    renderWithProviders(<App initialConsoleMode="producer" />);
+
+    // Focused unit is "alpha"; the ritual is for "beta" → no overlay here.
+    expect(screen.queryByTestId("phase-row-prompted")).toBeNull();
+  });
+
   it("renders the handoff overlay in the DEFAULT aim-console mode (regression #897)", () => {
-    // aim is DEFAULT_CONSOLE_MODE. Before the fix, App's aim-mode early return
-    // rendered only <AimConsole> and stranded the global handoff overlay in the
+    // aim is DEFAULT_CONSOLE_MODE. Before #897, App's aim-mode early return
+    // rendered only <AimConsole> and stranded the handoff overlay in the
     // producer-mode return below it, so a handoff triggered from the default
-    // surface showed nothing. The overlay must now mount in BOTH modes.
+    // surface showed nothing. The overlay must mount in BOTH modes — now
+    // threaded into the conversation panel via `handoffOverlay` (the real
+    // AimConsole places it in `.ac-session`; this stub renders the prop).
     useAgentsMock.mockReturnValue({
       agents: [agent({ id: "claude:prod" })],
       attentionCount: 0,
@@ -290,7 +325,7 @@ describe("App — handoff ritual wiring", () => {
 
     // The aim console is the default surface …
     expect(screen.getByTestId("aim-console-stub")).toBeTruthy();
-    // … and the global handoff overlay is co-visible with it.
+    // … and the handoff overlay is co-visible with it (via `handoffOverlay`).
     expect(screen.getByTestId("phase-row-prompted")).toBeTruthy();
   });
 });

--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -30,7 +30,14 @@
 // from the persisted `aimConsoleLayout` ui-pref, and drag end (not per-move)
 // writes it back.
 
-import { type CSSProperties, useCallback, useEffect, useRef, useState } from "react";
+import {
+  type CSSProperties,
+  type ReactNode,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
 import { useConfirm } from "@/components/layout/ConfirmDialog";
 import { advanceCursor, effectiveCursor } from "@/components/producer-console/r-panel/remote-delta";
 import type { AgentSnapshot, SlotResponse, TriggerHandoffRitualRequest } from "@/lib/api";
@@ -126,6 +133,13 @@ interface AimConsoleProps {
   /** ⚙ deep-link into Settings (auto-handoff threshold), forwarded to the
    *  Producer's shead. */
   onOpenSettings: () => void;
+  /** The in-progress handoff overlay (App-built from the single
+   *  `useHandoffRitual` state), rendered INSIDE the Session column so a handoff
+   *  covers only the conversation — not the whole console. `absolute inset-0`
+   *  against `.ac-session`'s `position: relative`; `null` when no ritual runs
+   *  for the focused unit. Threaded in (not built here) so the existing console
+   *  keeps the single ritual instance. */
+  handoffOverlay?: ReactNode;
 }
 
 export function AimConsole({
@@ -139,6 +153,7 @@ export function AimConsole({
   currentProjectPath,
   trigger,
   onOpenSettings,
+  handoffOverlay,
 }: AimConsoleProps) {
   // Remote-panel state (root-layout `conversation-anchor`). The collapsed 46px
   // rail (right edge) `remoteOpen`s to the Remote panel. The DEFAULT open mode
@@ -341,7 +356,11 @@ export function AimConsole({
           conversation never shifts. `.ac-main` is the positioned ancestor the
           overlay drawer floats over (see aim-console.css). */}
       <div className="ac-main" ref={mainRef}>
-        {/* CONVERSATION — the anchor (tabs + shead + term + S4 bash footer) */}
+        {/* CONVERSATION — the anchor (tabs + shead + term + S4 bash footer).
+            `.ac-session` is `position: relative` so the in-progress handoff
+            overlay (`handoffOverlay`, `absolute inset-0`) scopes to THIS column:
+            a handoff covers only the conversation, leaving the top-bar unit
+            tabs, the Aim worklist, and the Remote rail usable. */}
         <section className="ac-col ac-session" aria-label="Session">
           <SessionPane
             agents={agents}
@@ -350,6 +369,7 @@ export function AimConsole({
             trigger={trigger}
             repos={activeUnit?.repos ?? []}
           />
+          {handoffOverlay}
         </section>
 
         {/* gutter A — Conversation|Aim (resizes the anchor width) */}

--- a/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
@@ -172,6 +172,18 @@ describe("AimConsole — S1 shell", () => {
     // metaUnit = units[0].name when activeUnitName is null.
     expect(screen.getByText(/unit tmai · opus-4\.8 · max/)).toBeTruthy();
   });
+
+  it("renders the handoff overlay INSIDE the Session column (scoped to the conversation)", () => {
+    // The in-progress handoff overlay is threaded in via `handoffOverlay` and
+    // must land inside the Session (conversation) column — so a handoff covers
+    // only that panel, not the whole console. Here a marker stands in for the
+    // real overlay; the assertion is structural (it sits within `.ac-session`).
+    renderConsole({
+      handoffOverlay: <div data-testid="handoff-overlay-marker">handoff</div>,
+    });
+    const marker = screen.getByTestId("handoff-overlay-marker");
+    expect(marker.closest(".ac-session")).not.toBeNull();
+  });
 });
 
 // The remote-Δ freshness instrument used to live ONLY in the producer-console R

--- a/clients/react/src/components/producer-console/HandoffRitualOverlay.tsx
+++ b/clients/react/src/components/producer-console/HandoffRitualOverlay.tsx
@@ -218,13 +218,21 @@ export function HandoffRitualOverlay({ unitName, ritualId, phases }: HandoffRitu
   };
 
   return (
+    // Scoped to the CONVERSATION PANEL (its `position: relative` host), NOT a
+    // full-window takeover: a handoff busies ONE unit's conversation, so it
+    // covers only that panel and leaves the unit tabs, the Aim worklist, and
+    // the Remote rail usable while the ritual runs. `aria-modal` stays false —
+    // this no longer traps the whole app. The backdrop is TRANSLUCENT (not the
+    // old opaque `bg-background`) so the operator can faintly see the ritual
+    // prompt being delivered to the Producer underneath — visible proof the
+    // handoff is actually in flight, not a frozen wall.
     <div
       role="dialog"
-      aria-modal="true"
+      aria-modal="false"
       aria-label={
         isRespawn ? "Producer crash-respawn in progress" : "Handoff and restart in progress"
       }
-      className="fixed inset-0 z-50 flex items-center justify-center bg-background backdrop-blur-sm"
+      className="absolute inset-0 z-20 flex items-center justify-center bg-background/60 backdrop-blur-[2px]"
     >
       <div className="w-full max-w-lg rounded-xl border border-hairline-strong bg-surface-strong p-5 shadow-2xl">
         <h3 className="text-sm font-semibold text-foreground">

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -472,6 +472,10 @@
 /* ── SESSION pane (faux tabs row + S3 stub) ───────────────────────────── */
 .aim-console .ac-session {
   background: var(--bg);
+  /* Positioned host for the in-progress handoff overlay (App's `handoffOverlay`,
+     `absolute inset-0`): a handoff covers only THIS conversation column, not the
+     whole console, so the unit tabs / Aim / Remote stay usable. */
+  position: relative;
 }
 .aim-console .ac-stabs {
   display: flex;


### PR DESCRIPTION
## Problem

The handoff ritual overlay was a full-window **opaque** `fixed inset-0` takeover. While a handoff ran (`prompted → validated → awaiting_review → killed → launching → ready`) the operator was walled out of the **whole app**: no Aim edits, no PR checks, **not even switching units**. But a handoff busies **one unit's conversation**, not the console.

## Change

Scope the in-progress overlay to the **conversation panel** and make it **translucent**.

- **`HandoffRitualOverlay`**: `fixed inset-0 bg-background` (opaque, app-wide) → `absolute inset-0 bg-background/60 backdrop-blur-[2px]` (translucent, scoped); `aria-modal` → `false` (it no longer traps the app). The translucency lets the operator **faintly see the ritual prompt being delivered** underneath — visible proof the handoff is in flight, not a frozen wall.
- **`App`**: the in-progress overlay (`dispatching` + `in_progress`) moves out of the app-global `globalOverlays` into the **conversation panel of each mode** —
  - aim mode → `AimConsole`'s new `handoffOverlay` prop, rendered inside the `.ac-session` column;
  - producer mode → the centre conversation `div` (now `relative`).
  - **Gated on the focused unit**, so switching units reveals the other unit's conversation cleanly; the ritual keeps running and re-appears on switch-back.
  - The terminal **failure dialog + ready toast + help** stay app-global (a failure/completion is app-level news, not one panel's busy-state).
- **`.ac-session`** gains `position: relative` as the overlay's scoped host.

Result: during a handoff the **top-bar unit tabs** (outside `.ac-main`), the **Aim worklist**, and the **Remote rail** all stay usable.

## Visual (dark, default surface)

The overlay covers only the left conversation column; the top bar, Aim worklist, and PR/Issue rail stay clear, and the conversation shows faintly under the translucent panel:

```
┌── tmai console  [tmai][tmai-core] +            ⚙  ‹ console ──┐  ← top bar usable
│ ╭ faux prompt (faint) ──╮          │ AIM  SLACK               │
│ │ › producer            │          │ Aim  0 aims · 0 repos    │  ← Aim usable
│ │ ╭ Handoff & restart ╮ │          │ ▣0 drift ▣0 todo ▣0 done │
│ │ │ ✓ Prompted        │ │          │ [Frontier⚠][Tree] filter │  ← PR rail
│ │ │ ⟳ Validated       │ │          │ Loading…                 │     usable
│ │ │ ◌ Awaiting review │ │          │                          │
│ │ ╰───────────────────╯ │          │                          │
│ ╰───────────────────────╯          │                          │
└── conversation panel ONLY ─────────┴──────────────────────────┘
```

## Tests

- `App.handoff`: the overlay renders in the conversation panel (both modes) **and** a ritual for a non-focused unit shows nothing (focus-gating regression).
- `AimConsole`: `handoffOverlay` lands inside `.ac-session` (structural).

## Verify

- `tsc -b` = 0; full suite green (**991 passed**, 2 skipped); changed files biome-clean.
- Scoping + translucency confirmed visually in a local dark-mode headless preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)