### PR TITLE
chore(gen): sync generated spec + types from tmai-core@8227784f9a

### DIFF
--- a/api-spec/corevents.schema.json
+++ b/api-spec/corevents.schema.json
@@ -1024,6 +1024,13 @@
           },
           "type": "array"
         },
+        "last_synced_at": {
+          "description": "Wall-clock time (ISO-8601) of the last *successful* `gh` sync that\nproduced this row — the data-freshness anchor for the hub's\n\"· 2分前\" label (#606 §2, aim `pr-issue-ci` PROCESS ⑤⑥). Distinct from\nthe #524 vocab-event times above (\"when the issue changed\"): this is\n\"when we last actually pulled from GitHub\". Advanced only on a real\nfetch, never on a 30s-TTL cache hit, so the label never claims the data\nis fresher than it is. `Option` + `serde(default)` for the same\nforward-compat discipline as the vocab-event fields.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
         "number": {
           "format": "int64",
           "minimum": 0,
@@ -1144,6 +1151,13 @@
         },
         "is_draft": {
           "type": "boolean"
+        },
+        "last_synced_at": {
+          "description": "Wall-clock time (ISO-8601) of the last *successful* `gh` sync that\nproduced this row — the data-freshness anchor for the hub's\n\"· 2分前\" label (#606 §2, aim `pr-issue-ci` PROCESS ⑤⑥). Distinct from\nthe #524 vocab-event times above (\"when the PR changed\"): this is \"when\nwe last actually pulled from GitHub\". Advanced only on a real fetch,\nnever on a 30s-TTL cache hit, so the label never claims the data is\nfresher than it is. `Option` + `serde(default)` for the same\nforward-compat discipline as the vocab-event fields.",
+          "type": [
+            "string",
+            "null"
+          ]
         },
         "merge_commit_sha": {
           "description": "Kept for shape parity with `PrInfo`. `null` in practice even for the\nmerged rows of the recent-transition window — the unit-list fetch\ndoesn't request `mergeCommit`; the lifecycle fact is `state` +\n`merged_at`.",

--- a/api-spec/openapi.json
+++ b/api-spec/openapi.json
@@ -2374,6 +2374,13 @@
               "$ref": "#/components/schemas/IssueLabelWire"
             }
           },
+          "last_synced_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Wall-clock time (ISO-8601) of the last *successful* `gh` sync that\nproduced this row — the data-freshness anchor for the hub's\n\"· 2分前\" label (#606 §2, aim `pr-issue-ci` PROCESS ⑤⑥). Distinct from\nthe #524 vocab-event times above (\"when the issue changed\"): this is\n\"when we last actually pulled from GitHub\". Advanced only on a real\nfetch, never on a 30s-TTL cache hit, so the label never claims the data\nis fresher than it is. `Option` + `serde(default)` for the same\nforward-compat discipline as the vocab-event fields."
+          },
           "number": {
             "type": "integer",
             "format": "int64",
@@ -2501,6 +2508,13 @@
           },
           "is_draft": {
             "type": "boolean"
+          },
+          "last_synced_at": {
+            "type": [
+              "string",
+              "null"
+            ],
+            "description": "Wall-clock time (ISO-8601) of the last *successful* `gh` sync that\nproduced this row — the data-freshness anchor for the hub's\n\"· 2分前\" label (#606 §2, aim `pr-issue-ci` PROCESS ⑤⑥). Distinct from\nthe #524 vocab-event times above (\"when the PR changed\"): this is \"when\nwe last actually pulled from GitHub\". Advanced only on a real fetch,\nnever on a 30s-TTL cache hit, so the label never claims the data is\nfresher than it is. `Option` + `serde(default)` for the same\nforward-compat discipline as the vocab-event fields."
           },
           "merge_commit_sha": {
             "type": [

--- a/clients/ratatui/src/types/generated/issue_summary_wire.rs
+++ b/clients/ratatui/src/types/generated/issue_summary_wire.rs
@@ -16,6 +16,8 @@ pub struct IssueSummaryWire {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub created_at: Option<Value>,
     pub labels: Vec<IssueLabelWire>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_synced_at: Option<Value>,
     pub number: i64,
     pub state: String,
     pub title: String,

--- a/clients/ratatui/src/types/generated/pr_summary_wire.rs
+++ b/clients/ratatui/src/types/generated/pr_summary_wire.rs
@@ -27,6 +27,8 @@ pub struct PrSummaryWire {
     pub head_sha: String,
     pub is_draft: bool,
     #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_synced_at: Option<Value>,
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub merge_commit_sha: Option<Value>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub merged_at: Option<Value>,

--- a/clients/react/src/components/aim-console/__tests__/PrRail.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/PrRail.test.tsx
@@ -56,6 +56,7 @@ function pr(overrides: Partial<PrSummaryWire> = {}): PrSummaryWire {
     merged_at: null,
     closed_at: null,
     ci_completed_at: null,
+    last_synced_at: null,
     ...overrides,
   };
 }
@@ -70,6 +71,7 @@ function issue(overrides: Partial<IssueSummaryWire> = {}): IssueSummaryWire {
     assignees: [],
     created_at: null,
     closed_at: null,
+    last_synced_at: null,
     ...overrides,
   };
 }

--- a/clients/react/src/components/aim-console/__tests__/remote-delta.test.ts
+++ b/clients/react/src/components/aim-console/__tests__/remote-delta.test.ts
@@ -42,6 +42,7 @@ function pr(overrides: Partial<PrSummaryWire> = {}): PrSummaryWire {
     merged_at: null,
     closed_at: null,
     ci_completed_at: null,
+    last_synced_at: null,
     ...overrides,
   };
 }
@@ -56,6 +57,7 @@ function issue(overrides: Partial<IssueSummaryWire> = {}): IssueSummaryWire {
     assignees: [],
     created_at: null,
     closed_at: null,
+    last_synced_at: null,
     ...overrides,
   };
 }

--- a/clients/react/src/components/aim-console/__tests__/status-pills.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/status-pills.test.tsx
@@ -31,6 +31,7 @@ function pr(overrides: Partial<PrSummaryWire> = {}): PrSummaryWire {
     merged_at: null,
     closed_at: null,
     ci_completed_at: null,
+    last_synced_at: null,
     ...overrides,
   };
 }
@@ -45,6 +46,7 @@ function issue(overrides: Partial<IssueSummaryWire> = {}): IssueSummaryWire {
     assignees: [],
     created_at: null,
     closed_at: null,
+    last_synced_at: null,
     ...overrides,
   };
 }

--- a/clients/react/src/hooks/__tests__/useUnitIssues.test.ts
+++ b/clients/react/src/hooks/__tests__/useUnitIssues.test.ts
@@ -43,6 +43,7 @@ function response(unit: string, issueCount: number): UnitIssuesResponse {
           assignees: [],
           created_at: null,
           closed_at: null,
+          last_synced_at: null,
         })),
       },
     ],

--- a/clients/react/src/hooks/__tests__/useUnitPrs.test.ts
+++ b/clients/react/src/hooks/__tests__/useUnitPrs.test.ts
@@ -55,6 +55,7 @@ function response(unit: string, prCount: number): UnitPrsResponse {
           merged_at: null,
           closed_at: null,
           ci_completed_at: null,
+          last_synced_at: null,
         })),
       },
     ],

--- a/clients/react/src/types/generated/IssueSummaryWire.ts
+++ b/clients/react/src/types/generated/IssueSummaryWire.ts
@@ -18,4 +18,15 @@ created_at: string | null,
  * Close time (ISO-8601) — `null` while open. State-transition vocab
  * event (#524).
  */
-closed_at: string | null, };
+closed_at: string | null, 
+/**
+ * Wall-clock time (ISO-8601) of the last *successful* `gh` sync that
+ * produced this row — the data-freshness anchor for the hub's
+ * "· 2分前" label (#606 §2, aim `pr-issue-ci` PROCESS ⑤⑥). Distinct from
+ * the #524 vocab-event times above ("when the issue changed"): this is
+ * "when we last actually pulled from GitHub". Advanced only on a real
+ * fetch, never on a 30s-TTL cache hit, so the label never claims the data
+ * is fresher than it is. `Option` + `serde(default)` for the same
+ * forward-compat discipline as the vocab-event fields.
+ */
+last_synced_at: string | null, };

--- a/clients/react/src/types/generated/PrSummaryWire.ts
+++ b/clients/react/src/types/generated/PrSummaryWire.ts
@@ -59,4 +59,15 @@ closed_at: string | null,
  * conclusion" vocab event (#524). Deliberately NOT a raw `updated_at`:
  * comment/label churn must not look like a vocab event.
  */
-ci_completed_at: string | null, };
+ci_completed_at: string | null, 
+/**
+ * Wall-clock time (ISO-8601) of the last *successful* `gh` sync that
+ * produced this row — the data-freshness anchor for the hub's
+ * "· 2分前" label (#606 §2, aim `pr-issue-ci` PROCESS ⑤⑥). Distinct from
+ * the #524 vocab-event times above ("when the PR changed"): this is "when
+ * we last actually pulled from GitHub". Advanced only on a real fetch,
+ * never on a 30s-TTL cache hit, so the label never claims the data is
+ * fresher than it is. `Option` + `serde(default)` for the same
+ * forward-compat discipline as the vocab-event fields.
+ */
+last_synced_at: string | null, };


### PR DESCRIPTION
Generated-From: trust-delta/tmai-core@8227784f9a4b73e9bdb74fac95106fba7930ac5c

Auto-opened by tmai-core's `gen-spec-pr` workflow.
Do not hand-edit these files — they are regenerated from Rust
contract-layer types via `tmai-xtask`.

<details><summary>diff stat</summary>

```
 api-spec/corevents.schema.json                            | 14 ++++++++++++++
 api-spec/openapi.json                                     | 14 ++++++++++++++
 clients/ratatui/src/types/generated/issue_summary_wire.rs |  2 ++
 clients/ratatui/src/types/generated/pr_summary_wire.rs    |  2 ++
 clients/react/src/types/generated/IssueSummaryWire.ts     | 13 ++++++++++++-
 clients/react/src/types/generated/PrSummaryWire.ts        | 13 ++++++++++++-
 6 files changed, 56 insertions(+), 2 deletions(-)
```

</details>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * Issueおよびプルリクエストの概要情報に、最後に正常同期された日時を示す`last_synced_at`項目を追加しました。
  * 値が取得できない場合は`null`として返されます（短時間のキャッシュ更新では変わらない場合があります）。
* **テスト**
  * 既存テストのモックデータに`last_synced_at`（`null`）を反映し、検証の整合性を維持しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->