### PR TITLE
feat(react): cross-unit remote-Δ freshness tab dot

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -1,7 +1,8 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { AimConsole } from "@/components/aim-console/AimConsole";
 import { HandoffRitualFailureDialog } from "@/components/aim-console/HandoffRitualFailureDialog";
 import { HandoffRitualOverlay } from "@/components/aim-console/HandoffRitualOverlay";
+import { advanceCursor, unitHasUnobserved } from "@/components/aim-console/remote-delta";
 import {
   handoffOwesReview,
   resolveUnitSignal,
@@ -13,6 +14,7 @@ import { ProducerLaunchPicker } from "@/components/project/ProducerLaunchPicker"
 import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import { useApplyTheme } from "@/hooks/useActiveTheme";
 import { useAgents } from "@/hooks/useAgents";
+import { useCrossUnitRemoteDelta } from "@/hooks/useCrossUnitRemoteDelta";
 import { useHandoffRitual } from "@/hooks/useHandoffRitual";
 import { useIdleNotification } from "@/hooks/useIdleNotification";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -31,6 +33,7 @@ import { closeUnitSlot } from "@/lib/close-unit-slot";
 import { currentProjectBelongsToLiveProject } from "@/lib/current-project";
 import { findProducerForUnit } from "@/lib/producer";
 import { useSSE } from "@/lib/sse-provider";
+import { useUIPref } from "@/lib/ui-prefs-provider";
 
 // Grace window before the focus auto-default bounces a unit whose Producer
 // briefly left the live set (handoff respawn / restart kill→relaunch) to
@@ -160,22 +163,55 @@ export function App() {
     retryRefused: handoffRetryRefused,
   } = useHandoffRitual();
 
+  // Remote-Δ freshness cursors (client-state, UIPrefs context). AimConsole
+  // owns the focused unit's close act (R-panel collapse → `collapseRemote`);
+  // App owns the cross-unit stamp below. Both write the SAME context field, so
+  // they stay in sync (the provider is a single source).
+  const [cursors, setCursors] = useUIPref("remoteDeltaCursors");
+
+  // Fan the remote-Δ read across every live unit (aim `cross-unit-remote-delta`).
+  // The focused-unit instrument only ever polled the one focused unit; this
+  // lifts the same per-unit PR / issue read to every tab so a NON-focused unit's
+  // unobserved artifact can light its tab. Keyed by unit name, 60s poll.
+  const slotNames = useMemo(() => (slotsData?.slots ?? []).map((s) => s.name), [slotsData]);
+  const crossUnitDelta = useCrossUnitRemoteDelta(slotNames);
+
+  // Tab-leave close act — the cross-unit analog of the R-panel collapse (aim
+  // `cross-unit-remote-delta` PROCESS: cursor = "when this tab was last looked
+  // at"). Switching focus AWAY from a unit stamps its `panel` cursor, so its
+  // freshness dot clears and only NEW activity re-lights it. This is the THIRD
+  // cursor-advance act (alongside the R-panel + section collapses) — still an
+  // explicit operator act, not a timer / visibilitychange (the operator-ratified
+  // exclusion list in remote-delta.ts). Needed because the panel-collapse close
+  // act only fires when the R panel is OPEN; switching tabs with it closed (the
+  // common case) would otherwise never advance a non-focused unit's cursor,
+  // pinning its dot on forever.
+  const prevUnitRef = useRef<string | null>(null);
+  useEffect(() => {
+    const prev = prevUnitRef.current;
+    if (prev !== null && prev !== unitName) {
+      setCursors(advanceCursor(cursors, prev, "panel", new Date().toISOString()));
+    }
+    prevUnitRef.current = unitName;
+  }, [unitName, cursors, setCursors]);
+
   // Per-unit cross-unit tab signal (aim `1-worktree-merge`'s cross-unit
   // family). One dot per unit tab, precedence-collapsed (owed > fresh > idle).
-  // Only the `owed` source is wired today — a unit whose latest handoff phase
-  // is `awaiting_review` owes the operator a review act (aim
-  // `cross-unit-operator-owed`), surfaced even when that unit is NOT focused.
-  // `fresh` (`cross-unit-remote-delta`) / `idle` (`cross-unit-idle-passive`)
-  // sources drop in here later without re-architecting the tab.
+  // `owed` — a unit whose latest handoff phase is `awaiting_review` owes the
+  // operator a review act (aim `cross-unit-operator-owed`), surfaced even when
+  // NOT focused. `fresh` — a non-focused unit with any unobserved remote
+  // artifact (aim `cross-unit-remote-delta`). `idle` (`cross-unit-idle-passive`)
+  // drops in here later without re-architecting the tab.
   const unitSignals = useMemo(() => {
     const out: Record<string, UnitSignal | null> = {};
     for (const slot of slotsData?.slots ?? []) {
       out[slot.name] = resolveUnitSignal({
         owed: handoffOwesReview(handoffUnitPhases[slot.name]),
+        fresh: unitHasUnobserved(crossUnitDelta[slot.name], cursors, slot.name),
       });
     }
     return out;
-  }, [slotsData, handoffUnitPhases]);
+  }, [slotsData, handoffUnitPhases, crossUnitDelta, cursors]);
 
   // The Producer of the unit the ESCALATED handoff ritual is for
   // (`ritualState.unit`), resolved from the live membership — NOT from the

--- a/clients/react/src/components/aim-console/AimConsole.tsx
+++ b/clients/react/src/components/aim-console/AimConsole.tsx
@@ -177,8 +177,10 @@ export function AimConsole({
   const activeUnit = units.find((u) => u.name === activeUnitName) ?? null;
 
   // Remote-Δ freshness cursors (#822; #606 §1 lift) — the `remoteDeltaCursors`
-  // ui-pref is owned here (per-unit). Client state only, never sent to core;
-  // the Producer never reads it. `AimConsole` owns the cursor; `PrRail` is
+  // ui-pref (per-unit). Client state only, never sent to core; the Producer
+  // never reads it. `AimConsole` owns the FOCUSED unit's close act here; App
+  // owns the cross-unit tab-leave stamp (aim `cross-unit-remote-delta`) — both
+  // write the same UIPrefs field, which the context keeps in sync. `PrRail` is
   // presentational and only receives the effective cursors. The rail has ONE
   // close act — the rail
   // collapse — so it stamps the coarse `panel` cursor, which via `effectiveCursor`

--- a/clients/react/src/components/aim-console/__tests__/remote-delta.test.ts
+++ b/clients/react/src/components/aim-console/__tests__/remote-delta.test.ts
@@ -3,10 +3,10 @@
 //
 // Pinned exclusions (operator-ratified): the cursor is CLIENT STATE ONLY —
 // it is never sent to any endpoint and the Producer never reads it; there
-// is no per-row read-marking and no mute affordance; the cross-unit tab
-// accent is deferred until a second unit exists. `advanceCursor` is the
-// single mutation door and only the two close acts (panel collapse /
-// section collapse) call it.
+// is no per-row read-marking and no mute affordance. `advanceCursor` is the
+// single mutation door and only the "stopped looking" close acts call it
+// (panel collapse / section collapse / cross-unit tab-leave — the third act
+// added when `cross-unit-remote-delta` lifted the accent to the tab).
 
 import { describe, expect, it } from "vitest";
 import type { IssueSummaryWire, PrSummaryWire, RepoIssuesWire, RepoPrsWire } from "@/lib/api";
@@ -16,6 +16,7 @@ import {
   issueVocabTimestamp,
   isUnobserved,
   prVocabTimestamp,
+  unitHasUnobserved,
   unobservedIssueCount,
   unobservedPrCount,
 } from "../remote-delta";
@@ -213,5 +214,61 @@ describe("unobserved counts (within-unit only)", () => {
     expect(unobservedIssueCount(repos, cursor)).toBe(1);
     expect(unobservedIssueCount(repos, null)).toBe(2);
     expect(unobservedIssueCount(null, cursor)).toBe(0);
+  });
+});
+
+describe("unitHasUnobserved — cross-unit freshness presence bit", () => {
+  const reposWithPr = (created: string): RepoPrsWire[] => [
+    { repo_path: "/p/a", repo_label: "a", primary: true, prs: [pr({ created_at: created })] },
+  ];
+  const reposWithIssue = (created: string): RepoIssuesWire[] => [
+    {
+      repo_path: "/p/a",
+      repo_label: "a",
+      primary: true,
+      issues: [issue({ created_at: created })],
+    },
+  ];
+
+  it("undefined delta (not yet fanned out) is not fresh", () => {
+    expect(unitHasUnobserved(undefined, {}, "u")).toBe(false);
+  });
+
+  it("null cursor (never looked at this tab) + any row → fresh", () => {
+    const delta = { prs: reposWithPr("2026-06-13T00:00:00Z"), issues: null };
+    expect(unitHasUnobserved(delta, {}, "u")).toBe(true);
+  });
+
+  it("a PR newer than the unit's cursor → fresh", () => {
+    const delta = { prs: reposWithPr("2026-06-13T12:00:00Z"), issues: null };
+    const cursors = { u: { panel: "2026-06-13T10:00:00Z" } };
+    expect(unitHasUnobserved(delta, cursors, "u")).toBe(true);
+  });
+
+  it("only rows at/before the cursor → not fresh", () => {
+    const delta = { prs: reposWithPr("2026-06-13T08:00:00Z"), issues: null };
+    const cursors = { u: { panel: "2026-06-13T10:00:00Z" } };
+    expect(unitHasUnobserved(delta, cursors, "u")).toBe(false);
+  });
+
+  it("an unobserved ISSUE alone lights the bit", () => {
+    const delta = { prs: null, issues: reposWithIssue("2026-06-13T12:00:00Z") };
+    const cursors = { u: { panel: "2026-06-13T10:00:00Z" } };
+    expect(unitHasUnobserved(delta, cursors, "u")).toBe(true);
+  });
+
+  it("empty repos (genuinely none) → not fresh even with no cursor", () => {
+    expect(unitHasUnobserved({ prs: [], issues: [] }, {}, "u")).toBe(false);
+  });
+
+  it("both sections null (fetch failed, no prior) → not fresh", () => {
+    expect(unitHasUnobserved({ prs: null, issues: null }, {}, "u")).toBe(false);
+  });
+
+  it("uses THIS unit's cursor — another unit's cursor never applies", () => {
+    const delta = { prs: reposWithPr("2026-06-13T09:00:00Z"), issues: null };
+    // Only `other` has a (newer) cursor; unit `u` has none → still fresh.
+    const cursors = { other: { panel: "2026-06-13T23:00:00Z" } };
+    expect(unitHasUnobserved(delta, cursors, "u")).toBe(true);
   });
 });

--- a/clients/react/src/components/aim-console/remote-delta.ts
+++ b/clients/react/src/components/aim-console/remote-delta.ts
@@ -69,10 +69,13 @@ export function isUnobserved(vocabTs: string | null, cursor: string | null): boo
   return Date.parse(vocabTs) > Date.parse(cursor);
 }
 
-// Immutable cursor advance for one of the EXACTLY TWO act kinds: the R
-// panel collapse (`panel`) and a section collapse (`prs` / `issues`).
-// Nothing else may call this — no visibilitychange, no scroll, no per-row
-// marking, no timers (operator-ratified exclusion list).
+// Immutable cursor advance for one of the act kinds that all reduce to the
+// same "operator stopped looking" stamp: the R panel collapse (`panel`), a
+// section collapse (`prs` / `issues`), and — for the cross-unit tab dot
+// (`cross-unit-remote-delta`) — switching focus AWAY from a unit's tab, which
+// stamps that unit's `panel` cursor (App's tab-leave effect). All three are
+// EXPLICIT operator acts; nothing implicit may call this — no visibilitychange,
+// no scroll, no per-row marking, no timers (operator-ratified exclusion list).
 export function advanceCursor(
   cursors: Record<string, RemoteDeltaCursor>,
   unit: string,
@@ -101,5 +104,35 @@ export function unobservedIssueCount(
   return repos.reduce(
     (n, r) => n + r.issues.filter((i) => isUnobserved(issueVocabTimestamp(i), cursor)).length,
     0,
+  );
+}
+
+// One unit's raw remote-Δ slices as fanned out by `useCrossUnitRemoteDelta`
+// (aim `cross-unit-remote-delta`). `null` = that section's fetch failed this
+// cycle (the hook keeps the prior dot); an empty `repos[]` = the unit genuinely
+// has none.
+export interface UnitRemoteDelta {
+  prs: RepoPrsWire[] | null;
+  issues: RepoIssuesWire[] | null;
+}
+
+// Every live unit's slices, keyed by unit name.
+export type CrossUnitRemoteDelta = Record<string, UnitRemoteDelta>;
+
+// Does this unit have ANY unobserved PR or issue? The cross-unit tab signal
+// collapses the within-unit counts to a single presence BIT — the tab accent
+// carries freshness presence, never a count (the header note's cross-unit
+// rule). `undefined` delta (not yet fanned out) is not-fresh; a `null` cursor
+// (never looked at this tab) makes every row unobserved — the honest
+// 「一度も見ていない」, which self-clears on the first tab-leave / panel close.
+export function unitHasUnobserved(
+  delta: UnitRemoteDelta | undefined,
+  cursors: Record<string, RemoteDeltaCursor>,
+  unit: string,
+): boolean {
+  if (delta === undefined) return false;
+  return (
+    unobservedPrCount(delta.prs, effectiveCursor(cursors, unit, "prs")) > 0 ||
+    unobservedIssueCount(delta.issues, effectiveCursor(cursors, unit, "issues")) > 0
   );
 }

--- a/clients/react/src/hooks/__tests__/useCrossUnitRemoteDelta.test.ts
+++ b/clients/react/src/hooks/__tests__/useCrossUnitRemoteDelta.test.ts
@@ -1,0 +1,161 @@
+// @vitest-environment jsdom
+//
+// useCrossUnitRemoteDelta — fan the remote-Δ read across every live unit
+// (aim `cross-unit-remote-delta`). We mock api.unitPrs / api.unitIssues so each
+// test drives deterministic per-unit responses and asserts: empty unitNames
+// parks, a real set fans out over BOTH endpoints per unit, a transient per-unit
+// failure keeps that unit's last-known slice (anti-flicker), and the keyed
+// subscription re-fetches only when the SET of units changes (not on a fresh
+// array identity from the 10s slots poll).
+//
+// Timers stay real; the poll is exercised by capturing window.setInterval's
+// callback (waitFor cannot progress under fake timers) — same technique as
+// useUnitPrs.test.ts.
+
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("@/lib/api", () => ({
+  api: {
+    unitPrs: vi.fn(),
+    unitIssues: vi.fn(),
+  },
+}));
+
+import type { UnitIssuesResponse, UnitPrsResponse } from "@/lib/api";
+import { api } from "@/lib/api";
+import { useCrossUnitRemoteDelta } from "../useCrossUnitRemoteDelta";
+
+function prsResponse(unit: string, count: number): UnitPrsResponse {
+  return {
+    unit,
+    repos: [
+      {
+        repo_path: `/w/${unit}`,
+        repo_label: unit,
+        primary: true,
+        prs: Array.from({ length: count }, (_, i) => ({
+          number: BigInt(i + 1),
+          title: `PR ${i + 1}`,
+          state: "OPEN",
+          head_branch: `feat/${i + 1}`,
+          head_sha: "deadbee",
+          base_branch: "main",
+          url: `https://github.com/o/${unit}/pull/${i + 1}`,
+          review_decision: null,
+          check_status: null,
+          is_draft: false,
+          additions: 1n,
+          deletions: 0n,
+          comments: 0n,
+          reviews: 0n,
+          author: "alice",
+          merge_commit_sha: null,
+          created_at: null,
+          merged_at: null,
+          closed_at: null,
+          ci_completed_at: null,
+          last_synced_at: null,
+        })),
+      },
+    ],
+  };
+}
+
+function issuesResponse(unit: string, count: number): UnitIssuesResponse {
+  return {
+    unit,
+    repos: [
+      {
+        repo_path: `/w/${unit}`,
+        repo_label: unit,
+        primary: true,
+        issues: Array.from({ length: count }, (_, i) => ({
+          number: BigInt(i + 1),
+          title: `Issue ${i + 1}`,
+          state: "open",
+          url: `https://github.com/o/${unit}/issues/${i + 1}`,
+          labels: [],
+          assignees: [],
+          created_at: null,
+          closed_at: null,
+          last_synced_at: null,
+        })),
+      },
+    ],
+  };
+}
+
+describe("useCrossUnitRemoteDelta", () => {
+  beforeEach(() => {
+    vi.mocked(api.unitPrs).mockReset();
+    vi.mocked(api.unitIssues).mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("parks on empty unitNames — no fetch, empty map", () => {
+    const { result } = renderHook(() => useCrossUnitRemoteDelta([]));
+    expect(api.unitPrs).not.toHaveBeenCalled();
+    expect(api.unitIssues).not.toHaveBeenCalled();
+    expect(result.current).toEqual({});
+  });
+
+  it("fans out over both endpoints for every unit", async () => {
+    vi.mocked(api.unitPrs).mockImplementation((u: string) => Promise.resolve(prsResponse(u, 2)));
+    vi.mocked(api.unitIssues).mockImplementation((u: string) =>
+      Promise.resolve(issuesResponse(u, 1)),
+    );
+    const { result } = renderHook(() => useCrossUnitRemoteDelta(["tmai", "other"]));
+    await waitFor(() => {
+      expect(Object.keys(result.current).sort()).toEqual(["other", "tmai"]);
+    });
+    expect(api.unitPrs).toHaveBeenCalledWith("tmai");
+    expect(api.unitPrs).toHaveBeenCalledWith("other");
+    expect(api.unitIssues).toHaveBeenCalledWith("other");
+    expect(result.current.tmai.prs?.[0].prs).toHaveLength(2);
+    expect(result.current.tmai.issues?.[0].issues).toHaveLength(1);
+  });
+
+  it("keeps a unit's prior slice when a poll transiently fails (anti-flicker)", async () => {
+    const setIntervalSpy = vi.spyOn(window, "setInterval");
+    vi.mocked(api.unitIssues).mockResolvedValue(issuesResponse("tmai", 0));
+    vi.mocked(api.unitPrs).mockResolvedValueOnce(prsResponse("tmai", 3));
+    const { result } = renderHook(() => useCrossUnitRemoteDelta(["tmai"]));
+    await waitFor(() => expect(result.current.tmai?.prs?.[0].prs).toHaveLength(3));
+
+    // Second poll: PR fetch rejects → the prior slice must survive so the dot
+    // does not flicker off on a transient blip.
+    vi.mocked(api.unitPrs).mockRejectedValue(new Error("boom"));
+    const tick = setIntervalSpy.mock.calls[0]?.[0] as (() => void) | undefined;
+    expect(typeof tick).toBe("function");
+    await act(async () => {
+      tick?.();
+    });
+    await waitFor(() => expect(api.unitPrs).toHaveBeenCalledTimes(2));
+    expect(result.current.tmai.prs?.[0].prs).toHaveLength(3);
+  });
+
+  it("re-fetches only when the SET of units changes, not on array identity", async () => {
+    vi.mocked(api.unitPrs).mockImplementation((u: string) => Promise.resolve(prsResponse(u, 1)));
+    vi.mocked(api.unitIssues).mockImplementation((u: string) =>
+      Promise.resolve(issuesResponse(u, 0)),
+    );
+    const { result, rerender } = renderHook(({ names }) => useCrossUnitRemoteDelta(names), {
+      initialProps: { names: ["tmai"] },
+    });
+    await waitFor(() => expect(result.current.tmai).toBeDefined());
+    const callsAfterFirst = vi.mocked(api.unitPrs).mock.calls.length;
+
+    // Same names, fresh array identity → no re-subscribe / re-fetch.
+    rerender({ names: ["tmai"] });
+    expect(vi.mocked(api.unitPrs).mock.calls.length).toBe(callsAfterFirst);
+
+    // A new member changes the keyed subscription → re-fetch (now includes it).
+    rerender({ names: ["tmai", "other"] });
+    await waitFor(() => expect(result.current.other).toBeDefined());
+    expect(vi.mocked(api.unitPrs)).toHaveBeenCalledWith("other");
+  });
+});

--- a/clients/react/src/hooks/useCrossUnitRemoteDelta.ts
+++ b/clients/react/src/hooks/useCrossUnitRemoteDelta.ts
@@ -1,0 +1,86 @@
+// useCrossUnitRemoteDelta — fan the remote-Δ freshness read out across EVERY
+// live unit, not only the focused one (aim `cross-unit-remote-delta`). The
+// focused-unit instrument (useUnitPrs / useUnitIssues → PrRail Δ accent) only
+// ever computed for the ONE focused unit; this lifts the same per-unit PR /
+// issue read to a tab-level fan-out so a NON-focused unit's unobserved remote
+// artifact can light its tab's cyan freshness dot.
+//
+// One 60-second poll per unit — the same cadence as the focused-unit hooks;
+// cross-repo is already collapsed server-side (`GET /api/units/{unit}/prs|
+// issues` return `repos[]`), so this fans out over UNITS only. The unobserved
+// VERDICT (cursor comparison) stays with the caller: cursors are client-state
+// owned by the UIPrefs context, and the tab-signal seam that consumes this
+// already holds them (see `unitHasUnobserved` in remote-delta.ts).
+//
+// A transient per-unit fetch failure keeps that unit's LAST-known slice (a blip
+// must not flicker its freshness dot off); a unit with genuinely zero PRs /
+// issues returns an empty `repos[]`, which stays distinct from a failed fetch's
+// `null`. Empty `unitNames` parks the hook (no fetch, no interval).
+
+import { useEffect, useState } from "react";
+import type { CrossUnitRemoteDelta, UnitRemoteDelta } from "@/components/aim-console/remote-delta";
+import { api } from "@/lib/api";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export function useCrossUnitRemoteDelta(unitNames: string[]): CrossUnitRemoteDelta {
+  const [data, setData] = useState<CrossUnitRemoteDelta>({});
+  // Stable dependency: re-subscribe only when the SET of units changes, not on
+  // every 10s slots poll returning a fresh array identity. JSON of the sorted
+  // names is separator-safe and lets the effect recover `names` from `key`
+  // alone, so `unitNames`'s per-render identity stays out of the deps.
+  const key = JSON.stringify([...unitNames].sort());
+
+  useEffect(() => {
+    const names = JSON.parse(key) as string[];
+    if (names.length === 0) {
+      setData({});
+      return;
+    }
+    let cancelled = false;
+
+    const fetchOnce = async () => {
+      const entries = await Promise.all(
+        names.map(async (name): Promise<[string, UnitRemoteDelta]> => {
+          const [prsRes, issuesRes] = await Promise.allSettled([
+            api.unitPrs(name),
+            api.unitIssues(name),
+          ]);
+          return [
+            name,
+            {
+              prs: prsRes.status === "fulfilled" ? prsRes.value.repos : null,
+              issues: issuesRes.status === "fulfilled" ? issuesRes.value.repos : null,
+            },
+          ];
+        }),
+      );
+      if (cancelled) return;
+      // Keep a unit's prior slice on a transient failure so its dot doesn't
+      // flicker; an empty `repos[]` (genuinely none) overwrites, `null` (failed)
+      // falls back to the last-known.
+      setData((prev) => {
+        const next: CrossUnitRemoteDelta = {};
+        for (const [name, delta] of entries) {
+          const prior = prev[name];
+          next[name] = {
+            prs: delta.prs ?? prior?.prs ?? null,
+            issues: delta.issues ?? prior?.issues ?? null,
+          };
+        }
+        return next;
+      });
+    };
+
+    void fetchOnce();
+    const id = window.setInterval(() => {
+      void fetchOnce();
+    }, POLL_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearInterval(id);
+    };
+  }, [key]);
+
+  return data;
+}

--- a/clients/react/src/lib/ui-prefs.ts
+++ b/clients/react/src/lib/ui-prefs.ts
@@ -50,9 +50,10 @@ export interface AimConsoleLayout {
 //   - a freshness instrument, NOT a confirmation ledger — the cursor records
 //     "when the operator last stopped looking" (見ていた), it never claims
 //     anything was 確認済み;
-//   - exactly two advance acts (panel collapse / section collapse) — no
-//     visibilitychange, no scroll, no per-row read-marking, no timers, no
-//     mute affordance.
+//   - three advance acts, all "stopped looking" stamps (panel collapse /
+//     section collapse / switching focus away from a unit's tab — the
+//     cross-unit `cross-unit-remote-delta` dot) — no visibilitychange, no
+//     scroll, no per-row read-marking, no timers, no mute affordance.
 // Multi-client divergence is semantically correct: each screen's cursor
 // means "what THIS screen last saw".
 export interface RemoteDeltaCursor {


### PR DESCRIPTION
Wires the **`fresh` source** of the cross-unit tab-signal container (aim `1-worktree-merge` → `cross-unit-remote-delta`). Until now only `owed` was wired (#955); `fresh` and `idle` were declared-but-stubbed. This lands `fresh`.

## What it does
A non-focused unit with any **unobserved** remote artifact (new PR / issue / CI change) now lights its tab with a **cyan freshness dot**. The focused-unit remote-Δ instrument (`PrRail` Δ accent, #822/#907) only ever computed for the one focused unit; this lifts the same per-unit read to a per-tab fan-out.

- **`useCrossUnitRemoteDelta`** — 60s fan-out poll of `/units/{u}/prs|issues` over every live slot. Transient per-unit failure keeps the last-known slice (anti-flicker); an empty `repos[]` stays distinct from a failed fetch's `null`.
- **`unitHasUnobserved`** — collapses the within-unit unobserved counts to a single **presence bit** (never a count) fed into the container's `fresh` field. Precedence (owed > fresh > idle) is unchanged.
- **tab-leave cursor stamp** — switching focus away from a unit stamps its `panel` cursor ("last looked at this tab"), so its dot clears and only NEW activity re-lights it.

## Decisions to surface (operator judgment)
1. **Implemented HUB-ONLY — no core wire.** The aim body's IS originally assumed the fan-out needed core-side aggregation. It does not: the per-unit REST endpoints already exist, and issues have no core monitor to add a unit-tag to (an SSE approach would force new issue-delta polling infra). Reusing the existing endpoints + the pure `remote-delta.ts` helpers + the already-unit-keyed cursor store keeps this entirely client-side — same pattern as the owed source landing hub-only. I'll correct the aim body's IS + flip its PROCESS `[todo]→[done]` once this merges.
2. **tab-leave is a THIRD cursor-advance act.** The remote-Δ cursor had an operator-ratified "exactly two advance acts" exclusion list (panel collapse / section collapse — no timers, no visibilitychange). Tab-leave is a third, but still an **explicit operator act**, not an implicit one. It's needed because the panel-collapse close act only fires while the R panel is *open*; switching tabs with it closed (the common case) would otherwise never advance a non-focused unit's cursor and pin its dot on forever. Comments in `remote-delta.ts` / `ui-prefs.ts` updated to record the extension.

## Verification
Gate all green: biome + `tsc --noEmit` + vitest (**767 pass / 2 skip**, incl. new fan-out + `unitHasUnobserved` tests) + vite build. **Not browser-verified** — cross-unit surfaces can't be truly e2e-verified in single-unit dogfood, and running the vite dev server carries a known WSL-crash risk; reasoning + unit tests carry it (same posture as #956/#957).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - 複数ユニットの未確認PR・Issueを取得し、各ユニットのタブに鮮度インジケーターを表示するようになりました。
  - 別ユニットへ移動した際の確認状態を記録し、タブ表示をより正確に更新します。
  - リモート差分は定期的に更新され、一時的な取得失敗時も直前の表示を維持します。

- **改善**
  - パネルやセクションを閉じた際の確認状態と、ユニット間移動時の状態を一貫して管理します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->