### PR TITLE
test(handoff): pin the wrapper-unit overlay gate seam (tmai-core #676)

### DIFF
--- a/clients/react/src/__tests__/App.handoff.test.tsx
+++ b/clients/react/src/__tests__/App.handoff.test.tsx
@@ -16,10 +16,12 @@ import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { AgentSnapshot } from "@/lib/api";
 import { renderWithProviders } from "@/test/render";
+import type { SlotResponse } from "@/types/generated/SlotResponse";
 
 // ── hook mocks ──
 const useAgentsMock = vi.fn();
 const useHandoffRitualMock = vi.fn();
+const useSlotsMock = vi.fn();
 
 vi.mock("@/lib/sse-provider", () => ({
   useSSE: () => undefined,
@@ -34,12 +36,12 @@ vi.mock("@/hooks/useAgents", () => ({ useAgents: () => useAgentsMock() }));
 vi.mock("@/hooks/useWorktrees", () => ({
   useWorktrees: () => ({ worktrees: [], loading: false, refresh: vi.fn() }),
 }));
-// Loaded-empty membership: `unitName` then resolves by basename of the synthetic
-// `/p/...` paths these tests use (no live slot). Must be `loading: false` so
-// App's slots-load gate releases `unitName`.
-vi.mock("@/hooks/useSlots", () => ({
-  useSlots: () => ({ data: { slots: [] }, loading: false, error: null }),
-}));
+// Slot membership is per-test. The default (set in `beforeEach`) is loaded-empty
+// so `unitName` resolves by basename of the synthetic `/p/...` paths most tests
+// use (no live slot); the wrapper-unit regression below overrides it with a
+// populated multi-repo unit. Must be `loading: false` so App's slots-load gate
+// releases `unitName`.
+vi.mock("@/hooks/useSlots", () => ({ useSlots: () => useSlotsMock() }));
 vi.mock("@/hooks/useNotificationConfig", () => ({ useNotificationConfig: () => ({}) }));
 vi.mock("@/hooks/useIdleNotification", () => ({
   useIdleNotification: () => ({ handleAgentStopped: vi.fn() }),
@@ -80,7 +82,9 @@ function agent(overrides: { id: string; cwd?: string }): AgentSnapshot {
     git_branch: null,
     git_dirty: null,
     is_worktree: false,
-    git_common_dir: "/p/alpha/.git",
+    // Derive from cwd so a non-default cwd (the secondary-repo case below)
+    // groups onto its OWN repo path, not a hardcoded `/p/alpha`.
+    git_common_dir: `${cwd}/.git`,
     worktree_name: null,
     worktree_base_branch: null,
     effort_level: null,
@@ -105,10 +109,24 @@ function idleRitual() {
   };
 }
 
+// The real multi-repo unit from #674: the Producer runs at the wrapper `…/tmai`,
+// the unit "tmai" spans a primary repo (`…/tmai/tmai`, basename matches the unit
+// name) and a SECONDARY repo (`…/tmai/tmai-core`, basename "tmai-core" does NOT).
+// This is the post-#675 membership — the state the backend respawn now preserves.
+const TMAI_UNIT: SlotResponse = {
+  name: "tmai",
+  repos: [
+    { path: "/home/u/works/tmai/tmai", primary: true },
+    { path: "/home/u/works/tmai/tmai-core", primary: false },
+  ],
+};
+
 beforeEach(() => {
   useAgentsMock.mockReset();
   useHandoffRitualMock.mockReset();
   useHandoffRitualMock.mockReturnValue(idleRitual());
+  useSlotsMock.mockReset();
+  useSlotsMock.mockReturnValue({ data: { slots: [] }, loading: false, error: null });
 });
 
 describe("App — handoff ritual wiring", () => {
@@ -135,6 +153,44 @@ describe("App — handoff ritual wiring", () => {
     // The aim console is the sole surface …
     expect(screen.getByTestId("aim-console-stub")).toBeTruthy();
     // … and the handoff overlay is co-visible with it (via `handoffOverlay`).
+    expect(screen.getByTestId("phase-row-prompted")).toBeTruthy();
+  });
+
+  // Regression for the #674 front-side facet (tmai-core #676). The in-progress
+  // overlay is gated by `ritualState.unit === unitName` (App.tsx). `unitName`
+  // comes from `resolveUnitName(currentProject, slots)`; `ritualState.unit` is
+  // server-authoritative off the SSE stream. #674's mismatch was the backend
+  // respawning the Producer at the PRIMARY repo root, collapsing the unit's
+  // membership so a SECONDARY-repo `currentProject` matched no slot →
+  // `resolveUnitName` fell back to the basename "tmai-core" → it never equalled
+  // the ritual's server unit "tmai" → the overlay stayed hidden and the ritual
+  // stuck at `awaiting_review` (context loss, observed 2026-07-11). tmai-core
+  // #675 restored the membership; this pins the FRONT-SIDE composition seam
+  // #674 slipped through: with membership present and the focused unit's
+  // `currentProject` on the SECONDARY repo, the gate must resolve the wrapper
+  // unit and SHOW the overlay. The other case above uses empty slots + a
+  // basename-matching path, so it never exercised this seam.
+  it("shows the overlay for a wrapper unit whose currentProject is a SECONDARY repo (tmai-core #676)", () => {
+    // Membership present (the post-#675 state the backend respawn now preserves).
+    useSlotsMock.mockReturnValue({ data: { slots: [TMAI_UNIT] }, loading: false, error: null });
+    // Sole agent sits on the SECONDARY repo → `currentProject` = `…/tmai-core`,
+    // basename "tmai-core" ≠ the unit name "tmai".
+    useAgentsMock.mockReturnValue({
+      agents: [agent({ id: "claude:prod", cwd: "/home/u/works/tmai/tmai-core" })],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+    // The ritual's server unit is the wrapper unit "tmai".
+    useHandoffRitualMock.mockReturnValue({
+      ...idleRitual(),
+      state: { kind: "in_progress", ritualId: "r-1", unit: "tmai", phases: [] },
+    });
+
+    renderWithProviders(<App />);
+
+    // `resolveUnitName("…/tmai-core", [TMAI_UNIT])` === "tmai" === ritual unit →
+    // gate holds → overlay shows. A basename fallback ("tmai-core") would hide it.
     expect(screen.getByTestId("phase-row-prompted")).toBeTruthy();
   });
 });


### PR DESCRIPTION
## What

Adds an App-level regression test pinning the front-side composition seam that tmai-core **#674** slipped through, closing the front-side facet tracked by tmai-core **#676**.

## Why

The in-progress handoff overlay is gated by `ritualState.unit === unitName` (`App.tsx`):
- `unitName` = `resolveUnitName(currentProject, slots)`
- `ritualState.unit` = server-authoritative, off the SSE stream

**#674's front-side mismatch:** the backend respawned the Producer at the PRIMARY repo root, collapsing a multi-repo unit's membership. A SECONDARY-repo `currentProject` then matched no slot → `resolveUnitName` fell back to the basename (`tmai-core`) → it never equalled the ritual's server unit (`tmai`) → the overlay stayed hidden and the ritual stuck at `awaiting_review` (context loss, observed 2026-07-11).

**tmai-core #675** fixed the *backend* (respawn at `unit.launch_dir()`, preserving membership; guarded by `respawn_spawns_at_unit_launch_dir_preserving_membership`). This PR is the **verify** half of #676: with membership restored, the front-side gate resolves the wrapper unit and shows the overlay — confirmed transitively fixed, no residual re-hydration gap independent of cwd, **no front-side code change needed**.

`resolveUnitName` (`resolve-unit-name.test.ts`) and the overlay gate (`App.handoff.test.tsx` #897 case) were each unit-tested, but **no test exercised the composition seam** — the existing App case uses empty slots + a basename-matching path. This adds the missing case: membership present + `currentProject` on the SECONDARY repo → overlay must show.

## Verification

- Falsified: under the collapsed-membership (pre-#675) state (empty slots), the new test **fails** — so it genuinely guards the seam, not a tautology.
- Test-only change. Local gate all green: `tsc --noEmit`, `biome check`, `vitest` (739 passed / 2 skipped), `vite build`.

Refs: tmai-core #674, #675, #676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **テスト**
  * ハンドオフ機能について、セカンダリリポジトリ経由でも適切なオーバーレイが表示されるケースを追加検証しました。
  * テストごとにスロット状態を切り替えられるようになり、空の状態とデータがある状態の両方を確認できるようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->