### PR TITLE
chore(gen): sync generated spec + types from tmai-core@50a831f30d

### DIFF
--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -108,7 +108,7 @@
           "producer"
         ],
         "summary": "Documentation stub for `POST /api/producer/launch` (by-path, #581).",
-        "description": "Engine-composed direct `claude` Producer launch, resolved BY PATH (supersedes\nthe #566 by-name `/api/units/{unit}/producer/launch`). The launch cwd DEFINES\nthe unit (aim `producer-cwd`): the `ProducerLaunchRequest` body carries the\npicked `path`, and the engine derives the unit via `Settings::unit_for_path`\n(the owning configured `[[unit]]`, else a `from_dir` synthesis) — so a\nbrand-new project root (the `+` Add-unit bootstrap) launches where by-name\nresolution 404'd. Runs the shared launch builder\n(`producer_cli::build_producer_launch` — compose + #541 readiness + boot file\n#373 + the exact `claude` argv, the SAME builder the terminal `tmai producer`\nCLI uses), then spawns `claude` DIRECTLY into a PTY with the\n`role=producer`/`unit`/`vendor=claude` hints at the spawn act — no bash-wrap /\ntmai-CLI chain. Honors the same capacity (503) + cwd-exists (400) guards as\n`/api/spawn`. The 200 body mirrors `/api/spawn`'s response:\n`{ session_id, pid (0), command (\"claude\"), dispatch_id }`. Real handler:\n`crate::web::api::launch_producer_at_path`.",
+        "description": "Engine-composed direct `claude` Producer launch, resolved BY PATH (supersedes\nthe #566 by-name `/api/units/{unit}/producer/launch`). The launch cwd DEFINES\nthe unit (aim `producer-cwd`): the `ProducerLaunchRequest` body carries the\npicked `path`, and the engine derives the unit via `Settings::unit_for_path`\n(the owning configured `[[unit]]`, else a `from_dir` synthesis) — so a\nbrand-new project root (the `+` Add-unit bootstrap) launches where by-name\nresolution 404'd. Runs the shared launch builder\n(`producer_cli::build_producer_launch` — compose + #541 readiness + boot file\n#373 + the exact `claude` argv, the SAME builder the terminal `tmai producer`\nCLI uses), then spawns `claude` DIRECTLY into a PTY with the\n`role=producer`/`unit`/`vendor=claude` hints at the spawn act — no bash-wrap /\ntmai-CLI chain. Honors the same cwd-exists (400) guard as\n`/api/spawn`. The 200 body mirrors `/api/spawn`'s response:\n`{ session_id, pid (0), command (\"claude\"), dispatch_id }`. Real handler:\n`crate::web::api::launch_producer_at_path`.",
         "operationId": "launch_producer_at_path_doc",
         "requestBody": {
           "content": {
@@ -131,7 +131,7 @@
             "description": "Compose / boot-file / spawn failed"
           },
           "503": {
-            "description": "Dispatch capacity exceeded, or PTY-server not connected"
+            "description": "PTY-server not connected"
           }
         }
       }


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@50a831f30dad14f22387c5064da469a9b834935e

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/openapi.json | 4 ++--
 1 file changed, 2 insertions(+), 2 deletions(-)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * APIドキュメントの説明を更新しました。
  * `503` エラーの案内をより明確にし、対象条件を「PTY-server not connected」に絞りました。
  * リクエスト実行時の注意書きから、不要な記述を整理しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->