### PR TITLE
feat(aim-console): copy-to-clipboard [[slug]] / [[slug]]+todo reference buttons

### DIFF
--- a/clients/react/src/components/aim-console/AimBody.tsx
+++ b/clients/react/src/components/aim-console/AimBody.tsx
@@ -23,6 +23,7 @@
 import { useMemo } from "react";
 import Markdown, { type Components, defaultUrlTransform } from "react-markdown";
 import remarkGfm from "remark-gfm";
+import { CopyRefButton } from "./AimCopyRef";
 import {
   type AimBodySection,
   type AimBodySectionKind,
@@ -61,6 +62,9 @@ const sectionKey = (s: AimBodySection): string =>
 
 interface AimBodyProps {
   body: string;
+  /** The owning node's slug — the anchor a per-means-item copy button emits
+   *  (`[[slug]] <item text>`), so the operator can cite a specific todo. */
+  slug: string;
   /** Which surface's tokens to speak. */
   variant: AimBodyVariant;
   /** Does this slug name a loaded aim node (in the selection's repo)? */
@@ -69,7 +73,7 @@ interface AimBodyProps {
   onNavigate: (slug: string) => void;
 }
 
-export function AimBody({ body, variant, resolves, onNavigate }: AimBodyProps) {
+export function AimBody({ body, slug, variant, resolves, onNavigate }: AimBodyProps) {
   const sections = useMemo(() => parseAimBody(body), [body]);
 
   // An empty body renders nothing (a pure-ought node stays clean).
@@ -89,6 +93,7 @@ export function AimBody({ body, variant, resolves, onNavigate }: AimBodyProps) {
         <SectionView
           key={`lead-${sectionKey(s)}`}
           section={s}
+          slug={slug}
           variant={variant}
           resolves={resolves}
           onNavigate={onNavigate}
@@ -104,6 +109,7 @@ export function AimBody({ body, variant, resolves, onNavigate }: AimBodyProps) {
               <SectionView
                 key={sectionKey(s)}
                 section={s}
+                slug={slug}
                 variant={variant}
                 resolves={resolves}
                 onNavigate={onNavigate}
@@ -118,6 +124,7 @@ export function AimBody({ body, variant, resolves, onNavigate }: AimBodyProps) {
         <SectionView
           key={`prose-${sectionKey(s)}`}
           section={s}
+          slug={slug}
           variant={variant}
           resolves={resolves}
           onNavigate={onNavigate}
@@ -131,11 +138,13 @@ export function AimBody({ body, variant, resolves, onNavigate }: AimBodyProps) {
 
 function SectionView({
   section,
+  slug,
   variant,
   resolves,
   onNavigate,
 }: {
   section: AimBodySection;
+  slug: string;
   variant: AimBodyVariant;
   resolves: (slug: string) => boolean;
   onNavigate: (slug: string) => void;
@@ -160,7 +169,13 @@ function SectionView({
 
   const body =
     means !== null ? (
-      <MeansBody means={means} variant={variant} resolves={resolves} onNavigate={onNavigate} />
+      <MeansBody
+        means={means}
+        slug={slug}
+        variant={variant}
+        resolves={resolves}
+        onNavigate={onNavigate}
+      />
     ) : (
       <Md content={section.content} variant={variant} resolves={resolves} onNavigate={onNavigate} />
     );
@@ -200,11 +215,13 @@ function SectionView({
 
 function MeansBody({
   means,
+  slug,
   variant,
   resolves,
   onNavigate,
 }: {
   means: ParsedMeans;
+  slug: string;
   variant: AimBodyVariant;
   resolves: (slug: string) => boolean;
   onNavigate: (slug: string) => void;
@@ -220,6 +237,7 @@ function MeansBody({
           <MeansItemRow
             key={`${item.status ?? "·"}:${item.text}`}
             item={item}
+            slug={slug}
             variant={variant}
             resolves={resolves}
             onNavigate={onNavigate}
@@ -232,11 +250,13 @@ function MeansBody({
 
 function MeansItemRow({
   item,
+  slug,
   variant,
   resolves,
   onNavigate,
 }: {
   item: MeansItem;
+  slug: string;
   variant: AimBodyVariant;
   resolves: (slug: string) => boolean;
   onNavigate: (slug: string) => void;
@@ -274,6 +294,13 @@ function MeansItemRow({
             inline
           />
         </span>
+        {/* Cite THIS todo to the Producer: `[[slug]] <raw item text>`. The text
+            is the stable anchor (positions shift on edit), NOT the glyph/status. */}
+        <CopyRefButton
+          text={`[[${slug}]] ${item.text}`}
+          variant={variant}
+          label={`copy [[${slug}]] + todo reference`}
+        />
       </span>
       {item.detail !== "" && (
         <div className={variant === "console" ? "ac-means-detail" : "ml-4 text-subtle-foreground"}>

--- a/clients/react/src/components/aim-console/AimCopyRef.tsx
+++ b/clients/react/src/components/aim-console/AimCopyRef.tsx
@@ -1,0 +1,82 @@
+// Copy-reference affordance (aim: `operator-cites-aim`). A small, unobtrusive
+// glyph button that writes a POINTER to the clipboard so the operator can hand
+// the Producer a reference to an aim node (`[[slug]]`) or to a specific PROCESS
+// todo (`[[slug]] <item text>`) without retyping the slug + the item text.
+//
+// The payload is a POINTER ONLY — no intent verb ("do" / "explain"). The
+// operator adds the verb; tmai just makes the reference cheap to hand over
+// (the `[[slug]]` wikilink the Producer resolves via get_aims / get_status).
+//
+// Clipboard mechanism mirrors `terminal/CopySourceOverlay.tsx`: guard on
+// `navigator.clipboard` (absent in some embeddings / jsdom) and never throw.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { cn } from "@/lib/utils";
+import type { AimBodyVariant } from "./AimBody";
+
+interface CopyRefButtonProps {
+  /** The exact string written to the clipboard — an already-formatted pointer. */
+  text: string;
+  /** Which surface's tokens to speak (console `.ac-*` / rpanel tailwind). */
+  variant: AimBodyVariant;
+  /** Accessible label / tooltip — the operator hears WHAT this copies. */
+  label: string;
+  /** Test hook; distinct per placement (slug head vs per-item) when needed. */
+  testId?: string;
+}
+
+// A brief post-copy ✓, cleared after this long — long enough to register, short
+// enough not to linger as state on the row.
+const COPIED_MS = 1200;
+
+export function CopyRefButton({
+  text,
+  variant,
+  label,
+  testId = "aim-copy-ref",
+}: CopyRefButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) clearTimeout(timerRef.current);
+    },
+    [],
+  );
+
+  const onCopy = useCallback(() => {
+    // No clipboard API → no-op (never throw); same guard as CopySourceOverlay.
+    if (!navigator.clipboard) return;
+    navigator.clipboard.writeText(text).then(
+      () => {
+        setCopied(true);
+        if (timerRef.current !== null) clearTimeout(timerRef.current);
+        timerRef.current = setTimeout(() => setCopied(false), COPIED_MS);
+      },
+      () => {},
+    );
+  }, [text]);
+
+  const className =
+    variant === "console"
+      ? "ac-copyref"
+      : cn(
+          "ml-1 shrink-0 rounded font-mono text-[10px] leading-none transition-colors",
+          copied ? "text-success" : "text-subtle-foreground hover:text-info",
+        );
+
+  return (
+    <button
+      type="button"
+      className={className}
+      onClick={onCopy}
+      aria-label={label}
+      title={label}
+      data-testid={testId}
+      data-copied={copied ? "true" : undefined}
+    >
+      <span aria-hidden="true">{copied ? "✓" : "⧉"}</span>
+    </button>
+  );
+}

--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -59,6 +59,7 @@ import type { AimState } from "@/types/generated/AimState";
 import type { AimWire } from "@/types/generated/AimWire";
 import type { RepoAimsWire } from "@/types/generated/RepoAimsWire";
 import { AimBody } from "./AimBody";
+import { CopyRefButton } from "./AimCopyRef";
 import {
   AIM_STATE_LABEL,
   type AimTone,
@@ -1066,6 +1067,14 @@ function Inspector({
             ) : (
               <span key={a.slug} className="ac-icrumb-cur">
                 {a.slug}
+                {/* Cite this aim node to the Producer: the bare `[[slug]]`
+                    wikilink, copied for hand-off (aim: operator-cites-aim). */}
+                <CopyRefButton
+                  text={`[[${a.slug}]]`}
+                  variant="console"
+                  label={`copy [[${a.slug}]] reference`}
+                  testId="aim-copy-slug"
+                />
               </span>
             ),
           )}
@@ -1103,6 +1112,7 @@ function Inspector({
 
         <AimBody
           body={node.body}
+          slug={node.slug}
           variant="console"
           resolves={(slug) => bySlug.has(slug)}
           onNavigate={onSelectAncestor}

--- a/clients/react/src/components/aim-console/__tests__/AimBody.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimBody.test.tsx
@@ -4,15 +4,23 @@
 // sections. Covers: the canonical is/障害/手段/DAG/history scaffold (reading
 // order + empty slots); the 手段 progress checklist (status glyphs + done/todo
 // ratio); `[[slug]]` cross-edges (clickable when resolved, plain when not); a
-// pure-prose body skipping the scaffold; an empty body rendering nothing.
+// pure-prose body skipping the scaffold; an empty body rendering nothing; and
+// the per-means-item copy-reference button (aim: operator-cites-aim).
 
-import { fireEvent, render, screen } from "@testing-library/react";
-import { describe, expect, it, vi } from "vitest";
+import { fireEvent, render, screen, within } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AimBody } from "../AimBody";
 
 const all = () => true;
 const none = () => false;
 const noop = () => {};
+
+// Clipboard mock — jsdom has no `navigator.clipboard`; mirror CopySourceOverlay.
+const writeText = vi.fn<(s: string) => Promise<void>>().mockResolvedValue(undefined);
+beforeEach(() => {
+  writeText.mockClear();
+  Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
+});
 
 const DRIFT_BODY = [
   "# is — 前提",
@@ -33,7 +41,15 @@ const DRIFT_BODY = [
 
 describe("AimBody", () => {
   it("renders sections in canonical order with empty slots (rpanel)", () => {
-    render(<AimBody body={DRIFT_BODY} variant="rpanel" resolves={all} onNavigate={noop} />);
+    render(
+      <AimBody
+        body={DRIFT_BODY}
+        slug="drift-surfacing"
+        variant="rpanel"
+        resolves={all}
+        onNavigate={noop}
+      />,
+    );
     const sections = screen.getAllByTestId("aim-body-section");
     expect(sections.map((s) => s.getAttribute("data-kind"))).toEqual([
       "is",
@@ -50,7 +66,15 @@ describe("AimBody", () => {
   });
 
   it("renders 手段 as a progress checklist with a done/todo ratio", () => {
-    render(<AimBody body={DRIFT_BODY} variant="rpanel" resolves={all} onNavigate={noop} />);
+    render(
+      <AimBody
+        body={DRIFT_BODY}
+        slug="drift-surfacing"
+        variant="rpanel"
+        resolves={all}
+        onNavigate={noop}
+      />,
+    );
     expect(screen.getByTestId("aim-means-progress").textContent).toContain("done 1 / todo 1");
     const items = screen.getAllByTestId("aim-means-item");
     expect(items.map((i) => i.getAttribute("data-status"))).toEqual(["todo", "done"]);
@@ -62,6 +86,7 @@ describe("AimBody", () => {
     render(
       <AimBody
         body={"# 手段\n\nfoo（means・未実装）\n\n- a detail bullet"}
+        slug="x"
         variant="rpanel"
         resolves={all}
         onNavigate={noop}
@@ -77,6 +102,7 @@ describe("AimBody", () => {
     render(
       <AimBody
         body={"# DAG\n\n- 依存 [[git-local-fact-source]]"}
+        slug="x"
         variant="rpanel"
         resolves={all}
         onNavigate={onNavigate}
@@ -90,6 +116,7 @@ describe("AimBody", () => {
     render(
       <AimBody
         body={"# DAG\n\n- [[not-yet-authored]]"}
+        slug="x"
         variant="rpanel"
         resolves={none}
         onNavigate={noop}
@@ -103,6 +130,7 @@ describe("AimBody", () => {
     render(
       <AimBody
         body={"just a note, no headings"}
+        slug="x"
         variant="rpanel"
         resolves={all}
         onNavigate={noop}
@@ -113,7 +141,15 @@ describe("AimBody", () => {
   });
 
   it("renders the console variant's sections", () => {
-    render(<AimBody body={DRIFT_BODY} variant="console" resolves={all} onNavigate={noop} />);
+    render(
+      <AimBody
+        body={DRIFT_BODY}
+        slug="drift-surfacing"
+        variant="console"
+        resolves={all}
+        onNavigate={noop}
+      />,
+    );
     const sections = screen.getAllByTestId("aim-body-section");
     expect(sections.some((s) => s.getAttribute("data-kind") === "means")).toBe(true);
     expect(screen.getByTestId("aim-means-progress").textContent).toContain("done 1 / todo 1");
@@ -121,9 +157,62 @@ describe("AimBody", () => {
 
   it("renders nothing for an empty / whitespace-only body", () => {
     const { container } = render(
-      <AimBody body={"   \n  "} variant="rpanel" resolves={all} onNavigate={noop} />,
+      <AimBody body={"   \n  "} slug="x" variant="rpanel" resolves={all} onNavigate={noop} />,
     );
     expect(container.innerHTML).toBe("");
     expect(screen.queryByTestId("aim-body")).toBeNull();
+  });
+
+  // ── per-means-item copy reference (aim: operator-cites-aim) ────────────────
+  describe("means-item copy reference", () => {
+    it("copies `[[slug]] <item text>` — the anchor + a space + the raw text", () => {
+      render(
+        <AimBody
+          body={DRIFT_BODY}
+          slug="drift-surfacing"
+          variant="console"
+          resolves={all}
+          onNavigate={noop}
+        />,
+      );
+      const items = screen.getAllByTestId("aim-means-item");
+      // items[0] = the [未実装] within-node item.
+      fireEvent.click(within(items[0]).getByTestId("aim-copy-ref"));
+      expect(writeText).toHaveBeenCalledWith(
+        "[[drift-surfacing]] within-node: aim 行 ts vs body ts",
+      );
+    });
+
+    it("copies the RAW item text — no glyph / status marker", () => {
+      render(
+        <AimBody
+          body={DRIFT_BODY}
+          slug="drift-surfacing"
+          variant="console"
+          resolves={all}
+          onNavigate={noop}
+        />,
+      );
+      const items = screen.getAllByTestId("aim-means-item");
+      // items[1] = the [実装済] item; the payload carries neither ✓ nor 実装済.
+      fireEvent.click(within(items[1]).getByTestId("aim-copy-ref"));
+      expect(writeText).toHaveBeenCalledWith("[[drift-surfacing]] 既存 parser split_frontmatter");
+    });
+
+    it("gives each means item its own copy button (rpanel variant too)", () => {
+      render(
+        <AimBody
+          body={DRIFT_BODY}
+          slug="drift-surfacing"
+          variant="rpanel"
+          resolves={all}
+          onNavigate={noop}
+        />,
+      );
+      const items = screen.getAllByTestId("aim-means-item");
+      for (const item of items) {
+        expect(within(item).getByTestId("aim-copy-ref")).toBeTruthy();
+      }
+    });
   });
 });

--- a/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
@@ -23,6 +23,8 @@ import type { AimWorkingDeltaWire } from "@/types/generated/AimWorkingDeltaWire"
 const aimsMock = vi.fn();
 const createAimMock = vi.fn();
 const editAimMock = vi.fn();
+// Clipboard mock for the copy-reference buttons (jsdom has no navigator.clipboard).
+const writeText = vi.fn<(s: string) => Promise<void>>().mockResolvedValue(undefined);
 
 vi.mock("@/lib/api", async () => {
   const actual = await vi.importActual<typeof import("@/lib/api")>("@/lib/api");
@@ -187,6 +189,8 @@ beforeEach(() => {
   aimsMock.mockReset();
   createAimMock.mockReset();
   editAimMock.mockReset();
+  writeText.mockClear();
+  Object.defineProperty(navigator, "clipboard", { value: { writeText }, configurable: true });
 });
 
 describe("AimPane — load + ledger", () => {
@@ -339,6 +343,35 @@ describe("AimPane — inspector", () => {
     await waitFor(() =>
       expect(screen.getByTestId("aim-inspector").textContent).toContain("amplify judgment"),
     );
+  });
+});
+
+describe("AimPane — copy reference (aim: operator-cites-aim)", () => {
+  it("the slug-head button copies the bare `[[slug]]` pointer", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await awaitLoaded();
+    // Tree mode so the calm (non-owed) aim-system is reachable.
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+    selectRow("aim-system");
+
+    const insp = await screen.findByTestId("aim-inspector");
+    fireEvent.click(within(insp).getByTestId("aim-copy-slug"));
+    expect(writeText).toHaveBeenCalledWith("[[aim-system]]");
+  });
+
+  it("a PROCESS todo button copies `[[slug]] <item text>`", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await awaitLoaded();
+    // amplify-human-judgment is owed (todo) → selectable in the default Frontier
+    // view; its body PROCESS carries one `- [todo] todo 0` item.
+    selectRow("amplify-human-judgment");
+
+    const insp = await screen.findByTestId("aim-inspector");
+    const item = within(insp).getAllByTestId("aim-means-item")[0];
+    fireEvent.click(within(item).getByTestId("aim-copy-ref"));
+    expect(writeText).toHaveBeenCalledWith("[[amplify-human-judgment]] todo 0");
   });
 });
 

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -2146,6 +2146,31 @@
   border-bottom: none;
   cursor: default;
 }
+/* copy-reference affordance (aim: operator-cites-aim) — an unobtrusive glyph
+   button that copies a `[[slug]]` / `[[slug]] <todo>` POINTER for the operator
+   to hand the Producer. Faint until hovered; a brief ✓ (green) on copy. */
+.aim-console .ac-copyref {
+  flex: none;
+  margin-left: 4px;
+  padding: 0 3px;
+  border: none;
+  border-radius: 3px;
+  background: none;
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 10px;
+  line-height: 1;
+  color: var(--faint);
+  opacity: 0.7;
+}
+.aim-console .ac-copyref:hover {
+  color: var(--cyan);
+  opacity: 1;
+}
+.aim-console .ac-copyref[data-copied="true"] {
+  color: var(--green);
+  opacity: 1;
+}
 /* 手段 (means) — a progress-bearing checklist. Each item carries a status
    glyph (✓ 実装済 / ◌ 未実装 / · plain); the section header carries a done/todo
    ratio + a thin bar. done = green (calm), todo = ochre (owed, not alarming). */


### PR DESCRIPTION
## What / where

Copy-to-clipboard affordances in the **aim console** so the operator can cite an aim node (or a specific PROCESS todo) to the Producer without retyping the slug + text. Implements aim `operator-cites-aim` (tmai-core `doc/aims/operator-cites-aim.md`).

- **New `AimCopyRef.tsx`** — a small, unobtrusive `⧉` glyph button that writes a **pointer** to the clipboard. Reuses the `CopySourceOverlay` clipboard idiom: `navigator.clipboard.writeText(...)` behind the `!navigator.clipboard` guard; a brief ✓ on copy. `aria-label`ed per placement.
- **Slug-head button** — `AimPane.tsx` Inspector, beside the breadcrumb slug tail (where the selected node's slug is shown). Copies `[[slug]]`.
- **Per-means-item button** — `AimBody.tsx` `MeansItemRow` (the PROCESS 手段 checklist items). Copies `` `[[slug]] <raw item text>` ``. Threads a **required** `slug: string` prop `AimBody → SectionView → MeansBody → MeansItemRow`.
- **`.ac-copyref`** styling in `aim-console.css` (faint → cyan hover → green ✓), plus the rpanel tailwind variant.

## Reference format (the payload)

- **aim-level**: `[[slug]]`
- **per-means-item**: `[[slug]] <item text>` — the `[[slug]]` anchor + a space + the item's **raw text** (NOT the glyph/status; the text is the stable anchor since positions shift on edit).

The payload is a **pointer only** — no intent verb ("do"/"explain"); the operator adds those. The Producer resolves the `[[slug]]` wikilink via get_aims/get_status.

## Note on call sites

The brief flagged `AimBody` as shared by both the rpanel (`RAimsSection`) and console surfaces. `RAimsSection`/the R-panel aims surface **no longer exists** (removed in the recent R-panel dead-UI cleanup) — the only production `AimBody` render is `AimPane` (console variant), which now passes `node.slug`. The `rpanel` variant survives only in `AimBody`'s tests, which were updated to pass the now-required `slug`.

## Gate results

- ✅ biome lint (`pnpm lint`) — clean
- ✅ typecheck (`tsc -b`) — clean, no `any`
- ✅ test (`pnpm test`) — 722 passed / 2 skipped (pre-existing). Extended `AimBody.test.tsx` (means-item payload, raw-text/no-marker, per-item button on both variants) + added `AimPane.test.tsx` copy-reference tests (slug button → `[[slug]]`, PROCESS todo button → `[[slug]] <text>`), driven through the real inspector DOM with a mocked `writeText`.
- ✅ build (`pnpm build`) — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * インスペクタや手段一覧で、項目の参照文字列をワンクリックでコピーできるようになりました。
  * コピー後は一時的に完了表示へ切り替わり、見やすい状態が分かります。
* **Bug Fixes**
  * コピー機能は、利用できない環境ではエラーにならないよう改善されました。
* **Style**
  * コピー用ボタンの見た目を、通常時・ホバー時・コピー完了時で分かりやすく調整しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->