### PR TITLE
feat(aim-console): state pill/select read the 解決/未解決 frame

### DIFF
--- a/clients/react/src/components/aim-console/AimPane.tsx
+++ b/clients/react/src/components/aim-console/AimPane.tsx
@@ -1086,7 +1086,7 @@ function Inspector({
 
         <div className="ac-imeta">
           <span className={cn("ac-pill", repo.primary && "op")}>repo: {repo.repo_label}</span>
-          <span className="ac-pill op">
+          <span className="ac-pill op" data-testid="aim-state-pill">
             state: {AIM_STATE_LABEL[node.state]}
             {node.parent === null ? " · root" : ""}
           </span>
@@ -1455,9 +1455,9 @@ function CreateEditModal({
                   value={state}
                   onChange={(e) => setState(e.target.value as AimState)}
                 >
-                  <option value="open">open</option>
-                  <option value="done">done — aim 到達 / confirmed</option>
-                  <option value="dead">dead — self-death（系譜は残す・親無傷）</option>
+                  <option value="open">open — 未解決（作業中 / owed）</option>
+                  <option value="done">done — 解決（aim 到達 / confirmed）</option>
+                  <option value="dead">dead — 放棄（self-death・系譜は残す・親無傷）</option>
                 </select>
                 {/* Resignation inventory at done-set (#811): when the operator
                     is putting this node TO done, show what this done will park

--- a/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimPane.test.tsx
@@ -346,6 +346,50 @@ describe("AimPane — inspector", () => {
   });
 });
 
+describe("AimPane — state resolution wording (aim: aim-resolution-outcome)", () => {
+  it("the state pill reads state in the 解決 / 未解決 / 放棄 frame per lifecycle value", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await awaitLoaded();
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+
+    // open → 未解決
+    selectRow("aim-system");
+    let pill = within(await screen.findByTestId("aim-inspector")).getByTestId("aim-state-pill");
+    expect(pill.textContent).toContain("open · 未解決");
+
+    // done → 解決 (到達); NEVER labelled 満足 — the 満足/諦め split is per-PROCESS
+    // and lives in the resignation inventory, not the state label.
+    selectRow("attention-backend");
+    pill = within(screen.getByTestId("aim-inspector")).getByTestId("aim-state-pill");
+    expect(pill.textContent).toContain("done · 解決");
+    expect(pill.textContent).not.toContain("満足");
+
+    // dead → 放棄 (self-death, lineage kept)
+    selectRow("aim-honesty");
+    pill = within(screen.getByTestId("aim-inspector")).getByTestId("aim-state-pill");
+    expect(pill.textContent).toContain("dead · 放棄");
+  });
+
+  it("the edit-modal state options carry the resolution gloss (values unchanged)", async () => {
+    aimsMock.mockResolvedValue(responseStub());
+    renderPane();
+    await awaitLoaded();
+    fireEvent.click(screen.getByRole("button", { name: "Tree" }));
+    selectRow("aim-system");
+    const insp = await screen.findByTestId("aim-inspector");
+    fireEvent.click(within(insp).getByRole("button", { name: /編集/ }));
+
+    const modal = await screen.findByTestId("aim-create-modal");
+    const stateSel = within(modal).getByLabelText("state") as HTMLSelectElement;
+    expect(stateSel.textContent).toContain("未解決");
+    expect(stateSel.textContent).toContain("解決");
+    expect(stateSel.textContent).toContain("放棄");
+    // The option VALUES stay the raw lifecycle tokens (the write path is unchanged).
+    expect(Array.from(stateSel.options).map((o) => o.value)).toEqual(["open", "done", "dead"]);
+  });
+});
+
 describe("AimPane — copy reference (aim: operator-cites-aim)", () => {
   it("the slug-head button copies the bare `[[slug]]` pointer", async () => {
     aimsMock.mockResolvedValue(responseStub());

--- a/clients/react/src/components/aim-console/aim-tree.ts
+++ b/clients/react/src/components/aim-console/aim-tree.ts
@@ -41,10 +41,16 @@ export const AIM_GLYPH: Record<AimState, string> = {
   dead: "⊘",
 };
 
+// State label — the raw lifecycle token PLUS a 解決 / 未解決 gloss, so the pill
+// + tooltip read `state` in the frame `aim-frontmatter` gives it (`state` = 解決
+// ・未解決). open = 未解決; done = 解決 (到達); dead = 放棄 (self-death, the
+// lineage is kept). The 満足 / 諦め split of a done is per-PROCESS-item and
+// lives in the resignation inventory (`aim-resolution-outcome`), NOT here — the
+// label never calls a done "満足" (a done mixes reached 満足 and parked 諦め).
 export const AIM_STATE_LABEL: Record<AimState, string> = {
-  open: "open",
-  done: "done",
-  dead: "dead",
+  open: "open · 未解決",
+  done: "done · 解決",
+  dead: "dead · 放棄",
 };
 
 // Flatten the per-repo wire response into a single cross-repo node set — used


### PR DESCRIPTION
**`aim-frontmatter` `:15`** — `state` は「解決・未解決」を表すフィールドなのに、UI は raw な `open/done/dead` token しか出していなかった。解決/未解決 の枠を表示語に付す。

## What
`AIM_STATE_LABEL`（inspector pill + row tooltip）と edit-modal の state select に **解決 gloss** を付加:

| state | 表示 |
|---|---|
| open | `open · 未解決` |
| done | `done · 解決` |
| dead | `dead · 放棄` |

- **done を「満足」とはラベルしない** — done は到達で、満足(実装済)/諦め(未実装)の混在。その per-PROCESS の仕分けは既存の resignation inventory（`aim-resolution-outcome`）が担う。state label は過剰主張しない。
- modal の option **value は不変**（`open`/`done`/`dead`）— write path は無変更。

## Changes
- `aim-tree.ts` — `AIM_STATE_LABEL` に gloss + 根拠 doc comment
- `AimPane.tsx` — modal option 3 行の gloss、state pill に `data-testid`
- tests — state pill の語彙 3 値 + modal option gloss + value 不変

## Verify
`tsc -b` clean · biome clean · 全 726 tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)