### PR TITLE
docs(aim-refs): repoint retired-DR citations to live aims + reconcile removed-component refs

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -78,10 +78,9 @@ export function App() {
   const [mainPanel, setMainPanel] = useState<"agents" | "settings">("agents");
   const [showHelp, setShowHelp] = useState(false);
   const showSettings = mainPanel === "settings";
-  // Phase B of the Producer-console rebuild
-  // (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`)
-  // routes orchestrator-era controls behind a `<details>` section
-  // inside SettingsPanel. The flag below distinguishes:
+  // Post-inversion default (aim `producer-centric-project`): orchestrator-era
+  // controls are routed behind a `<details>` section inside SettingsPanel so
+  // the Producer-relevant sections show first. The flag below distinguishes:
   //
   // - regular Settings entry (StatusBar button / Ctrl+,) → Advanced
   //   stays collapsed; the Producer-relevant sections are what you
@@ -214,14 +213,12 @@ export function App() {
     dismissHandoff();
   }, [producerForUnit, dismissHandoff]);
 
-  // "Open Producer terminal" affordance from <ProducerConsole>.
+  // The "Open Producer terminal" affordance.
   //
-  // Decision `doc/decisions/2026-05-14-react-producer-console-rebuild.md`
-  // §Producer chat: the Producer conversation stays on the terminal
-  // substrate (substrate swap is rejected per cross-ref
-  // `tmai-core@2026-05-13-agent-view-does-not-replace-multiplexer-
-  // substrate`). The WebUI's job is just to make the canonical
-  // command trivially copy-pasteable.
+  // Per aim `cli-pty-server`: the Producer conversation stays on the terminal
+  // substrate (substrate swap is rejected — see aim `configurable-cli-substrate`).
+  // The WebUI's job is just to make the canonical command trivially
+  // copy-pasteable.
   //
   // `navigator.clipboard.writeText` requires a secure context;
   // `localhost` qualifies, so it works in dev. When the API isn't

--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -168,12 +168,11 @@ export function AimConsole({
   // `repos` is empty there — the footer falls back to `currentProjectPath`.
   const activeUnit = units.find((u) => u.name === activeUnitName) ?? null;
 
-  // Remote-Δ freshness cursors (#822; #606 §1 lift) — the SAME `remoteDeltaCursors`
-  // ui-pref the producer-console R panel owns, so a looking-act in either console
-  // is one human looking-act (the cursor is mode-independent, per-unit). Client
-  // state only, never sent to core; the Producer never reads it. `AimConsole`
-  // owns the cursor here (mirroring `RPanel`); `PrRail` is presentational and
-  // only receives the effective cursors. The rail has ONE close act — the rail
+  // Remote-Δ freshness cursors (#822; #606 §1 lift) — the `remoteDeltaCursors`
+  // ui-pref is owned here (per-unit). Client state only, never sent to core;
+  // the Producer never reads it. `AimConsole` owns the cursor; `PrRail` is
+  // presentational and only receives the effective cursors. The rail has ONE
+  // close act — the rail
   // collapse — so it stamps the coarse `panel` cursor, which via `effectiveCursor`
   // = MAX(panel, section) clears BOTH sections (collapsing the whole rail = done
   // looking at all of it). No section-level close acts, no timers, no per-row

--- a/clients/react/src/components/aim-console/Gutters.tsx
+++ b/clients/react/src/components/aim-console/Gutters.tsx
@@ -199,7 +199,7 @@ export function ConvAimGutter({
   const { live, readout, handlers } = useGutterDrag({ axis: "x", onStart, onMove, onEnd, onReset });
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter (RPanel precedent)
+    // biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter
     <div
       className={cn("ac-vgut", live && "live")}
       role="separator"
@@ -271,7 +271,7 @@ export function OverlayEdgeGutter({
   const { live, readout, handlers } = useGutterDrag({ axis: "x", onStart, onMove, onEnd, onReset });
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter (RPanel precedent)
+    // biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter
     <div
       className={cn("ac-ovgut", live && "live")}
       role="separator"
@@ -350,7 +350,7 @@ export function AimRemoteGutter({
   });
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter (RPanel precedent)
+    // biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter
     <div
       className={cn("ac-vgut", !active && "off", live && "live")}
       role="separator"
@@ -424,7 +424,7 @@ export function FooterGutter({
   const { live, readout, handlers } = useGutterDrag({ axis: "y", onStart, onMove, onEnd, onReset });
 
   return (
-    // biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter (RPanel precedent)
+    // biome-ignore lint/a11y/useSemanticElements: a div is the draggable splitter
     <div
       className={cn("ac-hgut", live && "live")}
       role="separator"

--- a/clients/react/src/components/aim-console/HandoffRitualFailureDialog.tsx
+++ b/clients/react/src/components/aim-console/HandoffRitualFailureDialog.tsx
@@ -1,8 +1,8 @@
 // Failure dialog for a rejected / errored handoff-and-restart ritual.
 //
-// Renders the 4-choice surface from DR
-// `tmai-core/doc/decisions/2026-05-14-handoff-lifecycle-and-kill-ux.md`
-// §E. Behaviors (PR4 — intentionally narrow):
+// Renders the 4-choice failure surface for aim `conversation-handoff`
+// (the handoff-and-restart ritual's WebUI lifecycle). Behaviors (PR4 —
+// intentionally narrow):
 //
 //   ┌──────────────────────┬─────────────────────────────────────────┐
 //   │ Force kill           │ POST /api/agents/{id}/kill on the live  │

--- a/clients/react/src/components/aim-console/PrRail.tsx
+++ b/clients/react/src/components/aim-console/PrRail.tsx
@@ -4,14 +4,13 @@
 // open-counts + a static `‹ EXTERNAL` framing) that expands to a per-repo
 // PR + Issue inventory grouped across the whole unit.
 //
-// REUSE, DON'T REBUILD: the data comes from `useUnitPrs` / `useUnitIssues`
-// (the same unit-scoped, multi-repo hooks the Producer console's R panel
-// uses), and each row's categorical status pill is derived by the SAME
-// `prStatusPills` / `issueStatusPills` functions (import-only) so the
-// lifecycle/CI colour story stays consistent with `RPrsSection` /
-// `RIssuesSection`. WHY the pills are rendered here as local `.ac-pst` spans
-// instead of the shared `StatusPills` component: `StatusPills` carries the
-// producer-console theme classes; the aim-console reproduces the mock's
+// REUSE, DON'T REBUILD: the data comes from the unit-scoped, multi-repo
+// `useUnitPrs` / `useUnitIssues` hooks, and each row's categorical status pill
+// is derived by the SAME `prStatusPills` / `issueStatusPills` functions
+// (import-only) so the lifecycle/CI colour story stays consistent wherever
+// those pills render. WHY the pills are rendered here as local `.ac-pst` spans
+// instead of the shared `StatusPills` component: `StatusPills` carries its own
+// `TONE_CLASS` tokens; the aim-console reproduces the mock's
 // dev-tool `.pst` look in its own scoped tokens (issue #801 bounding —
 // touch ONLY `aim-console/**` + `aim-console.css`). The colour is still
 // CATEGORICAL, never appraisal (`2026-05-26-tmai-states-facts-not-appraisals`):
@@ -27,15 +26,14 @@
 // `onExpand` / `onCollapse` — it never owns the open state.
 //
 // REMOTE-Δ FRESHNESS (#606 §1 / aim `pr-issue-ci` / instrument #822): the
-// remote-Δ instrument used to live ONLY in the producer-console R panel
-// (`RPrsSection` / `RIssuesSection`), so the aim-console — the DEFAULT surface
+// remote-Δ instrument first shipped (#822/#823) in the now-removed
+// producer-console R panel, so the aim-console — the DEFAULT surface
 // since #850/#851 — showed PR/issue rows but not "which changed since you last
 // looked" (a stranding regression, the same shape as the #897/#898 handoff
-// overlay lift). This rail now carries the instrument too. WHAT it reuses: the
-// pure `remote-delta.ts` helpers (logic, no theme — same import category as the
-// `prStatusPills` derivation). WHAT it does NOT reuse: the producer-console
-// `UnobservedDelta` component, because it carries the producer theme's
-// `text-info` token; the dev-tool Δ accent is its own `.ac-unobs` (cyan = the
+// overlay lift). #606 §1 lifted it here, and the 2026-07-01 producer-console
+// rip made this rail the sole home. WHAT it reuses: the pure `remote-delta.ts`
+// helpers (logic, no theme — same import category as the `prStatusPills`
+// derivation). The Δ accent is its own `.ac-unobs` (cyan = the
 // aim-console info-family token), keeping the #801 bounding (touch ONLY
 // `aim-console/**` + `aim-console.css`). The cursor itself is OWNED by
 // `AimConsole` (the rail-collapse close act stamps the unit's `panel` cursor in

--- a/clients/react/src/components/aim-console/prose.ts
+++ b/clients/react/src/components/aim-console/prose.ts
@@ -1,10 +1,10 @@
-// Shared markdown prose classes for the R₂ viewers (PR content + record
-// excerpt). Same palette the transcript / digest markdown uses so bodies
-// and excerpts read like the rest of the WebUI. Extracted from
-// `RPrViewer` so the record viewer (`RRecordViewer`) reuses the EXACT
-// styling without restyling — per `2026-05-29-artifact-content-viewer`,
-// standard markdown rendering is the ONE allowed convention inside the
-// viewer's prose, and it must look identical across both R₂ kinds.
+// Shared markdown prose classes. Same palette the transcript / aim-body
+// markdown uses so bodies read like the rest of the WebUI. Standard markdown
+// rendering is the ONE allowed convention inside prose. Consumed by
+// `TranscriptView` and `AimBody`; the R₂ content viewers (`RPrViewer` /
+// `RRecordViewer`) were removed in the 2026-07-01 producer-console rip and a
+// live-fetch confirm viewer is being rebuilt on the aim console (aim
+// `act-in-tmai`).
 
 export const PROSE_CLASSES = `prose prose-invert prose-sm max-w-none
   prose-headings:text-foreground prose-headings:font-semibold

--- a/clients/react/src/components/aim-console/status-pills.tsx
+++ b/clients/react/src/components/aim-console/status-pills.tsx
@@ -130,8 +130,8 @@ export function StatusPills({ pills }: { pills: StatusPill[] }) {
 }
 
 // "EXTERNAL · github = source of truth" framing for the PR / Issue rail
-// headers (C2). PRs and Issues are the GitHub-resident artifacts on the R
-// panel (vs the git-resident decisions / approaches / aims), so this tag
+// headers (C2). PRs and Issues are the GitHub-resident artifacts on the rail
+// (vs the git-resident decisions / approaches / aims), so this tag
 // states that github — not tmai — is their source of truth. Subtle / mono,
 // pushed to the right edge of the section header.
 export function ExternalSourceBadge() {

--- a/clients/react/src/components/settings/SettingsPanel.tsx
+++ b/clients/react/src/components/settings/SettingsPanel.tsx
@@ -12,9 +12,8 @@ import { WorktreeSection } from "./WorktreeSection";
 
 interface SettingsPanelProps {
   onClose: () => void;
-  /** Phase B of the Producer-console rebuild
-   *  (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`)
-   *  collapses orchestrator-era controls behind an Advanced section.
+  /** Post-inversion default (aim `producer-centric-project`): orchestrator-era
+   *  controls are collapsed behind an Advanced section.
    *  When the operator arrives here from `ProducerConsoleActions`'
    *  Operator-override panel, we want Advanced open by default so
    *  the deep-link lands on the controls the operator was after.

--- a/clients/react/src/hooks/useHandoffRitual.ts
+++ b/clients/react/src/hooks/useHandoffRitual.ts
@@ -1,7 +1,6 @@
-// Hook for the Producer handoff-and-restart ritual (DR
-// `tmai-core/doc/decisions/2026-05-14-handoff-lifecycle-and-kill-ux.md`
-// §E — WebUI surface). Drives the ProducerConsole's in-progress
-// overlay and the 4-choice failure dialog.
+// Hook for the Producer handoff-and-restart ritual (aim `handoff-non-blocking`
+// — WebUI surface). Drives the conversation panel's in-progress overlay and
+// the 4-choice failure dialog.
 //
 // Lifecycle:
 //

--- a/clients/react/src/hooks/useHandover.ts
+++ b/clients/react/src/hooks/useHandover.ts
@@ -1,8 +1,6 @@
-// Hand-over digest aggregator for the Producer console.
+// Hand-over digest aggregator.
 //
-// Background — `doc/decisions/2026-05-14-react-producer-console-rebuild.md`
-// (cross-refs `tmai-core@doc/decisions/2026-05-13-producer-feedback-loop-
-// and-decision-tiers.md`): the Producer's session-start hand-over is
+// Per aim `conversation-handoff`: the Producer's session-start hand-over is
 // composed from four sections — ▶ Where-you-left-off, ⬢ Cross-unit
 // status, ⬡ Settled decisions, ◐ Working-with-this-human.
 //

--- a/clients/react/src/hooks/useResponsiveLayout.ts
+++ b/clients/react/src/hooks/useResponsiveLayout.ts
@@ -46,9 +46,8 @@ export function useResponsiveLayout(): UseResponsiveLayoutResult {
     if (typeof window !== "undefined" && !window.matchMedia(NARROW_BREAKPOINT).matches) {
       return true; // Auto-collapse on narrow screens
     }
-    // Phase B of the Producer-console rebuild
-    // (`doc/decisions/2026-05-14-react-producer-console-rebuild.md`)
-    // flips the default to *collapsed* so the legacy AgentList stops
+    // Post-inversion default (aim `producer-centric-project`): the sidebar
+    // default flips to *collapsed* so the legacy AgentList stops
     // being on the main flow. Existing operators are unaffected — their
     // localStorage value (set by `toggleSidebar` on first use) keeps
     // overriding the default. New / clean-state users land on the

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -211,8 +211,8 @@ export function isAiAgent(agentType: AgentType): boolean {
 /// `id` carries the canonical scheme (`claude:` / `codex:` / `gemini:` /
 /// `opencode:`) even when the spawn command was wrapped — e.g. the
 /// Producer launch wraps `tmai producer <unit>` under `bash -c` to
-/// satisfy tmai-core's `/api/spawn` allow-list (see
-/// `doc/decisions/2026-05-14-react-producer-console-rebuild.md` polish v4).
+/// satisfy tmai-core's `/api/spawn` allow-list (see aim `producer-cwd`,
+/// Phase 3 — the bash wrap retires when respawn cuts over to engine-direct).
 /// In that wrapped case `agent_type` stays `Custom("bash")` and the
 /// plain `isAiAgent(agent_type)` check misses the Producer.
 ///


### PR DESCRIPTION
## What

Continues #917's **code→aim reference reconcile**. Two drifts left by the d/a→aim migration and the 2026-07-01 producer-console rip (#916). **Comment-only, no behavior change.**

### 1. Dangling DR-path citations (8)

The migration moved the design records to `doc/archive` (hub `bb61d2f`; core to `doc/archive/{approaches,decisions}`), but 8 code comments still cited the now-nonexistent `doc/decisions/…` paths. Per operator choice, repointed each to its **live successor aim** (point at the governing aim, not the frozen archive path):

| Site | archived DR → **live aim** |
|---|---|
| `App.tsx:81` settings routing · `useResponsiveLayout:49` sidebar default · `SettingsPanel:15` Advanced collapse | react-producer-console-rebuild → **`producer-centric-project`** |
| `App.tsx:217` terminal substrate | react-producer-console-rebuild → **`cli-pty-server`** (+ `configurable-cli-substrate` for the substrate-swap-rejected cross-ref) |
| `useHandover.ts:1` session-start digest | react-producer-console-rebuild → **`conversation-handoff`** |
| `api-http.ts:214` producer bash-wrap | react-producer-console-rebuild → **`producer-cwd`** (Phase 3) |
| `HandoffRitualFailureDialog.tsx:3` failure surface | handoff-lifecycle-and-kill-ux → **`conversation-handoff`** |
| `useHandoffRitual.ts:1` in-progress overlay | handoff-lifecycle-and-kill-ux → **`handoff-non-blocking`** |

### 2. Removed-component references

The producer-console rip (#916) removed `RPanel` / `RPrsSection` / `RIssuesSection` / `UnobservedDelta` / `RPrViewer` / `RRecordViewer` and the `<ProducerConsole>` component, but several comments still named them in the **present tense**. Reworded to the aim-console sole-seat reality:

- `AimConsole.tsx` — cursor ownership ("either console" / "mirroring RPanel" → AimConsole owns it, per-unit)
- `PrRail.tsx` — header REUSE + REMOTE-Δ FRESHNESS blocks (RPrsSection/RIssuesSection/UnobservedDelta → now-removed / historical)
- `prose.ts` — R₂-viewer origin → current consumers (`TranscriptView`/`AimBody`) + honest removal note
- `Gutters.tsx` ×4 — dropped "(RPanel precedent)" from the biome-ignore justification
- `status-pills.tsx` — `ExternalSourceBadge` "on the R panel" → "on the rail"

**Still-live symbols left intact**: `StatusPills` (moved into `aim-console/status-pills.tsx`), `ProducerConsoleActions`.

## Verification

- `tsc -b` green
- `vitest run` — 90 files, 818 passed, 2 skipped
- biome: only working-tree CRLF noise (normalized by `core.autocrlf`; CI sees LF)

## Deferred (out of scope)

- **Partially-live "Producer console" naming** (`ProducerConsoleActions`, "Open Producer terminal" affordance) — needs adjudication on what's actually dead vs re-homed; not a clean citation fix.
- **Dead code paths** (behavior-adjacent, separate rip): `AimBody` `"rpanel"` `AimBodyVariant` (no caller passes it) · `ui-prefs.ts` `rPanelExpandedSections` (unread by any component).
- **Core-side** `AimWire` / `AimWorkingDeltaWire` generated-type comments still naming `aim-drift-commit-boundary` — generated from Rust → WSL (already noted deferred in #917).

🤖 Generated with [Claude Code](https://claude.com/claude-code)