### PR TITLE
feat(aim-console): per-node cross-edge inspector (inbound/outbound)

### DIFF
--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -86,6 +86,7 @@ import {
   type WorkingDeltaKind,
   workingDeltaKind,
 } from "./aim-tree";
+import { buildCrossEdges, type CrossEdge, type CrossEdgeGraph, resolveEdges } from "./cross-edges";
 import { RESIGNATION_FRONTIER, resignationInventory } from "./resignation";
 import { suggestSlug, validateAimSlug } from "./slug";
 
@@ -139,6 +140,10 @@ export function AimFace({ unitName }: { unitName: string | null }) {
   const allNodes = useMemo(() => flattenRepos(data), [data]);
   const ledger = useMemo(() => ledgerCounts(allNodes), [allNodes]);
   const ticks = useMemo(() => rulerOrder(repos), [repos]);
+  // Cross-edge graph + forest index for the inspector — forest-wide (a DAG edge
+  // crosses the repo boundary), derived once per forest, not per selection.
+  const crossEdges = useMemo(() => buildCrossEdges(allNodes), [allNodes]);
+  const allBySlug = useMemo(() => bySlugMap(allNodes), [allNodes]);
 
   const [mode, setMode] = useUIPref("aimMode");
   const [query, setQuery] = useState("");
@@ -399,6 +404,8 @@ export function AimFace({ unitName }: { unitName: string | null }) {
           <Inspector
             key={sel.node.slug}
             sel={sel}
+            crossEdges={crossEdges}
+            allBySlug={allBySlug}
             onSelectAncestor={select}
             onEdit={() => openEdit(sel.node.slug)}
             onAddChild={(parent) => openCreate(sel.repo.repo_root, parent)}
@@ -1016,12 +1023,16 @@ function OverviewRuler({
 
 function Inspector({
   sel,
+  crossEdges,
+  allBySlug,
   onSelectAncestor,
   onEdit,
   onAddChild,
   onClose,
 }: {
   sel: Selection;
+  crossEdges: CrossEdgeGraph;
+  allBySlug: ReadonlyMap<string, AimWire>;
   onSelectAncestor: (slug: string) => void;
   onEdit: () => void;
   onAddChild: (parent: string) => void;
@@ -1030,6 +1041,15 @@ function Inspector({
   const { node, repo, bySlug } = sel;
   const chain = useMemo(() => ancestry(node.slug, bySlug), [node.slug, bySlug]);
   const wd = workingDeltaKind(node);
+  // This node's lateral DAG edges, resolved forest-wide against `allBySlug`.
+  const outbound = useMemo(
+    () => resolveEdges(crossEdges.outbound.get(node.slug) ?? [], allBySlug),
+    [crossEdges, node.slug, allBySlug],
+  );
+  const inbound = useMemo(
+    () => resolveEdges(crossEdges.inbound.get(node.slug) ?? [], allBySlug),
+    [crossEdges, node.slug, allBySlug],
+  );
 
   return (
     <div className="ac-insp-in" data-testid="aim-inspector">
@@ -1117,6 +1137,12 @@ function Inspector({
           resolves={(slug) => bySlug.has(slug)}
           onNavigate={onSelectAncestor}
         />
+
+        {/* Cross-edge inspector (aim: aim-cross-edge-link) — the node's lateral
+            DAG edges both ways: → outbound (what its body links to) and ←
+            inbound (what links to it, which the body itself cannot show).
+            Rendered only when the node has an edge in either direction. */}
+        <CrossEdgeInspector outbound={outbound} inbound={inbound} onNavigate={onSelectAncestor} />
 
         {/* Resignation inventory (#811) — done is reversible attention-parking,
           so on an already-done node the parked objects stay visible, quietly.
@@ -1220,6 +1246,86 @@ function ResignationInventoryView({
       <div className="ac-resig-frontier" data-testid="resig-frontier">
         {RESIGNATION_FRONTIER}
       </div>
+    </div>
+  );
+}
+
+// ── cross-edge inspector (aim: aim-cross-edge-link) ───────────────────
+//
+// The node's lateral DAG position, derived from body `[[slug]]` links (NOT the
+// tree/parent edges the breadcrumb shows). Two directions:
+//   → outbound — the slugs THIS body links to. A compact complement to the
+//     body's `# DAG` prose (which carries the descriptions); a dangling target
+//     (unknown slug) shows dim + non-navigable — surfaced, never dropped.
+//   ← inbound  — the nodes whose body links HERE ("referenced by"), the view
+//     the body itself cannot render. Each source is a real node (resolved).
+// An isolated node (no edge either way) renders nothing — no empty weight on a
+// leaf. Facts only: adjacency in graph order, never ranked or scored.
+function CrossEdgeInspector({
+  outbound,
+  inbound,
+  onNavigate,
+}: {
+  outbound: CrossEdge[];
+  inbound: CrossEdge[];
+  onNavigate: (slug: string) => void;
+}) {
+  if (outbound.length === 0 && inbound.length === 0) return null;
+  return (
+    <div className="ac-xedge" data-testid="aim-cross-edges">
+      <div className="ac-isec">cross-edges — 依存グラフ（body [[slug]]）</div>
+      <CrossEdgeRow dir="out" label="→ outbound" edges={outbound} onNavigate={onNavigate} />
+      <CrossEdgeRow dir="in" label="← inbound" edges={inbound} onNavigate={onNavigate} />
+    </div>
+  );
+}
+
+function CrossEdgeRow({
+  dir,
+  label,
+  edges,
+  onNavigate,
+}: {
+  dir: "out" | "in";
+  label: string;
+  edges: CrossEdge[];
+  onNavigate: (slug: string) => void;
+}) {
+  return (
+    <div className="ac-xedge-row" data-testid={`aim-cross-${dir}`} data-count={edges.length}>
+      <span className="ac-xedge-dir">
+        {label} <span className="ac-xedge-n">{edges.length}</span>
+      </span>
+      {edges.length === 0 ? (
+        <span className="ac-xedge-none">— なし —</span>
+      ) : (
+        <span className="ac-xedge-chips">
+          {edges.map((e) =>
+            e.node !== null ? (
+              <button
+                key={e.slug}
+                type="button"
+                className="ac-bodylink"
+                data-slug={e.slug}
+                onClick={() => onNavigate(e.slug)}
+                title={e.node.aim}
+              >
+                {e.slug}
+              </button>
+            ) : (
+              <span
+                key={e.slug}
+                className="ac-bodylink dim"
+                data-slug={e.slug}
+                data-dangling="true"
+                title="このforestに未読込 — 未解決 / repo を跨ぐ参照"
+              >
+                {e.slug}
+              </span>
+            ),
+          )}
+        </span>
+      )}
     </div>
   );
 }

--- a/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
@@ -908,3 +908,105 @@ describe("AimPane — working_delta presence facts (#817)", () => {
     expect(ledger.textContent).toMatch(/0\s*done/);
   });
 });
+
+describe("AimPane — cross-edge inspector (aim: aim-cross-edge-link)", () => {
+  // A forest whose bodies carry `[[slug]]` DAG links, spanning both repos:
+  //   tmai-core:  xe-a  (root) → body links [[xe-b]] + [[xe-ghost]] (dangling)
+  //               xe-b  (child of xe-a) — no links; referenced by xe-a AND xe-c
+  //               xe-iso (root) — no links, unreferenced (isolated)
+  //   tmai:       xe-c  (root) → body links [[xe-b]] (a CROSS-REPO edge)
+  const XCORE: AimWire[] = [
+    aimStub({
+      slug: "xe-a",
+      aim: "the a bearing",
+      body: "# DAG\n- 依存: [[xe-b]] — leans on b\n- 関連: [[xe-ghost]] — a missing target",
+    }),
+    aimStub({ slug: "xe-b", aim: "the b bearing", parent: "xe-a" }),
+    aimStub({ slug: "xe-iso", aim: "the isolated bearing" }),
+  ];
+  const XUI: AimWire[] = [
+    aimStub({ slug: "xe-c", aim: "the c bearing", body: "# IS\nbuilds on [[xe-b]] here." }),
+  ];
+  const xResponse = () =>
+    responseStub([
+      { label: "tmai-core", primary: true, aims: XCORE },
+      { label: "tmai", primary: false, aims: XUI },
+    ]);
+
+  // The cross-edge section, scoped to the open inspector.
+  function xedge(): HTMLElement {
+    const insp = screen.getByTestId("aim-inspector");
+    return within(insp).getByTestId("aim-cross-edges");
+  }
+  const slugsIn = (dir: "out" | "in"): string[] =>
+    Array.from(xedge().querySelectorAll(`[data-testid="aim-cross-${dir}"] [data-slug]`)).map(
+      (el) => (el as HTMLElement).dataset.slug ?? "",
+    );
+
+  async function selectInTree(slug: string) {
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+    selectRow(slug);
+    await screen.findByTestId("aim-inspector");
+  }
+
+  it("outbound lists the body's `[[slug]]` links; a dangling target shows dim + non-navigable", async () => {
+    aimsMock.mockResolvedValue(xResponse());
+    renderPane();
+    await awaitLoaded();
+    await selectInTree("xe-a");
+
+    const out = within(xedge()).getByTestId("aim-cross-out");
+    expect(out.dataset.count).toBe("2");
+    expect(slugsIn("out")).toEqual(["xe-b", "xe-ghost"]);
+
+    // The resolved target is a navigable button carrying the target's ought as title.
+    const bChip = out.querySelector('[data-slug="xe-b"]') as HTMLElement;
+    expect(bChip.tagName).toBe("BUTTON");
+    expect(bChip.getAttribute("title")).toBe("the b bearing");
+    // The dangling target is a non-button span, marked, surfaced not dropped.
+    const ghost = out.querySelector('[data-slug="xe-ghost"]') as HTMLElement;
+    expect(ghost.tagName).toBe("SPAN");
+    expect(ghost.dataset.dangling).toBe("true");
+
+    // xe-a is referenced by nobody → inbound is an explicit "none".
+    const inb = within(xedge()).getByTestId("aim-cross-in");
+    expect(inb.dataset.count).toBe("0");
+    expect(inb.textContent).toContain("なし");
+  });
+
+  it("inbound lists who references the node — across the repo boundary", async () => {
+    aimsMock.mockResolvedValue(xResponse());
+    renderPane();
+    await awaitLoaded();
+    await selectInTree("xe-b");
+
+    // xe-b links to nothing…
+    expect(within(xedge()).getByTestId("aim-cross-out").dataset.count).toBe("0");
+    // …but is referenced by xe-a (same repo) AND xe-c (the other repo).
+    expect(within(xedge()).getByTestId("aim-cross-in").dataset.count).toBe("2");
+    expect(slugsIn("in")).toEqual(["xe-a", "xe-c"]);
+  });
+
+  it("clicking an inbound chip navigates the inspector to that referrer", async () => {
+    aimsMock.mockResolvedValue(xResponse());
+    renderPane();
+    await awaitLoaded();
+    await selectInTree("xe-b");
+
+    const cChip = xedge().querySelector(
+      '[data-testid="aim-cross-in"] [data-slug="xe-c"]',
+    ) as HTMLElement;
+    fireEvent.click(cChip);
+    await waitFor(() =>
+      expect(screen.getByTestId("aim-inspector").textContent).toContain("the c bearing"),
+    );
+  });
+
+  it("renders no cross-edge section for an isolated node (no edge either way)", async () => {
+    aimsMock.mockResolvedValue(xResponse());
+    renderPane();
+    await awaitLoaded();
+    await selectInTree("xe-iso");
+    expect(within(screen.getByTestId("aim-inspector")).queryByTestId("aim-cross-edges")).toBeNull();
+  });
+});

--- a/clients/react/src/components/aim-console/__tests__/cross-edges.test.ts
+++ b/clients/react/src/components/aim-console/__tests__/cross-edges.test.ts
@@ -1,0 +1,115 @@
+// Cross-edge graph — pure model, no React, no DOM. Covers the body `[[slug]]`
+// extraction (dedup, order, whole-body, self-drop), the forest-wide inbound /
+// outbound adjacency, and the dangling-target honesty. Fixtures author a body
+// with cross-links via `linkBody`.
+
+import { describe, expect, it } from "vitest";
+import type { AimWire } from "@/types/generated/AimWire";
+import { bySlugMap } from "../aim-tree";
+import { buildCrossEdges, extractBodyLinks, resolveEdges } from "../cross-edges";
+
+function aim(overrides: Partial<AimWire> & Pick<AimWire, "slug">): AimWire {
+  return {
+    aim: `aim ${overrides.slug}`,
+    parent: null,
+    state: "open",
+    depends_on: [],
+    serves: [],
+    related: [],
+    body: "",
+    drift: null,
+    working_delta: null,
+    ...overrides,
+  };
+}
+
+// A body that links to each of `slugs` — spread across sections (IS + DAG) so
+// the whole-body extraction (not DAG-only) is exercised.
+function linkBody(slugs: string[]): string {
+  const [first, ...rest] = slugs;
+  const is = first ? `# IS\nleans on [[${first}]] here.\n` : "";
+  const dag =
+    rest.length > 0 ? `# DAG\n${rest.map((s) => `- 依存: [[${s}]] — 説明`).join("\n")}` : "";
+  return `${is}${dag}`;
+}
+
+describe("extractBodyLinks", () => {
+  it("pulls distinct `[[slug]]` targets in first-appearance order", () => {
+    const body = "# IS\nsee [[a]] then [[b]].\n# DAG\n- 依存: [[c]] — x";
+    expect(extractBodyLinks(body)).toEqual(["a", "b", "c"]);
+  });
+
+  it("dedupes a slug that appears more than once", () => {
+    const body = "[[a]] and again [[a]] and [[b]]";
+    expect(extractBodyLinks(body)).toEqual(["a", "b"]);
+  });
+
+  it("trims whitespace inside the brackets", () => {
+    expect(extractBodyLinks("[[ spaced-slug ]]")).toEqual(["spaced-slug"]);
+  });
+
+  it("returns [] for a body with no links (empty or pure prose)", () => {
+    expect(extractBodyLinks("")).toEqual([]);
+    expect(extractBodyLinks("# IS\njust prose, no links.")).toEqual([]);
+  });
+});
+
+// A small forest:
+//   a  — body links to b, c
+//   b  — body links to c
+//   c  — no links
+//   d  — body links to a and to `ghost` (a dangling / cross-repo target)
+const NODES: AimWire[] = [
+  aim({ slug: "a", body: linkBody(["b", "c"]) }),
+  aim({ slug: "b", body: linkBody(["c"]) }),
+  aim({ slug: "c" }),
+  aim({ slug: "d", body: linkBody(["a", "ghost"]) }),
+];
+
+describe("buildCrossEdges", () => {
+  const { outbound, inbound } = buildCrossEdges(NODES);
+
+  it("maps each node to the distinct slugs its body links to", () => {
+    expect(outbound.get("a")).toEqual(["b", "c"]);
+    expect(outbound.get("b")).toEqual(["c"]);
+    expect(outbound.get("c")).toEqual([]);
+    expect(outbound.get("d")).toEqual(["a", "ghost"]);
+  });
+
+  it("inverts to inbound — who links to each node, in wire order", () => {
+    expect(inbound.get("c")).toEqual(["a", "b"]);
+    expect(inbound.get("a")).toEqual(["d"]);
+    expect(inbound.get("b")).toEqual(["a"]);
+  });
+
+  it("has no inbound entry for a node nothing links to", () => {
+    expect(inbound.get("d")).toBeUndefined();
+  });
+
+  it("records a dangling outbound target on inbound too (surfaced, not dropped)", () => {
+    // `ghost` names no node in the forest, but the edge is real and inverted.
+    expect(inbound.get("ghost")).toEqual(["d"]);
+  });
+
+  it("drops a self-link (a node is not its own cross-edge)", () => {
+    const g = buildCrossEdges([aim({ slug: "selfy", body: "refs [[selfy]] and [[a]]" })]);
+    expect(g.outbound.get("selfy")).toEqual(["a"]);
+    expect(g.inbound.get("selfy")).toBeUndefined();
+  });
+});
+
+describe("resolveEdges", () => {
+  const bySlug = bySlugMap(NODES);
+
+  it("resolves known slugs to their node", () => {
+    const edges = resolveEdges(["b", "c"], bySlug);
+    expect(edges.map((e) => e.slug)).toEqual(["b", "c"]);
+    expect(edges.every((e) => e.node !== null)).toBe(true);
+  });
+
+  it("leaves an unknown slug's node null (dangling), preserving order", () => {
+    const edges = resolveEdges(["ghost", "a"], bySlug);
+    expect(edges[0]).toEqual({ slug: "ghost", node: null });
+    expect(edges[1]?.node?.slug).toBe("a");
+  });
+});

--- a/clients/react/src/components/aim-console/cross-edges.ts
+++ b/clients/react/src/components/aim-console/cross-edges.ts
@@ -1,0 +1,96 @@
+// Cross-edge graph — the pure computation behind the per-node cross-edge
+// inspector (aim node `aim-cross-edge-link`: `[todo] body link を抽出して DAG を
+// 構成（computed 導出）` + `[todo] per-node cross-edge inspector（inbound/
+// outbound）`).
+//
+// The aim's bearing (its IS): a tree-crossing dependency is expressed in the
+// body prose as a `[[slug]]` link — in the BODY (the knowing side), NOT the
+// frontmatter (pure bearing). So the DAG is not an authored structure; the
+// machine EXTRACTS the links and DERIVES the graph (the resolver / close-act
+// pattern). This module is that derivation, client-side — the same surface
+// that already renders `[[slug]]` as an in-tree cross-ref (`AimBody`), read the
+// other way to answer "what links here?".
+//
+// Operator-ratified invariants this module embodies (mirrors `resignation.ts`):
+//   - ZERO new asserted fields — the edges are read out of `body`, already on
+//     the wire. The frontmatter `depends_on` / `serves` / `related` arrays are
+//     deliberately NOT used: the aim puts the edge in the body, and the live
+//     corpus authors it there (a `# DAG` bullet), leaving those arrays empty.
+//   - Facts, not appraisals — this lists adjacency; it never scores, ranks by
+//     importance, or judges an edge. First-appearance / wire (slug-sorted)
+//     order is preserved.
+//   - Nothing vanishes — an outbound link to a slug absent from the loaded
+//     forest (a dangling / cross-repo-unloaded target) is surfaced as an
+//     unresolved edge, the same honesty `findRoots` gives a dangling parent.
+//
+// Scope note: `[todo] 抽出した辺を drift-git の wavefront へ供給` is the OTHER
+// consumer of these edges and lives in core (drift propagation over the graph);
+// this module only supplies the read-side inspector view of the same edges.
+
+import type { AimWire } from "@/types/generated/AimWire";
+
+// The body cross-edge syntax — a `[[slug]]` wikilink. The SAME shape `AimBody`
+// renders as a cross-ref; kept as a separate regex instance on purpose (that
+// one is a stateful `/g` used in `.replace`). Keep the two in sync — together
+// they define what a body cross-edge IS.
+const WIKILINK = /\[\[([^[\]]+)\]\]/g;
+
+// The distinct `[[slug]]` cross-edge targets in an aim body, first-appearance
+// order, deduped and trimmed. EVERY section counts: a `[[slug]]` in IS or
+// HISTORY is as much a node→node reference as one under `# DAG`, and reading
+// the whole body is what makes the inverse ("referenced by") complete.
+export function extractBodyLinks(body: string): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const m of body.matchAll(WIKILINK)) {
+    const target = m[1].trim();
+    if (target === "" || seen.has(target)) continue;
+    seen.add(target);
+    out.push(target);
+  }
+  return out;
+}
+
+// The forest-wide cross-edge adjacency, both directions keyed by slug:
+//   - `outbound`: slug → the distinct slugs its body links to (body order).
+//   - `inbound`:  slug → the distinct slugs whose body links to it (wire order).
+// Forest-wide because a DAG edge crosses the tree AND the repo boundary; the
+// caller passes the flattened forest (`flattenRepos`), not one repo. A node's
+// self-link is dropped — a node is not its own cross-edge.
+export interface CrossEdgeGraph {
+  outbound: Map<string, string[]>;
+  inbound: Map<string, string[]>;
+}
+
+export function buildCrossEdges(nodes: readonly AimWire[]): CrossEdgeGraph {
+  const outbound = new Map<string, string[]>();
+  const inbound = new Map<string, string[]>();
+  for (const n of nodes) {
+    const targets = extractBodyLinks(n.body).filter((t) => t !== n.slug);
+    outbound.set(n.slug, targets);
+    for (const t of targets) {
+      const sources = inbound.get(t) ?? [];
+      sources.push(n.slug);
+      inbound.set(t, sources);
+    }
+  }
+  return { outbound, inbound };
+}
+
+// A cross-edge decorated for render: the target slug + the node it resolves to
+// (`null` when the slug names nothing in the loaded forest — a dangling edge,
+// surfaced not hidden). `aim` is lifted for the row title without the caller
+// re-deriving it.
+export interface CrossEdge {
+  slug: string;
+  node: AimWire | null;
+}
+
+// Resolve a direction's slug list against the forest index — the trivial
+// decorate step the inspector renders from. Order is preserved.
+export function resolveEdges(
+  slugs: readonly string[],
+  bySlug: ReadonlyMap<string, AimWire>,
+): CrossEdge[] {
+  return slugs.map((slug) => ({ slug, node: bySlug.get(slug) ?? null }));
+}

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -2264,6 +2264,43 @@
   padding-top: 7px;
 }
 
+/* ── cross-edge inspector (aim: aim-cross-edge-link) ───────────────────────
+   The node's lateral DAG edges (body `[[slug]]`), both directions. Reuses the
+   inspector's `.ac-isec` section header + the `.ac-bodylink` cross-ref chip
+   (cyan = resolved / dim = dangling); only the two-direction layout is new.
+   Facts, not owed work — no drift amber, no severity ramp. */
+.aim-console .ac-xedge {
+  margin-top: 10px;
+}
+.aim-console .ac-xedge-row {
+  display: flex;
+  gap: 8px;
+  align-items: baseline;
+  flex-wrap: wrap;
+  padding: 3px 0;
+  font-size: 12px;
+}
+.aim-console .ac-xedge-dir {
+  flex: none;
+  font-family: var(--mono);
+  font-size: 9.5px;
+  letter-spacing: 0.5px;
+  color: var(--dim);
+}
+.aim-console .ac-xedge-n {
+  color: var(--faint);
+}
+.aim-console .ac-xedge-none {
+  font-size: 11px;
+  color: var(--faint);
+}
+.aim-console .ac-xedge-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px 10px;
+  min-width: 0;
+}
+
 /* ── buttons (inspector + modal) ──────────────────────────────────────── */
 .aim-console .ac-btn {
   padding: 6px 12px;


### PR DESCRIPTION
Implements **`aim-cross-edge-link`** `:14` (body `[[slug]]` link 抽出 → computed DAG) + `:16` (per-node inbound/outbound inspector), **hub-side only**. `:15` (辺を drift-git wavefront へ供給) は core ゆえ対象外で `[todo]` のまま。

## What
The inspector gains a **cross-edge** section (aim: `aim-cross-edge-link`) below the body:
- **→ outbound** — the slugs this node's body links to (a compact complement to the body `# DAG` prose).
- **← inbound** — the nodes whose body links *here* — the view the body itself cannot render.

Edges are derived from **body `[[slug]]` prose**, matching the aim's bearing *「frontmatter でなく body」* — the unused frontmatter `depends_on`/`serves`/`related` arrays are deliberately not read (the live corpus authors edges in the body). Forest-wide (a DAG edge crosses the repo boundary). Dangling targets surface **dim + non-navigable** (never dropped, mirroring `findRoots`' dangling-parent honesty); an isolated node renders nothing. Facts only — no relation-type classification, no ranking (`read-side 過投資を避ける`).

## Changes (+456 / −0, additive)
- `cross-edges.ts` — pure model: `extractBodyLinks` / `buildCrossEdges` / `resolveEdges`
- `AimPane.tsx` — forest-wide graph memo → `Inspector` → `CrossEdgeInspector` after `AimBody`
- `aim-console.css` — `.ac-xedge*` (reuses `.ac-isec` / `.ac-bodylink`, theme-safe vars)
- tests — 11 pure-model + 5 render (cross-repo inbound, dangling, isolated, navigation)

## Verify
`tsc -b` clean · biome clean · **739 tests green** (261 aim-console incl.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * AIMインスペクタに、ノード間の横断リンク（クロスエッジ）を表示するセクションを追加しました。
  * 本文中の `[[slug]]` 参照をもとに、送信先・参照元を一覧でき、解決できない参照は未解決として表示されます。
  * 参照元チップをクリックすると、該当ノードへ移動できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->