### PR TITLE
fix(react): scope handoff failure-dialog actions to the ritual's unit, not focus

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -137,11 +137,6 @@ export function App() {
     return resolveUnitName(currentProject, slotsData?.slots ?? []);
   }, [currentProject, slotsData, slotsLoading]);
 
-  const unitReposForCurrent = useMemo(() => {
-    if (unitName === null) return null;
-    return slotsData?.slots.find((s) => s.name === unitName)?.repos ?? null;
-  }, [slotsData, unitName]);
-
   // ── Producer handoff-and-restart ritual (lifted to App level) ──
   //
   // Exactly ONE `useHandoffRitual` instance for the whole app. The
@@ -182,22 +177,24 @@ export function App() {
     return out;
   }, [slotsData, handoffUnitPhases]);
 
-  // The single live Producer for the focused unit. Drives the
-  // conversation-header gate (only show it when the selected agent IS
-  // this Producer), the failure dialog's Force-kill target, and its
-  // Resume-in-CC id. Shares the `findProducerForUnit` resolver with the
-  // digest button and the ctx readout so all surfaces agree.
-  //
-  // Cross-repo aware: when the units wire has resolved this unit's
-  // membership, we pass the full `UnitRepoWire[]` so the resolver can
-  // pin the Producer to the unit's PRIMARY repo even if `currentProject`
-  // happens to point at a non-primary repo. The single-path fallback
-  // keeps the resolver working pre-wire-load and for cwd-synthesized
-  // units that the units endpoint doesn't enumerate.
-  const producerForUnit = useMemo(
-    () => findProducerForUnit(agents, unitReposForCurrent ?? currentProject),
-    [agents, unitReposForCurrent, currentProject],
-  );
+  // The Producer of the unit the ESCALATED handoff ritual is for
+  // (`ritualState.unit`), resolved from the live membership — NOT from the
+  // focused unit. The handoff FAILURE dialog is shown for `ritualState.unit`
+  // regardless of which unit is focused, so every action it drives (Force-kill
+  // target, Retry, Resume-in-CC id) must target THAT unit. Deriving these from
+  // the focused unit mis-fired: a failed handoff whose Producer dropped from
+  // the live set auto-bounced focus (`FOCUS_GRACE_MS`) to another unit, and
+  // Force-kill then killed the WRONG, unopened unit's Producer
+  // (operator-reported 2026-07-15). `null` when the ritual's unit has no live
+  // Producer — the dialog then disables Force-kill / Resume rather than falling
+  // back to the focused unit's Producer. `findProducerForUnit` scoped to the
+  // ritual unit's own repos can only ever match that unit's Producer, so a
+  // cross-unit mis-kill is now structurally impossible.
+  const ritualUnitProducer = useMemo(() => {
+    if (ritualState.kind !== "escalated" || ritualState.unit === "") return null;
+    const repos = slotsData?.slots.find((s) => s.name === ritualState.unit)?.repos ?? null;
+    return repos === null ? null : findProducerForUnit(agents, repos);
+  }, [ritualState, slotsData, agents]);
 
   // Auto-dismiss `ready` with a brief success toast (handoff-lifecycle
   // DR §E overlay spec). Moved up from ProducerConsoleActions with the
@@ -214,20 +211,26 @@ export function App() {
   }, [ritualState.kind, dismissHandoff]);
 
   const handleHandoffRetry = useCallback(() => {
-    if (unitName === null) return;
-    void retryHandoff(unitName, { trigger: "manual" });
-  }, [retryHandoff, unitName]);
+    // Retry re-attempts the handoff for the unit the ritual FAILED for
+    // (`ritualState.unit`), not the focused unit — the failure dialog can be
+    // showing for a unit other than the focused one (see `ritualUnitProducer`).
+    if (ritualState.kind !== "escalated" || ritualState.unit === "") return;
+    void retryHandoff(ritualState.unit, { trigger: "manual" });
+  }, [retryHandoff, ritualState]);
 
   const handleHandoffForceKill = useCallback(async () => {
-    if (producerForUnit === null) return;
+    // Kill the RITUAL unit's Producer, never the focused unit's (see
+    // `ritualUnitProducer`). `null` → the ritual unit has no live Producer, so
+    // there is nothing to kill (the dialog's Force-kill is already disabled).
+    if (ritualUnitProducer === null) return;
     try {
-      await api.killAgent(producerForUnit.target);
+      await api.killAgent(ritualUnitProducer.target);
     } catch {
       // Best-effort — if the kill fails (already dead, etc.) we still
       // dismiss; the dialog already surfaced the upstream failure.
     }
     dismissHandoff();
-  }, [producerForUnit, dismissHandoff]);
+  }, [ritualUnitProducer, dismissHandoff]);
 
   // The "Open Producer terminal" affordance.
   //
@@ -504,7 +507,7 @@ export function App() {
           // The supervisor's `crash_loop_halted` halt is a different failure
           // than an operator-rejected handoff — manual relaunch, not retry.
           mode={ritualState.reason === "crash_loop_halted" ? "crash_loop" : "handoff"}
-          producerAgentId={producerForUnit?.id ?? null}
+          producerAgentId={ritualUnitProducer?.id ?? null}
           retryCount={handoffRetryCount}
           retryRefused={handoffRetryRefused}
           onForceKill={() => void handleHandoffForceKill()}

--- a/clients/react/src/__tests__/App.handoff.test.tsx
+++ b/clients/react/src/__tests__/App.handoff.test.tsx
@@ -11,10 +11,10 @@
 // `handoffOverlay` prop, and the overlay itself is the REAL component so we
 // assert on its phase rows.
 
-import { screen } from "@testing-library/react";
+import { fireEvent, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AgentSnapshot } from "@/lib/api";
+import { type AgentSnapshot, api } from "@/lib/api";
 import { renderWithProviders } from "@/test/render";
 import type { SlotResponse } from "@/types/generated/SlotResponse";
 
@@ -195,5 +195,98 @@ describe("App — handoff ritual wiring", () => {
     // `resolveUnitName("…/tmai-core", [TMAI_UNIT])` === "tmai" === ritual unit →
     // gate holds → overlay shows. A basename fallback ("tmai-core") would hide it.
     expect(screen.getByTestId("phase-row-prompted")).toBeTruthy();
+  });
+
+  // Cross-unit mis-kill guard (operator-reported 2026-07-15). A handoff
+  // escalated for one unit; the failure dialog's Force-kill / Retry / Resume
+  // must target the RITUAL unit, never the FOCUSED unit. The reported harm: a
+  // failed handoff dropped its Producer from the live set, focus auto-bounced
+  // to another unit, and Force-kill killed THAT (unopened) unit's Producer.
+  it("disables Force-kill when the failed ritual's unit has no live Producer — never falls back to the focused unit (mis-kill guard)", () => {
+    // `tmai` is the only live unit (so it is focused); the ritual escalated for
+    // a DIFFERENT unit "gamma" whose Producer already left the live set.
+    useSlotsMock.mockReturnValue({ data: { slots: [TMAI_UNIT] }, loading: false, error: null });
+    useAgentsMock.mockReturnValue({
+      agents: [
+        {
+          ...agent({ id: "claude:tmai-prod", cwd: "/home/u/works/tmai/tmai" }),
+          is_producer: true,
+          unit: "tmai",
+        },
+      ],
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+    useHandoffRitualMock.mockReturnValue({
+      ...idleRitual(),
+      state: {
+        kind: "escalated",
+        ritualId: "r-1",
+        unit: "gamma",
+        reason: "handoff_timeout",
+        message: null,
+      },
+    });
+
+    renderWithProviders(<App />);
+
+    // The dialog is for unit "gamma" (gone) — Force-kill must be DISABLED, not
+    // wired to tmai's Producer. (The buggy code enabled it, killing tmai.)
+    const forceKill = screen.getByRole("button", { name: "Force kill" }) as HTMLButtonElement;
+    expect(forceKill.disabled).toBe(true);
+  });
+
+  it("Force-kill targets the RITUAL unit's Producer, not the focused unit's", async () => {
+    // Two live units. `groupByProject` orders by first-seen agent, so the
+    // FOCUSED unit is whichever Producer is first — put "focused" first, then
+    // escalate the ritual for the OTHER unit "gamma".
+    const focusedProd = {
+      ...agent({ id: "claude:focused-prod", cwd: "/p/focused" }),
+      is_producer: true,
+      unit: "focused",
+    };
+    const gammaProd = {
+      ...agent({ id: "claude:gamma-prod", cwd: "/p/gamma" }),
+      is_producer: true,
+      unit: "gamma",
+    };
+    useSlotsMock.mockReturnValue({
+      data: {
+        slots: [
+          { name: "focused", repos: [{ path: "/p/focused", primary: true }] },
+          { name: "gamma", repos: [{ path: "/p/gamma", primary: true }] },
+        ],
+      },
+      loading: false,
+      error: null,
+    });
+    useAgentsMock.mockReturnValue({
+      agents: [focusedProd, gammaProd], // focused first → it is the focused unit
+      attentionCount: 0,
+      loading: false,
+      refresh: vi.fn(),
+    });
+    useHandoffRitualMock.mockReturnValue({
+      ...idleRitual(),
+      state: {
+        kind: "escalated",
+        ritualId: "r-1",
+        unit: "gamma",
+        reason: "rejected",
+        message: null,
+      },
+    });
+    const killSpy = vi.spyOn(api, "killAgent").mockResolvedValue(undefined);
+
+    renderWithProviders(<App />);
+
+    const forceKill = screen.getByRole("button", { name: "Force kill" }) as HTMLButtonElement;
+    expect(forceKill.disabled).toBe(false);
+    fireEvent.click(forceKill);
+
+    await waitFor(() => expect(killSpy).toHaveBeenCalledWith("claude:gamma-prod"));
+    expect(killSpy).not.toHaveBeenCalledWith("claude:focused-prod");
+    killSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Bug (operator-reported — cross-unit mis-kill)

In another unit, Claude Code's output broke; the operator pressed **Handoff**. The handoff didn't produce a baton — a **timeout / failure modal** appeared. Pressing **Force kill** in that modal killed **a DIFFERENT, unopened unit's Producer** (the operator's active session), not the unit the handoff was for. Recovery required `claude --resume`.

## Root cause

The handoff **failure dialog** (`ritualState.kind === "escalated"`) renders for `ritualState.unit` **regardless of which unit is focused** (`App.tsx` — it is a global overlay, not gated on focus like the in-progress overlay). But every action it drove was resolved from the **focused** unit:

- Force-kill target + Resume-in-CC id: `producerForUnit = findProducerForUnit(agents, unitReposForCurrent ?? currentProject)` — the **focused** unit's Producer.
- Retry: `retryHandoff(unitName, …)` — the **focused** unit.

These match the ritual's unit only while focus === ritual unit. A failed handoff commonly **drops its Producer from the live set** (the Producer was broken — that's why the handoff failed), which trips the focus auto-default (`FOCUS_GRACE_MS`) to **bounce focus to another live unit**. `producerForUnit` then resolves to that other unit, and Force-kill kills it. That is exactly the reported harm.

## Fix

Resolve the dialog's Producer from **`ritualState.unit`** via the live membership, never from focus:

```ts
const ritualUnitProducer = useMemo(() => {
  if (ritualState.kind !== "escalated" || ritualState.unit === "") return null;
  const repos = slotsData?.slots.find((s) => s.name === ritualState.unit)?.repos ?? null;
  return repos === null ? null : findProducerForUnit(agents, repos);
}, [ritualState, slotsData, agents]);
```

- Force-kill target, `producerAgentId` (Resume-in-CC id + disabled gating), and Retry all use `ritualState.unit` now.
- `findProducerForUnit` scoped to the ritual unit's **own repos** can only ever match that unit's Producer — a cross-unit mis-kill is now **structurally impossible**.
- When the ritual's unit has **no live Producer** (the drop case that caused the bug), `ritualUnitProducer` is `null` → the dialog **disables** Force-kill / Resume rather than falling back to the focused unit's Producer.
- Removes the now-unused `producerForUnit` / `unitReposForCurrent` (focus-derived; their only consumer was this dialog).

## Tests (`App.handoff.test.tsx`)

- **Mis-kill guard**: ritual escalated for unit `gamma` whose Producer is gone, while `tmai` is the sole live+focused unit → **Force-kill is disabled** (the buggy code enabled it, targeting `tmai`).
- **Positive targeting**: two live units, focus pinned to `focused` (first in `groupByProject` order), ritual escalated for `gamma` → clicking Force-kill calls `killAgent("claude:gamma-prod")`, **not** `focused`'s Producer.

## Verification

`pnpm lint` (biome) clean · `pnpm build` (tsc -b + vite) green · `pnpm test` **755 pass** / 2 skip (78 files), incl. the 2 new safety tests. (Not browser-reproduced — deliberately: reproducing would kill a live Producer. The tests exercise the exact focus-vs-ritual divergence at the unit level.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
