### PR TITLE
chore: CLAUDE.local.md を gitignore する

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ crates/tmai-app/web/tsconfig.tsbuildinfo
 
 # AI assistants
 CLAUDE.md
+CLAUDE.local.md
 AGENTS.md
 GEMINI.md
 .claude/


### PR DESCRIPTION
`.gitignore` の `# AI assistants` ブロックは `CLAUDE.md` / `AGENTS.md` / `GEMINI.md` を弾くが、**`CLAUDE.local.md` が抜けていた**。Claude Code はこれも自動読込するので、そこにローカルの agent context を置いた人はそれを commit してしまう。

[`tmai-core#664`](https://github.com/trust-delta/tmai-core/pull/664) が core 側で塞いだのと同じ穴。aim [`aim-without-tmai`](https://github.com/trust-delta/tmai-core/blob/main/docs/aims/aim-without-tmai.md) の `PROCESS` に残っていた最後の 1 行。

## hub には guard ジョブが無い

core は CI の `repo guards` が「この 4 ファイルが tracked でないこと」を検証するが、hub には相当するものが無い。今回は範囲外として足していない — hub は aim 木を持たず、frame の導線も要らないため、同じ機構を移すべきかは別の判断になる。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * ローカル環境向けの設定・メモファイルが、誤ってバージョン管理に含まれないよう除外しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->