### PR TITLE
docs(aim-refs): repoint code comments from archived aims to live successors

### DIFF
--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -4,8 +4,9 @@
 // (`origin/mock/aim-ui-sample` → `assets/ui-sample.html`, dev-tool / scale
 // variant): a full-window 3-pane console — Aim (worklist) ⟂ Session (raw CC)
 // ⟂ PR-rail — under a sober top bar (brand + unit tabs + meta). Serves aim
-// node `aim-ui` (`tmai-core:doc/aims/aim-ui.md`), part of the aim-model
-// dogfood.
+// node `aim-project-artifact` (`tmai-core:doc/aims/aim-project-artifact.md`) —
+// the console IS the first-class artifact display + operation surface. (The old
+// `aim-ui` node was archived in the corpus rebuild, tmai-core #528.)
 //
 // THE SOLE SURFACE: the legacy ProducerConsole / R-panel shell was ripped —
 // aim is the only console now (no mode toggle, no EXIT pair). This console is

--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -2,7 +2,8 @@
 // the destination mock (`origin/mock/aim-ui-sample` → `assets/ui-sample.html`,
 // the `.aim` section + the create-aim modal) in the aim-console's scoped
 // dev-tool tokens (`.ac-*` family, `styles/aim-console.css`). Serves aim node
-// `aim-ui` (`tmai-core:doc/aims/aim-ui.md`).
+// `aim-project-artifact` (`tmai-core:doc/aims/aim-project-artifact.md`; the old
+// `aim-ui` node was archived in the corpus rebuild, tmai-core #528).
 //
 // THE KEY MOVE — REUSE the logic, REPRODUCE the presentation. The entire aim
 // data + owed/frontier/rollup/ledger/ruler model already exists, built against

--- a/clients/react/src/components/aim-console/aim-tree.ts
+++ b/clients/react/src/components/aim-console/aim-tree.ts
@@ -142,7 +142,8 @@ export function aimTone(n: AimWire): AimTone {
 
 // ── Working-tree presence facts (#817) ────────────────────────────────
 //
-// Design B of tmai-core's `doc/aims/aim-drift-commit-boundary.md`: the
+// Design B of tmai-core's `doc/aims/drift-git.md` (the working-delta concept,
+// ported from the archived `aim-drift-commit-boundary`): the
 // committed layer (`drift`) states ORDER judgments; `working_delta` states
 // PRESENCE only. The one fact it surfaces to the operator: "the drift verdict
 // on screen is HEAD-based and does not see your uncommitted edit yet" —

--- a/clients/react/src/components/aim-console/resignation.ts
+++ b/clients/react/src/components/aim-console/resignation.ts
@@ -1,5 +1,6 @@
 // Resignation inventory — the pure computation behind the done-set view
-// (issue #811; aim node `aim-resignation-inventory`, parent `aim-recoil-loop`).
+// (issue #811; aim node `aim-resolution-outcome` — the console resignation
+//  inventory ported from the archived `aim-resignation-inventory`, tmai-core #528).
 //
 // done = the human's 満足と諦め status; the weight is on 諦め — accepting the
 // uninspected remainder WITHOUT knowing it. tmai does NOT mechanize done; it

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -3,15 +3,16 @@
 
    Faithful port of the destination mock (`origin/mock/aim-ui-sample` →
    `assets/ui-sample.html`, dev-tool / scale variant). Serves aim node
-   `aim-ui` (`tmai-core:doc/aims/aim-ui.md`).
+   `aim-project-artifact` (`tmai-core:doc/aims/aim-project-artifact.md`; the
+   old `aim-ui` node was archived in the corpus rebuild, tmai-core #528).
 
-   COEXIST, DO NOT RIP: the existing console keeps its own
-   tokens/themes (globals.css + lib/theme.ts). EVERYTHING here is scoped
-   under `.aim-console` so the dev-tool palette (low-chroma, k9s/lazygit
-   tone) and the 12.5px/27px density NEVER bleed into the existing
-   console. Custom properties declared on `.aim-console` only inherit
-   DOWN into the aim-console subtree, so the existing UI — which is never
-   a descendant of `.aim-console` — cannot see them.
+   SCOPED HYGIENE: the rest of the app keeps its own tokens/themes
+   (globals.css + lib/theme.ts) — Settings, dialogs, toasts. EVERYTHING here
+   is scoped under `.aim-console` so the dev-tool palette (low-chroma,
+   k9s/lazygit tone) and the 12.5px/27px density NEVER bleed into those
+   surfaces. Custom properties declared on `.aim-console` only inherit DOWN
+   into the aim-console subtree, so non-console UI — never a descendant of
+   `.aim-console` — cannot see them.
 
    This file is NOT processed by Tailwind (it has no `@import "tailwindcss"`)
    and is NOT linted/formatted by biome (CSS is disabled in biome.json), so


### PR DESCRIPTION
## What

Fix **code→aim reference drift**: the corpus rebuild (tmai-core #528) archived the old aim vocabulary, but several comments still named the archived nodes as the aim they "serve". Repoint each to its live successor (mappings verified against the live corpus + operator-confirmed).

| Comment | archived → **live successor** |
|---|---|
| `AimConsole` / `AimPane` / `aim-console.css` | `aim-ui` → **`aim-project-artifact`** |
| `aim-tree.ts` | `aim-drift-commit-boundary` → **`drift-git`** |
| `resignation.ts` | `aim-resignation-inventory` / `aim-recoil-loop` → **`aim-resolution-outcome`** |

The `aim-resolution-outcome` mapping is confirmed by the aim itself — its PROCESS says it *"ported"* the archived `aim-resignation-inventory`.

Also refreshes `aim-console.css`'s stale *"COEXIST with the existing console"* framing (that console was ripped in #916) to the still-valid `.aim-console` scoping-hygiene rationale.

## Scope

- **Comment-only** — no behavior change.
- `mock/aim-ui-sample` references are left as-is (they point at the design **mock branch**, not the aim).
- **Deferred (core-side)**: two generated-type comments (`AimWire` / `AimWorkingDeltaWire`) also name `aim-drift-commit-boundary`, but they're generated from the tmai-core Rust source → separate fix + regen (WSL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * コンソール関連の説明文を更新し、参照先や用語を最新の内容に合わせました。
  * コンソールの表示・操作に関する案内を、現在の構成に沿って整理しました。
  * ワーキング差分やアーカイブに関する注記を見直し、説明の一貫性を高めました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->