### PR TITLE
rip(lib): remove the dead lib/index.ts re-export barrel

### DIFF
--- a/clients/react/src/lib/index.ts
+++ b/clients/react/src/lib/index.ts
@@ -1,7 +1,0 @@
-// Library exports - use Tauri-aware API by default
-
-export type { CoreEvent } from "../hooks/useTauriEvents";
-export * from "./api";
-export { connectTerminal, subscribeSSE } from "./api";
-export { api } from "./api-tauri";
-export { tauri } from "./tauri";


### PR DESCRIPTION
Completing the UI dead-code audit — a `lib/` orphan scan (same importer-graph method as #924–#926). Result: **one orphan**, `lib/index.ts`.

It's a re-export barrel that **nothing imports** — no `@/lib` (bare), `@/lib/index`, or side-effect import anywhere in `src`. Every consumer uses the concrete paths (`@/lib/api`, `@/lib/api-tauri`, `@/lib/tauri`, …) directly, so the barrel has been dead surface.

Rest of `lib/` is clean (every other file has a live importer).

Verified: `tsc -b` clean (nothing imported it) · `biome lint` clean. Full suite runs in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)