### PR TITLE
chore(dirbrowser): match the picker overlay to the Settings overlay style

### DIFF
--- a/clients/react/src/components/project/DirBrowser.tsx
+++ b/clients/react/src/components/project/DirBrowser.tsx
@@ -60,7 +60,7 @@ export function DirBrowser({ onSelect, onCancel, startPath, actionSlot }: DirBro
     // Backdrop
     <div
       role="dialog"
-      className="fixed inset-0 z-50 flex items-center justify-center bg-background"
+      className="fixed inset-0 z-50 flex items-center justify-center bg-background/60 backdrop-blur-[2px] animate-fade-in"
       onClick={onCancel}
       onKeyDown={(e) => {
         if (e.key === "Escape") onCancel();
@@ -70,7 +70,7 @@ export function DirBrowser({ onSelect, onCancel, startPath, actionSlot }: DirBro
       {/* biome-ignore lint/a11y/noStaticElementInteractions: stops click propagation to close backdrop */}
       <div
         role="presentation"
-        className="glass mx-4 flex w-full max-w-lg flex-col rounded-2xl border border-hairline-strong shadow-2xl"
+        className="mx-4 flex w-full max-w-lg flex-col rounded-xl border border-hairline-strong bg-background shadow-2xl animate-scale-in"
         onClick={(e) => e.stopPropagation()}
         onKeyDown={(e) => e.stopPropagation()}
       >


### PR DESCRIPTION
Follow-up to #922 — align the **new-Producer launch panel** to the Settings overlay look.

The launch panel is `ProducerLaunchPicker`, which delegates its shell to the shared **`DirBrowser`**. DirBrowser had:
- an **opaque** full-screen backdrop (`bg-background`) — fully hid the app behind
- a **`glass` card** (`var(--glass-bg)` + `blur(20px)`)

Aligned to the Settings overlay (the #922 look):
- backdrop → `bg-background/60 backdrop-blur-[2px]` + `animate-fade-in` (translucent + blur)
- card → opaque `bg-background`, `rounded-xl`, `border-hairline-strong`, `shadow-2xl`, `animate-scale-in`

## Blast radius (intentional)

DirBrowser is the shared picker shell, so this unifies **all four** instances — `ProducerLaunchPicker`, `NewAgentLauncher` (sidebar launcher), and the `GeneralSection` / `ProducerSection` **Browse** buttons — with the Settings overlay. Consistent by design; if you want the launch picker styled differently from the Settings-Browse pickers, say so and I'll parameterize the shell instead.

## Verification (D:\)

`tsc -b` clean · `biome lint` clean · `vitest run` (project + settings) → **16 files, 84 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * ディレクトリ選択モーダルの見た目を調整し、背景のぼかしやフェードイン、拡大アニメーションを追加しました。
  * モーダル本体のデザインを更新し、余白・角丸・影を強調して、より見やすい表示に改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->