### PR TITLE
chore(gen): sync generated spec + types from tmai-core@f60f5a0223

### DIFF
--- a/api-spec/mcp-tools.json
+++ b/api-spec/mcp-tools.json
@@ -364,6 +364,23 @@
     }
   },
   {
+    "description": "Get the unit's current-state bundle in one call: aim-tree nav + live agents + open PRs + open issues + open-todo backlog count. Unit-scoped, read-only — pull at boot or any 'where do things stand' moment.",
+    "name": "get_status",
+    "parameters_schema": {
+      "$schema": "https://json-schema.org/draft/2020-12/schema",
+      "properties": {
+        "unit": {
+          "description": "Unit name — a configured `[[unit]]` (e.g. `tmai`, `tmai-product`).",
+          "type": "string"
+        }
+      },
+      "required": [
+        "unit"
+      ],
+      "type": "object"
+    }
+  },
+  {
     "description": "Get the conversation transcript of an agent",
     "name": "get_transcript",
     "parameters_schema": {


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@f60f5a022313a28b36fa64ea400f579306156f27

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/mcp-tools.json | 17 +++++++++++++++++
 1 file changed, 17 insertions(+)
```

</details>