### PR TITLE
fix(react): align findProducerForUnit with core's Producer predicate

### DIFF
--- a/clients/react/src/lib/__tests__/find-producer-for-unit.test.ts
+++ b/clients/react/src/lib/__tests__/find-producer-for-unit.test.ts
@@ -54,6 +54,7 @@ function stubAgent(partial: Partial<AgentSnapshot> & { id: string }): AgentSnaps
     team_info: partial.team_info ?? null,
     attention: partial.attention ?? null,
     is_producer: partial.is_producer,
+    dead: partial.dead,
   };
 }
 
@@ -391,5 +392,86 @@ describe("findProducerForUnit — restart-adopt (adopt-resilient is_producer + u
       // is_producer + unit deliberately omitted
     });
     expect(findProducerForUnit([producer], unit)).toBe(producer);
+  });
+});
+
+describe("findProducerForUnit — aligned with core predicate (!dead, !unit.is_empty)", () => {
+  // Core's Producer resolver (tmai-core handoff_ritual.rs) filters
+  // `is_producer && !dead && !unit.is_empty() && unit == unit`. This
+  // resolver mirrors the `!dead` and `!unit.is_empty()` clauses so core and
+  // UI agree on "who is a Producer" — otherwise a unit with exactly one live
+  // Producer plus a stray claude:-scheme session shows as >1 → null.
+
+  it("excludes a claude:-id agent with an EMPTY unit (mis-promoted bash) — real Producer still resolves", () => {
+    // Regression (tmai-core #690 residue): a hint-less `bash` sharing the
+    // primary repo's cwd got a `claude:<uuid>` id from the pre-fix transcript
+    // clobber. It carries `unit: ""` and is NOT a Producer. Before the guard
+    // it was admitted by the cwd rule, so the unit had 2 candidates → null →
+    // "no Producer" even though there is exactly one real Producer.
+    const producer = stubAgent({
+      id: "claude:prod-1",
+      cwd: "/repo",
+      git_common_dir: "/repo/.git",
+      is_worktree: false,
+      is_producer: true,
+      unit: "repo",
+    });
+    const phantomBash = stubAgent({
+      id: "claude:f673819b",
+      agent_type: { Custom: "bash" },
+      cwd: "/repo",
+      git_common_dir: "/repo/.git",
+      is_worktree: false,
+      unit: "", // hint-less: attributed to no unit
+      // is_producer omitted → false on the wire
+    });
+    expect(findProducerForUnit([producer, phantomBash], "/repo")).toBe(producer);
+  });
+
+  it("a lone empty-unit claude: agent at the primary cwd is NOT resolved as the Producer", () => {
+    const phantomBash = stubAgent({
+      id: "claude:f673819b",
+      agent_type: { Custom: "bash" },
+      cwd: "/repo",
+      git_common_dir: "/repo/.git",
+      is_worktree: false,
+      unit: "",
+    });
+    expect(findProducerForUnit([phantomBash], "/repo")).toBeNull();
+  });
+
+  it("excludes a `dead` agent even with is_producer + unit set", () => {
+    const deadProducer = stubAgent({
+      id: "claude:prod-dead",
+      cwd: "/var/stale",
+      git_common_dir: null,
+      is_worktree: false,
+      is_producer: true,
+      unit: "acme",
+      dead: true,
+    });
+    const live = stubAgent({
+      id: "claude:prod-live",
+      cwd: "/var/stale",
+      git_common_dir: null,
+      is_worktree: false,
+      is_producer: true,
+      unit: "acme",
+    });
+    // With the dead one filtered out, exactly the live Producer resolves.
+    expect(findProducerForUnit([deadProducer, live], "/works/acme/acme")).toBe(live);
+  });
+
+  it('preserves old-engine back-compat: an UNDEFINED unit (not "") still resolves via cwd', () => {
+    // The `unit === \"\"` guard must NOT catch an agent whose `unit` field is
+    // absent (old engine not serving it) — that path still resolves by cwd.
+    const producer = stubAgent({
+      id: "claude:prod-1",
+      cwd: "/repo",
+      git_common_dir: "/repo/.git",
+      is_worktree: false,
+      // unit + is_producer deliberately omitted (undefined, not "")
+    });
+    expect(findProducerForUnit([producer], "/repo")).toBe(producer);
   });
 });

--- a/clients/react/src/lib/producer.ts
+++ b/clients/react/src/lib/producer.ts
@@ -118,6 +118,26 @@ export function findProducerForUnit(
   const candidates = agents.filter((a) => {
     if (!a.id.startsWith(PRODUCER_ID_SCHEME)) return false;
     if (a.is_worktree === true) return false;
+    // Align with core's own Producer predicate (`is_producer && !dead &&
+    // !unit.is_empty() && unit == unit` — tmai-core `handoff_ritual.rs`).
+    // React's resolver had diverged from it, which is the core↔UI asymmetry
+    // behind "every session shows as non-Producer": core marks every
+    // Producer-role session `is_producer` (past ones included) while this
+    // resolver, via the cwd rule below, ALSO admitted non-Producer agents —
+    // so a unit ended up with >1 candidate and returned null.
+    //
+    // (1) A dead session is never the live Producer.
+    if (a.dead === true) return false;
+    // (2) A `claude:`-scheme agent with an EXPLICITLY empty `unit` is
+    // attributed to no unit, so it is not this (or any) unit's Producer.
+    // This is the wire signature of a hint-less `bash` that a pre-fix
+    // transcript-clobber (tmai-core #690) mis-promoted to a `claude:<uuid>`
+    // id: it shares the primary repo's cwd and would otherwise be admitted
+    // by rule 3b, making a single-Producer unit ambiguous (>1 candidate →
+    // null → "no Producer"). Core excludes it via `!unit.is_empty()`; we
+    // mirror that. An OLD engine not serving `unit` leaves it `undefined`
+    // (NOT ""), so the pre-`is_producer` cwd back-compat (rule 3b) is intact.
+    if (a.unit === "") return false;
     // Rule 3a — adopt-resilient identity. Resolves the Producer at
     // restart-adopt, before the hook re-derives cwd. `is_producer`
     // narrows `unit` (which a worker shares) down to the single Producer,


### PR DESCRIPTION
## Symptom

After an engine restart, **every session rendered as "non-Producer"** in the
aim-console — including units that have exactly one live Producer.

## Root cause — a core↔UI asymmetry in "who is a Producer"

- **Core** derives `is_producer` purely from the `role=producer` spawn hint
  (`queries.rs` `derive_is_producer_in_state`) — so EVERY producer-role
  session is `is_producer`, past/abandoned ones included.
- **Core's own resolver** (`handoff_ritual.rs`) narrows that with
  `is_producer && !dead && !unit.is_empty() && unit == unit`.
- **React `findProducerForUnit`** had DIVERGED from that predicate. Its cwd
  rule (3b) admits any `claude:`-scheme agent sitting at the unit's
  primary/wrapper cwd **without** the `!dead` / `!unit.is_empty()` clauses.

So a unit could accumulate **>1 candidate**, and the resolver returns `null`
by its "single Producer, never guess" invariant → **no Producer shown**.

The concrete extra candidate on the dogfood `tmai` unit was
`claude:f673819b`: a hint-less footer `bash` that shares `tmai/tmai`'s cwd and
was mis-promoted to a `claude:<uuid>` id by the pre-fix transcript-clobber
(tmai-core #690 residue). It has `unit: ""` and is not a Producer, but rule 3b
counted it → `tmai` had 2 candidates (the real Producer + this phantom) →
null.

## Fix

Mirror the two clauses core already applies that this resolver was missing:

- exclude `dead` agents;
- exclude agents whose `unit` is an **explicitly empty string** (attributed to
  no unit — the wire signature of a hint-less mis-promoted `bash`).

An OLD engine not serving `unit` leaves it `undefined` (**not** `""`), so the
pre-`is_producer` cwd back-compat (rule 3b) is intact — covered by the
existing "old engine" test plus a new explicit one.

## Result

Core and UI now agree on "who is a Producer":

- a unit with exactly one live Producer resolves it (the `tmai` phantom is
  dropped → this session shows as Producer again);
- a unit that GENUINELY has multiple live Producer sessions stays ambiguous in
  BOTH core and UI — a real duplicate to reap, no longer a core↔UI asymmetry.

Not covered here (separate, pre-existing): a unit legitimately running
multiple live Producer sessions (e.g. leftover `tmai producer <unit>`
sessions) still needs either reaping or a "current Producer" designation — a
design question tracked separately.

## Scope / verification

React-only (`clients/react/src/lib/producer.ts`). Hot-reloads under the vite
dev server (no engine restart); the bundled WebUI picks it up on the next
release build. Local gates green: `pnpm lint` (biome), `pnpm test` (778
passed / 2 skipped), `pnpm build` (tsc -b && vite build). 28 resolver unit
tests including 4 new alignment/regression cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **バグ修正**
  - 死亡状態の Producer が誤って選択される問題を修正しました。
  - 明示的に空の `unit` を持つセッションを候補から除外するよう改善しました。
  - 古いエンジンで `unit` が未設定の場合も、従来どおり現在の作業ディレクトリから解決できます。

- **テスト**
  - Producer の選択条件を強化し、実在する有効な Producer のみが解決されることを確認しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->