### PR TITLE
fix(react): cap bash footer height so it can't replace the conversation

### DIFF
--- a/clients/react/src/styles/aim-console.css
+++ b/clients/react/src/styles/aim-console.css
@@ -901,6 +901,18 @@
 }
 .aim-console .ac-footer.open {
   height: calc(var(--fh, 180px) + 33px);
+  /* Declarative ceiling — the footer may take at most FOOTER_MAX_SESSION_RATIO
+     (60%) of the Session pane, plus its 33px tab bar, so the conversation term
+     (.ac-term, flex:1 min-height:0) can never be crushed to ~0 and "replaced"
+     by the bash terminal. The JS reclamp (BashFooter, FOOTER_MAX_SESSION_RATIO)
+     enforced the same ceiling imperatively but was bypassable — it bailed on
+     short sessions, did not re-run on a cross-tab reseed, and the storage clamp
+     is floor-only — leaving a stale-large `--fh` to collapse the term. This
+     makes the browser enforce it CONTINUOUSLY. `%` resolves against the
+     definite-height `.ac-col.ac-session` grid item (the parent, and the very
+     element the JS measures via closest('.ac-session')); `.ac-ftbody` (flex:1)
+     reflows to the capped height. */
+  max-height: calc(60% + 33px);
 }
 .aim-console .ac-fbar {
   display: flex;


### PR DESCRIPTION
## Bug

The Producer conversation panel appears **replaced by the bash terminal** after using the docked bash footer (operator-reported, conditions unclear / intermittent).

## Root cause — not a state/selection bug, a flex-layout collapse

`.ac-footer.open` had **no declarative height ceiling**: `height: calc(var(--fh) + 33px)` with no `max-height`. The intended 60% ceiling (`FOOTER_MAX_SESSION_RATIO`) was enforced only by an **imperative JS reclamp** (`BashFooter`) that is bypassable:

- it **bails on short sessions** (`0.6*sessionH <= floor` → returns without clamping),
- it **does not re-run on a cross-tab reseed** (the reclamp effect doesn't depend on the stored pref),
- the storage clamp (`clampAimConsoleFooterHeight`) is **floor-only**.

So a stale-large `--fh` — a footer dragged tall and persisted, then opened on a shorter window; or a cross-tab reseed — squeezes the collapsible conversation term (`.ac-term { flex:1; min-height:0 }`) toward zero, so the bash footer visually occupies the conversation's place. That accounts for the "unknown conditions" intermittency.

Investigated and **refuted** the plausible state/selection paths: footer bash PTYs get a non-AI id and fail `isAiAgentLoose`, so they can never enter the session tab list or be selected as the conversation term, and `findProducerForUnit` requires a `claude:` id — no id collision into the conversation slot is possible. The only path is the layout collapse.

## Fix

Enforce the ceiling **declaratively** so the browser holds it continuously, regardless of `--fh` or the JS reclamp:

```css
.aim-console .ac-footer.open { max-height: calc(60% + 33px); }
```

- `%` resolves against the **definite-height** `.ac-col.ac-session` grid item (`.aim-console` is `100vh` grid `auto 1fr`; `.ac-main` is the `1fr` row; the session column stretches to it) — the same element the JS measures via `closest('.ac-session')`.
- `+ 33px` matches the footer's 33px tab bar, so `--fh ≤ 60% of session` exactly mirrors `FOOTER_MAX_SESSION_RATIO = 0.6` (no discrepancy on a healthy drag).
- `.ac-ftbody` (`flex:1`) reflows to the capped height, so the bash terminal shrinks rather than clipping.

## Verification

- `pnpm build` green · `pnpm test` footer / gutter / console suites **43 pass** (no regression to the JS clamp, which is unchanged).
- The fix is CSS layout — not jsdom-testable. **Manual repro to confirm**: open the bash footer, drag it as tall as possible, then shrink the window height (or, in a second tab, drag the footer tall to persist the pref, and reload this tab on a shorter window). Before: the conversation collapses to nothing. After: the footer caps at 60% and the conversation stays ≥40%.
- Browser visual verify was not run here (no dev server reachable); the live vite will HMR this on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - ドッキングされた Bash フッターを展開した際、セッションペインのターミナル領域が必要以上に縮小されないようになりました。
  - フッターの展開サイズが適切に制限され、セッション画面のレイアウトがより安定します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->