### PR TITLE
fix(handoff): key ritual UI state per unit so the review gate survives cross-unit handoffs

### DIFF
--- a/clients/react/src/App.tsx
+++ b/clients/react/src/App.tsx
@@ -16,7 +16,7 @@ import { SettingsPanel } from "@/components/settings/SettingsPanel";
 import { useApplyTheme } from "@/hooks/useActiveTheme";
 import { useAgents } from "@/hooks/useAgents";
 import { useCrossUnitRemoteDelta } from "@/hooks/useCrossUnitRemoteDelta";
-import { useHandoffRitual } from "@/hooks/useHandoffRitual";
+import { type RitualUiState, useHandoffRitual } from "@/hooks/useHandoffRitual";
 import { useIdleNotification } from "@/hooks/useIdleNotification";
 import { useKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
 import { useNotificationConfig } from "@/hooks/useNotificationConfig";
@@ -155,7 +155,7 @@ export function App() {
   // 2026-05-23). Two hook instances would mean two overlays, so this
   // MUST remain the only one.
   const {
-    state: ritualState,
+    states: ritualStates,
     unitPhases: handoffUnitPhases,
     trigger: triggerHandoff,
     retry: retryHandoff,
@@ -216,13 +216,39 @@ export function App() {
     return out;
   }, [slotsData, handoffUnitPhases, crossUnitDelta, cursors, agents]);
 
+  // The FOCUSED unit's ritual UI state (absent key == idle). Drives the
+  // in-progress overlay in the conversation panel. Because state is now keyed
+  // per unit, a handoff parked at `awaiting_review` on unit A survives
+  // triggering/completing a handoff on unit B and re-appears when the operator
+  // switches back to A — the lost-review-gate bug (operator-reported
+  // 2026-07-19) the single app-global state used to cause.
+  const focusedRitual = unitName !== null ? ritualStates[unitName] : undefined;
+
+  // The escalated ritual surfaced by the app-global FAILURE dialog. Only one
+  // dialog can show at a time, so pick the focused unit's escalation if it has
+  // one, else any escalated unit. Deliberately NOT focus-gated: a failed
+  // handoff whose Producer dropped from the live set auto-bounces focus
+  // (`FOCUS_GRACE_MS`) to another unit, and the failure dialog must still show
+  // for the ORIGINAL unit — else the operator loses the failure entirely.
+  const escalatedRitual = useMemo<{ unit: string; state: RitualUiState } | null>(() => {
+    const pick = (unit: string, s: RitualUiState | undefined) =>
+      s?.kind === "escalated" && unit !== "" ? { unit, state: s } : null;
+    const focused = unitName !== null ? pick(unitName, ritualStates[unitName]) : null;
+    if (focused) return focused;
+    for (const [unit, s] of Object.entries(ritualStates)) {
+      const hit = pick(unit, s);
+      if (hit) return hit;
+    }
+    return null;
+  }, [ritualStates, unitName]);
+
   // The Producer of the unit the ESCALATED handoff ritual is for
-  // (`ritualState.unit`), resolved from the live membership — NOT from the
-  // focused unit. The handoff FAILURE dialog is shown for `ritualState.unit`
-  // regardless of which unit is focused, so every action it drives (Force-kill
-  // target, Retry, Resume-in-CC id) must target THAT unit. Deriving these from
-  // the focused unit mis-fired: a failed handoff whose Producer dropped from
-  // the live set auto-bounced focus (`FOCUS_GRACE_MS`) to another unit, and
+  // (`escalatedRitual.unit`), resolved from the live membership — NOT from the
+  // focused unit. The handoff FAILURE dialog is shown for that unit regardless
+  // of which unit is focused, so every action it drives (Force-kill target,
+  // Retry, Resume-in-CC id) must target THAT unit. Deriving these from the
+  // focused unit mis-fired: a failed handoff whose Producer dropped from the
+  // live set auto-bounced focus (`FOCUS_GRACE_MS`) to another unit, and
   // Force-kill then killed the WRONG, unopened unit's Producer
   // (operator-reported 2026-07-15). `null` when the ritual's unit has no live
   // Producer — the dialog then disables Force-kill / Resume rather than falling
@@ -230,46 +256,55 @@ export function App() {
   // ritual unit's own repos can only ever match that unit's Producer, so a
   // cross-unit mis-kill is now structurally impossible.
   const ritualUnitProducer = useMemo(() => {
-    if (ritualState.kind !== "escalated" || ritualState.unit === "") return null;
-    const repos = slotsData?.slots.find((s) => s.name === ritualState.unit)?.repos ?? null;
+    if (escalatedRitual === null) return null;
+    const repos = slotsData?.slots.find((s) => s.name === escalatedRitual.unit)?.repos ?? null;
     return repos === null ? null : findProducerForUnit(agents, repos);
-  }, [ritualState, slotsData, agents]);
+  }, [escalatedRitual, slotsData, agents]);
 
   // Auto-dismiss `ready` with a brief success toast (handoff-lifecycle
   // DR §E overlay spec). Moved up from ProducerConsoleActions with the
   // rest of the ritual UI.
+  // Any unit whose ritual reached `ready`. One toast at a time — if two units
+  // land ready together, the first is dismissed and the effect re-runs to pick
+  // up the next (rare; rituals are usually one-at-a-time per operator).
+  const readyUnit = useMemo(() => {
+    for (const [unit, s] of Object.entries(ritualStates)) {
+      if (s.kind === "ready") return unit;
+    }
+    return null;
+  }, [ritualStates]);
   const [handoffReadyToastVisible, setHandoffReadyToastVisible] = useState(false);
   useEffect(() => {
-    if (ritualState.kind !== "ready") return;
+    if (readyUnit === null) return;
     setHandoffReadyToastVisible(true);
     const t = setTimeout(() => {
       setHandoffReadyToastVisible(false);
-      dismissHandoff();
+      dismissHandoff(readyUnit);
     }, 2500);
     return () => clearTimeout(t);
-  }, [ritualState.kind, dismissHandoff]);
+  }, [readyUnit, dismissHandoff]);
 
   const handleHandoffRetry = useCallback(() => {
     // Retry re-attempts the handoff for the unit the ritual FAILED for
-    // (`ritualState.unit`), not the focused unit — the failure dialog can be
-    // showing for a unit other than the focused one (see `ritualUnitProducer`).
-    if (ritualState.kind !== "escalated" || ritualState.unit === "") return;
-    void retryHandoff(ritualState.unit, { trigger: "manual" });
-  }, [retryHandoff, ritualState]);
+    // (`escalatedRitual.unit`), not the focused unit — the failure dialog can
+    // be showing for a unit other than the focused one (see `ritualUnitProducer`).
+    if (escalatedRitual === null) return;
+    void retryHandoff(escalatedRitual.unit, { trigger: "manual" });
+  }, [retryHandoff, escalatedRitual]);
 
   const handleHandoffForceKill = useCallback(async () => {
     // Kill the RITUAL unit's Producer, never the focused unit's (see
     // `ritualUnitProducer`). `null` → the ritual unit has no live Producer, so
     // there is nothing to kill (the dialog's Force-kill is already disabled).
-    if (ritualUnitProducer === null) return;
+    if (ritualUnitProducer === null || escalatedRitual === null) return;
     try {
       await api.killAgent(ritualUnitProducer.target);
     } catch {
       // Best-effort — if the kill fails (already dead, etc.) we still
       // dismiss; the dialog already surfaced the upstream failure.
     }
-    dismissHandoff();
-  }, [ritualUnitProducer, dismissHandoff]);
+    dismissHandoff(escalatedRitual.unit);
+  }, [ritualUnitProducer, escalatedRitual, dismissHandoff]);
 
   // The "Open Producer terminal" affordance.
   //
@@ -513,13 +548,13 @@ export function App() {
   // (The terminal FAILURE dialog + ready toast + help stay app-global below —
   // a failure / completion is app-level news, not one panel's busy-state.)
   const handoffOverlay =
-    ritualState.kind === "dispatching" && unitName !== null ? (
+    unitName !== null && focusedRitual?.kind === "dispatching" ? (
       <HandoffRitualOverlay unitName={unitName} ritualId={null} phases={[]} />
-    ) : ritualState.kind === "in_progress" && ritualState.unit === unitName ? (
+    ) : unitName !== null && focusedRitual?.kind === "in_progress" ? (
       <HandoffRitualOverlay
-        unitName={ritualState.unit}
-        ritualId={ritualState.ritualId}
-        phases={ritualState.phases}
+        unitName={unitName}
+        ritualId={focusedRitual.ritualId}
+        phases={focusedRitual.phases}
       />
     ) : null;
 
@@ -538,20 +573,20 @@ export function App() {
     <>
       <HelpOverlay isOpen={showHelp} onClose={() => setShowHelp(false)} />
       <ToastContainer toasts={toast.toasts} onRemove={toast.removeToast} />
-      {ritualState.kind === "escalated" && ritualState.unit !== "" && (
+      {escalatedRitual !== null && escalatedRitual.state.kind === "escalated" && (
         <HandoffRitualFailureDialog
-          unitName={ritualState.unit}
-          reason={ritualState.reason}
-          message={ritualState.message}
+          unitName={escalatedRitual.unit}
+          reason={escalatedRitual.state.reason}
+          message={escalatedRitual.state.message}
           // The supervisor's `crash_loop_halted` halt is a different failure
           // than an operator-rejected handoff — manual relaunch, not retry.
-          mode={ritualState.reason === "crash_loop_halted" ? "crash_loop" : "handoff"}
+          mode={escalatedRitual.state.reason === "crash_loop_halted" ? "crash_loop" : "handoff"}
           producerAgentId={ritualUnitProducer?.id ?? null}
-          retryCount={handoffRetryCount}
-          retryRefused={handoffRetryRefused}
+          retryCount={handoffRetryCount[escalatedRitual.unit] ?? 0}
+          retryRefused={handoffRetryRefused[escalatedRitual.unit] ?? false}
           onForceKill={() => void handleHandoffForceKill()}
           onRetry={handleHandoffRetry}
-          onDismiss={dismissHandoff}
+          onDismiss={() => dismissHandoff(escalatedRitual.unit)}
         />
       )}
       {handoffReadyToastVisible && (

--- a/clients/react/src/__tests__/App.handoff.test.tsx
+++ b/clients/react/src/__tests__/App.handoff.test.tsx
@@ -7,13 +7,14 @@
 // fix, App's aim-mode early return rendered only <AimConsole> and stranded the
 // overlay in the since-removed producer-mode branch below it, so a handoff from
 // the default surface showed nothing. `useHandoffRitual` is mocked so we can
-// drive `state` deterministically; AimConsole is stubbed to render its
+// drive `states` deterministically; AimConsole is stubbed to render its
 // `handoffOverlay` prop, and the overlay itself is the REAL component so we
 // assert on its phase rows.
 
 import { fireEvent, screen, waitFor } from "@testing-library/react";
 import type { ReactNode } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { RitualUiState } from "@/hooks/useHandoffRitual";
 import { type AgentSnapshot, api } from "@/lib/api";
 import { renderWithProviders } from "@/test/render";
 import type { SlotResponse } from "@/types/generated/SlotResponse";
@@ -100,15 +101,17 @@ function agent(overrides: { id: string; cwd?: string }): AgentSnapshot {
 
 function idleRitual() {
   return {
-    state: { kind: "idle" as const },
+    // Ritual UI state keyed per unit (absent key == idle). Empty == all idle.
+    states: {} as Record<string, RitualUiState>,
     // Per-unit latest handoff phase (cross-unit owed tab signal). Empty here —
-    // this file exercises the single-ritual overlay, not the tab dots.
+    // this file exercises the overlay, not the tab dots.
     unitPhases: {},
     trigger: vi.fn(),
     retry: vi.fn(),
     dismiss: vi.fn(),
-    retryCount: 0,
-    retryRefused: false,
+    // Retry budget keyed per unit (absent key == 0 / false).
+    retryCount: {} as Record<string, number>,
+    retryRefused: {} as Record<string, boolean>,
   };
 }
 
@@ -148,7 +151,7 @@ describe("App — handoff ritual wiring", () => {
     });
     useHandoffRitualMock.mockReturnValue({
       ...idleRitual(),
-      state: { kind: "in_progress", ritualId: "r-1", unit: "alpha", phases: [] },
+      states: { alpha: { kind: "in_progress", ritualId: "r-1", unit: "alpha", phases: [] } },
     });
 
     renderWithProviders(<App />);
@@ -160,8 +163,9 @@ describe("App — handoff ritual wiring", () => {
   });
 
   // Regression for the #674 front-side facet (tmai-core #676). The in-progress
-  // overlay is gated by `ritualState.unit === unitName` (App.tsx). `unitName`
-  // comes from `resolveUnitName(currentProject, slots)`; `ritualState.unit` is
+  // overlay reads `states[unitName]` (App.tsx `focusedRitual`), so it shows only
+  // when the focused unit resolves to the ritual's own unit key. `unitName`
+  // comes from `resolveUnitName(currentProject, slots)`; the ritual's unit key is
   // server-authoritative off the SSE stream. #674's mismatch was the backend
   // respawning the Producer at the PRIMARY repo root, collapsing the unit's
   // membership so a SECONDARY-repo `currentProject` matched no slot →
@@ -187,7 +191,7 @@ describe("App — handoff ritual wiring", () => {
     // The ritual's server unit is the wrapper unit "tmai".
     useHandoffRitualMock.mockReturnValue({
       ...idleRitual(),
-      state: { kind: "in_progress", ritualId: "r-1", unit: "tmai", phases: [] },
+      states: { tmai: { kind: "in_progress", ritualId: "r-1", unit: "tmai", phases: [] } },
     });
 
     renderWithProviders(<App />);
@@ -220,12 +224,14 @@ describe("App — handoff ritual wiring", () => {
     });
     useHandoffRitualMock.mockReturnValue({
       ...idleRitual(),
-      state: {
-        kind: "escalated",
-        ritualId: "r-1",
-        unit: "gamma",
-        reason: "handoff_timeout",
-        message: null,
+      states: {
+        gamma: {
+          kind: "escalated",
+          ritualId: "r-1",
+          unit: "gamma",
+          reason: "handoff_timeout",
+          message: null,
+        },
       },
     });
 
@@ -269,12 +275,14 @@ describe("App — handoff ritual wiring", () => {
     });
     useHandoffRitualMock.mockReturnValue({
       ...idleRitual(),
-      state: {
-        kind: "escalated",
-        ritualId: "r-1",
-        unit: "gamma",
-        reason: "rejected",
-        message: null,
+      states: {
+        gamma: {
+          kind: "escalated",
+          ritualId: "r-1",
+          unit: "gamma",
+          reason: "rejected",
+          message: null,
+        },
       },
     });
     const killSpy = vi.spyOn(api, "killAgent").mockResolvedValue(undefined);

--- a/clients/react/src/hooks/__tests__/useHandoffRitual.test.ts
+++ b/clients/react/src/hooks/__tests__/useHandoffRitual.test.ts
@@ -4,6 +4,11 @@
 // Producer handoff-and-restart ritual landed server-side in
 // tmai-core#352 (DR `2026-05-14-handoff-lifecycle-and-kill-ux.md`).
 //
+// State is keyed PER UNIT (`states`, `retryCount`, `retryRefused` are all
+// `Record<unit, …>`). The `*Of(result)` helpers below read the "tmai" unit's
+// slot (absent key == idle) so most single-unit assertions stay terse; the
+// per-unit isolation describe block exercises two units at once.
+//
 // `useSSE` is captured so each test can synthesize wire events in
 // place of a real `/api/events` subscription. `api.triggerHandoffRitual`
 // is mocked with a resolved/rejected promise per scenario.
@@ -30,7 +35,22 @@ vi.mock("@/lib/sse-provider", () => ({
 }));
 
 import { api, HandoffRitualRequestError } from "@/lib/api";
+import type { RitualUiState, UseHandoffRitualResult } from "../useHandoffRitual";
 import { useHandoffRitual } from "../useHandoffRitual";
+
+type HookResult = { current: UseHandoffRitualResult };
+
+// Read one unit's slot (absent key == idle) so the single-unit tests read as
+// tersely as they did against the old app-global `state`.
+function stateOf(result: HookResult, unit = "tmai"): RitualUiState {
+  return result.current.states[unit] ?? { kind: "idle" };
+}
+function retryCountOf(result: HookResult, unit = "tmai"): number {
+  return result.current.retryCount[unit] ?? 0;
+}
+function retryRefusedOf(result: HookResult, unit = "tmai"): boolean {
+  return result.current.retryRefused[unit] ?? false;
+}
 
 interface PhaseEventOverrides {
   unit?: string;
@@ -83,9 +103,9 @@ afterEach(() => {
 describe("useHandoffRitual — state machine", () => {
   it("starts in idle state", () => {
     const { result } = renderHook(() => useHandoffRitual());
-    expect(result.current.state.kind).toBe("idle");
-    expect(result.current.retryCount).toBe(0);
-    expect(result.current.retryRefused).toBe(false);
+    expect(stateOf(result).kind).toBe("idle");
+    expect(retryCountOf(result)).toBe(0);
+    expect(retryRefusedOf(result)).toBe(false);
   });
 
   it("trigger transitions idle → dispatching → in_progress with the returned ritual_id", async () => {
@@ -97,10 +117,11 @@ describe("useHandoffRitual — state machine", () => {
       await result.current.trigger("tmai", { trigger: "manual" });
     });
 
-    expect(result.current.state.kind).toBe("in_progress");
-    if (result.current.state.kind === "in_progress") {
-      expect(result.current.state.ritualId).toBe("r-1");
-      expect(result.current.state.phases).toEqual([]);
+    const s = stateOf(result);
+    expect(s.kind).toBe("in_progress");
+    if (s.kind === "in_progress") {
+      expect(s.ritualId).toBe("r-1");
+      expect(s.phases).toEqual([]);
     }
   });
 
@@ -133,9 +154,10 @@ describe("useHandoffRitual — state machine", () => {
       capturedSSEHandlers?.onEvent?.("handoff_ritual", phasedEvent("r-1", "validated"));
     });
 
-    expect(result.current.state.kind).toBe("in_progress");
-    if (result.current.state.kind === "in_progress") {
-      expect(result.current.state.phases.map((p) => p.phase)).toEqual(["prompted", "validated"]);
+    const s = stateOf(result);
+    expect(s.kind).toBe("in_progress");
+    if (s.kind === "in_progress") {
+      expect(s.phases.map((p) => p.phase)).toEqual(["prompted", "validated"]);
     }
   });
 
@@ -148,12 +170,13 @@ describe("useHandoffRitual — state machine", () => {
     });
 
     act(() => {
-      // Different ritual id — must not append.
+      // Different ritual id, SAME unit — must not append.
       capturedSSEHandlers?.onEvent?.("handoff_ritual", phasedEvent("r-different", "prompted"));
     });
 
-    if (result.current.state.kind === "in_progress") {
-      expect(result.current.state.phases).toHaveLength(0);
+    const s = stateOf(result);
+    if (s.kind === "in_progress") {
+      expect(s.phases).toHaveLength(0);
     } else {
       throw new Error("expected in_progress state");
     }
@@ -167,8 +190,9 @@ describe("useHandoffRitual — state machine", () => {
       await result.current.trigger("tmai", { trigger: "manual" });
     });
 
-    if (result.current.state.kind === "in_progress") {
-      expect(result.current.state.unit).toBe("tmai");
+    const s = stateOf(result);
+    if (s.kind === "in_progress") {
+      expect(s.unit).toBe("tmai");
     } else {
       throw new Error("expected in_progress state");
     }
@@ -189,9 +213,10 @@ describe("useHandoffRitual — state machine", () => {
       );
     });
 
-    expect(result.current.state.kind).toBe("ready");
-    if (result.current.state.kind === "ready") {
-      expect(result.current.state.newAgentId).toBe("claude:abc-123");
+    const s = stateOf(result);
+    expect(s.kind).toBe("ready");
+    if (s.kind === "ready") {
+      expect(s.newAgentId).toBe("claude:abc-123");
     }
   });
 
@@ -213,10 +238,11 @@ describe("useHandoffRitual — state machine", () => {
       );
     });
 
-    expect(result.current.state.kind).toBe("escalated");
-    if (result.current.state.kind === "escalated") {
-      expect(result.current.state.reason).toBe("missing_handoff_ready");
-      expect(result.current.state.message).toBe("Producer never wrote HANDOFF READY");
+    const s = stateOf(result);
+    expect(s.kind).toBe("escalated");
+    if (s.kind === "escalated") {
+      expect(s.reason).toBe("missing_handoff_ready");
+      expect(s.message).toBe("Producer never wrote HANDOFF READY");
     }
   });
 
@@ -230,14 +256,15 @@ describe("useHandoffRitual — state machine", () => {
       await result.current.trigger("tmai", { trigger: "manual" });
     });
 
-    expect(result.current.state.kind).toBe("escalated");
-    if (result.current.state.kind === "escalated") {
-      expect(result.current.state.reason).toBe("http_404");
-      expect(result.current.state.message).toBe("unknown unit");
+    const s = stateOf(result);
+    expect(s.kind).toBe("escalated");
+    if (s.kind === "escalated") {
+      expect(s.reason).toBe("http_404");
+      expect(s.message).toBe("unknown unit");
     }
   });
 
-  it("dismiss clears state back to idle and resets the retry budget", async () => {
+  it("dismiss clears the unit back to idle and resets its retry budget", async () => {
     vi.mocked(api.triggerHandoffRitual).mockResolvedValue({ ritual_id: "r-1" });
 
     const { result } = renderHook(() => useHandoffRitual());
@@ -246,12 +273,110 @@ describe("useHandoffRitual — state machine", () => {
     });
 
     act(() => {
-      result.current.dismiss();
+      result.current.dismiss("tmai");
     });
 
-    expect(result.current.state.kind).toBe("idle");
-    expect(result.current.retryCount).toBe(0);
-    expect(result.current.retryRefused).toBe(false);
+    expect(stateOf(result).kind).toBe("idle");
+    expect(retryCountOf(result)).toBe(0);
+    expect(retryRefusedOf(result)).toBe(false);
+  });
+});
+
+// The operator-reported 2026-07-19 bug: with a single app-global ritual state,
+// triggering / completing a handoff on unit B silently erased unit A's parked
+// `awaiting_review` overlay. Per-unit keying must keep the two units' rituals
+// fully independent.
+describe("useHandoffRitual — per-unit isolation (lost review-gate bug, 2026-07-19)", () => {
+  it("triggering unit B does not clobber unit A's parked review-gate state", async () => {
+    vi.mocked(api.triggerHandoffRitual)
+      .mockResolvedValueOnce({ ritual_id: "r-A" })
+      .mockResolvedValueOnce({ ritual_id: "r-B" });
+
+    const { result } = renderHook(() => useHandoffRitual());
+
+    // Unit A reaches the review gate (awaiting_review).
+    await act(async () => {
+      await result.current.trigger("unitA", { trigger: "manual" });
+    });
+    act(() => {
+      capturedSSEHandlers?.onEvent?.(
+        "handoff_ritual",
+        phasedEvent("r-A", "awaiting_review", { unit: "unitA" }),
+      );
+    });
+    expect(stateOf(result, "unitA").kind).toBe("in_progress");
+
+    // Operator triggers a handoff on unit B — must NOT touch unit A.
+    await act(async () => {
+      await result.current.trigger("unitB", { trigger: "manual" });
+    });
+
+    const a = stateOf(result, "unitA");
+    expect(a.kind).toBe("in_progress");
+    if (a.kind === "in_progress") {
+      expect(a.ritualId).toBe("r-A");
+      expect(a.phases.map((p) => p.phase)).toEqual(["awaiting_review"]);
+    }
+    expect(stateOf(result, "unitB").kind).toBe("in_progress");
+  });
+
+  it("completing + dismissing unit B leaves unit A's review-gate state intact", async () => {
+    vi.mocked(api.triggerHandoffRitual)
+      .mockResolvedValueOnce({ ritual_id: "r-A" })
+      .mockResolvedValueOnce({ ritual_id: "r-B" });
+
+    const { result } = renderHook(() => useHandoffRitual());
+
+    await act(async () => {
+      await result.current.trigger("unitA", { trigger: "manual" });
+    });
+    act(() => {
+      capturedSSEHandlers?.onEvent?.(
+        "handoff_ritual",
+        phasedEvent("r-A", "awaiting_review", { unit: "unitA" }),
+      );
+    });
+
+    await act(async () => {
+      await result.current.trigger("unitB", { trigger: "manual" });
+    });
+    // Unit B runs to ready, then the operator dismisses it.
+    act(() => {
+      capturedSSEHandlers?.onEvent?.(
+        "handoff_ritual",
+        phasedEvent("r-B", "ready", { unit: "unitB", new_agent_id: "claude:b-fresh" }),
+      );
+    });
+    expect(stateOf(result, "unitB").kind).toBe("ready");
+    act(() => {
+      result.current.dismiss("unitB");
+    });
+
+    // Unit B is gone; unit A's parked review gate survives.
+    expect(stateOf(result, "unitB").kind).toBe("idle");
+    const a = stateOf(result, "unitA");
+    expect(a.kind).toBe("in_progress");
+    if (a.kind === "in_progress") {
+      expect(a.ritualId).toBe("r-A");
+      expect(a.phases.map((p) => p.phase)).toEqual(["awaiting_review"]);
+    }
+  });
+
+  it("keeps each unit's retry budget independent", async () => {
+    vi.mocked(api.triggerHandoffRitual).mockResolvedValue({ ritual_id: "r-x" });
+
+    const { result } = renderHook(() => useHandoffRitual());
+
+    await act(async () => {
+      await result.current.trigger("unitA", { trigger: "manual" });
+    });
+    await act(async () => {
+      await result.current.retry("unitA", { trigger: "manual" });
+    });
+
+    expect(retryCountOf(result, "unitA")).toBe(1);
+    // Unit B never retried — its budget is untouched.
+    expect(retryCountOf(result, "unitB")).toBe(0);
   });
 });
 
@@ -272,17 +397,18 @@ describe("useHandoffRitual — retry budget (DR §E)", () => {
         phasedEvent("r-1", "escalate", { reason: "timeout" }),
       );
     });
-    expect(result.current.state.kind).toBe("escalated");
+    expect(stateOf(result).kind).toBe("escalated");
 
     await act(async () => {
       await result.current.retry("tmai", { trigger: "manual" });
     });
 
-    expect(result.current.retryCount).toBe(1);
-    expect(result.current.state.kind).toBe("in_progress");
-    if (result.current.state.kind === "in_progress") {
-      expect(result.current.state.ritualId).toBe("r-2");
-      expect(result.current.state.phases).toEqual([]);
+    expect(retryCountOf(result)).toBe(1);
+    const s = stateOf(result);
+    expect(s.kind).toBe("in_progress");
+    if (s.kind === "in_progress") {
+      expect(s.ritualId).toBe("r-2");
+      expect(s.phases).toEqual([]);
     }
   });
 
@@ -306,14 +432,14 @@ describe("useHandoffRitual — retry budget (DR §E)", () => {
     await act(async () => {
       await result.current.retry("tmai", { trigger: "manual" });
     });
-    expect(result.current.retryCount).toBe(2);
+    expect(retryCountOf(result)).toBe(2);
 
     // 3rd retry — refused per DR §E "second rejection is a hard
     // escalate (no further automatic retry)"
     await act(async () => {
       await result.current.retry("tmai", { trigger: "manual" });
     });
-    expect(result.current.retryRefused).toBe(true);
+    expect(retryRefusedOf(result)).toBe(true);
     // triggerHandoffRitual called exactly 3 times (initial + 2 retries)
     expect(vi.mocked(api.triggerHandoffRitual).mock.calls.length).toBe(3);
   });
@@ -329,13 +455,13 @@ describe("useHandoffRitual — retry budget (DR §E)", () => {
     await act(async () => {
       await result.current.retry("tmai", { trigger: "manual" });
     });
-    expect(result.current.retryCount).toBe(1);
+    expect(retryCountOf(result)).toBe(1);
 
     // Fresh trigger session — counter must reset.
     await act(async () => {
       await result.current.trigger("tmai", { trigger: "manual" });
     });
-    expect(result.current.retryCount).toBe(0);
+    expect(retryCountOf(result)).toBe(0);
   });
 });
 
@@ -344,17 +470,18 @@ describe("useHandoffRitual — supervisor crash-respawn adoption (#540 / #546)",
 
   it("adopts an unsolicited supervisor `launching` from idle", () => {
     const { result } = renderHook(() => useHandoffRitual());
-    expect(result.current.state.kind).toBe("idle");
+    expect(stateOf(result).kind).toBe("idle");
 
     act(() => {
       capturedSSEHandlers?.onEvent?.("handoff_ritual", phasedEvent(SUP, "launching"));
     });
 
-    expect(result.current.state.kind).toBe("in_progress");
-    if (result.current.state.kind === "in_progress") {
-      expect(result.current.state.ritualId).toBe(SUP);
-      expect(result.current.state.unit).toBe("tmai");
-      expect(result.current.state.phases.map((p) => p.phase)).toEqual(["launching"]);
+    const s = stateOf(result);
+    expect(s.kind).toBe("in_progress");
+    if (s.kind === "in_progress") {
+      expect(s.ritualId).toBe(SUP);
+      expect(s.unit).toBe("tmai");
+      expect(s.phases.map((p) => p.phase)).toEqual(["launching"]);
     }
   });
 
@@ -370,10 +497,11 @@ describe("useHandoffRitual — supervisor crash-respawn adoption (#540 / #546)",
       );
     });
 
-    expect(result.current.state.kind).toBe("ready");
-    if (result.current.state.kind === "ready") {
-      expect(result.current.state.unit).toBe("tmai");
-      expect(result.current.state.newAgentId).toBe("claude:fresh");
+    const s = stateOf(result);
+    expect(s.kind).toBe("ready");
+    if (s.kind === "ready") {
+      expect(s.unit).toBe("tmai");
+      expect(s.newAgentId).toBe("claude:fresh");
     }
   });
 
@@ -386,11 +514,12 @@ describe("useHandoffRitual — supervisor crash-respawn adoption (#540 / #546)",
       );
     });
 
-    expect(result.current.state.kind).toBe("escalated");
-    if (result.current.state.kind === "escalated") {
-      expect(result.current.state.reason).toBe("crash_loop_halted");
-      expect(result.current.state.ritualId).toBe(SUP);
-      expect(result.current.state.unit).toBe("tmai");
+    const s = stateOf(result);
+    expect(s.kind).toBe("escalated");
+    if (s.kind === "escalated") {
+      expect(s.reason).toBe("crash_loop_halted");
+      expect(s.ritualId).toBe(SUP);
+      expect(s.unit).toBe("tmai");
     }
   });
 
@@ -400,7 +529,7 @@ describe("useHandoffRitual — supervisor crash-respawn adoption (#540 / #546)",
       capturedSSEHandlers?.onEvent?.("handoff_ritual", phasedEvent("uuid-r-9", "launching"));
     });
     // A stray operator-ritual event without a live ritual is ignored.
-    expect(result.current.state.kind).toBe("idle");
+    expect(stateOf(result).kind).toBe("idle");
   });
 
   it("never lets a supervisor respawn clobber a live operator handoff", async () => {
@@ -409,23 +538,26 @@ describe("useHandoffRitual — supervisor crash-respawn adoption (#540 / #546)",
     await act(async () => {
       await result.current.trigger("tmai", { trigger: "manual" });
     });
-    expect(result.current.state.kind).toBe("in_progress");
+    expect(stateOf(result).kind).toBe("in_progress");
 
     act(() => {
-      // A concurrent supervisor respawn for another unit must not hijack the
-      // operator's live overlay (different ritual_id, prev is in_progress).
+      // A concurrent supervisor respawn for ANOTHER unit lands in that unit's
+      // own slot and must not touch the operator's live "tmai" overlay.
       capturedSSEHandlers?.onEvent?.(
         "handoff_ritual",
         phasedEvent("slot-supervisor:other", "launching", { unit: "other" }),
       );
     });
 
-    if (result.current.state.kind === "in_progress") {
-      expect(result.current.state.ritualId).toBe("r-1");
-      expect(result.current.state.phases).toHaveLength(0);
+    const s = stateOf(result);
+    if (s.kind === "in_progress") {
+      expect(s.ritualId).toBe("r-1");
+      expect(s.phases).toHaveLength(0);
     } else {
       throw new Error("expected the operator ritual to stay in_progress");
     }
+    // The respawn was adopted into its own unit's slot.
+    expect(stateOf(result, "other").kind).toBe("in_progress");
   });
 });
 
@@ -454,8 +586,9 @@ describe("useHandoffRitual — SSE event hygiene", () => {
       });
     });
 
-    if (result.current.state.kind === "in_progress") {
-      expect(result.current.state.phases).toHaveLength(0);
+    const s = stateOf(result);
+    if (s.kind === "in_progress") {
+      expect(s.phases).toHaveLength(0);
     } else {
       throw new Error("expected in_progress state");
     }
@@ -476,8 +609,9 @@ describe("useHandoffRitual — SSE event hygiene", () => {
       capturedSSEHandlers?.onEvent?.("handoff_ritual", null);
     });
 
-    if (result.current.state.kind === "in_progress") {
-      expect(result.current.state.phases).toHaveLength(0);
+    const s = stateOf(result);
+    if (s.kind === "in_progress") {
+      expect(s.phases).toHaveLength(0);
     } else {
       throw new Error("expected in_progress state");
     }
@@ -498,13 +632,13 @@ describe("useHandoffRitual — SSE event hygiene", () => {
     });
 
     // Before the API resolves, the hook is in `dispatching`.
-    expect(result.current.state.kind).toBe("dispatching");
+    expect(stateOf(result).kind).toBe("dispatching");
 
     await act(async () => {
       resolve?.({ ritual_id: "r-late" });
       await triggerPromise;
     });
 
-    await waitFor(() => expect(result.current.state.kind).toBe("in_progress"));
+    await waitFor(() => expect(stateOf(result).kind).toBe("in_progress"));
   });
 });

--- a/clients/react/src/hooks/useHandoffRitual.ts
+++ b/clients/react/src/hooks/useHandoffRitual.ts
@@ -2,7 +2,7 @@
 // — WebUI surface). Drives the conversation panel's in-progress overlay and
 // the 4-choice failure dialog.
 //
-// Lifecycle:
+// Lifecycle (PER UNIT — see the state model note below):
 //
 //   idle
 //     │ trigger(unit, body)                       (kicks POST)
@@ -13,25 +13,36 @@
 //     │ phase: escalate                           ─► escalated
 //     ▼
 //   { ready | escalated }
-//     │ dismiss() | retry(unit, body)
+//     │ dismiss(unit) | retry(unit, body)
 //     ▼
 //   idle
 //
-// The hook ignores SSE events whose `ritual_id` does not match the
-// currently live `ritual_id` so concurrent rituals across units
-// (or operator retries against the same unit) never cross-talk into
-// the overlay — with ONE exception: an unsolicited supervisor
-// crash-respawn (synthetic `slot-supervisor:<unit>` id, tmai-core
-// #540 / #546) is ADOPTED from idle, so a Producer that the engine
-// auto-relaunches surfaces the same overlay without an operator
-// trigger. It is adopted only from idle, so it never clobbers a live
-// operator handoff or an open failure dialog.
+// State model — ONE ENTRY PER UNIT, keyed by unit name (`states`,
+// `retryCount`, `retryRefused` are all `Record<unit, …>`). This mirrors the
+// backend, whose review gate + ritual lock are per-unit HashMaps: a handoff
+// parked at `awaiting_review` on unit A stays armed server-side while the
+// operator triggers/completes a handoff on unit B. A single app-global
+// `state` used to hold only ONE unit's ritual, so triggering unit B's handoff
+// overwrote unit A's `in_progress`, and unit B's `ready`/`dismiss` cleared it
+// — so switching back to unit A found its review-gate overlay silently gone
+// even though the backend gate was still armed (operator-reported 2026-07-19).
+// Keying by unit is the front-side half of that fix: `trigger(B)` writes only
+// `states.B`, `dismiss(B)` clears only `states.B`, and `states.A` survives.
 //
-// Retry budget (DR §E): the dialog refuses a third retry from the
-// hook side — "second rejection is a hard escalate (no further
-// automatic retry)". The hook does not silently swallow the third
-// retry; it surfaces a `retryRefused` flag the dialog can read so
-// the operator gets a clear reason for the disabled Retry button.
+// The hook ignores SSE events whose `ritual_id` does not match the unit's own
+// live `ritual_id` so concurrent rituals across units (or operator retries
+// against the same unit) never cross-talk into each other's overlay — with ONE
+// exception: an unsolicited supervisor crash-respawn (synthetic
+// `slot-supervisor:<unit>` id, tmai-core #540 / #546) is ADOPTED from idle, so
+// a Producer that the engine auto-relaunches surfaces the same overlay without
+// an operator trigger. It is adopted only from that unit's idle, so it never
+// clobbers a live operator handoff or an open failure dialog.
+//
+// Retry budget (DR §E): the dialog refuses a third retry from the hook side —
+// "second rejection is a hard escalate (no further automatic retry)". The hook
+// does not silently swallow the third retry; it surfaces a `retryRefused` flag
+// (per unit) the dialog can read so the operator gets a clear reason for the
+// disabled Retry button.
 
 import { useCallback, useState } from "react";
 import {
@@ -57,24 +68,30 @@ export type RitualUiState =
   | { kind: "escalated"; ritualId: string; unit: string; reason: string; message: string | null };
 
 export interface UseHandoffRitualResult {
-  state: RitualUiState;
+  /** Ritual UI state per unit, keyed by unit name. An absent key means idle.
+   *  The in-progress overlay reads the FOCUSED unit's entry; the app-global
+   *  failure dialog derives its escalated unit from this map. Keeping this
+   *  per-unit (not a single app-global state) is what lets a non-focused
+   *  unit's handoff survive another unit's concurrent ritual. */
+  states: Record<string, RitualUiState>;
   /** Latest handoff-ritual phase observed per unit, across ALL units on the
-   *  global `handoff_ritual` SSE stream — not just the single adopted
-   *  `state`. Lets a non-focused unit's `awaiting_review` surface as a
+   *  global `handoff_ritual` SSE stream — not just the units with an adopted
+   *  `states` entry. Lets a non-focused unit's `awaiting_review` surface as a
    *  cross-unit tab signal (aim `cross-unit-operator-owed`): the operator,
    *  working in unit X, learns unit Y owes a handoff review. Retains only the
    *  LATEST phase per unit, so a forward phase (killed/…/ready) or `escalate`
    *  supersedes `awaiting_review` and the owe clears mechanically. */
   unitPhases: Record<string, HandoffRitualEvent["phase"]>;
-  /** Number of retries already attempted in this session. Used by the
-   *  dialog to disable the Retry button after the 2nd rejection. */
-  retryCount: number;
-  /** True after the 3rd `trigger`/`retry` attempt is refused. */
-  retryRefused: boolean;
+  /** Retries already attempted this session, per unit. Used by the dialog to
+   *  disable the Retry button after the 2nd rejection. Absent key means 0. */
+  retryCount: Record<string, number>;
+  /** True (per unit) after the 3rd `trigger`/`retry` attempt is refused.
+   *  Absent key means false. */
+  retryRefused: Record<string, boolean>;
   trigger: (unit: string, body: TriggerHandoffRitualRequest) => Promise<void>;
   retry: (unit: string, body: TriggerHandoffRitualRequest) => Promise<void>;
-  /** Clear back to `idle` and reset the retry budget. */
-  dismiss: () => void;
+  /** Clear the given unit back to idle and reset its retry budget. */
+  dismiss: (unit: string) => void;
 }
 
 const MAX_RETRIES = 2;
@@ -89,95 +106,105 @@ function looksLikeHandoffRitualEvent(data: unknown): data is HandoffRitualEvent 
   );
 }
 
+// Advance ONE unit's ritual UI state by a single SSE event. Pure function so
+// the per-unit map updater stays trivial. Two routes:
+//
+//   1. An OPERATOR ritual that this hook dispatched: events whose `ritual_id`
+//      matches the unit's live `in_progress` ritual advance it.
+//   2. An UNSOLICITED supervisor crash-respawn (synthetic `slot-supervisor:
+//      <unit>` id, tmai-core #540 / #546): adopted ONLY from that unit's
+//      `idle`, so it surfaces the same overlay without an operator trigger but
+//      never clobbers a live operator handoff or an open failure dialog. The
+//      supervisor stream begins at `launching` (no prompted/validated/killed
+//      FRONT) and may also arrive as a bare `escalate` (`crash_loop_halted`)
+//      if the hook attaches mid-loop — adoption handles every phase from idle.
+//
+// Returns `prev` unchanged when the event does not apply (the caller skips the
+// state write on referential equality).
+function advanceRitualState(prev: RitualUiState, event: HandoffRitualEvent): RitualUiState {
+  const isSupervisor = event.ritual_id.startsWith(SUPERVISOR_RITUAL_PREFIX);
+
+  // Adopt a supervisor respawn from idle, landing in whatever phase the first
+  // observed event carries.
+  if (prev.kind === "idle") {
+    if (!isSupervisor) return prev; // operator events require a live ritual
+    if (event.phase === "ready") {
+      return {
+        kind: "ready",
+        ritualId: event.ritual_id,
+        unit: event.unit,
+        newAgentId: event.new_agent_id ?? null,
+      };
+    }
+    if (event.phase === "escalate") {
+      return {
+        kind: "escalated",
+        ritualId: event.ritual_id,
+        unit: event.unit,
+        reason: event.reason,
+        message: event.message ?? null,
+      };
+    }
+    return {
+      kind: "in_progress",
+      ritualId: event.ritual_id,
+      unit: event.unit,
+      phases: [event],
+    };
+  }
+
+  // Otherwise only the unit's live in-progress ritual's own events advance it;
+  // a mismatched `ritual_id` (a concurrent ritual / cross-unit respawn) never
+  // cross-talks into this unit's overlay.
+  if (prev.kind !== "in_progress") return prev;
+  if (event.ritual_id !== prev.ritualId) return prev;
+
+  if (event.phase === "ready") {
+    return {
+      kind: "ready",
+      ritualId: event.ritual_id,
+      unit: prev.unit,
+      newAgentId: event.new_agent_id ?? null,
+    };
+  }
+  if (event.phase === "escalate") {
+    return {
+      kind: "escalated",
+      ritualId: event.ritual_id,
+      unit: prev.unit,
+      reason: event.reason,
+      message: event.message ?? null,
+    };
+  }
+  // Intermediate phases — append (dedupe on exact phase if the server were to
+  // re-emit, though tmai-core PR #352 only emits each phase once).
+  const lastPhase = prev.phases[prev.phases.length - 1]?.phase;
+  if (lastPhase === event.phase) return prev;
+  return {
+    ...prev,
+    phases: [...prev.phases, event],
+  };
+}
+
 export function useHandoffRitual(): UseHandoffRitualResult {
-  const [state, setState] = useState<RitualUiState>({ kind: "idle" });
-  const [retryCount, setRetryCount] = useState(0);
-  const [retryRefused, setRetryRefused] = useState(false);
-  // Latest phase per unit, fed by EVERY handoff_ritual event (not gated by the
-  // adopted `state`'s ritual_id). This is the cross-unit owed-signal source:
-  // the single `state` above is scoped to one adopted ritual for the overlay,
-  // but the tab dots need every unit's current phase.
+  const [states, setStates] = useState<Record<string, RitualUiState>>({});
+  const [retryCount, setRetryCount] = useState<Record<string, number>>({});
+  const [retryRefused, setRetryRefused] = useState<Record<string, boolean>>({});
+  // Latest phase per unit, fed by EVERY handoff_ritual event (not gated by any
+  // adopted `states` entry). This is the cross-unit owed-signal source: the
+  // per-unit `states` above are scoped to adopted rituals for the overlay, but
+  // the tab dots need every unit's current phase.
   const [unitPhases, setUnitPhases] = useState<Record<string, HandoffRitualEvent["phase"]>>({});
 
-  // Single state-driven event router (no ref mirror — matching reads `prev`
-  // inside the updater, so the SSE handler can register once and never go
-  // stale). Two routes:
-  //
-  //   1. An OPERATOR ritual that this hook dispatched: events whose
-  //      `ritual_id` matches the live `in_progress` ritual advance it.
-  //   2. An UNSOLICITED supervisor crash-respawn (synthetic
-  //      `slot-supervisor:<unit>` id, tmai-core #540 / #546): adopted ONLY
-  //      from `idle`, so it surfaces the same overlay without an operator
-  //      trigger but never clobbers a live operator handoff or an open
-  //      failure dialog. The supervisor stream begins at `launching` (no
-  //      prompted/validated/killed FRONT) and may also arrive as a bare
-  //      `escalate` (`crash_loop_halted`) if the hook attaches mid-loop —
-  //      adoption handles every phase from idle, not just `launching`.
+  // State-driven event router (no ref mirror — the updater reads the latest
+  // map, so the SSE handler can register once and never go stale). Routes the
+  // event to its own unit's slot and advances just that slot.
   const applyEvent = useCallback((event: HandoffRitualEvent) => {
-    setState((prev) => {
-      const isSupervisor = event.ritual_id.startsWith(SUPERVISOR_RITUAL_PREFIX);
-
-      // Adopt a supervisor respawn from idle, landing in whatever phase the
-      // first observed event carries.
-      if (prev.kind === "idle") {
-        if (!isSupervisor) return prev; // operator events require a live ritual
-        if (event.phase === "ready") {
-          return {
-            kind: "ready",
-            ritualId: event.ritual_id,
-            unit: event.unit,
-            newAgentId: event.new_agent_id ?? null,
-          };
-        }
-        if (event.phase === "escalate") {
-          return {
-            kind: "escalated",
-            ritualId: event.ritual_id,
-            unit: event.unit,
-            reason: event.reason,
-            message: event.message ?? null,
-          };
-        }
-        return {
-          kind: "in_progress",
-          ritualId: event.ritual_id,
-          unit: event.unit,
-          phases: [event],
-        };
-      }
-
-      // Otherwise only the live in-progress ritual's own events advance it;
-      // a mismatched `ritual_id` (a concurrent ritual / cross-unit respawn)
-      // never cross-talks into this overlay.
-      if (prev.kind !== "in_progress") return prev;
-      if (event.ritual_id !== prev.ritualId) return prev;
-
-      if (event.phase === "ready") {
-        return {
-          kind: "ready",
-          ritualId: event.ritual_id,
-          unit: prev.unit,
-          newAgentId: event.new_agent_id ?? null,
-        };
-      }
-      if (event.phase === "escalate") {
-        return {
-          kind: "escalated",
-          ritualId: event.ritual_id,
-          unit: prev.unit,
-          reason: event.reason,
-          message: event.message ?? null,
-        };
-      }
-      // Intermediate phases — append (dedupe on exact phase if the
-      // server were to re-emit, though tmai-core PR #352 only emits
-      // each phase once).
-      const lastPhase = prev.phases[prev.phases.length - 1]?.phase;
-      if (lastPhase === event.phase) return prev;
-      return {
-        ...prev,
-        phases: [...prev.phases, event],
-      };
+    setStates((all) => {
+      const prev = all[event.unit] ?? { kind: "idle" as const };
+      const next = advanceRitualState(prev, event);
+      if (next === prev) return all;
+      return { ...all, [event.unit]: next };
     });
   }, []);
 
@@ -186,7 +213,7 @@ export function useHandoffRitual(): UseHandoffRitualResult {
       if (eventName !== "handoff_ritual") return;
       if (!looksLikeHandoffRitualEvent(data)) return;
       // Track the latest phase for EVERY unit (cross-unit owed signal),
-      // independent of which single ritual `applyEvent` adopts for the overlay.
+      // independent of which rituals `applyEvent` adopts for the overlay.
       setUnitPhases((prev) =>
         prev[data.unit] === data.phase ? prev : { ...prev, [data.unit]: data.phase },
       );
@@ -195,10 +222,13 @@ export function useHandoffRitual(): UseHandoffRitualResult {
   });
 
   const dispatchRitual = useCallback(async (unit: string, body: TriggerHandoffRitualRequest) => {
-    setState({ kind: "dispatching" });
+    setStates((all) => ({ ...all, [unit]: { kind: "dispatching" } }));
     try {
       const { ritual_id } = await api.triggerHandoffRitual(unit, body);
-      setState({ kind: "in_progress", ritualId: ritual_id, unit, phases: [] });
+      setStates((all) => ({
+        ...all,
+        [unit]: { kind: "in_progress", ritualId: ritual_id, unit, phases: [] },
+      }));
     } catch (err) {
       // Surface 400/404/etc. as an `escalated` terminal — the dialog
       // can render the reason verbatim. We use a synthetic ritualId
@@ -206,21 +236,18 @@ export function useHandoffRitual(): UseHandoffRitualResult {
       const isTyped = err instanceof HandoffRitualRequestError;
       const reason = isTyped ? `http_${err.status}` : "request_failed";
       const message = isTyped ? err.detail : err instanceof Error ? err.message : String(err);
-      setState({
-        kind: "escalated",
-        ritualId: "",
-        unit,
-        reason,
-        message,
-      });
+      setStates((all) => ({
+        ...all,
+        [unit]: { kind: "escalated", ritualId: "", unit, reason, message },
+      }));
     }
   }, []);
 
   const trigger = useCallback(
     async (unit: string, body: TriggerHandoffRitualRequest) => {
-      // A fresh `trigger` starts a new session: reset the retry budget.
-      setRetryCount(0);
-      setRetryRefused(false);
+      // A fresh `trigger` starts a new session for this unit: reset its budget.
+      setRetryCount((m) => ({ ...m, [unit]: 0 }));
+      setRetryRefused((m) => ({ ...m, [unit]: false }));
       await dispatchRitual(unit, body);
     },
     [dispatchRitual],
@@ -230,21 +257,36 @@ export function useHandoffRitual(): UseHandoffRitualResult {
     async (unit: string, body: TriggerHandoffRitualRequest) => {
       // DR §E: second rejection is a hard escalate. After the 2nd retry
       // (i.e. the 3rd attempt total counting the initial trigger), refuse.
-      if (retryCount >= MAX_RETRIES) {
-        setRetryRefused(true);
+      if ((retryCount[unit] ?? 0) >= MAX_RETRIES) {
+        setRetryRefused((m) => ({ ...m, [unit]: true }));
         return;
       }
-      setRetryCount((n) => n + 1);
+      setRetryCount((m) => ({ ...m, [unit]: (m[unit] ?? 0) + 1 }));
       await dispatchRitual(unit, body);
     },
     [dispatchRitual, retryCount],
   );
 
-  const dismiss = useCallback(() => {
-    setState({ kind: "idle" });
-    setRetryCount(0);
-    setRetryRefused(false);
+  const dismiss = useCallback((unit: string) => {
+    setStates((all) => {
+      if (!(unit in all)) return all;
+      const next = { ...all };
+      delete next[unit];
+      return next;
+    });
+    setRetryCount((m) => {
+      if (!(unit in m)) return m;
+      const next = { ...m };
+      delete next[unit];
+      return next;
+    });
+    setRetryRefused((m) => {
+      if (!(unit in m)) return m;
+      const next = { ...m };
+      delete next[unit];
+      return next;
+    });
   }, []);
 
-  return { state, unitPhases, retryCount, retryRefused, trigger, retry, dismiss };
+  return { states, unitPhases, retryCount, retryRefused, trigger, retry, dismiss };
 }


### PR DESCRIPTION
## Problem (operator-reported 2026-07-19)

Doing a handoff on unit **tmai** and a **concurrent** handoff on another unit,
then completing the other unit's handoff and returning to tmai, made tmai's
handoff **modal disappear**. Re-triggering forced the operator into **force
kill**, which booted a new Producer off an **un-approved baton** — the review
gate (`handoff-review-gate`) was bypassed.

## Root cause

A **core↔UI asymmetry**. The backend review gate + ritual lock are **per-unit**
HashMaps (`handoff_review_gate: HashMap<unit, ReviewGate>`), but the React
`useHandoffRitual` hook held a **single app-global `RitualUiState`**. Under
interleaved multi-unit handoffs:

1. tmai reaches `awaiting_review` → global state holds tmai's ritual; overlay shown.
2. `trigger(unitB)` **unconditionally overwrites** the single global state → tmai's ritual evicted (its backend gate stays armed).
3. unitB's `ready`/`dismiss` clears the single slot → global state idle.
4. Switch back to tmai → focused unit ≠ any stored ritual → **overlay gone**; the tab's `awaiting_review` dot still lit, but no way to re-open the modal.

The same single-global model already produced a cross-unit mis-kill
(2026-07-15).

## Fix

Align the front side with the backend — make ritual UI state **per unit**:
`states`, `retryCount`, `retryRefused` become `Record<unit, …>`.

- `trigger(B)` writes only `states.B`; `dismiss(B)` clears only `states.B`; `states.A` survives.
- The in-progress overlay reads the **focused unit's** entry and re-appears on switch-back.
- The app-global failure dialog derives its escalated unit from the map (focused unit preferred, else any escalated unit), preserving the **2026-07-15 mis-kill guard** — every dialog action still targets the ritual's unit, never the focused one.

No hook-instance duplication (App's "exactly one `useHandoffRitual`" invariant is untouched); a single overlay is still visible at a time.

## Scope

Front-side only (`clients/react`). The force-kill escape hatch booting a fresh
Producer off an un-reviewed baton (DR §E deferred TODO) is intentionally out of
scope — with the overlay no longer lost, the operator is no longer forced into
force-kill.

## Tests

- Adapted the `useHandoffRitual` state-machine suite and the `App.handoff` wiring suite to the per-unit API.
- Added a **per-unit isolation** describe block reproducing the 2026-07-19 bug: trigger/complete/dismiss on unit B must not touch unit A's parked review gate; retry budgets stay independent.

Gates green locally: biome lint · tsc · vitest (781 passed / 2 skipped, incl. 3 new isolation tests) · build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * 複数のハンドオフ処理をユニット単位で独立して管理できるようになりました。
  * あるユニットの進行状況や失敗、リトライ操作が、別ユニットの表示や状態に影響しなくなりました。
  * 会話パネルの進行中表示、失敗ダイアログ、完了通知が対象ユニットに正しく紐づいて表示されます。
  * Force-kill、Retry、Dismiss操作の対象が明確になり、誤ったユニットへの操作を防止します。

* **テスト**
  * 複数ユニットの並行処理、状態分離、リトライ上限に関する検証を強化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->