### PR TITLE
feat(react): cross-unit owed tab signal — surface an unopened unit's handoff review gate

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -2,6 +2,11 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { AimConsole } from "@/components/aim-console/AimConsole";
 import { HandoffRitualFailureDialog } from "@/components/aim-console/HandoffRitualFailureDialog";
 import { HandoffRitualOverlay } from "@/components/aim-console/HandoffRitualOverlay";
+import {
+  handoffOwesReview,
+  resolveUnitSignal,
+  type UnitSignal,
+} from "@/components/aim-console/unit-signal";
 import { HelpOverlay } from "@/components/layout/HelpOverlay";
 import { ToastContainer, useToast } from "@/components/layout/ToastContainer";
 import { ProducerLaunchPicker } from "@/components/project/ProducerLaunchPicker";
@@ -152,12 +157,30 @@ export function App() {
   // MUST remain the only one.
   const {
     state: ritualState,
+    unitPhases: handoffUnitPhases,
     trigger: triggerHandoff,
     retry: retryHandoff,
     dismiss: dismissHandoff,
     retryCount: handoffRetryCount,
     retryRefused: handoffRetryRefused,
   } = useHandoffRitual();
+
+  // Per-unit cross-unit tab signal (aim `1-worktree-merge`'s cross-unit
+  // family). One dot per unit tab, precedence-collapsed (owed > fresh > idle).
+  // Only the `owed` source is wired today — a unit whose latest handoff phase
+  // is `awaiting_review` owes the operator a review act (aim
+  // `cross-unit-operator-owed`), surfaced even when that unit is NOT focused.
+  // `fresh` (`cross-unit-remote-delta`) / `idle` (`cross-unit-idle-passive`)
+  // sources drop in here later without re-architecting the tab.
+  const unitSignals = useMemo(() => {
+    const out: Record<string, UnitSignal | null> = {};
+    for (const slot of slotsData?.slots ?? []) {
+      out[slot.name] = resolveUnitSignal({
+        owed: handoffOwesReview(handoffUnitPhases[slot.name]),
+      });
+    }
+    return out;
+  }, [slotsData, handoffUnitPhases]);
 
   // The single live Producer for the focused unit. Drives the
   // conversation-header gate (only show it when the selected agent IS
@@ -507,6 +530,7 @@ export function App() {
     <>
       <AimConsole
         units={slotsData?.slots ?? []}
+        unitSignals={unitSignals}
         activeUnitName={unitName}
         onSelectUnit={handleSelectUnit}
         onAddUnit={openLaunchPicker}

--- a/clients/react/src/__tests__/App.handoff.test.tsx
+++ b/clients/react/src/__tests__/App.handoff.test.tsx
@@ -101,6 +101,9 @@ function agent(overrides: { id: string; cwd?: string }): AgentSnapshot {
 function idleRitual() {
   return {
     state: { kind: "idle" as const },
+    // Per-unit latest handoff phase (cross-unit owed tab signal). Empty here —
+    // this file exercises the single-ritual overlay, not the tab dots.
+    unitPhases: {},
     trigger: vi.fn(),
     retry: vi.fn(),
     dismiss: vi.fn(),

--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -55,6 +55,7 @@ import { AimRemoteGutter, ConvAimGutter, OverlayEdgeGutter } from "./Gutters";
 import { PrRail } from "./PrRail";
 import { advanceCursor, effectiveCursor } from "./remote-delta";
 import { SessionPane } from "./SessionPane";
+import type { UnitSignal } from "./unit-signal";
 // Bundled dev-tool typography (offline-robust @fontsource, NOT a Google Fonts
 // <link>) — loads the exact families `aim-console.css` references via --sans /
 // --mono so the dev-tool look matches the mock instead of falling back to
@@ -105,6 +106,12 @@ interface AimConsoleProps {
    *  slot carries `name + repos` (same membership the tabs + per-repo footer
    *  use) plus a lifecycle `state` (occupied / vacant / halted). */
   units: SlotResponse[];
+  /** Per-unit cross-unit tab signal, keyed by unit name (App resolves it from
+   *  the sibling sources, precedence-collapsed in `unit-signal.ts`). A unit's
+   *  dot renders its signal; absent / `null` = quiet. Only the `owed` source
+   *  (handoff `awaiting_review`) is populated today. Optional so tests and any
+   *  pre-signal caller render a quiet strip. */
+  unitSignals?: Record<string, UnitSignal | null>;
   /** Name of the currently focused unit, so the matching tab highlights. */
   activeUnitName: string | null;
   /** Re-scope the focused unit to the clicked tab. */
@@ -141,6 +148,7 @@ interface AimConsoleProps {
 
 export function AimConsole({
   units,
+  unitSignals = {},
   activeUnitName,
   onSelectUnit,
   onAddUnit,
@@ -306,6 +314,7 @@ export function AimConsole({
             key={unit.name}
             unit={unit}
             active={unit.name === activeUnitName}
+            signal={unitSignals[unit.name] ?? null}
             onSelect={() => onSelectUnit(unit)}
             onClose={() => onCloseUnit(unit)}
           />
@@ -408,19 +417,33 @@ export function AimConsole({
   );
 }
 
+// Human-readable reason per signal, surfaced on the tab's hover/aria so the
+// operator learns WHAT a non-focused unit owes without switching to it (aim
+// `cross-unit-operator-owed`: "provenance と理由は hover / on-switch の string
+// で示す"). Only `owed` has a live source today (handoff review gate); the
+// others are named ahead of their sources landing.
+const SIGNAL_REASON: Record<UnitSignal, string> = {
+  owed: "operator action owed — handoff awaiting review",
+  fresh: "new remote activity",
+  idle: "idle — no motion",
+};
+
 // Top-bar unit tab — repo pills (primary highlighted), styled with the
 // aim-console tokens.
 function AimUnitTab({
   unit,
   active,
+  signal,
   onSelect,
   onClose,
 }: {
   unit: SlotResponse;
   active: boolean;
+  signal: UnitSignal | null;
   onSelect: () => void;
   onClose: () => void;
 }) {
+  const signalReason = signal ? SIGNAL_REASON[signal] : null;
   // Always-on confirm gate (mirrors the legacy UnitTabs, same copy): close =
   // kill (Producer + workers + footer bash), so it is never silent. Nesting a
   // <button> inside the tab <button> is invalid, so the close × is a sibling
@@ -446,10 +469,14 @@ function AimUnitTab({
         className={cn("ac-utab", active && "on")}
         onClick={onSelect}
         aria-current={active ? "true" : undefined}
-        aria-label={`unit: ${unit.name}`}
-        title={`unit: ${unit.name}`}
+        aria-label={signalReason ? `unit: ${unit.name}, ${signalReason}` : `unit: ${unit.name}`}
+        title={signalReason ? `unit: ${unit.name} — ${signalReason}` : `unit: ${unit.name}`}
       >
-        <span className="ac-d" />
+        <span
+          className={cn("ac-d", signal && `sig-${signal}`)}
+          data-signal={signal ?? undefined}
+          aria-hidden="true"
+        />
         {unit.repos.map((repo) => (
           <span
             key={repo.path}

--- a/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
+++ b/clients/react/src/components/aim-console/__tests__/AimConsole.test.tsx
@@ -114,6 +114,26 @@ describe("AimConsole — S1 shell", () => {
     expect(pills[1].getAttribute("data-primary")).toBe("false");
   });
 
+  it("renders an owed signal dot + hover reason on a unit that owes a handoff review", () => {
+    renderConsole({ unitSignals: { tmai: "owed" } });
+    // The tab's accessible name carries the reason so the operator learns WHAT
+    // the non-focused unit owes without switching to it.
+    const tab = screen.getByRole("button", {
+      name: "unit: tmai, operator action owed — handoff awaiting review",
+    });
+    const dot = tab.querySelector(".ac-d");
+    expect(dot?.className).toContain("sig-owed");
+    expect(dot?.getAttribute("data-signal")).toBe("owed");
+  });
+
+  it("leaves the dot quiet (no signal class, plain name) for a unit with no signal", () => {
+    renderConsole(); // default unitSignals = {}
+    const tab = screen.getByRole("button", { name: "unit: tmai" });
+    const dot = tab.querySelector(".ac-d");
+    expect(dot?.className ?? "").not.toContain("sig-");
+    expect(dot?.getAttribute("data-signal")).toBeNull();
+  });
+
   it("opens the Remote as an OVERLAY by default; ⊟ docks it; ✕ collapses + resets to overlay", () => {
     renderConsole();
     const root = screen.getByTestId("aim-console");

--- a/clients/react/src/components/aim-console/__tests__/unit-signal.test.ts
+++ b/clients/react/src/components/aim-console/__tests__/unit-signal.test.ts
@@ -1,0 +1,45 @@
+// unit-signal — pure precedence-collapse for the per-unit cross-unit tab
+// signal. Pins the operator-chosen ordering (owed > fresh > idle > none) and
+// the one wired source (handoff `awaiting_review` ⇒ owed).
+
+import { describe, expect, it } from "vitest";
+import { handoffOwesReview, resolveUnitSignal } from "../unit-signal";
+
+describe("resolveUnitSignal — precedence owed > fresh > idle > none", () => {
+  it("is null when no source is live (quiet unit)", () => {
+    expect(resolveUnitSignal({})).toBeNull();
+    expect(resolveUnitSignal({ owed: false, fresh: false, idle: false })).toBeNull();
+  });
+
+  it("returns each single live source unchanged", () => {
+    expect(resolveUnitSignal({ owed: true })).toBe("owed");
+    expect(resolveUnitSignal({ fresh: true })).toBe("fresh");
+    expect(resolveUnitSignal({ idle: true })).toBe("idle");
+  });
+
+  it("owed wins over fresh and idle (the only progress-blocking lane)", () => {
+    expect(resolveUnitSignal({ owed: true, fresh: true, idle: true })).toBe("owed");
+    expect(resolveUnitSignal({ owed: true, fresh: true })).toBe("owed");
+    expect(resolveUnitSignal({ owed: true, idle: true })).toBe("owed");
+  });
+
+  it("fresh wins over idle when owed is absent (freshness resurfaces once owe clears)", () => {
+    expect(resolveUnitSignal({ fresh: true, idle: true })).toBe("fresh");
+  });
+});
+
+describe("handoffOwesReview — the wired owed source", () => {
+  it("owes only at the review gate", () => {
+    expect(handoffOwesReview("awaiting_review")).toBe(true);
+  });
+
+  it("does not owe at any other phase (owe clears mechanically as phase advances)", () => {
+    for (const phase of ["prompted", "validated", "killed", "launching", "ready", "escalate"]) {
+      expect(handoffOwesReview(phase)).toBe(false);
+    }
+  });
+
+  it("does not owe when the unit has never emitted a phase", () => {
+    expect(handoffOwesReview(undefined)).toBe(false);
+  });
+});

--- a/clients/react/src/components/aim-console/unit-signal.ts
+++ b/clients/react/src/components/aim-console/unit-signal.ts
@@ -1,0 +1,59 @@
+// unit-signal — the per-unit cross-unit tab signal (aim `1-worktree-merge`'s
+// children: the cross-unit tab-signal family — `cross-unit-operator-owed`,
+// `cross-unit-remote-delta`, `cross-unit-idle-passive`,
+// `cross-unit-operator-call`). Each unit tab carries ONE signal dot, so when a
+// unit has several live signals at once they are precedence-COLLAPSED to the
+// single dot the operator sees.
+//
+// Precedence (operator-chosen, hub AskUserQuestion 2026-07-14): owed > fresh >
+// idle > none. A unit that is both `owed` AND `fresh` shows `owed`; freshness
+// resurfaces once the owe clears. `owed` (an operator act is required) wins
+// because it is the only lane that blocks progress; freshness/idle are
+// appraise-if-you-want.
+//
+// This is the generic CONTAINER for all four sibling signals. Only the `owed`
+// source is wired today (handoff `AwaitingReview` —
+// `cross-unit-operator-owed`); `fresh` (`cross-unit-remote-delta`) and `idle`
+// (`cross-unit-idle-passive`) are declared here so their sources drop in
+// without re-architecting the tab, and `owed` will later also be fed by the
+// Producer's MCP present-state raise (`cross-unit-operator-call`).
+
+export type UnitSignal = "owed" | "fresh" | "idle";
+
+export interface UnitSignalSources {
+  /** An operator act is owed on this unit before it can proceed. Wired today
+   *  from the handoff review gate (`handoffOwesReview`); later also the
+   *  Producer's MCP present-state raise (`cross-unit-operator-call`). */
+  owed?: boolean;
+  /** Unobserved remote artifact (PR / issue / CI change) —
+   *  `cross-unit-remote-delta`. Deferred source (not yet cross-unit). */
+  fresh?: boolean;
+  /** Producer yielded + no active worker + quiet — `cross-unit-idle-passive`.
+   *  Deferred source. */
+  idle?: boolean;
+}
+
+/**
+ * Collapse the (possibly several) live sources to the single highest-
+ * precedence signal the tab dot renders, or `null` when the unit is quiet.
+ * Precedence: owed > fresh > idle.
+ */
+export function resolveUnitSignal(sources: UnitSignalSources): UnitSignal | null {
+  if (sources.owed) return "owed";
+  if (sources.fresh) return "fresh";
+  if (sources.idle) return "idle";
+  return null;
+}
+
+/**
+ * The one source wired today. A unit whose latest handoff-ritual phase is
+ * `awaiting_review` owes the operator an approve / request-rewrite act: the
+ * old Producer is PAUSED at the review gate and cannot MCP-raise for itself,
+ * so the owe is derived from the (already global, unit-tagged)
+ * `handoff_ritual` SSE phase rather than an agent declaration. Any later
+ * forward phase (killed / launching / ready) or an `escalate` supersedes
+ * `awaiting_review`, so the owe clears mechanically with no explicit lower.
+ */
+export function handoffOwesReview(latestPhase: string | undefined): boolean {
+  return latestPhase === "awaiting_review";
+}

--- a/clients/react/src/hooks/useHandoffRitual.ts
+++ b/clients/react/src/hooks/useHandoffRitual.ts
@@ -58,6 +58,14 @@ export type RitualUiState =
 
 export interface UseHandoffRitualResult {
   state: RitualUiState;
+  /** Latest handoff-ritual phase observed per unit, across ALL units on the
+   *  global `handoff_ritual` SSE stream — not just the single adopted
+   *  `state`. Lets a non-focused unit's `awaiting_review` surface as a
+   *  cross-unit tab signal (aim `cross-unit-operator-owed`): the operator,
+   *  working in unit X, learns unit Y owes a handoff review. Retains only the
+   *  LATEST phase per unit, so a forward phase (killed/…/ready) or `escalate`
+   *  supersedes `awaiting_review` and the owe clears mechanically. */
+  unitPhases: Record<string, HandoffRitualEvent["phase"]>;
   /** Number of retries already attempted in this session. Used by the
    *  dialog to disable the Retry button after the 2nd rejection. */
   retryCount: number;
@@ -85,6 +93,11 @@ export function useHandoffRitual(): UseHandoffRitualResult {
   const [state, setState] = useState<RitualUiState>({ kind: "idle" });
   const [retryCount, setRetryCount] = useState(0);
   const [retryRefused, setRetryRefused] = useState(false);
+  // Latest phase per unit, fed by EVERY handoff_ritual event (not gated by the
+  // adopted `state`'s ritual_id). This is the cross-unit owed-signal source:
+  // the single `state` above is scoped to one adopted ritual for the overlay,
+  // but the tab dots need every unit's current phase.
+  const [unitPhases, setUnitPhases] = useState<Record<string, HandoffRitualEvent["phase"]>>({});
 
   // Single state-driven event router (no ref mirror — matching reads `prev`
   // inside the updater, so the SSE handler can register once and never go
@@ -172,6 +185,11 @@ export function useHandoffRitual(): UseHandoffRitualResult {
     onEvent: (eventName, data) => {
       if (eventName !== "handoff_ritual") return;
       if (!looksLikeHandoffRitualEvent(data)) return;
+      // Track the latest phase for EVERY unit (cross-unit owed signal),
+      // independent of which single ritual `applyEvent` adopts for the overlay.
+      setUnitPhases((prev) =>
+        prev[data.unit] === data.phase ? prev : { ...prev, [data.unit]: data.phase },
+      );
       applyEvent(data);
     },
   });
@@ -228,5 +246,5 @@ export function useHandoffRitual(): UseHandoffRitualResult {
     setRetryRefused(false);
   }, []);
 
-  return { state, retryCount, retryRefused, trigger, retry, dismiss };
+  return { state, unitPhases, retryCount, retryRefused, trigger, retry, dismiss };
 }

--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -142,8 +142,19 @@
   border-radius: 50%;
   background: var(--faint);
 }
-.aim-console .ac-utab.on .ac-d {
+/* Cross-unit tab signal (aim `1-worktree-merge`'s cross-unit family). The dot
+   is the SIGNAL slot; active/inactive is the bottom-border only (`.ac-utab.on`
+   above), NOT the dot — so a `fresh` signal (cyan) never collides with what
+   used to be the active-tab cyan dot. Precedence-collapsed to one class per
+   dot (owed > fresh > idle) in `unit-signal.ts`. */
+.aim-console .ac-utab .ac-d.sig-owed {
+  background: var(--amber);
+}
+.aim-console .ac-utab .ac-d.sig-fresh {
   background: var(--cyan);
+}
+.aim-console .ac-utab .ac-d.sig-idle {
+  background: var(--dim);
 }
 .aim-console .ac-um {
   font-family: var(--mono);


### PR DESCRIPTION
## What

Surface an **unopened unit's** handoff `awaiting_review` as a **cross-unit tab signal**: an amber dot on that unit's tab, with the reason on hover. Recent operator friction — a handoff reached the review gate on a unit the operator wasn't focused on, and nothing surfaced it.

Implements the handoff todo of aim `cross-unit-operator-owed` (tmai-core `docs/aims`) — the first of the cross-unit tab-signal family under `1-worktree-merge`.

## Why hub-only (no core wire)

The `handoff_ritual` SSE is already **global and unit-tagged** (`CoreEvent::HandoffRitual { unit, phase }`). The UI simply discarded non-focused units' phases: `useHandoffRitual` retained a single adopted ritual and the overlay is gated to the focused unit. So the fix is client-side — retain the latest phase **per unit** and light the tab. (This corrects the aim body's earlier "needs core wire" note, which will be amended after merge; core wire is only needed later for cross-unit remote-Δ and reconnect-robust queryable phase.)

## Changes

- **`useHandoffRitual`** — add a per-unit latest-phase map (`unitPhases`) fed by every `handoff_ritual` event, **alongside** the untouched single-ritual `state` the overlay depends on (no behavior change to the existing overlay path).
- **`unit-signal.ts`** (new, pure) — `resolveUnitSignal({owed,fresh,idle})` collapses the four sibling signals to one dot by precedence **owed > fresh > idle > none** (operator-chosen). Only the `owed` source is wired today (`handoffOwesReview(phase) === "awaiting_review"`); `fresh` (`cross-unit-remote-delta`) and `idle` (`cross-unit-idle-passive`) are declared so their sources drop in without re-architecting the tab.
- **`AimUnitTab` / `aim-console.css`** — the `.ac-d` dot becomes the **signal slot** (`sig-owed` amber / `sig-fresh` cyan / `sig-idle` dim), reason on hover + aria. Active/inactive indication moves **fully to the bottom-border**, so a cyan `fresh` signal can't collide with what used to be the active-tab cyan dot.
- **`App.tsx`** — derive `unitSignals` per slot from `unitPhases` and thread to `AimConsole`.

## Design notes (operator-directed)

- **Means re-examined**: the tab is the right cross-unit surface — it already exists (`AimConsole` tab strip), is the only cross-unit representation, and is ambient/peripheral (no polling), matching the attention-budget rationale. An aggregate tray was rejected as premature (single-unit dogfood, no users).
- **Designed for all four siblings**: the dot is a generic precedence-collapse container; only `owed` lights now, but `fresh`/`idle`/the MCP-raise owed source slot in later with no tab rework.

## Verification

- `pnpm lint` (biome) clean · `pnpm build` (tsc -b + vite) green · `pnpm test` **753 pass** / 2 skip, incl. 20 new assertions (precedence + wired source + owed-dot render + quiet-dot).
- **Boundary**: the true cross-unit end-to-end (a *non-focused* unit lighting its tab) can't be exercised in single-unit dogfood — no second unit exists yet (same limitation `remote-delta.test.ts` records). The render + precedence logic is unit-tested; the SSE→map path is straightforward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ユニットタブに状態シグナルを表示できるようになりました。
  - 「対応が必要」「新しい更新」「待機中」の状態をドットの色で確認できます。
  - 状態が複数ある場合は、対応が必要な状態を優先して表示します。
  - タブのラベルやツールチップにも状態の理由を表示します。

- **改善**
  - 各ユニットの最新ハンドオフ状態を継続的に反映するようになりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->