### PR TITLE
chore(gen): sync generated spec + types from tmai-core@2ec85a39d5

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -373,28 +373,6 @@
       "description": "Classification of what was dispatched. Drives notification phrasing,\ngatekeeper rules (#11), and selector disambiguation (multiple dispatches\nmay reference the same PR number; the resolver reports them as ambiguous).",
       "oneOf": [
         {
-          "description": "Work attached to a GitHub issue (no PR yet).",
-          "properties": {
-            "kind": {
-              "enum": [
-                "issue"
-              ],
-              "type": "string"
-            },
-            "number": {
-              "description": "Issue number.",
-              "format": "int64",
-              "minimum": 0,
-              "type": "integer"
-            }
-          },
-          "required": [
-            "number",
-            "kind"
-          ],
-          "type": "object"
-        },
-        {
           "description": "Work attached to an existing pull request (e.g. follow-up commits).",
           "properties": {
             "kind": {
@@ -447,15 +425,6 @@
           "description": "Branch the dispatched work targets.",
           "type": [
             "string",
-            "null"
-          ]
-        },
-        "issue_number": {
-          "description": "Issue number when applicable.",
-          "format": "int64",
-          "minimum": 0,
-          "type": [
-            "integer",
             "null"
           ]
         },
@@ -2712,7 +2681,7 @@
       "description": "A side-effect API action was performed (for orchestrator notification)",
       "properties": {
         "action": {
-          "description": "API action name (e.g., \"dispatch_issue\", \"kill_agent\", \"merge_pr\")",
+          "description": "API action name (e.g., \"spawn_worktree\", \"kill_agent\", \"merge_pr\")",
           "type": "string"
         },
         "origin": {

--- a/api-spec/mcp-tools.json
+++ b/api-spec/mcp-tools.json
@@ -6,7 +6,7 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "id": {
-          "description": "Agent ID — accepts stable ID (e.g., \"a1b2c3d4\"), pane target (e.g., \"main:0.0\"), PTY session UUID, \"issue:N\", or \"pr:N\"",
+          "description": "Agent ID — accepts stable ID (e.g., \"a1b2c3d4\"), pane target (e.g., \"main:0.0\"), PTY session UUID, or \"pr:N\"",
           "type": "string"
         }
       },
@@ -47,72 +47,13 @@
     }
   },
   {
-    "description": "Dispatch a GitHub issue: fetch issue, create worktree, spawn agent with issue context",
-    "name": "dispatch_issue",
-    "parameters_schema": {
-      "$schema": "https://json-schema.org/draft/2020-12/schema",
-      "properties": {
-        "additional_instructions": {
-          "default": null,
-          "description": "Extra instructions appended after the auto-generated issue prompt",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "base_branch": {
-          "default": null,
-          "description": "Base branch to fork from (defaults to main)",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "effort": {
-          "default": null,
-          "description": "Per-dispatch effort override. See `SpawnAgentParams::effort`.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "issue_number": {
-          "description": "GitHub issue number to dispatch",
-          "format": "uint64",
-          "minimum": 0,
-          "type": "integer"
-        },
-        "model": {
-          "default": null,
-          "description": "Per-dispatch model override. See `SpawnAgentParams::model`.",
-          "type": [
-            "string",
-            "null"
-          ]
-        },
-        "repo": {
-          "default": null,
-          "description": "Repository path (optional, defaults to cwd or first registered project)",
-          "type": [
-            "string",
-            "null"
-          ]
-        }
-      },
-      "required": [
-        "issue_number"
-      ],
-      "type": "object"
-    }
-  },
-  {
     "description": "Get detailed info about a specific agent",
     "name": "get_agent",
     "parameters_schema": {
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "id": {
-          "description": "Agent ID — accepts stable ID (e.g., \"a1b2c3d4\"), pane target (e.g., \"main:0.0\"), PTY session UUID, \"issue:N\", or \"pr:N\"",
+          "description": "Agent ID — accepts stable ID (e.g., \"a1b2c3d4\"), pane target (e.g., \"main:0.0\"), PTY session UUID, or \"pr:N\"",
           "type": "string"
         }
       },
@@ -129,7 +70,7 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "id": {
-          "description": "Agent ID — accepts stable ID (e.g., \"a1b2c3d4\"), pane target (e.g., \"main:0.0\"), PTY session UUID, \"issue:N\", or \"pr:N\"",
+          "description": "Agent ID — accepts stable ID (e.g., \"a1b2c3d4\"), pane target (e.g., \"main:0.0\"), PTY session UUID, or \"pr:N\"",
           "type": "string"
         }
       },
@@ -429,7 +370,7 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "id": {
-          "description": "Agent ID — accepts stable ID (e.g., \"a1b2c3d4\"), pane target (e.g., \"main:0.0\"), PTY session UUID, \"issue:N\", or \"pr:N\"",
+          "description": "Agent ID — accepts stable ID (e.g., \"a1b2c3d4\"), pane target (e.g., \"main:0.0\"), PTY session UUID, or \"pr:N\"",
           "type": "string"
         }
       },
@@ -520,7 +461,7 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "id": {
-          "description": "Agent ID — accepts stable ID (e.g., \"a1b2c3d4\"), pane target (e.g., \"main:0.0\"), PTY session UUID, \"issue:N\", or \"pr:N\"",
+          "description": "Agent ID — accepts stable ID (e.g., \"a1b2c3d4\"), pane target (e.g., \"main:0.0\"), PTY session UUID, or \"pr:N\"",
           "type": "string"
         }
       },
@@ -774,7 +715,7 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "id": {
-          "description": "Agent ID — accepts stable ID, pane target, PTY session UUID, \"issue:N\", or \"pr:N\"",
+          "description": "Agent ID — accepts stable ID, pane target, PTY session UUID, or \"pr:N\"",
           "type": "string"
         },
         "key": {
@@ -796,7 +737,7 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "id": {
-          "description": "Agent ID — accepts stable ID, pane target, PTY session UUID, \"issue:N\", or \"pr:N\"",
+          "description": "Agent ID — accepts stable ID, pane target, PTY session UUID, or \"pr:N\"",
           "type": "string"
         },
         "prompt": {
@@ -818,7 +759,7 @@
       "$schema": "https://json-schema.org/draft/2020-12/schema",
       "properties": {
         "id": {
-          "description": "Agent ID — accepts stable ID, pane target, PTY session UUID, \"issue:N\", or \"pr:N\"",
+          "description": "Agent ID — accepts stable ID, pane target, PTY session UUID, or \"pr:N\"",
           "type": "string"
         },
         "text": {
@@ -896,16 +837,6 @@
             "null"
           ]
         },
-        "issue_number": {
-          "default": null,
-          "description": "GitHub issue number. When provided: auto-generates worktree name from issue title\n(if name is omitted) and composes a resolve prompt with the issue context.",
-          "format": "uint64",
-          "minimum": 0,
-          "type": [
-            "integer",
-            "null"
-          ]
-        },
         "model": {
           "default": null,
           "description": "Per-dispatch model override. See `SpawnAgentParams::model`.",
@@ -915,12 +846,8 @@
           ]
         },
         "name": {
-          "default": null,
-          "description": "Worktree name (optional if issue_number is provided — auto-generated from issue title)",
-          "type": [
-            "string",
-            "null"
-          ]
+          "description": "Worktree name (e.g. \"174-feat-foo\"). The Producer chooses it — tmai no\nlonger derives names or prompts from GitHub issues (the issue-dispatch\nresolution path is retired; the Producer reads the issue and writes the\nspec into `prompt`).",
+          "type": "string"
         },
         "prompt": {
           "default": null,
@@ -939,6 +866,9 @@
           ]
         }
       },
+      "required": [
+        "name"
+      ],
       "type": "object"
     }
   },
@@ -954,7 +884,7 @@
         },
         "repo": {
           "default": null,
-          "description": "Optional repo path; matches the `dispatch_issue` `repo` param\nshape. When omitted, falls back to the MCP client's current\nworking directory. The server resolves the owning unit from this\npath via `Settings::unit_for_path`.",
+          "description": "Optional repo path; matches the `spawn_worktree` `repo` param\nshape. When omitted, falls back to the MCP client's current\nworking directory. The server resolves the owning unit from this\npath via `Settings::unit_for_path`.",
           "type": [
             "string",
             "null"

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -25,7 +25,7 @@
           {
             "name": "id",
             "in": "path",
-            "description": "Agent identifier — canonical AgentId, target, pty_session_id, or semantic (issue:N / pr:N)",
+            "description": "Agent identifier — canonical AgentId, target, pty_session_id, or semantic (pr:N)",
             "required": true,
             "schema": {
               "type": "string"
@@ -1592,7 +1592,7 @@
             "properties": {
               "action": {
                 "type": "string",
-                "description": "API action name (e.g., \"dispatch_issue\", \"kill_agent\", \"merge_pr\")"
+                "description": "API action name (e.g., \"spawn_worktree\", \"kill_agent\", \"merge_pr\")"
               },
               "origin": {
                 "$ref": "#/components/schemas/ActionOrigin",
@@ -1861,28 +1861,6 @@
         "oneOf": [
           {
             "type": "object",
-            "description": "Work attached to a GitHub issue (no PR yet).",
-            "required": [
-              "number",
-              "kind"
-            ],
-            "properties": {
-              "kind": {
-                "type": "string",
-                "enum": [
-                  "issue"
-                ]
-              },
-              "number": {
-                "type": "integer",
-                "format": "int64",
-                "description": "Issue number.",
-                "minimum": 0
-              }
-            }
-          },
-          {
-            "type": "object",
             "description": "Work attached to an existing pull request (e.g. follow-up commits).",
             "required": [
               "number",
@@ -1942,15 +1920,6 @@
               "null"
             ],
             "description": "Branch the dispatched work targets."
-          },
-          "issue_number": {
-            "type": [
-              "integer",
-              "null"
-            ],
-            "format": "int64",
-            "description": "Issue number when applicable.",
-            "minimum": 0
           },
           "pr_number": {
             "type": [

--- a/clients/ratatui/src/types/generated/dispatch_refs.rs
+++ b/clients/ratatui/src/types/generated/dispatch_refs.rs
@@ -15,8 +15,6 @@ pub struct DispatchRefs {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub branch: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub issue_number: Option<Value>,
-    #[serde(skip_serializing_if = "Option::is_none")]
     pub pr_number: Option<Value>,
     pub project_root: String,
     pub title: String,

--- a/clients/react/src/components/settings/ProducerDispatchSection.tsx
+++ b/clients/react/src/components/settings/ProducerDispatchSection.tsx
@@ -25,7 +25,7 @@ interface DispatchRole {
 const ROLES: DispatchRole[] = [
   {
     title: "Implementer",
-    subtitle: "dispatch_issue / spawn_worktree",
+    subtitle: "spawn_worktree",
     read: (s) => s.dispatch.implementer ?? null,
     write: (s, bundle) => ({ ...s, dispatch: { ...s.dispatch, implementer: bundle } }),
   },

--- a/clients/react/src/components/settings/__tests__/DispatchBundleEditor.test.tsx
+++ b/clients/react/src/components/settings/__tests__/DispatchBundleEditor.test.tsx
@@ -11,7 +11,7 @@ function renderEditor(bundle: DispatchBundle | null) {
   render(
     <DispatchBundleEditor
       title="Implementer"
-      subtitle="dispatch_issue / spawn_worktree"
+      subtitle="spawn_worktree"
       bundle={bundle}
       onAtomicChange={onAtomic}
       onTextDraft={onDraft}

--- a/clients/react/src/types/generated/CoreEvent.ts
+++ b/clients/react/src/types/generated/CoreEvent.ts
@@ -222,7 +222,7 @@ pid: number, } | { "type": "ActionPerformed",
  */
 origin: ActionOrigin, 
 /**
- * API action name (e.g., "dispatch_issue", "kill_agent", "merge_pr")
+ * API action name (e.g., "spawn_worktree", "kill_agent", "merge_pr")
  */
 action: string, 
 /**

--- a/clients/react/src/types/generated/DispatchKind.ts
+++ b/clients/react/src/types/generated/DispatchKind.ts
@@ -5,11 +5,7 @@
  * gatekeeper rules (#11), and selector disambiguation (multiple dispatches
  * may reference the same PR number; the resolver reports them as ambiguous).
  */
-export type DispatchKind = { "kind": "issue", 
-/**
- * Issue number.
- */
-number: bigint, } | { "kind": "pr", 
+export type DispatchKind = { "kind": "pr", 
 /**
  * PR number.
  */

--- a/clients/react/src/types/generated/DispatchRefs.ts
+++ b/clients/react/src/types/generated/DispatchRefs.ts
@@ -25,10 +25,6 @@ branch?: string,
  */
 base_branch?: string, 
 /**
- * Issue number when applicable.
- */
-issue_number?: bigint, 
-/**
  * PR number when applicable.
  */
 pr_number?: bigint, 


### PR DESCRIPTION
Mirrors the **dispatch_issue / issue-as-addressable-concept rip** — tmai-core #617 (`2ec85a3`).

## Generated (regenerated via `tmai-xtask` from merged core main)

- `api-spec/`: `openapi.json`, `corevents.schema.json`, `mcp-tools.json` — the `dispatch_issue` MCP tool removed, `spawn_worktree` params changed (`issue_number`/`additional_instructions` dropped, `name` required), `DispatchKind` loses its `Issue` variant, `DispatchRefs` loses `issue_number`.
- `clients/react/src/types/generated/`: `CoreEvent.ts`, `DispatchKind.ts`, `DispatchRefs.ts`.
- `clients/ratatui/src/types/generated/`: `dispatch_refs.rs`.

## Companion consumer fix (hand-written)

The Implementer dispatch-bundle subtitle `"dispatch_issue / spawn_worktree"` → `"spawn_worktree"` (`ProducerDispatchSection.tsx` + its test) — `dispatch_issue` is retired. No other hub consumer referenced the removed `DispatchKind::Issue` variant or `refs.issue_number` (verified hub-wide).

## Verified locally

- `cargo check` (clients/ratatui) — clean
- `tsc -b` (clients/react) — clean
- `vitest run src/components/settings` — 68 passed

Generated-From: trust-delta/tmai-core@2ec85a39d57c1c9f17682c496c8486b578a71f06

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * エージェントや端末関連の参照方法の説明を整理し、利用可能な形式をより分かりやすくしました。
  * 作業開始時の案内から、古い表記を हटし、現在の名称に統一しました。
* **Documentation**
  * 端末接続や作業生成に関する仕様説明を更新し、表示される例示文言を最新化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->