### PR TITLE
feat(react): cross-unit idle-passive tab signal (dim idle dot)

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -3,6 +3,7 @@ import { AimConsole } from "@/components/aim-console/AimConsole";
 import { HandoffRitualFailureDialog } from "@/components/aim-console/HandoffRitualFailureDialog";
 import { HandoffRitualOverlay } from "@/components/aim-console/HandoffRitualOverlay";
 import { advanceCursor, unitHasUnobserved } from "@/components/aim-console/remote-delta";
+import { unitIsIdle } from "@/components/aim-console/unit-idle";
 import {
   handoffOwesReview,
   resolveUnitSignal,
@@ -200,18 +201,20 @@ export function App() {
   // `owed` — a unit whose latest handoff phase is `awaiting_review` owes the
   // operator a review act (aim `cross-unit-operator-owed`), surfaced even when
   // NOT focused. `fresh` — a non-focused unit with any unobserved remote
-  // artifact (aim `cross-unit-remote-delta`). `idle` (`cross-unit-idle-passive`)
-  // drops in here later without re-architecting the tab.
+  // artifact (aim `cross-unit-remote-delta`). `idle` — the unit's Producer is
+  // quiescent (terminal producing no output) with no active worker (aim
+  // `cross-unit-idle-passive`); low-confidence, so `owed`/`fresh` collapse it.
   const unitSignals = useMemo(() => {
     const out: Record<string, UnitSignal | null> = {};
     for (const slot of slotsData?.slots ?? []) {
       out[slot.name] = resolveUnitSignal({
         owed: handoffOwesReview(handoffUnitPhases[slot.name]),
         fresh: unitHasUnobserved(crossUnitDelta[slot.name], cursors, slot.name),
+        idle: unitIsIdle(agents, slot.name, slot.repos),
       });
     }
     return out;
-  }, [slotsData, handoffUnitPhases, crossUnitDelta, cursors]);
+  }, [slotsData, handoffUnitPhases, crossUnitDelta, cursors, agents]);
 
   // The Producer of the unit the ESCALATED handoff ritual is for
   // (`ritualState.unit`), resolved from the live membership — NOT from the

--- a/clients/react/src/components/aim-console/__tests__/unit-idle.test.ts
+++ b/clients/react/src/components/aim-console/__tests__/unit-idle.test.ts
@@ -1,0 +1,97 @@
+// @vitest-environment jsdom
+//
+// unit-idle — the cross-unit idle-passive source. A unit is idle when its
+// Producer's terminal is quiescent (no output) AND no LIVE worker is still
+// active (non-quiescent). Pins: an idle (quiescent) worker does not block idle,
+// a DEAD worker's lingering record does not block idle, and a worker in ANOTHER
+// unit is irrelevant.
+
+import { describe, expect, it } from "vitest";
+import type { AgentSnapshot } from "@/lib/api";
+import { unitIsIdle } from "../unit-idle";
+
+const REPO = "/works/tmai";
+
+function stubAgent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnapshot {
+  return {
+    id: partial.id,
+    target: partial.target ?? partial.id,
+    agent_type: partial.agent_type ?? "ClaudeCode",
+    title: partial.title ?? partial.id,
+    cwd: partial.cwd ?? REPO,
+    display_cwd: partial.display_cwd ?? "tmai",
+    display_name: partial.display_name ?? partial.id,
+    detection_source: partial.detection_source ?? "pty_server",
+    git_branch: partial.git_branch ?? "main",
+    git_dirty: partial.git_dirty ?? false,
+    is_worktree: partial.is_worktree ?? false,
+    git_common_dir: partial.git_common_dir === undefined ? `${REPO}/.git` : partial.git_common_dir,
+    unit: partial.unit,
+    worktree_name: partial.worktree_name ?? null,
+    worktree_base_branch: partial.worktree_base_branch ?? null,
+    effort_level: partial.effort_level ?? null,
+    active_subagents: partial.active_subagents ?? 0,
+    compaction_count: partial.compaction_count ?? 0,
+    pty_session_id: partial.pty_session_id ?? "sess",
+    is_virtual: partial.is_virtual ?? false,
+    team_info: partial.team_info ?? null,
+    attention: partial.attention ?? null,
+    is_producer: partial.is_producer,
+    dead: partial.dead,
+    quiescent: partial.quiescent,
+  };
+}
+
+const producer = (quiescent?: boolean): AgentSnapshot =>
+  stubAgent({ id: "claude:prod", is_producer: true, unit: "tmai", is_worktree: false, quiescent });
+
+const worker = (over: Partial<AgentSnapshot>): AgentSnapshot =>
+  stubAgent({
+    id: over.id ?? "claude:w1",
+    is_producer: false,
+    unit: over.unit ?? "tmai",
+    is_worktree: true,
+    cwd: `${REPO}/.worktrees/w1`,
+    git_common_dir: `${REPO}/.git`,
+    ...over,
+  });
+
+describe("unitIsIdle", () => {
+  it("Producer quiescent + no workers → idle", () => {
+    expect(unitIsIdle([producer(true)], "tmai", REPO)).toBe(true);
+  });
+
+  it("Producer NOT quiescent (still moving) → not idle", () => {
+    expect(unitIsIdle([producer(undefined)], "tmai", REPO)).toBe(false);
+    expect(unitIsIdle([producer(false)], "tmai", REPO)).toBe(false);
+  });
+
+  it("no resolvable Producer → not idle", () => {
+    expect(unitIsIdle([], "tmai", REPO)).toBe(false);
+    // a lone worker, no Producer
+    expect(unitIsIdle([worker({ quiescent: true })], "tmai", REPO)).toBe(false);
+  });
+
+  it("an ACTIVE (non-quiescent) worker blocks idle", () => {
+    const agents = [producer(true), worker({ id: "claude:w1", quiescent: undefined })];
+    expect(unitIsIdle(agents, "tmai", REPO)).toBe(false);
+  });
+
+  it("an idle (quiescent) worker does NOT block idle", () => {
+    const agents = [producer(true), worker({ id: "claude:w1", quiescent: true })];
+    expect(unitIsIdle(agents, "tmai", REPO)).toBe(true);
+  });
+
+  it("a DEAD non-quiescent worker does NOT block idle (its record just lingers)", () => {
+    const agents = [producer(true), worker({ id: "claude:w1", quiescent: undefined, dead: true })];
+    expect(unitIsIdle(agents, "tmai", REPO)).toBe(true);
+  });
+
+  it("an active worker in ANOTHER unit is irrelevant", () => {
+    const agents = [
+      producer(true),
+      worker({ id: "claude:w-other", unit: "other-unit", quiescent: undefined }),
+    ];
+    expect(unitIsIdle(agents, "tmai", REPO)).toBe(true);
+  });
+});

--- a/clients/react/src/components/aim-console/unit-idle.ts
+++ b/clients/react/src/components/aim-console/unit-idle.ts
@@ -1,0 +1,40 @@
+// unit-idle — the cross-unit idle-passive source (aim `cross-unit-idle-passive`).
+//
+// A unit is idle when its Producer's terminal is QUIESCENT (producing no
+// output) AND no worker in the unit is still active (non-quiescent). `quiescent`
+// is the vendor-neutral core signal (tmai-core: a terminal static beyond the
+// idle threshold — a working CLI agent redraws a spinner continuously, an idle
+// one is static), so this needs NO Claude-Code hook turn-state.
+//
+// Low-confidence BY DESIGN: it reports "nothing is moving," not "the operator is
+// needed" — a dim hint. Any higher-precedence signal (owed / fresh) collapses it
+// away in `resolveUnitSignal` (owed > fresh > idle), so an idle unit that also
+// owes a review shows owed, never the dim idle dot.
+
+import type { AgentSnapshot, UnitRepoWire } from "@/lib/api";
+import { findProducerForUnit } from "@/lib/producer";
+
+/**
+ * Is this unit idle — Producer quiescent and no active (non-quiescent) worker?
+ *
+ * `unitRepos` is the slot's `repos` membership (or a bare primary-repo string),
+ * threaded to `findProducerForUnit` so a same-unit worker sitting at a secondary
+ * repo is never mistaken for the Producer.
+ */
+export function unitIsIdle(
+  agents: AgentSnapshot[],
+  unitName: string,
+  unitRepos: string | UnitRepoWire[] | null,
+): boolean {
+  const producer = findProducerForUnit(agents, unitRepos);
+  // No resolvable Producer, or its terminal is still moving → not idle. Absent
+  // `quiescent` (agent still active / engine not yet serving it) reads falsy.
+  if (producer?.quiescent !== true) return false;
+  // Any LIVE worker in the unit still producing output means the unit is
+  // progressing — an idle (quiescent) worker does not count as active, and a
+  // dead worker's record lingers but is not active.
+  const workerActive = agents.some(
+    (a) => !a.is_producer && !a.dead && a.unit === unitName && a.quiescent !== true,
+  );
+  return !workerActive;
+}

--- a/clients/react/src/lib/api-http.ts
+++ b/clients/react/src/lib/api-http.ts
@@ -275,6 +275,22 @@ export interface AgentSnapshot {
    *  `is_orchestrator?` mirror was removed (#836) so any read of the
    *  absent field is now a tsc error, not a silent `false`. */
   is_producer?: boolean;
+  /** Whether the agent's process / pane is gone (tmai-core decision
+   *  2026-05-07 Δ7). Orthogonal to `attention`; a finished agent's record
+   *  lingers so the console can show it stopped. Wire field `dead`
+   *  (`skip_serializing_if` → absent/falsy when alive). Hand-mirrored because
+   *  `AgentSnapshot` is serde-only on the Rust side. */
+  dead?: boolean;
+  /** True when the agent's terminal has been static beyond the idle threshold
+   *  — it is producing no output (a working CLI redraws a spinner; an idle one
+   *  is static). Vendor-neutral and hook-independent (tmai-core:
+   *  `terminal_changed_at` → `quiescent`, recomputed each ~2s sync cycle).
+   *  Drives the cross-unit idle-passive tab signal (aim
+   *  `cross-unit-idle-passive`): the hub folds a unit's Producer `quiescent` +
+   *  no non-quiescent worker into a dim idle dot. `skip_serializing_if` →
+   *  absent/falsy while the terminal is active; hand-mirrored because
+   *  `AgentSnapshot` is serde-only. */
+  quiescent?: boolean;
   /** Attention axis introduced by Step 4 of the agent-state attention
    *  rebuild (decision tmai-core@2026-05-07). `null` / absent on the
    *  wire encodes "unknown" — the sampler bootstrap window per Δ6.


### PR DESCRIPTION
The **hub half** of the idle-passive arc — wiring the **`idle` source** of the cross-unit tab-signal container (aim `cross-unit-idle-passive`). This is the **last of the four sibling signals** (owed ✓, fresh ✓, idle — this PR; operator-call remains). Pairs with the core signal in **tmai-core #689**.

## What it does
A unit shows a **dim idle dot** when its Producer's terminal is **quiescent** (producing no output) AND no worker is still active.

- **`unitIsIdle`** — per unit: Producer `quiescent === true` ∧ no live non-quiescent worker. An **idle** (quiescent) worker does not block idle; a **dead** worker's lingering record does not block; a worker in another unit is irrelevant.
- **Vendor-neutral, hook-independent.** `quiescent` (tmai-core #689) is derived from terminal output: a working CLI agent redraws its terminal continuously (Claude Code spins a spinner), an idle one is static. No Claude-Code hook turn-state.
- **`AgentSnapshot` interface** — hand-mirror `quiescent?` and `dead?`. `AgentSnapshot` is serde-only on the Rust side (no `ts_rs`/`utoipa`), so these are hand-added, not generated — no gen-spec bot PR.
- Feeds `resolveUnitSignal`'s existing `idle` field; precedence **owed > fresh > idle** already collapses it (an idle unit that also owes a review shows owed). The dim CSS (`.ac-d.sig-idle`) + `SIGNAL_REASON.idle` already exist.

## Dependency & sequencing
- Needs **tmai-core #689** (the `quiescent` wire field) merged + the **engine rebuilt** to show live data. **Forward-compatible**: with an engine not yet serving `quiescent`, `producer?.quiescent !== true` reads falsy → no idle dots, no error. Safe to merge in either order.

## Verification
Gate all green: biome + `tsc --noEmit` + vitest (**774 pass / 2 skip**, incl. 7 new `unitIsIdle` cases) + vite build. **Not browser-verified** — cross-unit surfaces can't be truly e2e-verified in single-unit dogfood, and the vite dev server is the known WSL-crash suspect; reasoning + tests carry it. (The core `quiescent` signal was separately observed live on the running engine — the Producer's snapshot reports `quiescent: true` after a quiet window.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * ユニットのアイドル状態を、プロデューサーとワーカーの稼働状況に基づいて正確に表示できるようになりました。
  * 終了済み（dead）および静止中（quiescent）の状態情報を取得し、状態表示に反映します。

* **不具合修正**
  * 別ユニットのワーカー状態が、対象ユニットのアイドル判定に影響しないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->