### PR TITLE
chore(docs): repoint slack-ore provenance citations to doc/archive/slack/

### DIFF
--- a/clients/react/src/components/aim-console/__tests__/remote-delta.test.ts
+++ b/clients/react/src/components/aim-console/__tests__/remote-delta.test.ts
@@ -1,5 +1,5 @@
 // remote-delta — pure helpers for the remote-Δ freshness instrument (#822;
-// design: tmai-core doc/slack/2026-06-12-161334.md §3).
+// design: tmai-core doc/archive/slack/2026-06-12-161334.md §3).
 //
 // Pinned exclusions (operator-ratified): the cursor is CLIENT STATE ONLY —
 // it is never sent to any endpoint and the Producer never reads it; there

--- a/clients/react/src/components/aim-console/remote-delta.ts
+++ b/clients/react/src/components/aim-console/remote-delta.ts
@@ -1,5 +1,5 @@
 // Remote-Δ freshness — pure helpers (#822; design: tmai-core
-// `doc/slack/2026-06-12-161334.md` §3, aim `pr-issue-ci`,
+// `doc/archive/slack/2026-06-12-161334.md` §3, aim `pr-issue-ci`,
 // anchor 「リモートに変化があった場合、未観測の事実として表示する」).
 //
 // A row is UNOBSERVED when its newest vocab event timestamp is newer than

--- a/clients/react/src/components/terminal/CopySourceOverlay.tsx
+++ b/clients/react/src/components/terminal/CopySourceOverlay.tsx
@@ -9,7 +9,7 @@
 // DELIBERATE EXCLUSION — copy only, NO execute button: the operator's
 // paste + Enter stays the firing act. One-click execution of agent-authored
 // commands is the no-look-execution slide the design explicitly rejects
-// (tmai-core doc/slack/2026-06-12-163215.md); do not add a "run" affordance
+// (tmai-core doc/archive/slack/2026-06-12-163215.md); do not add a "run" affordance
 // here.
 
 import { useEffect, useRef, useState } from "react";

--- a/clients/react/src/lib/ui-prefs.ts
+++ b/clients/react/src/lib/ui-prefs.ts
@@ -37,7 +37,7 @@ export interface AimConsoleLayout {
 }
 
 // Remote-Δ freshness cursors (#822; design: tmai-core
-// `doc/slack/2026-06-12-161334.md` §3, aim `pr-issue-ci`).
+// `doc/archive/slack/2026-06-12-161334.md` §3, aim `pr-issue-ci`).
 // Per unit, the ISO timestamps of the operator's last CLOSE acts: `panel` =
 // the R panel collapse, `prs`/`issues` = that section's collapse. The
 // effective cursor for a section is the MAX of `panel` and the section's own


### PR DESCRIPTION
## What

Companion to tmai-core: the slack ore store moved `doc/slack/` → `doc/archive/slack/` (slack is fully retired — aim `slack.md` `state: dead`, core wire ripped in tmai-core #630, hub UI removed in #921 / #916). This repoints the 4 cross-repo provenance comments that cite the ore's design origin.

## Change (comment-only)

- `clients/react/src/components/aim-console/remote-delta.ts`
- `clients/react/src/components/aim-console/__tests__/remote-delta.test.ts`
- `clients/react/src/lib/ui-prefs.ts`
  → all cite `tmai-core doc/slack/2026-06-12-161334.md §3` (the remote-Δ freshness design ore) → `doc/archive/slack/…`
- `clients/react/src/components/terminal/CopySourceOverlay.tsx`
  → cites `tmai-core doc/slack/2026-06-12-163215.md` (the no-look-execution rejection) → `doc/archive/slack/…`

No behavior change — provenance-comment path updates only.

Pairs with tmai-core#631 (the actual `git mv` of the ore files + the core-side citations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * 参照コメント内のドキュメントパスを更新し、古い場所ではなくアーカイブ先を参照するように整理しました。
  * 動作や画面表示、設定内容には変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->